### PR TITLE
apport-cli: Fix AttributeError: 'bytes' object has no attribute 'fileno'

### DIFF
--- a/bin/apport-cli
+++ b/bin/apport-cli
@@ -180,14 +180,15 @@ class CLIUserInterface(apport.ui.UserInterface):
 
         return details
 
-    def ui_update_view(self):
+    def ui_update_view(self, stdout=None):
         self.in_update_view = True
         report = self._get_details()
         try:
             subprocess.run(
                 ["/usr/bin/sensible-pager"],
                 check=False,
-                stdin=report.encode("UTF-8"),
+                input=report.encode("UTF-8"),
+                stdout=stdout,
             )
         except OSError as error:
             # ignore broken pipe (premature quit)

--- a/tests/integration/test_ui_cli.py
+++ b/tests/integration/test_ui_cli.py
@@ -1,0 +1,69 @@
+# Copyright (C) 2022 Canonical Ltd.
+# Author: Benjamin Drung <benjamin.drung@canonical.com>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 2 of the License, or (at your
+# option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
+# the full text of the license.
+
+"""Command line Apport user interface tests."""
+
+import os
+import sys
+import unittest
+
+import apport.report
+from tests.helper import import_module_from_file, skip_if_command_is_missing
+from tests.paths import is_local_source_directory, local_test_environment
+
+if is_local_source_directory():
+    apport_cli_path = "bin/apport-cli"
+else:
+    apport_cli_path = os.path.join(
+        os.environ.get("APPORT_DATA_DIR", "/usr/share/apport"), "apport-cli"
+    )
+apport_cli = import_module_from_file(apport_cli_path)
+
+
+class TestApportCli(unittest.TestCase):
+    """Test apport-cli."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.orig_environ = os.environ.copy()
+        os.environ |= local_test_environment()
+
+    @classmethod
+    def tearDownClass(cls):
+        os.environ.clear()
+        os.environ.update(cls.orig_environ)
+
+    def setUp(self):
+        saved = sys.argv
+        sys.argv = [apport_cli_path]
+        self.app = apport_cli.CLIUserInterface()
+        sys.argv = saved
+
+        self.app.report = apport.report.Report()
+        self.app.report.add_os_info()
+        self.app.report["ExecutablePath"] = "/bin/bash"
+        self.app.report["Signal"] = "11"
+        self.app.report["CoreDump"] = b"\x01\x02"
+
+    @skip_if_command_is_missing("/usr/bin/sensible-pager")
+    def test_ui_update_view(self):
+        read_fd, write_fd = os.pipe()
+        with os.fdopen(write_fd, "w", buffering=1) as stdout:
+            self.app.ui_update_view(stdout=stdout)
+        with os.fdopen(read_fd, "r") as pipe:
+            report = pipe.read()
+        self.assertIn(
+            "== ExecutablePath =================================\n"
+            "/bin/bash\n\n"
+            "== ProblemType =================================\n"
+            "Crash\n\n"
+            "== Signal =================================\n"
+            "11\n\n",
+            report,
+        )


### PR DESCRIPTION
apport-cli fails when viewing the crash report:

```
Traceback (most recent call last):
  File "bin/apport-cli", line 187, in ui_update_view
    subprocess.run(
  File "/usr/lib/python3.10/subprocess.py", line 501, in run
    with Popen(*popenargs, **kwargs) as process:
  File "/usr/lib/python3.10/subprocess.py", line 835, in __init__
    errread, errwrite) = self._get_handles(stdin, stdout, stderr)
  File "/usr/lib/python3.10/subprocess.py", line 1606, in _get_handles
    p2cread = stdin.fileno()
AttributeError: 'bytes' object has no attribute 'fileno'
```

The `stdin` parameter for `subprocess.run` must be an existing file descriptor or an existing file object with a valid file descriptor. Use the `input` for byte sequences.

Bug: https://launchpad.net/bugs/1991200
Fixes: 9340a43dd934 ("Use subprocess.run instead of subprocess.Popen")