### PR TITLE
tests: Fix psutil.NoSuchProcess in wait_for_gdb_child_process

### DIFF
--- a/tests/integration/test_signal_crashes.py
+++ b/tests/integration/test_signal_crashes.py
@@ -1167,9 +1167,12 @@ class T(unittest.TestCase):
         while timeout < 5:
             gdb_children = gdb_process.children()
             for process in gdb_children:
-                if process.status() == "tracing-stop":
+                try:
+                    if process.status() == "tracing-stop":
+                        continue
+                    cmdline = process.cmdline()
+                except psutil.NoSuchProcess:  # pragma: no cover
                     continue
-                cmdline = process.cmdline()
                 if cmdline and cmdline[0] == command:
                     return process
 


### PR DESCRIPTION
`test_crash_setuid_unpackaged` is racy and rarely fails with:

```
======================================================================
ERROR: test_crash_setuid_unpackaged (tests.integration.test_signal_crashes.T)
report generation for unpackaged setuid program
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/psutil/_pslinux.py", line 1661, in wrapper
    return fun(self, *args, **kwargs)
  File "/usr/lib/python3/dist-packages/psutil/_pslinux.py", line 1782, in cmdline
    data = f.read()
ProcessLookupError: [Errno 3] No such process

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "tests/integration/test_signal_crashes.py", line 746, in test_crash_setuid_unpackaged
    self.do_crash(
  File "tests/integration/test_signal_crashes.py", line 918, in do_crash
    command_process = self.wait_for_gdb_child_process(
  File "tests/integration/test_signal_crashes.py", line 1088, in wait_for_gdb_child_process
    cmdline = process.cmdline()
  File "/usr/lib/python3/dist-packages/psutil/__init__.py", line 684, in cmdline
    return self._proc.cmdline()
  File "/usr/lib/python3/dist-packages/psutil/_pslinux.py", line 1665, in wrapper
    raise NoSuchProcess(self.pid, self._name)
psutil.NoSuchProcess: process no longer exists (pid=3767)

----------------------------------------------------------------------
```

Between listing the child processes and checking their cmdline, the processes can finish. Ignore processes that vanished.

Bug: https://launchpad.net/bugs/1989371