### PR TITLE
tests: Add skip_if_command_is_missing helper function

### DIFF
--- a/tests/helper.py
+++ b/tests/helper.py
@@ -4,6 +4,7 @@ import contextlib
 import importlib.machinery
 import importlib.util
 import os
+import shutil
 import subprocess
 import typing
 import unittest.mock
@@ -77,6 +78,17 @@ def read_shebang(command: str) -> typing.Optional[str]:
     if not first_line.startswith(b"#!"):
         return None
     return first_line.decode().split(" ", 1)[0][2:]
+
+
+def _id(obj):
+    return obj
+
+
+def skip_if_command_is_missing(cmd: str):
+    """Skip a test if the command is not found."""
+    if shutil.which(cmd) is None:
+        return unittest.skip(f"{cmd} not installed")
+    return _id
 
 
 @contextlib.contextmanager

--- a/tests/integration/test_apport_valgrind.py
+++ b/tests/integration/test_apport_valgrind.py
@@ -13,10 +13,11 @@ import subprocess
 import tempfile
 import unittest
 
+from tests.helper import skip_if_command_is_missing
 from tests.paths import local_test_environment
 
 
-@unittest.skipIf(shutil.which("valgrind") is None, "valgrind not installed")
+@skip_if_command_is_missing("valgrind")
 class T(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/tests/integration/test_java_crashes.py
+++ b/tests/integration/test_java_crashes.py
@@ -15,6 +15,7 @@ import unittest
 
 import apport.fileutils
 import apport.report
+from tests.helper import skip_if_command_is_missing
 from tests.paths import (
     SRCDIR,
     get_data_directory,
@@ -23,7 +24,7 @@ from tests.paths import (
 )
 
 
-@unittest.skipIf(shutil.which("java") is None, "Java not available")
+@skip_if_command_is_missing("java")
 class T(unittest.TestCase):
     def setUp(self):
         self.env = os.environ | local_test_environment()

--- a/tests/integration/test_packaging_apt_dpkg.py
+++ b/tests/integration/test_packaging_apt_dpkg.py
@@ -7,9 +7,10 @@ import time
 import unittest
 
 from apport.packaging_impl.apt_dpkg import impl
+from tests.helper import skip_if_command_is_missing
 
 
-@unittest.skipIf(shutil.which("dpkg") is None, "dpkg not available")
+@skip_if_command_is_missing("dpkg")
 class T(unittest.TestCase):
     # pylint: disable=protected-access
 

--- a/tests/integration/test_packaging_rpm.py
+++ b/tests/integration/test_packaging_rpm.py
@@ -1,5 +1,6 @@
-import shutil
 import unittest
+
+from tests.helper import skip_if_command_is_missing
 
 try:
     from apport.packaging_impl.rpm import impl
@@ -10,7 +11,7 @@ except ImportError:
 
 
 @unittest.skipUnless(HAS_RPM, "rpm module not available")
-@unittest.skipIf(shutil.which("rpm") is None, "rpm not available")
+@skip_if_command_is_missing("rpm")
 class T(unittest.TestCase):
     def test_get_dependencies(self):
         """get_dependencies()."""

--- a/tests/integration/test_report.py
+++ b/tests/integration/test_report.py
@@ -14,6 +14,7 @@ import unittest.mock
 import apport.packaging
 import apport.report
 import problem_report
+from tests.helper import skip_if_command_is_missing
 from tests.paths import patch_data_dir, restore_data_dir
 
 
@@ -547,9 +548,7 @@ class T(unittest.TestCase):
         self.assertEqual(pr["InterpreterPath"], "/usr/bin/python")
         self.assertNotIn("UnreportableReason", pr)
 
-    @unittest.skipIf(
-        shutil.which("twistd") is None, "twisted is not installed"
-    )
+    @skip_if_command_is_missing("twistd")
     def test_check_interpreted_twistd(self):
         """_check_interpreted() for programs ran through twistd"""
 

--- a/tests/system/test_apport_valgrind.py
+++ b/tests/system/test_apport_valgrind.py
@@ -13,6 +13,7 @@ import subprocess
 import tempfile
 import unittest
 
+from tests.helper import skip_if_command_is_missing
 from tests.paths import local_test_environment
 
 with open("/proc/meminfo", encoding="utf-8") as f:
@@ -22,7 +23,7 @@ with open("/proc/meminfo", encoding="utf-8") as f:
             break
 
 
-@unittest.skipIf(shutil.which("valgrind") is None, "valgrind not installed")
+@skip_if_command_is_missing("valgrind")
 class T(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/tests/system/test_packaging_apt_dpkg.py
+++ b/tests/system/test_packaging_apt_dpkg.py
@@ -9,10 +9,10 @@ import unittest
 from apt import apt_pkg
 
 from apport.packaging_impl.apt_dpkg import impl
-from tests.helper import has_internet
+from tests.helper import has_internet, skip_if_command_is_missing
 
 
-@unittest.skipIf(shutil.which("dpkg") is None, "dpkg not available")
+@skip_if_command_is_missing("dpkg")
 class T(unittest.TestCase):
     # pylint: disable=protected-access
 

--- a/tests/system/test_signal_crashes.py
+++ b/tests/system/test_signal_crashes.py
@@ -10,7 +10,7 @@ import time
 import unittest
 
 import apport.fileutils
-from tests.helper import get_init_system, pidof
+from tests.helper import get_init_system, pidof, skip_if_command_is_missing
 from tests.paths import (
     get_data_directory,
     is_local_source_directory,
@@ -209,9 +209,7 @@ class T(unittest.TestCase):
     @unittest.skipIf(
         get_init_system() != "systemd", "running init system is not systemd"
     )
-    @unittest.skipIf(
-        shutil.which("systemd-run") is None, "systemd-run not installed"
-    )
+    @skip_if_command_is_missing("systemd-run")
     @unittest.skipIf(os.geteuid() != 0, "this test needs to be run as root")
     def test_crash_system_slice(self):
         """report generation for a protected process running in the system


### PR DESCRIPTION
Add a `skip_if_command_is_missing` helper function to make the skip code line shorter.