### PR TITLE
apport-bug: Add /snap/bin to PATH for Firefox snap

### DIFF
--- a/bin/apport-bug
+++ b/bin/apport-bug
@@ -16,7 +16,7 @@
 # cannot abuse the environment to escape AppArmor confinement via this script
 # (LP: #1045986). This can be removed once AppArmor supports environment
 # filtering (LP: #1045985)
-PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
 
 # locate path of a particular program
 find_program() {


### PR DESCRIPTION
On LXQt `apport-bug` is unable to open the Firefox snap at the very end of the process:

```
$ env -i apport-bug apport
[...]
Choices:
  1: Launch a browser now
  C: Cancel
Please choose (1/C): 1
/usr/bin/xdg-open: 882: firefox: not found
/usr/bin/xdg-open: 882: firefox: not found
xdg-open: no method available for opening 'https://bugs.launchpad.net/ubuntu/+source/apport/+filebug/d7ffa3e0-d46d-11ec-a167-40a8f03099c8?'
```

The Firefox snap provides `/snap/bin/firefox`. `apport-bug` sets the environment variable `PATH`, but does not include `/snap/bin`:

```
$ PATH=/usr/sbin:/usr/bin:/sbin:/bin xdg-open https://ubuntu.com
/usr/bin/xdg-open: 882: firefox: not found
/usr/bin/xdg-open: 882: firefox: not found
xdg-open: no method available for opening 'https://ubuntu.com'
```

`xdg-open` behaves differently depending on the desktop environment. On GMOME `xdg-open` calls `gio open` and successfully opens Firefox regardless of `PATH`, but on LXQt it tries to call `firefox` directly.

Bug: https://launchpad.net/bugs/1973470