### PR TITLE
Fix mypy for 'suppress' in apport/ui.py

### DIFF
--- a/apport/ui.py
+++ b/apport/ui.py
@@ -968,7 +968,7 @@ class UserInterface:
         if len(sys.argv) > 0 and cmd.endswith("-bug"):
             suppress = argparse.SUPPRESS
         else:
-            suppress = False
+            suppress = None
 
         parser = argparse.ArgumentParser(
             usage=_(


### PR DESCRIPTION
mypy complains:

```
apport/ui.py:971: error: Incompatible types in assignment (expression has type "bool", variable has type "Union[_SUPPRESS_T, str]")
```

The `help` parameter for `add_argument` takes `Optional[Text]`. Therefore set `suppress` to `None` if the help should not be suppressed.