### PR TITLE
Address easy to fix pydocstyle complains in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,4 @@ profile = "black"
 [tool.pydocstyle]
 # TODO: Address the ignored codes (except D203,D213)
 ignore = "D1,D203,D205,D209,D213,D400,D401,D402,D415"
+match = ".*\\.py"

--- a/tests/integration/test_apport_unpack.py
+++ b/tests/integration/test_apport_unpack.py
@@ -53,7 +53,6 @@ class T(unittest.TestCase):
 
     def test_unpack(self):
         """apport-unpack for all possible data types"""
-
         self.assertEqual(
             self._call(["apport-unpack", self.report_file, self.unpack_dir]),
             (0, "", ""),
@@ -65,16 +64,14 @@ class T(unittest.TestCase):
         self.assertEqual(self._get_unpack("compressed"), b"FooFoo!")
 
     def test_help(self):
-        """calling apport-unpack with help"""
-
+        """Call apport-unpack with --help."""
         (ret, out, err) = self._call(["apport-unpack", "--help"])
         self.assertEqual(ret, 0)
         self.assertEqual(err, "")
         self.assertTrue(out.startswith("usage:"), out)
 
     def test_error(self):
-        """calling apport-unpack with wrong arguments"""
-
+        """Call apport-unpack with wrong arguments."""
         (ret, out, err) = self._call(["apport-unpack"])
         self.assertEqual(ret, 2)
         self.assertEqual(out, "")

--- a/tests/integration/test_apport_valgrind.py
+++ b/tests/integration/test_apport_valgrind.py
@@ -33,8 +33,7 @@ class T(unittest.TestCase):
         os.chdir(self.pwd)
 
     def test_valgrind_min_installed(self):
-        """valgrind is installed and recent enough"""
-
+        """Valgrind is installed and recent enough."""
         cmd = ["valgrind", "-q", "--extra-debuginfo-path=./", "ls"]
         (ret, out, err) = self._call(cmd)
         self.assertEqual(err, "")
@@ -53,8 +52,7 @@ class T(unittest.TestCase):
         return (process.returncode, process.stdout, process.stderr)
 
     def test_help_display(self):
-        """help display"""
-
+        """Display help."""
         cmd = ["apport-valgrind", "-h"]
         (ret, out, err) = self._call(cmd)
         self.assertEqual(err, "")
@@ -62,8 +60,7 @@ class T(unittest.TestCase):
         self.assertIn("--help", out)
 
     def test_invalid_args(self):
-        """return code is not 0 when invalid args are passed"""
-
+        """Return code is not 0 when invalid args are passed."""
         cmd = ["apport-valgrind", "-k", "pwd"]
         (ret, out, err) = self._call(cmd)
         self.assertEqual(out, "")
@@ -71,8 +68,7 @@ class T(unittest.TestCase):
         self.assertIn("unrecognized arguments: -k", err)
 
     def test_vlog_created(self):
-        """apport-valgrind creates valgrind.log with expected content"""
-
+        """apport-valgrind creates valgrind.log with expected content."""
         cmd = ["apport-valgrind", "--no-sandbox", "true"]
         os.chdir(self.workdir)
         self.assertEqual(self._call(cmd), (0, "", ""))
@@ -82,8 +78,7 @@ class T(unittest.TestCase):
         )
 
     def test_intentional_mem_leak_detection(self):
-        """apport-valgrind log reports intentional memory leak"""
-
+        """apport-valgrind log reports intentional memory leak."""
         os.chdir(self.workdir)
 
         # compile memleak.c to create memleak.o that intentionally creates a
@@ -141,8 +136,7 @@ void makeleak(void){
         )
 
     def test_unpackaged_exe(self):
-        """apport-valgrind creates valgrind log on unpackaged executable"""
-
+        """apport-valgrind creates valgrind log on unpackaged executable."""
         exepath = os.path.join(self.workdir, "pwd")
         shutil.copy("/bin/pwd", exepath)
         logpath = os.path.join(self.workdir, "unpackaged-exe.log")

--- a/tests/integration/test_crash_digger.py
+++ b/tests/integration/test_crash_digger.py
@@ -90,8 +90,7 @@ class T(unittest.TestCase):
         return (crash_digger.stdout, crash_digger.stderr)
 
     def test_crashes(self):
-        """Crash retracing"""
-
+        """Crash retracing."""
         (out, err) = self.call(
             [
                 "-c",
@@ -131,8 +130,7 @@ class T(unittest.TestCase):
         )
 
     def test_crashes_error(self):
-        """Crash retracing if apport-retrace fails on bug #1"""
-
+        """Crash retracing if apport-retrace fails on bug #1."""
         # make apport-retrace fail on bug 1
         os.rename(self.apport_retrace, self.apport_retrace + ".bak")
         with open(self.apport_retrace, "w", encoding="utf-8") as f:
@@ -189,8 +187,7 @@ class T(unittest.TestCase):
         os.rename(self.apport_retrace + ".bak", self.apport_retrace)
 
     def test_crashes_transient_error(self):
-        """Crash retracing if apport-retrace reports a transient error"""
-
+        """Crash retracing if apport-retrace reports a transient error."""
         # make apport-retrace fail on bug 1
         os.rename(self.apport_retrace, self.apport_retrace + ".bak")
         with open(self.apport_retrace, "w", encoding="utf-8") as f:
@@ -238,8 +235,7 @@ class T(unittest.TestCase):
         self.assertFalse(os.path.exists(self.lock_file))
 
     def test_dupcheck(self):
-        """Duplicate checking"""
-
+        """Duplicate checking."""
         (out, err) = self.call(
             [
                 "-a",
@@ -260,8 +256,7 @@ class T(unittest.TestCase):
         self.assertFalse(os.path.exists(self.lock_file))
 
     def test_stderr_redirection(self):
-        """apport-retrace's stderr is redirected to stdout"""
-
+        """apport-retrace's stderr is redirected to stdout."""
         with open(self.apport_retrace, "w", encoding="utf-8") as f:
             f.write("#!/bin/sh\necho ApportRetraceError >&2\n")
         (out, err) = self.call(
@@ -280,8 +275,7 @@ class T(unittest.TestCase):
         self.assertIn("ApportRetraceError", out)
 
     def test_publish_db(self):
-        """Duplicate database publishing"""
-
+        """Duplicate database publishing."""
         (out, err) = self.call(
             [
                 "-c",
@@ -304,8 +298,7 @@ class T(unittest.TestCase):
         )
 
     def test_alternate_crashdb(self):
-        """Alternate crash database name"""
-
+        """Alternate crash database name."""
         # existing DB "empty" has no crashes
         (out, err) = self.call(
             [

--- a/tests/integration/test_fileutils.py
+++ b/tests/integration/test_fileutils.py
@@ -32,8 +32,7 @@ class T(unittest.TestCase):
 
     @staticmethod
     def _create_reports(create_inaccessible=False):
-        """Create some test reports"""
-
+        """Create some test reports."""
         r1 = os.path.join(apport.fileutils.report_dir, "rep1.crash")
         r2 = os.path.join(apport.fileutils.report_dir, "rep2.crash")
 
@@ -55,7 +54,6 @@ class T(unittest.TestCase):
 
     def test_find_package_desktopfile(self):
         """find_package_desktopfile()"""
-
         # package without any .desktop file
         nodesktop = "bash"
         assert (
@@ -135,7 +133,6 @@ class T(unittest.TestCase):
 
     def test_find_file_package(self):
         """find_file_package()"""
-
         self.assertEqual(
             apport.fileutils.find_file_package("/bin/bash"), "bash"
         )
@@ -148,7 +145,6 @@ class T(unittest.TestCase):
 
     def test_seen(self):
         """get_new_reports() and seen_report()"""
-
         self.assertEqual(apport.fileutils.get_new_reports(), [])
         if os.getuid() == 0:
             tr = self._create_reports(True)
@@ -206,7 +202,6 @@ class T(unittest.TestCase):
 
     def test_get_all_reports(self):
         """get_all_reports()"""
-
         self.assertEqual(apport.fileutils.get_all_reports(), [])
         if os.getuid() == 0:
             tr = self._create_reports(True)
@@ -226,7 +221,6 @@ class T(unittest.TestCase):
 
     def test_get_system_reports(self):
         """get_all_system_reports() and get_new_system_reports()"""
-
         self.assertEqual(apport.fileutils.get_all_reports(), [])
         self.assertEqual(apport.fileutils.get_all_system_reports(), [])
         if os.getuid() == 0:
@@ -265,7 +259,6 @@ class T(unittest.TestCase):
     @unittest.mock.patch.object(pwd, "getpwuid")
     def test_get_system_reports_guest(self, getpwuid_mock, stat_mock):
         """get_all_system_reports() filters out reports from guest user"""
-
         self._create_reports()
 
         stat_mock.return_value.st_size = 1000
@@ -275,7 +268,6 @@ class T(unittest.TestCase):
 
     def test_unwritable_report(self):
         """get_all_reports() and get_new_reports() for unwritable report"""
-
         self.assertEqual(apport.fileutils.get_all_reports(), [])
         self.assertEqual(apport.fileutils.get_all_system_reports(), [])
 
@@ -293,7 +285,6 @@ class T(unittest.TestCase):
 
     def test_delete_report(self):
         """delete_report()"""
-
         tr = self._create_reports()
 
         while tr:
@@ -302,7 +293,6 @@ class T(unittest.TestCase):
 
     def test_make_report_file(self):
         """make_report_file()"""
-
         pr = problem_report.ProblemReport()
         self.assertRaises(ValueError, apport.fileutils.make_report_file, pr)
 
@@ -332,7 +322,6 @@ class T(unittest.TestCase):
 
     def test_check_files_md5(self):
         """check_files_md5()"""
-
         f1 = os.path.join(apport.fileutils.report_dir, "test 1.txt")
         f2 = os.path.join(apport.fileutils.report_dir, "test:2.txt")
         sumfile = os.path.join(apport.fileutils.report_dir, "sums.txt")
@@ -372,7 +361,6 @@ f6423dfbc4faf022e58b4d3f5ff71a70  %s
 
     def test_get_config(self):
         """get_config()"""
-
         # nonexisting
         apport.fileutils._config_file = "/nonexisting"
         self.assertEqual(apport.fileutils.get_config("main", "foo"), None)
@@ -448,7 +436,6 @@ f6423dfbc4faf022e58b4d3f5ff71a70  %s
 
     def test_shared_libraries(self):
         """shared_libraries()"""
-
         libs = apport.fileutils.shared_libraries(sys.executable)
         self.assertGreater(len(libs), 3)
         self.assertIn("libc.so.6", libs)
@@ -466,7 +453,6 @@ f6423dfbc4faf022e58b4d3f5ff71a70  %s
 
     def test_links_with_shared_library(self):
         """links_with_shared_library()"""
-
         self.assertTrue(
             apport.fileutils.links_with_shared_library(sys.executable, "libc")
         )
@@ -495,7 +481,6 @@ f6423dfbc4faf022e58b4d3f5ff71a70  %s
 
     def test_get_core_path(self):
         """get_core_path()"""
-
         boot_id = apport.fileutils.get_boot_id()
 
         # Basic test
@@ -542,7 +527,6 @@ f6423dfbc4faf022e58b4d3f5ff71a70  %s
 
     def test_clean_core_directory(self):
         """clean_core_directory()"""
-
         fake_uid = 5150
         extra_core_files = 4
         num_core_files = (

--- a/tests/integration/test_hooks.py
+++ b/tests/integration/test_hooks.py
@@ -43,7 +43,6 @@ class T(unittest.TestCase):
 
     def test_package_hook_nologs(self):
         """package_hook without any log files."""
-
         ph = subprocess.run(
             ["%s/package_hook" % datadir, "-p", "bash"],
             check=False,
@@ -69,7 +68,6 @@ class T(unittest.TestCase):
 
     def test_package_hook_uninstalled(self):
         """package_hook on an uninstalled package (might fail to install)."""
-
         pkg = apport.packaging.get_uninstalled_package()
         ph = subprocess.run(
             ["%s/package_hook" % datadir, "-p", pkg],
@@ -94,7 +92,6 @@ class T(unittest.TestCase):
 
     def test_package_hook_logs(self):
         """package_hook with a log dir and a log file."""
-
         with open(
             os.path.join(self.workdir, "log_1.log"), "w", encoding="utf-8"
         ) as f:
@@ -184,7 +181,6 @@ class T(unittest.TestCase):
 
     def test_kernel_crashdump_kexec(self):
         """kernel_crashdump using kexec-tools."""
-
         with open(
             os.path.join(apport.fileutils.report_dir, "vmcore"), "wb"
         ) as vmcore:
@@ -232,7 +228,6 @@ class T(unittest.TestCase):
 
     def test_kernel_crashdump_kdump(self):
         """kernel_crashdump using kdump-tools."""
-
         timedir = datetime.datetime.strftime(
             datetime.datetime.now(), "%Y%m%d%H%M"
         )
@@ -280,7 +275,7 @@ class T(unittest.TestCase):
         self.assertIn(os.uname()[2].split("-")[0], r["Package"])
 
     def test_kernel_crashdump_log_symlink(self):
-        """attempted DoS with vmcore.log symlink
+        """Attempt DoS with vmcore.log symlink.
 
         We must only accept plain files, otherwise vmcore.log might be a
         symlink to the .crash file, which would recursively fill itself.
@@ -306,8 +301,7 @@ class T(unittest.TestCase):
         self.assertEqual(apport.fileutils.get_new_reports(), [])
 
     def test_kernel_crashdump_kdump_log_symlink(self):
-        """attempted DoS with dmesg symlink with kdump-tools"""
-
+        """Attempt DoS with dmesg symlink with kdump-tools."""
         timedir = datetime.datetime.strftime(
             datetime.datetime.now(), "%Y%m%d%H%M"
         )
@@ -330,8 +324,7 @@ class T(unittest.TestCase):
 
     @unittest.skipIf(os.geteuid() != 0, "this test needs to be run as root")
     def test_kernel_crashdump_kdump_log_dir_symlink(self):
-        """attempted DoS with dmesg dir symlink with kdump-tools"""
-
+        """Attempted DoS with dmesg dir symlink with kdump-tools."""
         timedir = datetime.datetime.strftime(
             datetime.datetime.now(), "%Y%m%d%H%M"
         )
@@ -361,7 +354,6 @@ class T(unittest.TestCase):
     def _gcc_version_path():
         """Determine a valid version and executable path of gcc and return it
         as a tuple."""
-
         gcc = subprocess.run(
             ["gcc", "--version"], check=True, stdout=subprocess.PIPE, text=True
         )
@@ -383,7 +375,6 @@ class T(unittest.TestCase):
 
     def test_gcc_ide_hook_file(self):
         """gcc_ice_hook with a temporary file."""
-
         (gcc_version, gcc_path) = self._gcc_version_path()
 
         with tempfile.NamedTemporaryFile() as test_source:
@@ -420,7 +411,6 @@ class T(unittest.TestCase):
 
     def test_gcc_ide_hook_file_binary(self):
         """gcc_ice_hook with a temporary file with binary data."""
-
         gcc_path = self._gcc_version_path()[1]
 
         with tempfile.NamedTemporaryFile() as test_source:
@@ -447,7 +437,6 @@ class T(unittest.TestCase):
 
     def test_gcc_ide_hook_pipe(self):
         """gcc_ice_hook with piping."""
-
         (gcc_version, gcc_path) = self._gcc_version_path()
 
         test_source = "int f(int x);"

--- a/tests/integration/test_hookutils.py
+++ b/tests/integration/test_hookutils.py
@@ -20,7 +20,7 @@ class T(unittest.TestCase):
         shutil.rmtree(self.workdir)
 
     def test_module_license_evaluation(self):
-        """module licenses can be validated correctly"""
+        """Module licenses can be validated correctly."""
         # pylint: disable=protected-access
 
         def _build_ko(license_name):
@@ -62,7 +62,7 @@ class T(unittest.TestCase):
         self.assertIn(bad_ko, nonfree)
 
     def test_real_module_license_evaluation(self):
-        """module licenses can be validated correctly for real module"""
+        """Module licenses can be validated correctly for real module."""
         # pylint: disable=protected-access
         isofs_license = apport.hookutils._get_module_license("isofs")
         if isofs_license == "invalid":
@@ -78,7 +78,6 @@ class T(unittest.TestCase):
 
     def test_attach_file(self):
         """attach_file()"""
-
         with open("/etc/passwd", encoding="utf-8") as f:
             passwd_contents = f.read().strip()
         with open("/etc/issue", encoding="utf-8") as f:
@@ -144,7 +143,6 @@ class T(unittest.TestCase):
 
     def test_attach_file_binary(self):
         """attach_file() for binary files"""
-
         myfile = os.path.join(self.workdir, "data")
         with open(myfile, "wb") as f:
             f.write(b"a\xc3\xb6b\xffx")
@@ -162,7 +160,6 @@ class T(unittest.TestCase):
 
     def test_attach_file_if_exists(self):
         """attach_file_if_exists()"""
-
         with open("/etc/passwd", encoding="utf-8") as f:
             passwd_contents = f.read().strip()
 
@@ -198,7 +195,6 @@ class T(unittest.TestCase):
 
     def test_recent_syslog(self):
         """recent_syslog"""
-
         self.assertEqual(
             apport.hookutils.recent_syslog(
                 re.compile("."), path="/nonexisting"
@@ -224,7 +220,6 @@ class T(unittest.TestCase):
     )
     def test_attach_mac_events(self):
         """attach_mac_events()"""
-
         denied_log = (
             "[  351.624338] type=1400 audit(1343775571.688:27):"
             ' apparmor="DENIED" operation="capable" parent=1'
@@ -366,7 +361,6 @@ class T(unittest.TestCase):
 
     def test_recent_syslog_overflow(self):
         """recent_syslog on a huge file"""
-
         log = os.path.join(self.workdir, "syslog")
         with open(log, "w", encoding="utf-8") as f:
             lines = 1000000
@@ -424,7 +418,6 @@ class T(unittest.TestCase):
 
     def test_xsession_errors(self):
         """xsession_errors()"""
-
         with open(
             os.path.join(self.workdir, ".xsession-errors"),
             "w",
@@ -494,8 +487,7 @@ GdkPixbuf-CRITICAL **: gdk_pixbuf_scale_simple: another standard glib assertion
         unittest.mock.MagicMock(return_value=[]),
     )
     def test_no_crashes():
-        """functions do not crash (very shallow)"""
-
+        """Functions do not crash (very shallow)."""
         report = {}
         apport.hookutils.attach_hardware(report)
         apport.hookutils.attach_alsa(report)
@@ -538,8 +530,7 @@ GdkPixbuf-CRITICAL **: gdk_pixbuf_scale_simple: another standard glib assertion
 
     @staticmethod
     def _get_mem_usage():
-        """Get current memory usage in kB"""
-
+        """Get current memory usage in kB."""
         with open("/proc/self/status", encoding="utf-8") as f:
             for line in f:
                 if line.startswith("VmSize:"):

--- a/tests/integration/test_java_crashes.py
+++ b/tests/integration/test_java_crashes.py
@@ -51,8 +51,7 @@ class T(unittest.TestCase):
         apport.fileutils.report_dir = self.orig_report_dir
 
     def test_crash_class(self):
-        """Crash in a .class file"""
-
+        """Crash in a .class file."""
         crash_class = os.path.dirname(self.crash_jar_path) + "/crash.class"
         if not os.path.exists(crash_class):
             self.skipTest(f"{crash_class} missing")
@@ -78,8 +77,7 @@ class T(unittest.TestCase):
         self._check_crash_report(crash_class)
 
     def test_crash_jar(self):
-        """Crash in a .jar file"""
-
+        """Crash in a .jar file."""
         if not os.path.exists(self.crash_jar_path):
             self.skipTest(f"{self.crash_jar_path} missing")
         java = subprocess.run(
@@ -102,8 +100,7 @@ class T(unittest.TestCase):
         self._check_crash_report(self.crash_jar_path + "!/crash.class")
 
     def _check_crash_report(self, main_file):
-        """Check that we have one crash report, and verify its contents"""
-
+        """Check that we have one crash report, and verify its contents."""
         reports = apport.fileutils.get_new_reports()
         self.assertEqual(len(reports), 1, "did not create a crash report")
         r = apport.report.Report()

--- a/tests/integration/test_packaging.py
+++ b/tests/integration/test_packaging.py
@@ -6,7 +6,6 @@ import apport.packaging
 class T(unittest.TestCase):
     def test_get_uninstalled_package(self):
         """get_uninstalled_package()"""
-
         p = apport.packaging.get_uninstalled_package()
         self.assertNotEqual(p, None)
         self.assertNotEqual(apport.packaging.get_available_version(p), "")
@@ -15,7 +14,6 @@ class T(unittest.TestCase):
 
     def test_get_os_version(self):
         """get_os_version()"""
-
         (n, v) = apport.packaging.get_os_version()
         self.assertEqual(type(n), str)
         self.assertEqual(type(v), str)

--- a/tests/integration/test_packaging_apt_dpkg.py
+++ b/tests/integration/test_packaging_apt_dpkg.py
@@ -32,7 +32,6 @@ class T(unittest.TestCase):
 
     def test_check_files_md5(self):
         """_check_files_md5()."""
-
         td = tempfile.mkdtemp()
         try:
             f1 = os.path.join(td, "test 1.txt")
@@ -86,14 +85,12 @@ class T(unittest.TestCase):
 
     def test_get_version(self):
         """get_version()."""
-
         self.assertTrue(impl.get_version("libc6").startswith("2"))
         self.assertRaises(ValueError, impl.get_version, "nonexisting")
         self.assertRaises(ValueError, impl.get_version, "wukrainian")
 
     def test_get_available_version(self):
         """get_available_version()."""
-
         self.assertTrue(impl.get_available_version("libc6").startswith("2"))
         self.assertRaises(
             ValueError, impl.get_available_version, "nonexisting"
@@ -101,7 +98,6 @@ class T(unittest.TestCase):
 
     def test_get_dependencies(self):
         """get_dependencies()."""
-
         # package with both Depends: and Pre-Depends:
         d = impl.get_dependencies("bash")
         self.assertGreater(len(d), 2)
@@ -127,14 +123,12 @@ class T(unittest.TestCase):
 
     def test_get_source(self):
         """get_source()."""
-
         self.assertRaises(ValueError, impl.get_source, "nonexisting")
         self.assertEqual(impl.get_source("bash"), "bash")
         self.assertIn("glibc", impl.get_source("libc6"))
 
     def test_get_package_origin(self):
         """get_package_origin()."""
-
         # determine distro name
         distro = impl.get_os_version()[0]
 
@@ -147,14 +141,12 @@ class T(unittest.TestCase):
 
     def test_is_distro_package(self):
         """is_distro_package()."""
-
         self.assertRaises(ValueError, impl.is_distro_package, "nonexisting")
         self.assertTrue(impl.is_distro_package("bash"))
         # no False test here, hard to come up with a generic one
 
     def test_get_architecture(self):
         """get_architecture()."""
-
         self.assertRaises(ValueError, impl.get_architecture, "nonexisting")
         # just assume that bash uses the native architecture
         dpkg = subprocess.run(
@@ -168,13 +160,11 @@ class T(unittest.TestCase):
 
     def test_get_files(self):
         """get_files()."""
-
         self.assertRaises(ValueError, impl.get_files, "nonexisting")
         self.assertIn("/bin/bash", impl.get_files("bash"))
 
     def test_get_file_package(self):
         """get_file_package() on installed files."""
-
         self.assertEqual(impl.get_file_package("/bin/bash"), "bash")
         self.assertEqual(impl.get_file_package("/bin/cat"), "coreutils")
         self.assertEqual(
@@ -184,7 +174,6 @@ class T(unittest.TestCase):
 
     def test_get_file_package_uninstalled(self):
         """get_file_package() on uninstalled packages."""
-
         # generate a test Contents.gz
         basedir = tempfile.mkdtemp()
         try:
@@ -290,7 +279,6 @@ bin/true                                                admin/superutils
 
     def test_get_file_package_uninstalled_multiarch(self):
         """get_file_package() on foreign arches and releases"""
-
         # map "Foonux 3.14" to "mocky"
         orig_distro_release_to_codename = impl._distro_release_to_codename
         impl._distro_release_to_codename = (
@@ -484,7 +472,6 @@ usr/bin/frob                                            foo/frob
 
     def test_get_file_package_diversion(self):
         """get_file_package() for a diverted file."""
-
         output = subprocess.check_output(
             ["dpkg-divert", "--list"], env={}
         ).decode()
@@ -547,7 +534,6 @@ deb http://secondary.mirror tuxy extra
 
     def test_get_modified_conffiles(self):
         """get_modified_conffiles()"""
-
         # very shallow
         self.assertEqual(type(impl.get_modified_conffiles("bash")), type({}))
         self.assertEqual(type(impl.get_modified_conffiles("apport")), type({}))
@@ -557,7 +543,6 @@ deb http://secondary.mirror tuxy extra
 
     def test_get_system_architecture(self):
         """get_system_architecture()."""
-
         arch = impl.get_system_architecture()
         # must be nonempty without line breaks
         self.assertNotEqual(arch, "")
@@ -565,7 +550,6 @@ deb http://secondary.mirror tuxy extra
 
     def test_get_library_paths(self):
         """get_library_paths()."""
-
         paths = impl.get_library_paths()
         # must be nonempty without line breaks
         self.assertNotEqual(paths, "")
@@ -575,7 +559,6 @@ deb http://secondary.mirror tuxy extra
 
     def test_compare_versions(self):
         """compare_versions."""
-
         self.assertEqual(impl.compare_versions("1", "2"), -1)
         self.assertEqual(
             impl.compare_versions("1.0-1ubuntu1", "1.0-1ubuntu2"), -1
@@ -591,7 +574,6 @@ deb http://secondary.mirror tuxy extra
 
     def test_enabled(self):
         """enabled."""
-
         impl.configuration = "/nonexisting"
         self.assertEqual(impl.enabled(), True)
 
@@ -615,12 +597,10 @@ deb http://secondary.mirror tuxy extra
 
     def test_get_kernel_package(self):
         """get_kernel_package()."""
-
         self.assertIn("linux", impl.get_kernel_package())
 
     def test_package_name_glob(self):
         """package_name_glob()."""
-
         self.assertGreater(len(impl.package_name_glob("a*")), 5)
         self.assertIn("bash", impl.package_name_glob("ba*h"))
         self.assertEqual(impl.package_name_glob("bash"), ["bash"])

--- a/tests/integration/test_packaging_rpm.py
+++ b/tests/integration/test_packaging_rpm.py
@@ -15,28 +15,24 @@ except ImportError:
 class T(unittest.TestCase):
     def test_get_dependencies(self):
         """get_dependencies()."""
-
         deps = impl.get_dependencies("bash")
         self.assertNotEqual(deps, [])
 
     def test_get_header(self):
         """_get_header()."""
         # pylint: disable=protected-access
-
         hdr = impl._get_header("alsa-utils")
         self.assertEqual(hdr["n"], "alsa-utils")
 
     def test_get_headers_by_tag(self):
         """_get_headers_by_tag()."""
         # pylint: disable=protected-access
-
         headersByTag = impl._get_headers_by_tag("basenames", "/bin/bash")
         self.assertEqual(len(headersByTag), 1)
         self.assertTrue(headersByTag[0]["n"].startswith("bash"))
 
     def test_get_system_architecture(self):
         """get_system_architecture()."""
-
         arch = impl.get_system_architecture()
         # must be nonempty without line breaks
         self.assertNotEqual(arch, "")
@@ -44,7 +40,6 @@ class T(unittest.TestCase):
 
     def test_get_version(self):
         """get_version()."""
-
         ver = impl.get_version("bash")
         self.assertNotEqual(ver, None)
         ver = impl.get_version("alsa-utils")

--- a/tests/integration/test_problem_report.py
+++ b/tests/integration/test_problem_report.py
@@ -21,8 +21,7 @@ class T(unittest.TestCase):
         shutil.rmtree(self.workdir)
 
     def test_compressed_values(self):
-        """handling of CompressedValue values."""
-
+        """Handle of CompressedValue values."""
         large_val = b"A" * 5000000
 
         pr = problem_report.ProblemReport()
@@ -66,7 +65,6 @@ class T(unittest.TestCase):
 
     def test_write_append(self):
         """write() with appending to an existing file."""
-
         pr = problem_report.ProblemReport(date="now!")
         pr["Simple"] = "bar"
         pr["WhiteSpace"] = " foo   bar\nbaz\n  blip  "
@@ -116,7 +114,6 @@ class T(unittest.TestCase):
 
     def test_extract_keys(self):
         """extract_keys() with various binary elements."""
-
         # create a test report with binary elements
         large_val = b"A" * 5000000
 
@@ -181,8 +178,7 @@ class T(unittest.TestCase):
                 self.assertEqual(f.read(), expected)
 
     def test_write_file(self):
-        """writing a report with binary file data."""
-
+        """Write a report with binary file data."""
         with tempfile.NamedTemporaryFile() as temp:
             temp.write(bin_data)
             temp.flush()
@@ -247,8 +243,7 @@ class T(unittest.TestCase):
             )
 
     def test_write_delayed_fileobj(self):
-        """writing a report with file pointers and delayed data."""
-
+        """Write a report with file pointers and delayed data."""
         (fout, fin) = os.pipe()
 
         if os.fork() == 0:
@@ -278,8 +273,7 @@ class T(unittest.TestCase):
         self.assertEqual(pr2["BinFile"], "ab" * 512 * 1024 + "hello world")
 
     def test_big_file(self):
-        """writing and re-decoding a big random file."""
-
+        """Write and re-decoding a big random file."""
         # create 1 MB random file
         with tempfile.NamedTemporaryFile() as temp:
             data = os.urandom(1048576)
@@ -315,8 +309,7 @@ class T(unittest.TestCase):
         self.assertEqual(pr["File"].get_value(), data)
 
     def test_size_limit(self):
-        """writing and a big random file with a size limit key."""
-
+        """Write and a big random file with a size limit key."""
         # create 1 MB random file
         with tempfile.NamedTemporaryFile() as temp:
             data = os.urandom(1048576)
@@ -349,8 +342,7 @@ class T(unittest.TestCase):
         self.assertEqual(pr["ZAfter"], "ytesty")
 
     def test_add_to_existing(self):
-        """adding information to an existing report."""
-
+        """Add information to an existing report."""
         # original report
         pr = problem_report.ProblemReport()
         pr["old1"] = "11"
@@ -432,7 +424,6 @@ class T(unittest.TestCase):
 
     def test_write_mime_binary(self):
         """write_mime() for binary values and file references."""
-
         with tempfile.NamedTemporaryFile() as temp:
             with tempfile.NamedTemporaryFile() as tempgz:
                 temp.write(bin_data)
@@ -507,7 +498,6 @@ class T(unittest.TestCase):
 
     def test_write_mime_filter(self):
         """write_mime() with key filters."""
-
         pr = problem_report.ProblemReport(date="now!")
         pr["GoodText"] = "Hi"
         pr["BadText"] = "YouDontSeeMe"

--- a/tests/integration/test_python_crashes.py
+++ b/tests/integration/test_python_crashes.py
@@ -47,7 +47,6 @@ class T(unittest.TestCase):
 
     def _test_crash(self, extracode="", scriptname=None, relpath=False):
         """Create a test crash."""
-
         # put the script into /var/tmp, since that isn't ignored in the
         # hook
         if scriptname:
@@ -104,8 +103,7 @@ func(42)
         return script
 
     def test_general(self):
-        """general operation of the Python crash hook."""
-
+        """General operation of the Python crash hook."""
         script = self._test_crash()
 
         # did we get a report?
@@ -157,7 +155,6 @@ func(42)
 
     def test_existing(self):
         """Python crash hook overwrites seen existing files."""
-
         script = self._test_crash()
 
         # did we get a report?
@@ -187,8 +184,7 @@ func(42)
         self.assertEqual(len(reports), 1)
 
     def test_symlink(self):
-        """Python crash of a symlinked program resolves to target"""
-
+        """Python crash of a symlinked program resolves to target."""
         script = self._test_crash()
 
         # load report for this
@@ -237,8 +233,7 @@ func(42)
         self.assertEqual(pr1.crash_signature(), pr2.crash_signature())
 
     def test_no_argv(self):
-        """with zapped sys.argv."""
-
+        """With zapped sys.argv."""
         script = self._test_crash("import sys\nsys.argv = None")
 
         # did we get a report?
@@ -284,8 +279,7 @@ func(42)
         self.assertTrue(pr["Traceback"].startswith("Traceback"))
 
     def test_python_env(self):
-        """Python environmental variables appear in report"""
-
+        """Python environmental variables appear in report."""
         self._test_crash()
 
         # did we get a report?
@@ -305,7 +299,6 @@ func(42)
 
     def _assert_no_reports(self):
         """Assert that there are no crash reports."""
-
         reports = apport.fileutils.get_new_reports()
         self.assertEqual(
             len(reports), 0, "no crash reports present (cwd: %s)" % os.getcwd()
@@ -367,8 +360,7 @@ func(42)
         self._assert_no_reports()
 
     def test_interactive(self):
-        """interactive Python sessions never generate a report."""
-
+        """Interactive Python sessions never generate a report."""
         orig_cwd = os.getcwd()
         try:
             for d in ("/tmp", "/usr/local", "/usr"):
@@ -393,8 +385,7 @@ func(42)
             os.chdir(orig_cwd)
 
     def test_ignoring(self):
-        """the Python crash hook respects the ignore list."""
-
+        """The Python crash hook respects the ignore list."""
         # put the script into /var/tmp, since that isn't ignored in the
         # hook
         (fd, script) = tempfile.mkstemp(dir="/var/tmp")
@@ -453,8 +444,7 @@ func(42)
         self.assertEqual(len(reports), 0)
 
     def test_no_flooding(self):
-        """limit successive reports"""
-
+        """Limit successive reports."""
         count = 0
         limit = 5
         try:
@@ -477,8 +467,7 @@ func(42)
         self.assertLess(count, limit)
 
     def test_generic_os_error(self):
-        """OSError with errno and no known subclass"""
-
+        """Raise OSError with errno and no known subclass."""
         self._test_crash(
             extracode=textwrap.dedent(
                 """\
@@ -497,8 +486,7 @@ func(42)
         )
 
     def test_generic_os_error_no_errno(self):
-        """OSError without errno and no known subclass"""
-
+        """Raise OSError without errno and no known subclass."""
         self._test_crash(
             extracode=textwrap.dedent(
                 """\
@@ -517,7 +505,7 @@ func(42)
         )
 
     def test_getcwd_error(self):
-        """FileNotFoundError on os.getcwd() call"""
+        """Raise FileNotFoundError on os.getcwd() call."""
         for relpath in (True, False):
             with self.subTest(relpath=relpath):
                 self._test_crash(
@@ -541,8 +529,7 @@ func(42)
                 )
 
     def test_subclassed_os_error(self):
-        """OSError with known subclass"""
-
+        """Raise OSError with known subclass."""
         self._test_crash(
             extracode=textwrap.dedent(
                 """\
@@ -562,8 +549,7 @@ func(42)
         )
 
     def _load_report(self):
-        """Ensure that there is exactly one crash report and load it"""
-
+        """Ensure that there is exactly one crash report and load it."""
         reports = apport.fileutils.get_new_reports()
         self.assertEqual(
             len(reports), 1, "crashed Python program produced a report"

--- a/tests/integration/test_recoverable_problem.py
+++ b/tests/integration/test_recoverable_problem.py
@@ -61,7 +61,6 @@ class T(unittest.TestCase):
 
     def test_recoverable_problem(self):
         """recoverable_problem with valid data"""
-
         self.call_recoverable_problem("hello\0there")
         path = self.wait_for_report()
         with open(path, "rb") as report_path:
@@ -72,7 +71,6 @@ class T(unittest.TestCase):
 
     def test_recoverable_problem_dupe_sig(self):
         """recoverable_problem duplicate signature includes ExecutablePath"""
-
         self.call_recoverable_problem("Package\0test\0DuplicateSignature\0ds")
         path = self.wait_for_report()
         with open(path, "rb") as report_path:
@@ -86,7 +84,6 @@ class T(unittest.TestCase):
 
     def test_invalid_data(self):
         """recoverable_problem with invalid data"""
-
         self.assertRaises(
             subprocess.CalledProcessError,
             self.call_recoverable_problem,

--- a/tests/integration/test_report.py
+++ b/tests/integration/test_report.py
@@ -47,7 +47,6 @@ class T(unittest.TestCase):
 
     def test_add_package_info(self):
         """add_package_info()."""
-
         # determine bash version
         bashversion = apport.packaging.get_version("bash")
 
@@ -76,7 +75,6 @@ class T(unittest.TestCase):
 
     def test_add_os_info(self):
         """add_os_info()."""
-
         pr = apport.report.Report()
         pr.add_os_info()
         self.assertTrue(pr["Uname"].startswith("Linux"))
@@ -94,7 +92,6 @@ class T(unittest.TestCase):
 
     def test_add_user_info(self):
         """add_user_info()."""
-
         pr = apport.report.Report()
         pr.add_user_info()
         self.assertIn("UserGroups", pr)
@@ -108,7 +105,6 @@ class T(unittest.TestCase):
 
     def test_add_proc_info(self):
         """add_proc_info()."""
-
         # check without additional safe environment variables
         pr = apport.report.Report()
         self.assertEqual(pr.pid, None)
@@ -251,7 +247,6 @@ class T(unittest.TestCase):
 
     def test_add_proc_info_nonascii(self):
         """add_proc_info() for non-ASCII values"""
-
         lang = b"n\xc3\xb6_v\xc3\xb8lid"
 
         # one variable from each category (ignored/filtered/shown)
@@ -273,7 +268,6 @@ class T(unittest.TestCase):
 
     def test_add_proc_info_current_desktop(self):
         """add_proc_info() CurrentDesktop"""
-
         with subprocess.Popen(
             ["cat"], stdin=subprocess.PIPE, env={"LANG": "xx_YY.UTF-8"}
         ) as cat:
@@ -297,8 +291,7 @@ class T(unittest.TestCase):
         self.assertEqual(r["CurrentDesktop"], "Pixel Pusher")
 
     def test_add_path_classification(self):
-        """classification of $PATH."""
-
+        """Classification of $PATH."""
         # system default
         with subprocess.Popen(
             ["cat"],
@@ -340,7 +333,6 @@ class T(unittest.TestCase):
 
     def test_check_interpreted(self):
         """_check_interpreted()."""
-
         restore_root = False
         if os.getuid() == 0:
             # temporarily drop to normal user "mail"
@@ -529,7 +521,6 @@ class T(unittest.TestCase):
 
     def test_check_interpreted_no_exec(self):
         """_check_interpreted() does not run module code"""
-
         # python script through -m, with dot separator; top-level module
         pr = apport.report.Report()
         pr["ExecutablePath"] = "/usr/bin/python"
@@ -551,7 +542,6 @@ class T(unittest.TestCase):
     @skip_if_command_is_missing("twistd")
     def test_check_interpreted_twistd(self):
         """_check_interpreted() for programs ran through twistd"""
-
         # LP#761374
         pr = apport.report.Report()
         pr["ExecutablePath"] = "/usr/bin/python2.7"
@@ -720,7 +710,6 @@ int main() { return f(42); }
 
     def test_add_gdb_info(self):
         """add_gdb_info() with core dump file reference."""
-
         pr = apport.report.Report()
         # should not throw an exception for missing fields
         pr.add_gdb_info()
@@ -753,7 +742,6 @@ int main() { return f(42); }
 
     def test_add_gdb_info_load(self):
         """add_gdb_info() with inline core dump."""
-
         with tempfile.NamedTemporaryFile() as rep:
             self._generate_sigsegv_report(rep)
             rep.seek(0)
@@ -767,7 +755,6 @@ int main() { return f(42); }
 
     def test_add_gdb_info_damaged(self):
         """add_gdb_info() with damaged core dump"""
-
         pr = self._generate_sigsegv_report()
         del pr["Stacktrace"]
         del pr["StacktraceTop"]
@@ -788,7 +775,6 @@ int main() { return f(42); }
 
     def test_add_gdb_info_short_core_file(self):
         """add_gdb_info() with damaged core dump in gzip file"""
-
         pr = self._generate_sigsegv_report()
         del pr["Stacktrace"]
         del pr["StacktraceTop"]
@@ -811,7 +797,6 @@ int main() { return f(42); }
     @unittest.mock.patch("gzip.GzipFile.read")
     def test_add_gdb_info_damaged_gz_core(self, mock_gzread):
         """add_gdb_info() with damaged gzip file of core dump"""
-
         pr = self._generate_sigsegv_report()
         del pr["Stacktrace"]
         del pr["StacktraceTop"]
@@ -833,7 +818,6 @@ int main() { return f(42); }
 
     def test_add_gdb_info_exe_missing(self):
         """add_gdb_info() with missing executable"""
-
         pr = self._generate_sigsegv_report()
         # change it to something that doesn't exist
         pr["ExecutablePath"] = pr["ExecutablePath"].replace("crash", "gone")
@@ -882,7 +866,6 @@ int main() { return f(42); }
 
     def test_add_gdb_info_script(self):
         """add_gdb_info() with a script."""
-
         # This needs to handle different bash locations across releases
         # to get the core filename right
         shell = os.path.realpath("/bin/bash")
@@ -941,7 +924,6 @@ int main() { return f(42); }
         If these come from an assert(), the report should have the assertion
         message. Otherwise it should be marked as not reportable.
         """
-
         # abort with assert
         pr = self._generate_sigsegv_report(
             code=textwrap.dedent(
@@ -1093,7 +1075,6 @@ int main() { return f(42); }
 
     def test_search_bug_patterns(self):
         """search_bug_patterns()."""
-
         # create some test patterns
         patterns = textwrap.dedent(
             """\
@@ -1282,7 +1263,6 @@ int main() { return f(42); }
 
     def test_add_hooks_info(self):
         """add_hooks_info()."""
-
         orig_general_hook_dir = apport.report.GENERAL_HOOK_DIR
         apport.report.GENERAL_HOOK_DIR = tempfile.mkdtemp()
         orig_package_hook_dir = apport.report.PACKAGE_HOOK_DIR
@@ -1512,7 +1492,6 @@ int main() { return f(42); }
 
     def test_add_hooks_info_opt(self):
         """add_hooks_info() for a package in /opt"""
-
         orig_general_hook_dir = apport.report.GENERAL_HOOK_DIR
         apport.report.GENERAL_HOOK_DIR = tempfile.mkdtemp()
         orig_package_hook_dir = apport.report.PACKAGE_HOOK_DIR
@@ -1574,7 +1553,6 @@ int main() { return f(42); }
     @unittest.mock.patch("sys.stderr", new_callable=io.StringIO)
     def test_add_hooks_info_errors(self, stderr_mock):
         """add_hooks_info() with errors in hooks"""
-
         orig_general_hook_dir = apport.report.GENERAL_HOOK_DIR
         apport.report.GENERAL_HOOK_DIR = tempfile.mkdtemp()
         orig_package_hook_dir = apport.report.PACKAGE_HOOK_DIR
@@ -1643,7 +1621,6 @@ int main() { return f(42); }
 
     def test_ignoring(self):
         """mark_ignore() and check_ignored()."""
-
         orig_ignore_file = apport.report.apport.report._ignore_file
         workdir = tempfile.mkdtemp()
         apport.report.apport.report._ignore_file = os.path.join(
@@ -1715,7 +1692,6 @@ int main() { return f(42); }
 
     def test_blacklisting(self):
         """check_ignored() for system-wise blacklist."""
-
         orig_blacklist_dir = apport.report._blacklist_dir
         apport.report._blacklist_dir = tempfile.mkdtemp()
         orig_ignore_file = apport.report._ignore_file
@@ -1774,7 +1750,6 @@ int main() { return f(42); }
 
     def test_whitelisting(self):
         """check_ignored() for system-wise whitelist."""
-
         orig_whitelist_dir = apport.report._whitelist_dir
         apport.report._whitelist_dir = tempfile.mkdtemp()
         orig_ignore_file = apport.report.apport.report._ignore_file
@@ -1833,7 +1808,6 @@ int main() { return f(42); }
 
     def test_obsolete_packages(self):
         """obsolete_packages()."""
-
         report = apport.report.Report()
         self.assertEqual(report.obsolete_packages(), [])
 
@@ -1864,7 +1838,6 @@ int main() { return f(42); }
 
     def test_address_to_offset_live(self):
         """_address_to_offset() for current /proc/pid/maps"""
-
         # this primarily checks that the parser actually gets along with the
         # real /proc/pid/maps and not just with our static test case above
         pr = apport.report.Report()
@@ -1926,7 +1899,7 @@ int main() { return f(42); }
         self.assertIn(b"GCONV_PATH", out)
 
     def test_extrapath_preferred(self):
-        """if extrapath is passed it is preferred"""
+        """If extrapath is passed it is preferred."""
         bin_true = apport.report._which_extrapath("true", None)
         # need something to be preferred
         os.symlink("/bin/true", "/tmp/true")

--- a/tests/integration/test_signal_crashes.py
+++ b/tests/integration/test_signal_crashes.py
@@ -115,8 +115,7 @@ class T(unittest.TestCase):
             shutil.rmtree(self.workdir)
 
     def test_empty_core_dump(self):
-        """empty core dumps do not generate a report"""
-
+        """Empty core dumps do not generate a report."""
         test_proc = self.create_test_process()
         try:
             with subprocess.Popen(
@@ -144,8 +143,7 @@ class T(unittest.TestCase):
         self._check_report(expect_report=False)
 
     def test_crash_apport(self):
-        """report generation with apport"""
-
+        """Report generation with apport."""
         self.do_crash()
         st = os.stat(self.test_report)
 
@@ -214,8 +212,7 @@ class T(unittest.TestCase):
 
     @unittest.skip("fix test as multiple instances can be started within 30s")
     def test_parallel_crash(self):
-        """only one apport instance is ran at a time"""
-
+        """Only one apport instance is ran at a time."""
         test_proc = self.create_test_process()
         test_proc2 = self.create_test_process("/bin/dd", args=[])
         try:
@@ -287,8 +284,7 @@ class T(unittest.TestCase):
             test_proc2.wait()
 
     def test_unpackaged_binary(self):
-        """unpackaged binaries do not create a report"""
-
+        """Unpackaged binaries do not create a report."""
         local_exe = os.path.join(self.workdir, "mybin")
         with open(local_exe, "wb") as dest:
             with open(self.TEST_EXECUTABLE, "rb") as src:
@@ -297,8 +293,7 @@ class T(unittest.TestCase):
         self.do_crash(command=local_exe, expect_report=False)
 
     def test_unpackaged_script(self):
-        """unpackaged scripts do not create a report"""
-
+        """Unpackaged scripts do not create a report."""
         local_exe = os.path.join(self.workdir, "myscript")
         with open(local_exe, "w", encoding="utf-8") as f:
             f.write("#!/usr/bin/perl\nsleep(86400);\n")
@@ -312,7 +307,7 @@ class T(unittest.TestCase):
         self.do_crash(command="./myscript", args=[], expect_report=False)
 
     def test_unsupported_arguments_no_stderr(self):
-        """Write failure to log file when stderr is missing
+        """Write failure to log file when stderr is missing.
 
         The kernel calls apport with no stdout and stderr file
         descriptors set.
@@ -340,12 +335,11 @@ class T(unittest.TestCase):
         self.assertIn("the following arguments are required: -p/--pid", logged)
 
     def test_ignore_sigquit(self):
-        """apport ignores SIGQUIT"""
+        """Apport ignores SIGQUIT."""
         self.do_crash(sig=signal.SIGQUIT, expect_report=False)
 
     def test_leak_inaccessible_files(self):
-        """existence of user-inaccessible files does not leak"""
-
+        """Existence of user-inaccessible files do not leak."""
         local_exe = os.path.join(self.workdir, "myscript")
         with open(local_exe, "w", encoding="utf-8") as f:
             f.write(
@@ -373,8 +367,7 @@ class T(unittest.TestCase):
         apport.fileutils.delete_report(leak)
 
     def test_flood_limit(self):
-        """limitation of crash report flood"""
-
+        """Limitation of crash report flood."""
         count = 0
         while count < 7:
             sys.stderr.write("%i " % count)
@@ -392,8 +385,7 @@ class T(unittest.TestCase):
 
     @unittest.skipIf(os.geteuid() != 0, "this test needs to be run as root")
     def test_nonreadable_exe(self):
-        """report generation for non-readable exe"""
-
+        """Report generation for non-readable executable."""
         # CVE-2015-1324: if a user cannot read an executable, it behaves much
         # like a suid root binary in terms of writing a core dump
 
@@ -413,8 +405,7 @@ class T(unittest.TestCase):
         )
 
     def test_core_dump_packaged(self):
-        """packaged executables create core dumps on proper ulimits"""
-
+        """Packaged executables create core dumps on proper ulimits."""
         # for SEGV and ABRT we expect reports and core files
         for sig in (signal.SIGSEGV, signal.SIGABRT):
             for (kb, exp_file) in core_ulimit_table:
@@ -432,15 +423,14 @@ class T(unittest.TestCase):
             apport.fileutils.delete_report(self.test_report)
 
     def test_core_dump_packaged_sigquit(self):
-        """packaged executables create core files, no report for SIGQUIT"""
+        """Packaged executables create core files, no report for SIGQUIT."""
         resource.setrlimit(resource.RLIMIT_CORE, (-1, -1))
         self.do_crash(
             expect_corefile=True, expect_report=False, sig=signal.SIGQUIT
         )
 
     def test_core_dump_unpackaged(self):
-        """unpackaged executables create core dumps on proper ulimits"""
-
+        """Unpackaged executables create core dumps on proper ulimits."""
         local_exe = os.path.join(self.workdir, "mybin")
         with open(local_exe, "wb") as dest:
             with open(self.TEST_EXECUTABLE, "rb") as src:
@@ -459,8 +449,7 @@ class T(unittest.TestCase):
                 )
 
     def test_core_file_injection(self):
-        """cannot inject core file"""
-
+        """Cannot inject core file."""
         # CVE-2015-1325: ensure that apport does not re-open its .crash report,
         # as that allows us to intercept and replace the report and tinker with
         # the core dump
@@ -513,8 +502,7 @@ class T(unittest.TestCase):
         )
 
     def test_ignore(self):
-        """ignoring executables"""
-
+        """Ignore executables."""
         self.do_crash()
 
         pr = apport.Report()
@@ -527,8 +515,7 @@ class T(unittest.TestCase):
         self.do_crash(expect_report=False)
 
     def test_modify_after_start(self):
-        """ignores executables which got modified after process started"""
-
+        """Ignore executables which got modified after process started."""
         # create executable in a path we can modify which apport regards as
         # likely packaged
         (fd, myexe) = tempfile.mkstemp(dir="/var/tmp")
@@ -583,8 +570,7 @@ class T(unittest.TestCase):
         self._check_report(expect_report=False)
 
     def test_logging_file(self):
-        """outputs to log file, if available"""
-
+        """Output to log file, if available."""
         test_proc = self.create_test_process()
         log = os.path.join(self.workdir, "apport.log")
         try:
@@ -637,8 +623,7 @@ class T(unittest.TestCase):
         self.assertEqual(pr["CoreDump"], b"hel\x01lo")
 
     def test_logging_stderr(self):
-        """outputs to stderr if log is not available"""
-
+        """Output to stderr if log is not available."""
         test_proc = self.create_test_process()
         try:
             env = os.environ.copy()
@@ -684,8 +669,7 @@ class T(unittest.TestCase):
 
     @unittest.skipIf(os.geteuid() != 0, "this test needs to be run as root")
     def test_crash_setuid_keep(self):
-        """report generation for setuid program which stays root"""
-
+        """Report generation for setuid program which stays root."""
         # create suid root executable in a path we can modify which apport
         # regards as likely packaged
         (fd, myexe) = tempfile.mkstemp(dir="/var/tmp")
@@ -710,8 +694,7 @@ class T(unittest.TestCase):
     )
     @unittest.skipIf(os.geteuid() != 0, "this test needs to be run as root")
     def test_crash_setuid_drop(self):
-        """report generation for setuid program which drops root"""
-
+        """Report generation for setuid program which drops root."""
         # run ping as user "mail"
         resource.setrlimit(resource.RLIMIT_CORE, (-1, -1))
 
@@ -723,8 +706,7 @@ class T(unittest.TestCase):
 
     @unittest.skipIf(os.geteuid() != 0, "this test needs to be run as root")
     def test_crash_setuid_unpackaged(self):
-        """report generation for unpackaged setuid program"""
-
+        """Report generation for unpackaged setuid program."""
         # create suid root executable in a path we can modify which apport
         # regards as not packaged
         (fd, myexe) = tempfile.mkstemp(dir="/tmp")
@@ -748,7 +730,7 @@ class T(unittest.TestCase):
         )
 
     def test_coredump_from_socket(self):
-        """forwarding of a core dump through socket
+        """Forward a core dump through a socket.
 
         This is being used in a container via systemd activation, where the
         core dump gets read from /run/apport.socket.
@@ -762,7 +744,7 @@ class T(unittest.TestCase):
         self.assertEqual(pr["ExecutablePath"], self.TEST_EXECUTABLE)
 
     def test_core_dump_packaged_sigquit_via_socket(self):
-        """executable create core files via socket, no report for SIGQUIT"""
+        """Executable create core files via socket, no report for SIGQUIT."""
         resource.setrlimit(resource.RLIMIT_CORE, (-1, -1))
         self.do_crash(
             expect_corefile=True,
@@ -776,7 +758,7 @@ class T(unittest.TestCase):
     )
     @unittest.skipIf(os.geteuid() != 0, "this test needs to be run as root")
     def test_crash_setuid_drop_via_socket(self):
-        """report generation via socket for setuid program which drops root"""
+        """Report generation via socket for setuid program which drops root."""
         resource.setrlimit(resource.RLIMIT_CORE, (-1, -1))
         # run ping as user "mail"
         self.do_crash(
@@ -1121,8 +1103,7 @@ class T(unittest.TestCase):
         )
 
     def check_report_coredump(self, report_path):
-        """Check that given report file has a valid core dump"""
-
+        """Check that given report file has a valid core dump."""
         r = apport.Report()
         with open(report_path, "rb") as f:
             r.load(f)

--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -278,7 +278,6 @@ class T(unittest.TestCase):
 
     def test_format_filesize(self):
         """format_filesize()"""
-
         locale_numeric = locale.getlocale(locale.LC_NUMERIC)
         locale.setlocale(locale.LC_NUMERIC, "C")
         try:
@@ -295,7 +294,6 @@ class T(unittest.TestCase):
 
     def test_get_size_loaded(self):
         """get_complete_size() and get_reduced_size() for loaded Reports"""
-
         self.ui.load_report(self.report_file.name)
 
         fsize = os.path.getsize(self.report_file.name)
@@ -318,7 +316,6 @@ class T(unittest.TestCase):
 
     def test_get_size_constructed(self):
         """get_complete_size() and get_reduced_size() for on-the-fly Reports"""
-
         self.ui.report = apport.Report("Bug")
         self.ui.report["Hello"] = "World"
 
@@ -330,7 +327,6 @@ class T(unittest.TestCase):
 
     def test_load_report(self):
         """load_report()"""
-
         # valid report
         self.ui.load_report(self.report_file.name)
         self.assertEqual(set(self.ui.report.keys()), set(self.report.keys()))
@@ -365,7 +361,6 @@ class T(unittest.TestCase):
 
     def test_restart(self):
         """restart()"""
-
         # test with only ProcCmdline
         p = os.path.join(apport.fileutils.report_dir, "ProcCmdline")
         r = os.path.join(apport.fileutils.report_dir, "Custom")
@@ -398,7 +393,6 @@ class T(unittest.TestCase):
 
     def test_collect_info_distro(self):
         """collect_info() on report without information (distro bug)"""
-
         # report without any information (distro bug)
         self.ui.report = apport.Report("Bug")
         self.ui.collect_info()
@@ -415,7 +409,6 @@ class T(unittest.TestCase):
 
     def test_collect_info_exepath(self):
         """collect_info() on report with only ExecutablePath"""
-
         # report with only package information
         self.report = apport.Report("Bug")
         self.report["ExecutablePath"] = "/bin/bash"
@@ -454,7 +447,6 @@ class T(unittest.TestCase):
 
     def test_collect_info_package(self):
         """collect_info() on report with a package"""
-
         # report with only package information
         self.ui.report = apport.Report("Bug")
         self.ui.cur_package = "bash"
@@ -484,7 +476,6 @@ class T(unittest.TestCase):
 
     def test_collect_info_permissions(self):
         """collect_info() leaves the report accessible to the group"""
-
         self.ui.report = apport.Report("Bug")
         self.ui.cur_package = "bash"
         self.ui.report_file = self.report_file.name
@@ -532,7 +523,6 @@ class T(unittest.TestCase):
 
     def test_collect_info_crashdb_errors(self):
         """collect_info() with package hook setting a broken CrashDB field"""
-
         # nonexisting implementation
         self._write_crashdb_config_hook(
             "{ 'impl': 'nonexisting', 'local_opt': '1' }"
@@ -569,7 +559,6 @@ class T(unittest.TestCase):
 
     def test_handle_duplicate(self):
         """handle_duplicate()"""
-
         self.ui.load_report(self.report_file.name)
         self.assertEqual(self.ui.handle_duplicate(), False)
         self.assertEqual(self.ui.msg_title, None)
@@ -593,13 +582,12 @@ class T(unittest.TestCase):
         self.assertEqual(self.ui.opened_url, None)
 
     def test_run_nopending(self):
-        """running the frontend without any pending reports"""
+        """Run the frontend without any pending reports."""
         self.ui = TestSuiteUserInterface()
         self.assertEqual(self.ui.run_argv(), False)
 
     def test_run_restart(self):
-        """running the frontend with pending reports offers restart"""
-
+        """Running the frontend with pending reports offers restart."""
         r = self._gen_test_crash()
         report_file = os.path.join(apport.fileutils.report_dir, "test.crash")
         with open(report_file, "wb") as f:
@@ -617,7 +605,6 @@ class T(unittest.TestCase):
 
     def test_run_report_bug_noargs(self):
         """run_report_bug() without specifying arguments"""
-
         sys.argv = ["ui-test", "-f"]
         self.ui = TestSuiteUserInterface()
         self.assertEqual(self.ui.run_argv(), False)
@@ -626,7 +613,6 @@ class T(unittest.TestCase):
     @unittest.mock.patch("sys.stdout", new_callable=io.StringIO)
     def test_run_version(self, stdout_mock):
         """run_report_bug() as "ubuntu-bug" with version argument"""
-
         sys.argv = ["ubuntu-bug", "-v"]
         self.ui = TestSuiteUserInterface()
         self.assertEqual(self.ui.run_argv(), True)
@@ -634,7 +620,6 @@ class T(unittest.TestCase):
 
     def test_run_report_bug_package(self):
         """run_report_bug() for a package"""
-
         sys.argv = ["ui-test", "-f", "-p", "bash"]
         self.ui = TestSuiteUserInterface()
         self.ui.present_details_response = {
@@ -672,7 +657,6 @@ class T(unittest.TestCase):
 
     def test_run_report_bug_pid_tags(self):
         """run_report_bug() for a pid with extra tags"""
-
         # fork a test process
         pid = os.fork()
         if pid == 0:
@@ -721,8 +705,7 @@ class T(unittest.TestCase):
 
     @staticmethod
     def _find_unused_pid():
-        """Find and return an unused PID"""
-
+        """Find and return an unused PID."""
         pid = 1
         while True:
             pid += 1
@@ -735,7 +718,6 @@ class T(unittest.TestCase):
 
     def test_run_report_bug_wrong_pid(self):
         """run_report_bug() for a nonexisting pid"""
-
         # silently ignore missing PID; this happens when the user closes
         # the application prematurely
         pid = self._find_unused_pid()
@@ -745,7 +727,6 @@ class T(unittest.TestCase):
 
     def test_run_report_bug_noperm_pid(self):
         """run_report_bug() for a pid which runs as a different user"""
-
         restore_root = False
         if os.getuid() == 0:
             # temporarily drop to normal user "mail"
@@ -764,7 +745,6 @@ class T(unittest.TestCase):
 
     def test_run_report_bug_unpackaged_pid(self):
         """run_report_bug() for a pid of an unpackaged program"""
-
         # create unpackaged test program
         (fd, exename) = tempfile.mkstemp()
         with open(self.TEST_EXECUTABLE, "rb") as f:
@@ -828,7 +808,6 @@ class T(unittest.TestCase):
 
     def test_run_report_bug_file(self):
         """run_report_bug() with saving report into a file"""
-
         d = os.path.join(apport.fileutils.report_dir, "home")
         os.mkdir(d)
         reportfile = os.path.join(d, "bashisbad.apport")
@@ -870,8 +849,7 @@ class T(unittest.TestCase):
         self.assertTrue(self.ui.present_details_shown)
 
     def _gen_test_crash(self):
-        """Generate a Report with real crash data"""
-
+        """Generate a Report with real crash data."""
         core_path = os.path.join(self.workdir, "core")
         try:
             with subprocess.Popen(
@@ -926,7 +904,6 @@ class T(unittest.TestCase):
 
     def test_run_crash(self):
         """run_crash()"""
-
         r = self._gen_test_crash()
 
         # write crash report
@@ -1013,7 +990,6 @@ class T(unittest.TestCase):
 
     def test_run_crash_abort(self):
         """run_crash() for an abort() without assertion message"""
-
         r = self._gen_test_crash()
         r["Signal"] = "6"
         report_file = os.path.join(apport.fileutils.report_dir, "test.crash")
@@ -1046,7 +1022,6 @@ class T(unittest.TestCase):
 
     def test_run_crash_broken(self):
         """run_crash() for an invalid core dump"""
-
         # generate broken crash report
         r = apport.Report()
         r["ExecutablePath"] = self.TEST_EXECUTABLE
@@ -1079,7 +1054,6 @@ class T(unittest.TestCase):
     )
     def test_run_crash_argv_file(self):
         """run_crash() through a file specified on the command line"""
-
         # valid
         self.report["Package"] = "bash"
         self.update_report_file()
@@ -1136,7 +1110,6 @@ class T(unittest.TestCase):
     )
     def test_run_crash_unreportable(self):
         """run_crash() on a crash with the UnreportableReason field"""
-
         self.report["UnreportableReason"] = "It stinks."
         self.report["ExecutablePath"] = "/bin/bash"
         self.report["Package"] = "bash 1"
@@ -1163,7 +1136,6 @@ class T(unittest.TestCase):
     )
     def test_run_crash_malicious_crashdb(self):
         """run_crash() on a crash with malicious CrashDB"""
-
         self.report["ExecutablePath"] = "/bin/bash"
         self.report["Package"] = "bash 1"
         self.report["CrashDB"] = (
@@ -1189,7 +1161,6 @@ class T(unittest.TestCase):
     )
     def test_run_crash_malicious_package(self):
         """Package: path traversal"""
-
         with tempfile.NamedTemporaryFile(suffix=".py") as bad_hook:
             bad_hook.write(
                 b"def add_info(r, u):\n  open('/tmp/pwned', 'w').close()"
@@ -1216,7 +1187,6 @@ class T(unittest.TestCase):
 
     def test_run_crash_malicious_exec_path(self):
         """ExecutablePath: path traversal"""
-
         hook_dir = "/tmp/share/apport/package-hooks"
         os.makedirs(hook_dir, exist_ok=True)
         with tempfile.NamedTemporaryFile(
@@ -1256,7 +1226,6 @@ class T(unittest.TestCase):
 
     def test_run_crash_nocore(self):
         """run_crash() for a crash dump without CoreDump"""
-
         # create a test executable
         assert os.access(self.TEST_EXECUTABLE, os.X_OK), (
             self.TEST_EXECUTABLE + " is not executable"
@@ -1382,7 +1351,6 @@ class T(unittest.TestCase):
 
     def test_run_crash_errors(self):
         """run_crash() on various error conditions"""
-
         # crash report with invalid Package name
         r = apport.Report()
         r["ExecutablePath"] = "/bin/bash"
@@ -1405,7 +1373,6 @@ class T(unittest.TestCase):
 
     def test_run_crash_uninstalled(self):
         """run_crash() on reports with subsequently uninstalled packages"""
-
         # program got uninstalled between crash and report
         r = self._gen_test_crash()
         r["ExecutablePath"] = "/bin/nonexisting"
@@ -1454,7 +1421,6 @@ class T(unittest.TestCase):
 
     def test_run_crash_updated_binary(self):
         """run_crash() on binary that got updated in the meantime"""
-
         r = self._gen_test_crash()
         r["ExecutableTimestamp"] = str(int(r["ExecutableTimestamp"]) - 10)
         report_file = os.path.join(apport.fileutils.report_dir, "test.crash")
@@ -1485,7 +1451,6 @@ class T(unittest.TestCase):
 
     def test_run_crash_package(self):
         """run_crash() for a package error"""
-
         # generate crash report
         r = apport.Report("Package")
         r["Package"] = "bash"
@@ -1546,7 +1511,6 @@ class T(unittest.TestCase):
 
     def test_run_crash_kernel(self):
         """run_crash() for a kernel error"""
-
         sys_arch = apport.packaging.get_system_architecture()
         if sys_arch in ["amd64", "arm64", "ppc64el", "s390x"]:
             src_pkg = "linux-signed"
@@ -1630,7 +1594,6 @@ class T(unittest.TestCase):
 
     def test_run_crash_anonymity(self):
         """run_crash() anonymization"""
-
         r = self._gen_test_crash()
         utf8_val = (
             b"\xc3\xa4 " + os.uname()[1].encode("UTF-8") + b" \xe2\x99\xa5 "
@@ -1673,7 +1636,6 @@ class T(unittest.TestCase):
     def test_run_crash_anonymity_order(self):
         """run_crash() anonymization runs after info and duplicate
         collection"""
-
         # pretend the hostname looks like a hex number which matches
         # the stack trace address
         uname = os.uname()
@@ -1729,7 +1691,6 @@ class T(unittest.TestCase):
 
     def test_run_crash_anonymity_substring(self):
         """run_crash() anonymization only catches whole words"""
-
         # pretend the hostname is "ed", a substring of e. g. "crashed"
         uname = os.uname()
         uname = (uname[0], "ed", uname[2], uname[3], uname[4])
@@ -1775,7 +1736,6 @@ class T(unittest.TestCase):
 
     def test_run_crash_anonymity_escaping(self):
         """run_crash() anonymization escapes special chars"""
-
         # inject GECOS field with regexp control chars
         orig_getpwuid = pwd.getpwuid
         orig_getuid = os.getuid
@@ -1823,7 +1783,6 @@ class T(unittest.TestCase):
 
     def test_run_crash_known(self):
         """run_crash() for already known problem"""
-
         r = self._gen_test_crash()
         report_file = os.path.join(apport.fileutils.report_dir, "test.crash")
         self.ui = TestSuiteUserInterface()
@@ -1862,8 +1821,7 @@ class T(unittest.TestCase):
         self.assertEqual(self.ui.opened_url, "http://myreport/1")
 
     def test_run_crash_private_keys(self):
-        """does not upload private keys to crash db"""
-
+        """Do not upload private keys to crash DB."""
         r = self._gen_test_crash()
         r["_Temp"] = "boring"
 
@@ -1895,7 +1853,6 @@ class T(unittest.TestCase):
     @unittest.skipIf(logind_session is None, "not running in logind session")
     def test_run_crash_older_session(self):
         """run_crashes() skips crashes from older logind sessions"""
-
         latest_id_before = self.ui.crashdb.latest_id()
 
         # current crash report
@@ -1954,7 +1911,6 @@ class T(unittest.TestCase):
 
     def test_run_update_report_nonexisting_package_from_bug(self):
         """run_update_report() on a nonexisting package (from bug)"""
-
         sys.argv = ["ui-test", "-u", "1"]
         self.ui = TestSuiteUserInterface()
 
@@ -1964,7 +1920,6 @@ class T(unittest.TestCase):
 
     def test_run_update_report_nonexisting_package_cli(self):
         """run_update_report() on a nonexisting package (CLI argument)"""
-
         sys.argv = ["ui-test", "-u", "1", "-p", "bar"]
         self.ui = TestSuiteUserInterface()
 
@@ -1974,7 +1929,6 @@ class T(unittest.TestCase):
 
     def test_run_update_report_existing_package_from_bug(self):
         """run_update_report() on an existing package (from bug)"""
-
         sys.argv = ["ui-test", "-u", "1"]
         self.ui = TestSuiteUserInterface()
         self.ui.present_details_response = {
@@ -2001,7 +1955,6 @@ class T(unittest.TestCase):
     def test_run_update_report_existing_package_cli_tags(self):
         """run_update_report() on an existing package (CLI argument)
         with extra tag"""
-
         sys.argv = ["ui-test", "-u", "1", "-p", "bash", "--tag", "foo"]
         self.ui = TestSuiteUserInterface()
         self.ui.present_details_response = {
@@ -2026,7 +1979,6 @@ class T(unittest.TestCase):
 
     def test_run_update_report_existing_package_cli_cmdname(self):
         """run_update_report() on an existing package (-collect program)"""
-
         sys.argv = ["apport-collect", "-p", "bash", "1"]
         self.ui = TestSuiteUserInterface()
         self.ui.present_details_response = {
@@ -2050,7 +2002,6 @@ class T(unittest.TestCase):
 
     def test_run_update_report_noninstalled_but_hook(self):
         """run_update_report() on an uninstalled package with a source hook"""
-
         sys.argv = ["ui-test", "-u", "1"]
         self.ui = TestSuiteUserInterface()
         self.ui.present_details_response = {
@@ -2127,8 +2078,7 @@ class T(unittest.TestCase):
         self.ui.run_report_bug()
 
     def test_interactive_hooks_information(self):
-        """interactive hooks: HookUI.information()"""
-
+        """Interactive hooks: HookUI.information()"""
         self.ui.present_details_response = {
             "report": False,
             "blacklist": False,
@@ -2150,8 +2100,7 @@ class T(unittest.TestCase):
         self.assertEqual(self.ui.msg_text, "InfoText")
 
     def test_interactive_hooks_yesno(self):
-        """interactive hooks: HookUI.yesno()"""
-
+        """Interactive hooks: HookUI.yesno()"""
         self.ui.present_details_response = {
             "report": False,
             "blacklist": False,
@@ -2185,8 +2134,7 @@ class T(unittest.TestCase):
         self.assertEqual(self.ui.report["end"], "1")
 
     def test_interactive_hooks_file(self):
-        """interactive hooks: HookUI.file()"""
-
+        """Interactive hooks: HookUI.file()"""
         self.ui.present_details_response = {
             "report": False,
             "blacklist": False,
@@ -2215,8 +2163,7 @@ class T(unittest.TestCase):
         self.assertEqual(self.ui.report["end"], "1")
 
     def test_interactive_hooks_choices(self):
-        """interactive hooks: HookUI.choice()"""
-
+        """Interactive hooks: HookUI.choice()"""
         self.ui.present_details_response = {
             "report": False,
             "blacklist": False,
@@ -2269,8 +2216,7 @@ class T(unittest.TestCase):
         self.assertEqual(self.ui.report["answer"], "None")
 
     def test_interactive_hooks_cancel(self):
-        """interactive hooks: user cancels"""
-
+        """Interactive hooks: user cancels"""
         self.assertRaises(
             SystemExit,
             self._run_hook,
@@ -2289,7 +2235,6 @@ class T(unittest.TestCase):
     @unittest.mock.patch("sys.stderr", new_callable=io.StringIO)
     def test_run_symptom(self, stderr_mock):
         """run_symptom()"""
-
         # unknown symptom
         sys.argv = ["ui-test", "-s", "foobar"]
         self.ui = TestSuiteUserInterface()
@@ -2419,7 +2364,6 @@ class T(unittest.TestCase):
     def test_run_report_bug_list_symptoms(self):
         """run_report_bug() without specifying arguments and available
         symptoms"""
-
         self._write_symptom_script(
             "foo.py",
             textwrap.dedent(
@@ -2826,7 +2770,6 @@ class T(unittest.TestCase):
 
     def test_can_examine_locally_crash(self):
         """can_examine_locally() for a crash report"""
-
         self.ui.load_report(self.report_file.name)
 
         orig_path = os.environ["PATH"]
@@ -2862,7 +2805,6 @@ class T(unittest.TestCase):
 
     def test_can_examine_locally_nocrash(self):
         """can_examine_locally() for a non-crash report"""
-
         self.ui.load_report(self.report_file.name)
         del self.ui.report["CoreDump"]
 
@@ -2874,8 +2816,7 @@ class T(unittest.TestCase):
             self.ui.ui_has_terminal = orig_fn
 
     def test_db_no_accept(self):
-        """crash database does not accept report"""
-
+        """Crash database does not accept report."""
         # FIXME: This behaviour is not really correct, but necessary as long as
         # we only support a single crashdb and have whoopsie hardcoded
         # (see LP#957177)
@@ -2912,8 +2853,7 @@ class T(unittest.TestCase):
         self.assertEqual(self.ui.crashdb.latest_id(), latest_id_before)
 
     def test_get_desktop_entry(self):
-        """parsing of .desktop files"""
-
+        """Parsee .desktop files."""
         with tempfile.NamedTemporaryFile(mode="w+") as desktop_file:
             desktop_file.write(
                 textwrap.dedent(
@@ -2945,8 +2885,7 @@ class T(unittest.TestCase):
             )
 
     def test_get_desktop_entry_broken(self):
-        """parsing of broken .desktop files"""
-
+        """Parse broken .desktop files."""
         # duplicate key
         with tempfile.NamedTemporaryFile(mode="w+") as desktop_file:
             desktop_file.write(

--- a/tests/system/test_apport_valgrind.py
+++ b/tests/system/test_apport_valgrind.py
@@ -42,7 +42,6 @@ class T(unittest.TestCase):
     )
     def test_sandbox_cache_options(self):
         """apport-valgrind creates a user specified sandbox and cache"""
-
         sandbox = os.path.join(self.workdir, "test-sandbox")
         cache = os.path.join(self.workdir, "test-cache")
 

--- a/tests/system/test_packaging_apt_dpkg.py
+++ b/tests/system/test_packaging_apt_dpkg.py
@@ -275,7 +275,7 @@ class T(unittest.TestCase):
 
     @unittest.skipUnless(has_internet(), "online test")
     def test_install_packages_dependencies(self):
-        """install packages's dependencies"""
+        """Test install packages's dependencies."""
         release = self._setup_foonux_config()
         # coreutils should always depend on libc6
         result = impl.install_packages(
@@ -731,7 +731,7 @@ class T(unittest.TestCase):
 
     @unittest.skipUnless(has_internet(), "online test")
     def test_install_old_packages(self):
-        """sandbox will install older package versions from launchpad"""
+        """Sandbox will install older package versions from launchpad."""
         release = self._setup_foonux_config()
         wanted_package = "libcurl4"
         wanted_version = "7.81.0-1"  # pre-release version

--- a/tests/system/test_signal_crashes.py
+++ b/tests/system/test_signal_crashes.py
@@ -134,8 +134,7 @@ class T(unittest.TestCase):
         self.assertEqual(unexpected_reports, [])
 
     def test_limit_size(self):
-        """core dumps are capped on available memory size"""
-
+        """Core dumps are capped on available memory size."""
         # determine how much data we have to pump into apport in order to make
         # sure that it will refuse the core dump
         r = apport.Report()
@@ -212,7 +211,7 @@ class T(unittest.TestCase):
     @skip_if_command_is_missing("systemd-run")
     @unittest.skipIf(os.geteuid() != 0, "this test needs to be run as root")
     def test_crash_system_slice(self):
-        """report generation for a protected process running in the system
+        """Report generation for a protected process running in the system
         slice"""
         apport.fileutils.report_dir = self.orig_report_dir
         self.test_report = os.path.join(

--- a/tests/system/test_ui_gtk.py
+++ b/tests/system/test_ui_gtk.py
@@ -116,7 +116,8 @@ class T(unittest.TestCase):
         self.assertFalse(result["report"])
 
     def test_kernel_crash_layout(self):
-        """
+        """Display crash dialog for kernel crash.
+
         +-----------------------------------------------------------------+
         | [ logo] YourDistro has experienced an internal error.           |
         |            Send problem report to the developers?               |
@@ -152,7 +153,8 @@ class T(unittest.TestCase):
         )
 
     def test_package_crash_layout(self):
-        """
+        """Display crash dialog for a failed package installation.
+
         +-----------------------------------------------------------------+
         | [ error  ] Sorry, a problem occurred while installing software. |
         |            Send problem report to the developers?               |
@@ -212,7 +214,8 @@ class T(unittest.TestCase):
         self.assertEqual(self.app.w("continue_button").get_label(), _("Send"))
 
     def test_regular_crash_layout(self):
-        """
+        """Display crash dialog for an application crash.
+
         +-----------------------------------------------------------------+
         | [ apport ] The application Apport has closed unexpectedly.      |
         |            Send problem report to the developers?               |
@@ -270,7 +273,8 @@ class T(unittest.TestCase):
         )
 
     def test_regular_crash_layout_restart(self):
-        """
+        """Display crash dialog for an application crash offering a restart.
+
         +-----------------------------------------------------------------+
         | [ apport ] The application Apport has closed unexpectedly.      |
         |            Send problem report to the developers?               |
@@ -333,7 +337,8 @@ class T(unittest.TestCase):
         self.assertTrue(self.app.w("relaunch_app").get_active())
 
     def test_regular_crash_layout_norestart(self):
-        """
+        """Display crash dialog for an application crash offering no restart.
+
         +-----------------------------------------------------------------+
         | [ apport ] The application Apport has closed unexpectedly.      |
         |            Send problem report to the developers?               |
@@ -384,7 +389,8 @@ class T(unittest.TestCase):
         self.assertEqual(self.app.w("continue_button").get_label(), _("Send"))
 
     def test_hang_layout(self):
-        """
+        """Display crash dialog for a hanging process.
+
         +-----------------------------------------------------------------+
         | [ apport ] The application Apport has stopped responding.       |
         |            Send problem report to the developers?               |
@@ -447,7 +453,8 @@ class T(unittest.TestCase):
         )
 
     def test_system_crash_layout(self):
-        """
+        """Display crash dialog for a system application crash.
+
         +---------------------------------------------------------------+
         | [ logo ] Sorry, YourDistro has experienced an internal error. |
         |          Send problem report to the developers?               |
@@ -497,7 +504,8 @@ class T(unittest.TestCase):
         )
 
     def test_system_crash_from_console_layout(self):
-        """
+        """Display crash dialog from console.
+
         +-------------------------------------------------------------------+
         | [ ubuntu ] Sorry, the application apport has closed unexpectedly. |
         |            Send problem report to the developers?                 |
@@ -559,7 +567,8 @@ class T(unittest.TestCase):
         GTKUserInterface, "can_examine_locally", unittest.mock.MagicMock()
     )
     def test_examine_button(self):
-        """
+        """Crash dialog showing or not showing "Examine locally".
+
         +---------------------------------------------------------------------+
         | [ apport ] The application Apport has closed unexpectedly.          |
         |            Send problem report to the developers?                   |
@@ -584,7 +593,8 @@ class T(unittest.TestCase):
         self.assertTrue(result["examine"])
 
     def test_apport_bug_package_layout(self):
-        """
+        """Display report detail dialog.
+
         +-------------------------------------------------------------------+
         | [ error  ] Send problem report to the developers?                 |
         |                                                                   |
@@ -620,8 +630,7 @@ class T(unittest.TestCase):
         self.assertTrue(self.app.w("dialog_crash_new").get_resizable())
 
     def test_apport_bug_package_layout_load_file(self):
-        """bug layout from a loaded report"""
-
+        """Bug layout from a loaded report."""
         self.app.report_file = "/tmp/foo.apport"
         self.app.report = apport.report.Report("Bug")
         self.app.report["Package"] = "libfoo1"
@@ -650,7 +659,8 @@ class T(unittest.TestCase):
         self.assertTrue(self.app.w("dialog_crash_new").get_resizable())
 
     def test_recoverable_crash_layout(self):
-        """
+        """Display crash dialog for a recoverable crash.
+
         +-----------------------------------------------------------------+
         | [ logo ] The application Foo has experienced an internal error. |
         |            Send problem report to the developers?               |
@@ -841,8 +851,7 @@ class T(unittest.TestCase):
         unittest.mock.MagicMock(return_value=True),
     )
     def test_broken_crash_details(self):
-        """Broken crash report with showing details"""
-
+        """Broken crash report with showing details."""
         # pylint: disable=attribute-defined-outside-init
         self.error_title = None
         self.error_text = None
@@ -1040,8 +1049,7 @@ class T(unittest.TestCase):
         GTKUserInterface, "open_url", unittest.mock.MagicMock()
     )
     def test_update_report(self):
-        """Updating an existing report"""
-
+        """Updating an existing report."""
         self.app.report_file = None
 
         def cont():
@@ -1220,8 +1228,7 @@ class T(unittest.TestCase):
         )
 
     def test_immediate_close(self):
-        """Close details window immediately"""
-
+        """Close details window immediately."""
         # this reproduces https://launchpad.net/bugs/938090
         self.app.w("dialog_crash_new").destroy()
         GLib.idle_add(Gtk.main_quit)

--- a/tests/system/test_ui_kde.py
+++ b/tests/system/test_ui_kde.py
@@ -137,7 +137,8 @@ class T(unittest.TestCase):
         self.assertFalse(result["report"])
 
     def test_kernel_crash_layout(self):
-        """
+        """Display crash dialog for kernel crash.
+
         +-----------------------------------------------------------------+
         | [ logo ] YourDistro has experienced an internal error.          |
         |                                                                 |
@@ -163,7 +164,8 @@ class T(unittest.TestCase):
         self.assertFalse(self.app.dialog.text.isVisible())
 
     def test_package_crash_layout(self):
-        """
+        """Display crash dialog for a failed package installation.
+
         +-----------------------------------------------------------------+
         | [ error  ] Sorry, a problem occurred while installing software. |
         |            Package: apport 1.2.3~0ubuntu1                       |
@@ -202,7 +204,8 @@ class T(unittest.TestCase):
         self.assertEqual(self.app.dialog.continue_button.text(), _("Continue"))
 
     def test_regular_crash_layout(self):
-        """
+        """Display crash dialog for an application crash.
+
         +-----------------------------------------------------------------+
         | [ apport ] The application Apport has closed unexpectedly.      |
         |                                                                 |
@@ -252,7 +255,8 @@ class T(unittest.TestCase):
         )
 
     def test_regular_crash_layout_restart(self):
-        """
+        """Display crash dialog for an application crash offering a restart.
+
         +-----------------------------------------------------------------+
         | [ apport ] The application Apport has closed unexpectedly.      |
         |                                                                 |
@@ -304,7 +308,8 @@ class T(unittest.TestCase):
         )
 
     def test_regular_crash_layout_norestart(self):
-        """
+        """Display crash dialog for an application crash offering no restart.
+
         +-----------------------------------------------------------------+
         | [ apport ] The application Apport has closed unexpectedly.      |
         |                                                                 |
@@ -347,7 +352,8 @@ class T(unittest.TestCase):
         self.assertFalse(self.app.dialog.closed_button.isVisible())
 
     def test_system_crash_layout(self):
-        """
+        """Display crash dialog for a system application crash.
+
         +-----------------------------------------------------------------+
         | [ logo ] Sorry, YourDistro has experienced an internal error.   |
         |            If you notice further problems, try restarting the   |
@@ -388,7 +394,8 @@ class T(unittest.TestCase):
         )
 
     def test_apport_bug_package_layout(self):
-        """
+        """Display report detail dialog.
+
         +-------------------------------------------------------------------+
         | [ error  ] Send problem report to the developers?                 |
         |                                                                   |
@@ -419,7 +426,8 @@ class T(unittest.TestCase):
         self.assertTrue(self.app.dialog.treeview.isVisible())
 
     def test_recoverable_crash_layout(self):
-        """
+        """Display crash dialog for a recoverable crash.
+
         +-----------------------------------------------------------------+
         | [ logo ] The application Foo has experienced an internal error. |
         |          Developer-specified error text.                        |
@@ -636,8 +644,7 @@ class T(unittest.TestCase):
         self.assertIn("libc", r["Dependencies"])
 
     def test_bug_report_installed_package(self):
-        """Bug report for installed package"""
-
+        """Bug report for installed package."""
         self.app.report_file = None
         self.app.args.package = "bash"
 

--- a/tests/unit/test_crashdb.py
+++ b/tests/unit/test_crashdb.py
@@ -41,21 +41,18 @@ class T(unittest.TestCase):
         shutil.rmtree(self.workdir)
 
     def test_no_dummy_data(self):
-        """No dummy data is added by default"""
-
+        """No dummy data is added by default."""
         self.crashes = CrashDatabase(None, {})
         self.assertEqual(self.crashes.latest_id(), -1)
         self.assertRaises(IndexError, self.crashes.download, 0)
 
     def test_retrace_markers(self):
-        """Bookkeeping in retraced and dupchecked bugs"""
-
+        """Bookkeeping in retraced and dupchecked bugs."""
         self.assertEqual(self.crashes.get_unretraced(), set([0, 1, 2]))
         self.assertEqual(self.crashes.get_dup_unchecked(), set([3, 4]))
 
     def test_dynamic_crashdb_conf(self):
-        """Dynamic code in crashdb.conf"""
-
+        """Dynamic code in crashdb.conf."""
         # use our dummy crashdb
         with tempfile.NamedTemporaryFile(mode="w+") as crashdb_conf:
             crashdb_conf.write(
@@ -93,8 +90,7 @@ class T(unittest.TestCase):
             self.assertEqual(db.options["whoami"], "dynname")
 
     def test_accepts_default(self):
-        """accepts(): default configuration"""
-
+        """accepts(): default configuration."""
         # by default crash DBs accept any type
         self.assertTrue(self.crashes.accepts(apport.report.Report("Crash")))
         self.assertTrue(self.crashes.accepts(apport.report.Report("Bug")))
@@ -103,8 +99,7 @@ class T(unittest.TestCase):
         )
 
     def test_accepts_problem_types(self):
-        """accepts(): problem_types option in crashdb.conf"""
-
+        """accepts(): problem_types option in crashdb.conf."""
         # create a crash DB with type limits
         with tempfile.NamedTemporaryFile(mode="w+") as crashdb_conf:
             crashdb_conf.write(
@@ -134,8 +129,7 @@ class T(unittest.TestCase):
     #
 
     def test_submit(self):
-        """Crash uploading and downloading"""
-
+        """Crash uploading and downloading."""
         # setUp() already checks upload() and get_comment_url()
         r = self.crashes.download(0)
         self.assertEqual(r["SourcePackage"], "foo")
@@ -152,7 +146,6 @@ class T(unittest.TestCase):
 
     def test_update(self):
         """update()"""
-
         r = apport.report.Report()
         r["Package"] = "new"
         r["FooBar"] = "Bogus"
@@ -168,7 +161,6 @@ class T(unittest.TestCase):
 
     def test_update_filter(self):
         """update() with key_filter"""
-
         r = apport.report.Report()
         r["Package"] = "new"
         r["FooBar"] = "Bogus"
@@ -186,7 +178,6 @@ class T(unittest.TestCase):
 
     def test_update_traces(self):
         """update_traces()"""
-
         r = apport.report.Report()
         r["Package"] = "new"
         r["FooBar"] = "Bogus"
@@ -202,13 +193,11 @@ class T(unittest.TestCase):
 
     def test_get_distro_release(self):
         """get_distro_release()"""
-
         self.assertEqual(self.crashes.get_distro_release(0), "FooLinux Pi/2")
 
     def test_status(self):
         """get_unfixed(), get_fixed_version(), duplicate_of(),
         close_duplicate()"""
-
         self.assertEqual(self.crashes.get_unfixed(), set([0, 1, 2, 3, 4]))
         self.assertEqual(self.crashes.get_fixed_version(0), None)
         self.assertEqual(self.crashes.get_fixed_version(1), None)
@@ -227,7 +216,6 @@ class T(unittest.TestCase):
 
     def test_mark_regression(self):
         """mark_regression()"""
-
         self.crashes.reports[3]["fixed_version"] = "4.1"
 
         self.crashes.mark_regression(4, 3)
@@ -244,7 +232,6 @@ class T(unittest.TestCase):
 
     def test_duplicate_db_fixed(self):
         """duplicate_db_fixed()"""
-
         self.crashes.init_duplicate_db(":memory:")
         self.assertEqual(self.crashes.check_duplicate(0), None)
 
@@ -262,7 +249,6 @@ class T(unittest.TestCase):
 
     def test_duplicate_db_remove(self):
         """duplicate_db_remove()"""
-
         # db not yet initialized
         self.assertRaises(AssertionError, self.crashes.check_duplicate, 0)
 
@@ -294,7 +280,6 @@ class T(unittest.TestCase):
 
     def test_check_duplicate(self):
         """check_duplicate() and known()"""
-
         # db not yet initialized
         self.assertRaises(
             AssertionError,
@@ -443,7 +428,6 @@ class T(unittest.TestCase):
 
     def test_check_duplicate_utf8(self):
         """check_duplicate() with UTF-8 strings"""
-
         # assertion failure, with UTF-8 strings
         r = apport.report.Report()
         r["Package"] = "bash 5"
@@ -469,7 +453,6 @@ class T(unittest.TestCase):
 
     def test_check_duplicate_custom_signature(self):
         """check_duplicate() with custom DuplicateSignature: field"""
-
         r = apport.report.Report()
         r["SourcePackage"] = "bash"
         r["Package"] = "bash 5"
@@ -505,7 +488,6 @@ class T(unittest.TestCase):
 
     def test_check_duplicate_report_arg(self):
         """check_duplicate() with explicitly passing report"""
-
         self.crashes.init_duplicate_db(":memory:")
 
         # ID#0 -> no dup
@@ -605,7 +587,6 @@ class T(unittest.TestCase):
 
     def test_known_address_sig(self):
         """known() for address signatures"""
-
         self.crashes.init_duplicate_db(":memory:")
 
         r = apport.report.Report()
@@ -743,7 +724,6 @@ class T(unittest.TestCase):
 
     def test_duplicate_db_publish_long_sigs(self):
         """duplicate_db_publish() with very long signatures"""
-
         self.crashes.init_duplicate_db(":memory:")
 
         # give #0 a long symbolic sig which needs lots of quoting
@@ -769,7 +749,6 @@ class T(unittest.TestCase):
 
     def test_change_master_id(self):
         """duplicate_db_change_master_id()"""
-
         # db not yet initialized
         self.assertRaises(AssertionError, self.crashes.check_duplicate, 0)
 
@@ -812,8 +791,7 @@ class T(unittest.TestCase):
         )
 
     def test_db_corruption(self):
-        """Detection of DB file corruption"""
-
+        """Detection of DB file corruption."""
         try:
             (fd, db) = tempfile.mkstemp()
             os.close(fd)

--- a/tests/unit/test_fileutils.py
+++ b/tests/unit/test_fileutils.py
@@ -9,7 +9,6 @@ import apport.packaging
 class T(unittest.TestCase):
     def test_likely_packaged(self):
         """likely_packaged()"""
-
         self.assertEqual(apport.fileutils.likely_packaged("/bin/bash"), True)
         self.assertEqual(
             apport.fileutils.likely_packaged("/usr/bin/foo"), True
@@ -28,7 +27,6 @@ class T(unittest.TestCase):
 
     def test_get_recent_crashes(self):
         """get_recent_crashes()"""
-
         # incomplete fields
         r = io.BytesIO(b"""ProblemType: Crash""")
         self.assertEqual(apport.fileutils.get_recent_crashes(r), 0)
@@ -62,7 +60,6 @@ class T(unittest.TestCase):
 
     def test_get_dbus_socket(self):
         """get_dbus_socket()"""
-
         tests = [
             ("unix:path=/run/user/1000/bus", "/run/user/1000/bus"),
             ("unix:path=/run/user/1000/bus;unix:path=/run/user/0/bus", None),
@@ -80,7 +77,6 @@ class T(unittest.TestCase):
 
     def test_get_starttime(self):
         """get_starttime()"""
-
         template = (
             "2022799 (%s) S 1834041 2022799 2022799 34820 "
             "2022806 4194304 692 479 0 0 2 0 0 0 20 0 1 0 "
@@ -109,7 +105,6 @@ class T(unittest.TestCase):
 
     def test_get_uid_and_gid(self):
         """get_uid_and_gid()"""
-
         # Python 3's open uses universal newlines, which means all
         # line endings get replaced with \n, so we don't need to test
         # different line ending combinations

--- a/tests/unit/test_hookutils.py
+++ b/tests/unit/test_hookutils.py
@@ -20,7 +20,6 @@ class T(unittest.TestCase):
 
     def test_dmesg_overwrite(self):
         """attach_dmesg() does not overwrite already existing data"""
-
         report = {"CurrentDmesg": "existingcurrent"}
 
         apport.hookutils.attach_dmesg(report)
@@ -71,8 +70,7 @@ class T(unittest.TestCase):
         )
 
     def test_path_to_key(self):
-        """transforming a file path to a valid report key"""
-
+        """Transform a file path to a valid report key."""
         self.assertEqual(
             apport.hookutils.path_to_key("simple.txt"), "simple.txt"
         )

--- a/tests/unit/test_parse_segv.py
+++ b/tests/unit/test_parse_segv.py
@@ -133,11 +133,10 @@ DISASM = """\
 
 
 class T(unittest.TestCase):
-    """Test Segfault Parser"""
+    """Test Segfault Parser."""
 
     def test_invalid_00_registers(self):
-        """Require valid registers"""
-
+        """Require valid registers."""
         regs = "a 0x10\nb !!!\n"
         self.assertRaises(ValueError, parse_segv.ParseSegv, regs, "", "")
         try:
@@ -154,7 +153,7 @@ class T(unittest.TestCase):
         self.assertRaises(ValueError, segv.parse_disassembly, "")
 
     def test_invalid_01_disassembly(self):
-        """Require valid disassembly"""
+        """Require valid disassembly."""
         regs = "a 0x10"
 
         disasm = ""
@@ -267,8 +266,7 @@ class T(unittest.TestCase):
         self.assertEqual(segv.dest, "(%esp)", segv.dest)
 
     def test_ioport_operation(self):
-        """I/O port violations"""
-
+        """I/O port violations."""
         regs = "rax            0x3  3"
         disasm = (
             "0x4087f1 <snd_pcm_hw_params_set_channels_near@plt+19345>:\n"
@@ -295,7 +293,7 @@ class T(unittest.TestCase):
         )
 
     def test_invalid_02_maps(self):
-        """Require valid maps"""
+        """Require valid maps."""
         regs = "a 0x10"
         disasm = "Dump ...\n0x08083540 <main+0>:    lea    0x4(%esp),%ecx\n"
 
@@ -325,8 +323,7 @@ class T(unittest.TestCase):
         self.assertEqual(segv.maps[2]["name"], None, segv)
 
     def test_debug(self):
-        """Debug mode works"""
-
+        """Debug mode works."""
         regs = "a 0x10"
         disasm = "Dump ...\n0x08083540 <main+0>:    lea    0x4(%esp),%ecx\n"
         maps = (
@@ -340,8 +337,7 @@ class T(unittest.TestCase):
         self.assertTrue(segv is not None, segv)
 
     def test_register_values(self):
-        """Sub-register parsing"""
-
+        """Sub-register parsing."""
         disasm = """0x08083540 <main+0>:    mov    $1,%ecx"""
         segv = parse_segv.ParseSegv(REGS64, disasm, "")
 
@@ -355,8 +351,7 @@ class T(unittest.TestCase):
         self.assertEqual(val, 0x80, hex(val))
 
     def test_segv_unknown(self):
-        """Handles unknown segfaults"""
-
+        """Handle unknown segfaults."""
         disasm = """0x08083540 <main+0>:    mov    $1,%ecx"""
         segv = parse_segv.ParseSegv(REGS, disasm, MAPS)
         understood, _, details = segv.report()
@@ -402,8 +397,7 @@ class T(unittest.TestCase):
         )
 
     def test_segv_pc_missing(self):
-        """Handles PC in missing VMA"""
-
+        """Handle PC in missing VMA."""
         disasm = """0x00083540 <main+0>:    lea    0x4(%esp),%ecx"""
         segv = parse_segv.ParseSegv(REGS, disasm, MAPS)
         understood, reason, details = segv.report()
@@ -423,8 +417,7 @@ class T(unittest.TestCase):
         self.assertIn("executing unknown VMA", reason)
 
     def test_segv_pc_null(self):
-        """Handles PC in NULL VMA"""
-
+        """Handle PC in NULL VMA."""
         disasm = """0x00000540 <main+0>:    lea    0x4(%esp),%ecx"""
         segv = parse_segv.ParseSegv(REGS, disasm, MAPS)
         understood, reason, details = segv.report()
@@ -435,8 +428,7 @@ class T(unittest.TestCase):
         self.assertIn("executing NULL VMA", reason)
 
     def test_segv_pc_nx_writable(self):
-        """Handles PC in writable NX VMA"""
-
+        """Handle PC in writable NX VMA."""
         disasm = """0x005a3000 <main+0>:    lea    0x4(%esp),%ecx"""
         segv = parse_segv.ParseSegv(REGS, disasm, MAPS)
         understood, reason, details = segv.report()
@@ -445,8 +437,7 @@ class T(unittest.TestCase):
         self.assertIn("executing writable VMA /lib/libncurses.so.5.7", reason)
 
     def test_segv_pc_nx_unwritable(self):
-        """Handles PC in non-writable NX VMA"""
-
+        """Handle PC in non-writable NX VMA."""
         disasm = """0x00dfb000 <main+0>:    lea    0x4(%esp),%ecx"""
         segv = parse_segv.ParseSegv(REGS, disasm, MAPS)
         understood, reason, details = segv.report()
@@ -457,8 +448,7 @@ class T(unittest.TestCase):
         )
 
     def test_segv_src_missing(self):
-        """Handles source in missing VMA"""
-
+        """Handle source in missing VMA."""
         reg = REGS + "ecx            0x0006af24   0xbfc6af24"
         disasm = "0x08083547 <main+7>:    pushl  -0x4(%ecx)"
 
@@ -485,8 +475,7 @@ class T(unittest.TestCase):
         self.assertIn("reading unknown VMA", reason)
 
     def test_segv_src_null(self):
-        """Handles source in NULL VMA"""
-
+        """Handle source in NULL VMA."""
         reg = REGS + "ecx            0x00000024   0xbfc6af24"
         disasm = "0x08083547 <main+7>:    pushl  -0x4(%ecx)"
 
@@ -501,8 +490,7 @@ class T(unittest.TestCase):
         self.assertIn("reading NULL VMA", reason)
 
     def test_segv_src_not_readable(self):
-        """Handles source not in readable VMA"""
-
+        """Handle source not in readable VMA."""
         reg = REGS + "ecx            0x0026c080   0xbfc6af24"
         disasm = "0x08083547 <main+7>:    pushl  -0x4(%ecx)"
         segv = parse_segv.ParseSegv(reg, disasm, MAPS)
@@ -517,8 +505,7 @@ class T(unittest.TestCase):
         self.assertNotIn("Stack pointer not within stack segment", details)
 
     def test_segv_dest_missing(self):
-        """Handles destintation in missing VMA"""
-
+        """Handle destintation in missing VMA."""
         reg = REGS + "esp            0x0006af24   0xbfc6af24"
         disasm = "0x08083547 <main+7>:    pushl  -0x4(%ecx)"
 
@@ -533,8 +520,7 @@ class T(unittest.TestCase):
         self.assertIn("writing unknown VMA", reason)
 
     def test_segv_dest_null(self):
-        """Handles destintation in NULL VMA"""
-
+        """Handle destintation in NULL VMA."""
         reg = REGS + "esp            0x00000024   0xbfc6af24"
         disasm = "0x08083547 <main+7>:    pushl  -0x4(%ecx)"
 
@@ -549,8 +535,7 @@ class T(unittest.TestCase):
         self.assertIn("writing NULL VMA", reason)
 
     def test_segv_dest_not_writable(self):
-        """Handles destination not in writable VMA"""
-
+        """Handle destination not in writable VMA."""
         reg = REGS + "esp            0x08048080   0xbfc6af24"
         disasm = "0x08083547 <main+7>:    pushl  -0x4(%ecx)"
         segv = parse_segv.ParseSegv(reg, disasm, MAPS)
@@ -563,8 +548,7 @@ class T(unittest.TestCase):
         self.assertIn("writing VMA /usr/bin/gdb", reason)
 
     def test_segv_crackful_disasm(self):
-        """Rejects insane disassemblies"""
-
+        """Reject insane disassemblies."""
         disasm = "0x08083547 <main+7>:    pushl  -0x4(blah)"
         segv = parse_segv.ParseSegv(REGS, disasm, MAPS)
         self.assertRaises(ValueError, segv.report)
@@ -574,8 +558,7 @@ class T(unittest.TestCase):
         self.assertRaises(ValueError, segv.report)
 
     def test_segv_stack_failure(self):
-        """Handles walking off the stack"""
-
+        """Handle walking off the stack."""
         # Triggered via "push"
         reg = REGS + "esp            0xbfc56ff0   0xbfc56ff0"
         disasm = "0x08083547 <main+7>:    push  %eax"
@@ -615,8 +598,7 @@ class T(unittest.TestCase):
         self.assertIn("Stack pointer not within stack segment", details)
 
     def test_segv_stack_kernel_segfault(self):
-        """Handles unknown segfaults in kernel"""
-
+        """Handle unknown segfaults in kernel."""
         # Crash in valid code path
         disasm = """0x0056e010: ret"""
         segv = parse_segv.ParseSegv(REGS, disasm, MAPS)

--- a/tests/unit/test_problem_report.py
+++ b/tests/unit/test_problem_report.py
@@ -12,8 +12,7 @@ bin_data = b"ABABABABAB\0\0\0Z\x01\x02"
 
 class T(unittest.TestCase):
     def test_basic_operations(self):
-        """basic creation and operation."""
-
+        """Basic creation and operation."""
         pr = problem_report.ProblemReport()
         pr["foo"] = "bar"
         pr["bar"] = " foo   bar\nbaz\n   blip  "
@@ -35,7 +34,6 @@ class T(unittest.TestCase):
 
     def test_ctor_arguments(self):
         """non-default constructor arguments."""
-
         pr = problem_report.ProblemReport("KernelCrash")
         self.assertEqual(pr["ProblemType"], "KernelCrash")
         pr = problem_report.ProblemReport(date="19801224 12:34")
@@ -69,8 +67,7 @@ class T(unittest.TestCase):
         self.assertEqual(pr.get_timestamp(), None)
 
     def test_sanity_checks(self):
-        """various error conditions."""
-
+        """Various error conditions."""
         pr = problem_report.ProblemReport()
         self.assertRaises(ValueError, pr.__setitem__, "a b", "1")
         self.assertRaises(TypeError, pr.__setitem__, "a", 1)
@@ -89,7 +86,6 @@ class T(unittest.TestCase):
 
     def test_write(self):
         """write() and proper formatting."""
-
         pr = problem_report.ProblemReport(date="now!")
         pr["Simple"] = "bar"
         pr["SimpleUTF8"] = "1äö2Φ3".encode("UTF-8")
@@ -126,7 +122,6 @@ class T(unittest.TestCase):
 
     def test_load(self):
         """load() with various formatting."""
-
         report = textwrap.dedent(
             f"""\
             ProblemType: Crash
@@ -211,8 +206,7 @@ class T(unittest.TestCase):
         self.assertEqual(list(pr.keys()), ["ProblemType"])
 
     def test_write_fileobj(self):
-        """writing a report with a pointer to a file-like object."""
-
+        """Write a report with a pointer to a file-like object."""
         tempbin = io.BytesIO(bin_data)
         tempasc = io.BytesIO(b"Hello World")
 
@@ -229,9 +223,8 @@ class T(unittest.TestCase):
         self.assertEqual(pr["AscFile"], tempasc.getvalue().decode())
 
     def test_write_empty_fileobj(self):
-        """writing a report with a pointer to a file-like object with
+        """Write a report with a pointer to a file-like object with
         enforcing non-emptyness."""
-
         tempbin = io.BytesIO(b"")
         tempasc = io.BytesIO(b"")
 
@@ -246,8 +239,7 @@ class T(unittest.TestCase):
         self.assertRaises(OSError, pr.write, out)
 
     def test_read_file(self):
-        """reading a report with binary data."""
-
+        """Read a report with binary data."""
         bin_report = textwrap.dedent(
             """\
             ProblemType: Crash
@@ -279,9 +271,8 @@ class T(unittest.TestCase):
         self.assertEqual(pr["File"].get_value(), bin_data)
 
     def test_read_file_legacy(self):
-        """reading a report with binary data in legacy format without gzip
+        """Read a report with binary data in legacy format without gzip
         header."""
-
         bin_report = textwrap.dedent(
             """\
             ProblemType: Crash
@@ -318,7 +309,6 @@ class T(unittest.TestCase):
 
     def test_iter(self):
         """problem_report.ProblemReport iteration."""
-
         pr = problem_report.ProblemReport()
         pr["foo"] = "bar"
 
@@ -332,7 +322,6 @@ class T(unittest.TestCase):
 
     def test_modify(self):
         """reading, modifying fields, and writing back."""
-
         report = textwrap.dedent(
             """\
             ProblemType: Crash
@@ -381,7 +370,6 @@ class T(unittest.TestCase):
 
     def test_write_mime_text(self):
         """write_mime() for text values."""
-
         pr = problem_report.ProblemReport(date="now!")
         pr["Simple"] = "bar"
         pr["SimpleUTF8"] = "1äö2Φ3".encode("UTF-8")
@@ -487,7 +475,6 @@ class T(unittest.TestCase):
 
     def test_write_mime_extra_headers(self):
         """write_mime() with extra headers."""
-
         pr = problem_report.ProblemReport(date="now!")
         pr["Simple"] = "bar"
         pr["TwoLine"] = "first\nsecond\n"
@@ -514,7 +501,6 @@ class T(unittest.TestCase):
 
     def test_write_mime_order(self):
         """write_mime() with keys ordered."""
-
         pr = problem_report.ProblemReport(date="now!")
         pr["SecondText"] = "What"
         pr["FirstText"] = "Who"
@@ -562,7 +548,6 @@ class T(unittest.TestCase):
 
     def test_updating(self):
         """new_keys() and write() with only_new=True."""
-
         pr = problem_report.ProblemReport()
         self.assertEqual(pr.new_keys(), set(["ProblemType", "Date"]))
         pr.load(
@@ -589,8 +574,7 @@ class T(unittest.TestCase):
         self.assertEqual(out.getvalue(), b"NewKey: new new\n")
 
     def test_import_dict(self):
-        """importing a dictionary with update()."""
-
+        """Import a dictionary with update()."""
         pr = problem_report.ProblemReport()
         pr["oldtext"] = "Hello world"
         pr["oldbin"] = bin_data
@@ -609,8 +593,7 @@ class T(unittest.TestCase):
         self.assertEqual(pr["overwrite"], "I am good")
 
     def test_load_key_filter(self):
-        """load a report with filtering keys."""
-
+        """Load a report with filtering keys."""
         report = textwrap.dedent(
             """\
             ProblemType: Crash

--- a/tests/unit/test_report.py
+++ b/tests/unit/test_report.py
@@ -844,7 +844,7 @@ CR2: 00000000ffffb4ff
         )
 
     def test_nonascii_data(self):
-        """methods get along with non-ASCII data"""
+        """Methods get along with non-ASCII data."""
         # fake os.uname() into reporting a non-ASCII name
         uname = os.uname()
         uname = (

--- a/tests/unit/test_rethread.py
+++ b/tests/unit/test_rethread.py
@@ -18,7 +18,7 @@ def div(x, y):
 
 class T(unittest.TestCase):
     def test_return_value(self):
-        """return value works properly."""
+        """Return value works properly."""
         t = apport.REThread.REThread(target=div, args=(42, 2))
         t.start()
         t.join()
@@ -38,7 +38,7 @@ class T(unittest.TestCase):
         self.assertEqual(t.exc_info(), None)
 
     def test_exception(self):
-        """exception in thread is caught and passed."""
+        """Exception in thread is caught and passed."""
         t = apport.REThread.REThread(target=div, args=(1, 0))
         t.start()
         t.join()
@@ -72,7 +72,7 @@ class T(unittest.TestCase):
         self.assertTrue(raised)
 
     def test_exc_raise_complex(self):
-        """exceptions that can't be simply created are reraised correctly
+        """Exceptions that can't be simply created are reraised correctly.
 
         A unicode error takes several arguments on construction, so trying to
         recreate it by just passing an instance to the class, as the Python 3


### PR DESCRIPTION
`pydocstyle` ignores test files by default. Address the pydocstyle complains in the test files that are easy to address. Leave the more time consuming ones for later.