### PR TITLE
Fix FileNotFoundError: [Errno 2] No such file or directory: 'cgroup'

### DIFF
--- a/apport/report.py
+++ b/apport/report.py
@@ -2010,13 +2010,15 @@ class Report(problem_report.ProblemReport):
         Return (session_id, session_start_timestamp) if process is in a logind
         session, or None otherwise.
         """
-        if proc_pid_fd is not None:
-            cgroup_file = os.open("cgroup", os.O_RDONLY, dir_fd=proc_pid_fd)
-        else:
-            cgroup_file = "/proc/%s/cgroup" % pid
-
-        # determine cgroup
         try:
+            # determine cgroup
+            if proc_pid_fd is not None:
+                cgroup_file = os.open(
+                    "cgroup", os.O_RDONLY, dir_fd=proc_pid_fd
+                )
+            else:
+                cgroup_file = "/proc/%s/cgroup" % pid
+
             with io.open(cgroup_file, encoding="utf-8") as f:
                 for line in f:
                     line = line.strip()

--- a/tests/integration/test_report.py
+++ b/tests/integration/test_report.py
@@ -1893,6 +1893,15 @@ int main() { return f(42); }
             timestamp, time.mktime(time.strptime("2014-01-01", "%Y-%m-%d"))
         )
 
+    def test_get_logind_session_missing_cgroup(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            proc_pid_fd = os.open(
+                tmpdir, os.O_RDONLY | os.O_PATH | os.O_DIRECTORY
+            )
+            self.assertEqual(
+                apport.Report.get_logind_session(proc_pid_fd=proc_pid_fd), None
+            )
+
     def test_command_output_passes_env(self):
         fake_env = {"GCONV_PATH": "/tmp"}
         out = apport.report._command_output(["env"], env=fake_env)


### PR DESCRIPTION
apport fails if `/proc/<pid>/cgroup` is not present:

```
ERROR: apport (pid 4411) Tue Aug 2 19:02:05 2022: called for pid 1246, signal 11, core limit 18446744073709551615, dump mode 1
ERROR: apport (pid 4411) Tue Aug 2 19:02:05 2022: ignoring implausibly big core limit, treating as unlimited
ERROR: apport (pid 4411) Tue Aug 2 19:02:05 2022: Unhandled exception:
Traceback (most recent call last):
  File "/usr/share/apport/apport", line 712, in <module>
    info.add_proc_info(proc_pid_fd=proc_pid_fd)
  File "/usr/lib/python3/dist-packages/apport/report.py", line 649, in add_proc_info
    ret = self.get_logind_session(pid, proc_pid_fd)
  File "/usr/lib/python3/dist-packages/apport/report.py", line 1777, in get_logind_session
    cgroup_file = os.open('cgroup', os.O_RDONLY, dir_fd=proc_pid_fd)
```

Bug: https://launchpad.net/bugs/1990658