### PR TITLE
Disable debuginfod when collecting a report

### DIFF
--- a/apport/report.py
+++ b/apport/report.py
@@ -887,8 +887,14 @@ class Report(problem_report.ProblemReport):
                 "gdb not found in retracing env",
             )
 
-        # limit maximum backtrace depth (to avoid looped stacks)
-        gdb_cmd += ["--batch", "--ex", "set backtrace limit 2000"]
+        gdb_cmd += [
+            "--batch",
+            # limit maximum backtrace depth (to avoid looped stacks)
+            "--ex",
+            "set backtrace limit 2000",
+            "-iex",
+            "set debuginfod enable off",
+        ]
 
         value_keys = []
         # append the actual commands and something that acts as a separator

--- a/bin/apport-valgrind
+++ b/bin/apport-valgrind
@@ -203,8 +203,10 @@ except (KeyboardInterrupt, SystemExit):
     sys.stderr.write("\nInterrupted while preparing to create sandbox\n")
     _exit_on_interrupt()
 
+valgrind_env = {k: v for k, v in os.environ.items() if k != "DEBUGINFOD_URLS"}
+
 try:
-    subprocess.call(argv)
+    subprocess.call(argv, env=valgrind_env)
 except (KeyboardInterrupt, SystemExit):
     sys.stderr.write("\nInterrupted while running valgrind\n")
     _exit_on_interrupt()

--- a/tests/integration/test_apport_valgrind.py
+++ b/tests/integration/test_apport_valgrind.py
@@ -21,6 +21,7 @@ class T(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.env = os.environ | local_test_environment()
+        cls.env.pop("DEBUGINFOD_URLS", None)
 
     def setUp(self):
         self.workdir = tempfile.mkdtemp()

--- a/tests/integration/test_report.py
+++ b/tests/integration/test_report.py
@@ -662,6 +662,8 @@ int main() { return f(42); }
                 [
                     "gdb",
                     "--batch",
+                    "-iex",
+                    "set debuginfod enable off",
                     "--ex",
                     f"run{' ' + ' '.join(args) if args else ''}",
                     "--ex",
@@ -909,6 +911,8 @@ int main() { return f(42); }
                     [
                         "gdb",
                         "--batch",
+                        "-iex",
+                        "set debuginfod enable off",
                         "--ex",
                         f"run {script}",
                         "--ex",

--- a/tests/integration/test_signal_crashes.py
+++ b/tests/integration/test_signal_crashes.py
@@ -874,7 +874,16 @@ class T(unittest.TestCase):
         st = os.stat(core_path)
         self.assertGreater(st.st_size, 10000)
         gdb = subprocess.run(
-            ["gdb", "--batch", "--ex", "bt", command, core_path],
+            [
+                "gdb",
+                "--batch",
+                "-iex",
+                "set debuginfod enable off",
+                "--ex",
+                "bt",
+                command,
+                core_path,
+            ],
             check=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -1083,7 +1092,7 @@ class T(unittest.TestCase):
         Note: The arguments for the command must not contain spaces.
         Since there was no need for it, the support was not implemented.
         """
-        gdb_args = ["gdb", "--quiet"]
+        gdb_args = ["gdb", "--quiet", "-iex", "set debuginfod enable off"]
 
         args = " ".join(f" {a}" for a in args)
         if uid is not None:

--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -878,6 +878,8 @@ class T(unittest.TestCase):
                 [
                     "gdb",
                     "--batch",
+                    "-iex",
+                    "set debuginfod enable off",
                     "--ex",
                     f"run {' '.join(self.TEST_ARGS)}",
                     "--ex",


### PR DESCRIPTION
With the new Ubuntu debuginfod
service (https://debuginfod.ubuntu.com), and with the prospect of
having the system automatically fetch debuginfo from the internet
without user intervention, it is necessary to adjust apport to cope
with this scenario.

I had a conversation with bdmurray and he was concerned that having a
debuginfod-enabled GDB generate the corefiles that are eventually
submitted to Ubuntu can be a problem.

This commit disables GDB's debuginfod support when collecting a
report.  I chose not to touch GDB's settings on apport-retrace because
I think we should honour the user choice there.

Bug: https://launchpad.net/bugs/1989803