### PR TITLE
Pass around command line arguments to ease testing

### DIFF
--- a/bin/apport-cli
+++ b/bin/apport-cli
@@ -144,8 +144,8 @@ class CLIProgressDialog(CLIDialog):
 class CLIUserInterface(apport.ui.UserInterface):
     """Command line Apport user interface"""
 
-    def __init__(self):
-        apport.ui.UserInterface.__init__(self)
+    def __init__(self, argv: list[str]):
+        apport.ui.UserInterface.__init__(self, argv)
         self.in_update_view = False
         self.progress = None
 
@@ -439,6 +439,6 @@ class CLIUserInterface(apport.ui.UserInterface):
 
 
 if __name__ == "__main__":
-    app = CLIUserInterface()
+    app = CLIUserInterface(sys.argv)
     if not app.run_argv():
         print(_("No pending crash reports. Try --help for more information."))

--- a/gtk/apport-gtk
+++ b/gtk/apport-gtk
@@ -56,15 +56,15 @@ class GTKUserInterface(apport.ui.UserInterface):
 
         return self.widgets.get_object(widget)
 
-    def __init__(self):
-        apport.ui.UserInterface.__init__(self)
+    def __init__(self, argv: list[str]):
+        apport.ui.UserInterface.__init__(self, argv)
 
         # load UI
         Gtk.Window.set_default_icon_name("apport")
         self.widgets = Gtk.Builder()
         self.widgets.set_translation_domain(self.gettext_domain)
         self.widgets.add_from_file(
-            os.path.join(os.path.dirname(sys.argv[0]), "apport-gtk.ui")
+            os.path.join(os.path.dirname(argv[0]), "apport-gtk.ui")
         )
 
         # connect signal handlers
@@ -79,6 +79,7 @@ class GTKUserInterface(apport.ui.UserInterface):
             self.w("details_overlay")
         )
 
+        self.argv = argv
         self.md = None
 
         self.desktop_info = None
@@ -411,7 +412,7 @@ class GTKUserInterface(apport.ui.UserInterface):
         d.show()
         # don't steal focus when being called without arguments (i. e.
         # automatically launched)
-        if len(sys.argv) == 1:
+        if len(self.argv) == 1:
             d.set_focus_on_map(False)
 
         return_value = {
@@ -699,5 +700,5 @@ if __name__ == "__main__":
             "This program needs a running X session. Please see"
             ' "man apport-cli" for a command line version of Apport.'
         )
-    app = GTKUserInterface()
+    app = GTKUserInterface(sys.argv)
     app.run_argv()

--- a/kde/apport-kde
+++ b/kde/apport-kde
@@ -75,10 +75,10 @@ uic.properties.Properties._string = translate
 class Dialog(QDialog):
     """Main dialog wrapper"""
 
-    def __init__(self, ui, title, heading, text):
+    def __init__(self, ui_data_path, ui, title, heading, text):
         QDialog.__init__(self, None, Qt.Window)
 
-        uic.loadUi(os.path.join(os.path.dirname(sys.argv[0]), ui), self)
+        uic.loadUi(os.path.join(ui_data_path, ui), self)
 
         self.setWindowTitle(title)
         if self.findChild(QLabel, "heading"):
@@ -98,8 +98,8 @@ class Dialog(QDialog):
 class ChoicesDialog(Dialog):
     """Choices dialog wrapper"""
 
-    def __init__(self, title, text):
-        Dialog.__init__(self, "choices.ui", title, None, text)
+    def __init__(self, ui_data_path, title, text):
+        Dialog.__init__(self, ui_data_path, "choices.ui", title, None, text)
 
         self.setMaximumSize(1, 1)
 
@@ -112,8 +112,10 @@ class ChoicesDialog(Dialog):
 class ProgressDialog(Dialog):
     """Progress dialog wrapper"""
 
-    def __init__(self, title, heading, text):
-        Dialog.__init__(self, "progress.ui", title, heading, text)
+    def __init__(self, ui_data_path, title, heading, text):
+        Dialog.__init__(
+            self, ui_data_path, "progress.ui", title, heading, text
+        )
 
         self.setMaximumSize(1, 1)
 
@@ -140,7 +142,9 @@ class ReportDialog(Dialog):
         if "DistroRelease" not in report:
             report.add_os_info()
         distro = report["DistroRelease"]
-        Dialog.__init__(self, "bugreport.ui", distro.split()[0], "", "")
+        Dialog.__init__(
+            self, ui.ui_data_path, "bugreport.ui", distro.split()[0], "", ""
+        )
         self.details = self.findChild(QPushButton, "show_details")
         self.details.clicked.connect(self.on_show_details_clicked)
         self.continue_button = self.findChild(QPushButton, "continue_button")
@@ -166,7 +170,7 @@ class ReportDialog(Dialog):
         self.spinner = QLabel("", parent=self.treeview)
         self.spinner.setGeometry(0, 0, 32, 32)
         self.movie = QMovie(
-            os.path.join(os.path.dirname(sys.argv[0]), "spinner.gif"),
+            os.path.join(ui.ui_data_path, "spinner.gif"),
             QByteArray(),
             self.spinner,
         )
@@ -346,8 +350,8 @@ class ReportDialog(Dialog):
 class UserPassDialog(Dialog):
     """Username/Password dialog wrapper"""
 
-    def __init__(self, title, text):
-        Dialog.__init__(self, "userpass.ui", title, None, text)
+    def __init__(self, ui_data_path, title, text):
+        Dialog.__init__(self, ui_data_path, "userpass.ui", title, None, text)
         self.findChild(QLabel, "l_username").setText(_("Username:"))
         self.findChild(QLabel, "l_password").setText(_("Password:"))
 
@@ -360,8 +364,9 @@ class UserPassDialog(Dialog):
 class MainUserInterface(apport.ui.UserInterface):
     """The main user interface presented to the user"""
 
-    def __init__(self):
-        apport.ui.UserInterface.__init__(self)
+    def __init__(self, argv: list[str]):
+        apport.ui.UserInterface.__init__(self, argv)
+        self.ui_data_path = os.path.dirname(argv[0])
         # Help unit tests get at the dialog.
         self.dialog = None
         self.progress = None
@@ -452,6 +457,7 @@ class MainUserInterface(apport.ui.UserInterface):
         elif self.crashdb.accepts(self.report):
             # show a progress dialog if our DB accepts the crash
             self.progress = ProgressDialog(
+                self.ui_data_path,
                 _("Collecting Problem Information"),
                 _("Collecting problem information"),
                 _(
@@ -500,6 +506,7 @@ class MainUserInterface(apport.ui.UserInterface):
 
     def ui_start_upload_progress(self):
         self.progress = ProgressDialog(
+            self.ui_data_path,
             _("Uploading Problem Information"),
             _("Uploading problem information"),
             _(
@@ -542,7 +549,7 @@ class MainUserInterface(apport.ui.UserInterface):
         Return list of selected option indexes, or None if the user cancelled.
         If multiple is False, the list will always have one element.
         """
-        dialog = ChoicesDialog(_("Apport"), text)
+        dialog = ChoicesDialog(self.ui_data_path, _("Apport"), text)
 
         b = None
         for option in options:
@@ -594,5 +601,5 @@ if __name__ == "__main__":
     )
     app.installTranslator(translator)
 
-    UserInterface = MainUserInterface()
+    UserInterface = MainUserInterface(sys.argv)
     sys.exit(UserInterface.run_argv())

--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -12,6 +12,7 @@ import sys
 import tempfile
 import textwrap
 import time
+import typing
 import unittest
 import unittest.mock
 
@@ -34,7 +35,7 @@ logind_session = apport.Report.get_logind_session(os.getpid())
 class TestSuiteUserInterface(apport.ui.UserInterface):
     """Concrete apport.ui.UserInterface suitable for automatic testing"""
 
-    def __init__(self):
+    def __init__(self, argv: typing.Optional[list[str]] = None):
         # use our dummy crashdb
         # closed in __del__, pylint: disable=consider-using-with
         self.crashdb_conf = tempfile.NamedTemporaryFile()
@@ -59,7 +60,9 @@ class TestSuiteUserInterface(apport.ui.UserInterface):
 
         os.environ["APPORT_CRASHDB_CONF"] = self.crashdb_conf.name
 
-        apport.ui.UserInterface.__init__(self)
+        if argv is None:
+            argv = ["ui-test"]
+        apport.ui.UserInterface.__init__(self, argv)
 
         self.crashdb = apport.crashdb_impl.memory.CrashDatabase(
             None, {"dummy_data": 1, "dupdb_url": ""}
@@ -197,9 +200,6 @@ class T(unittest.TestCase):
         )
         os.mknod(apport.report._ignore_file)
 
-        # need to do this to not break ui's ctor
-        self.orig_argv = sys.argv
-        sys.argv = ["ui-test"]
         self.ui = TestSuiteUserInterface()
 
         # demo report
@@ -236,7 +236,6 @@ class T(unittest.TestCase):
         self.report_file.flush()
 
     def tearDown(self):
-        sys.argv = self.orig_argv
         apport.fileutils.report_dir = self.orig_report_dir
         self.orig_report_dir = None
         apport.ui.symptom_script_dir = self.orig_symptom_script_dir
@@ -605,23 +604,20 @@ class T(unittest.TestCase):
 
     def test_run_report_bug_noargs(self):
         """run_report_bug() without specifying arguments"""
-        sys.argv = ["ui-test", "-f"]
-        self.ui = TestSuiteUserInterface()
+        self.ui = TestSuiteUserInterface(["ui-test", "-f"])
         self.assertEqual(self.ui.run_argv(), False)
         self.assertEqual(self.ui.msg_severity, "error")
 
     @unittest.mock.patch("sys.stdout", new_callable=io.StringIO)
     def test_run_version(self, stdout_mock):
         """run_report_bug() as "ubuntu-bug" with version argument"""
-        sys.argv = ["ubuntu-bug", "-v"]
-        self.ui = TestSuiteUserInterface()
+        self.ui = TestSuiteUserInterface(["ubuntu-bug", "-v"])
         self.assertEqual(self.ui.run_argv(), True)
         self.assertEqual(stdout_mock.getvalue(), apport.ui.__version__ + "\n")
 
     def test_run_report_bug_package(self):
         """run_report_bug() for a package"""
-        sys.argv = ["ui-test", "-f", "-p", "bash"]
-        self.ui = TestSuiteUserInterface()
+        self.ui = TestSuiteUserInterface(["ui-test", "-f", "-p", "bash"])
         self.ui.present_details_response = {
             "report": True,
             "blacklist": False,
@@ -646,8 +642,8 @@ class T(unittest.TestCase):
         self.assertEqual(self.ui.report["ProblemType"], "Bug")
 
         # should not crash on nonexisting package
-        sys.argv = ["ui-test", "-f", "-p", "nonexisting_gibberish"]
-        self.ui = TestSuiteUserInterface()
+        argv = ["ui-test", "-f", "-p", "nonexisting_gibberish"]
+        self.ui = TestSuiteUserInterface(argv)
         try:
             self.ui.run_argv()
         except SystemExit:
@@ -666,8 +662,8 @@ class T(unittest.TestCase):
 
         try:
             # report a bug on text executable process
-            sys.argv = ["ui-test", "-f", "--tag", "foo", "-P", str(pid)]
-            self.ui = TestSuiteUserInterface()
+            argv = ["ui-test", "-f", "--tag", "foo", "-P", str(pid)]
+            self.ui = TestSuiteUserInterface(argv)
             self.ui.present_details_response = {
                 "report": True,
                 "blacklist": False,
@@ -721,8 +717,7 @@ class T(unittest.TestCase):
         # silently ignore missing PID; this happens when the user closes
         # the application prematurely
         pid = self._find_unused_pid()
-        sys.argv = ["ui-test", "-f", "-P", str(pid)]
-        self.ui = TestSuiteUserInterface()
+        self.ui = TestSuiteUserInterface(["ui-test", "-f", "-P", str(pid)])
         self.ui.run_argv()
 
     def test_run_report_bug_noperm_pid(self):
@@ -734,8 +729,7 @@ class T(unittest.TestCase):
             restore_root = True
 
         try:
-            sys.argv = ["ui-test", "-f", "-P", "1"]
-            self.ui = TestSuiteUserInterface()
+            self.ui = TestSuiteUserInterface(["ui-test", "-f", "-P", "1"])
             self.ui.run_argv()
 
             self.assertEqual(self.ui.msg_severity, "error")
@@ -761,8 +755,7 @@ class T(unittest.TestCase):
         time.sleep(0.2)
 
         try:
-            sys.argv = ["ui-test", "-f", "-P", str(pid)]
-            self.ui = TestSuiteUserInterface()
+            self.ui = TestSuiteUserInterface(["ui-test", "-f", "-P", str(pid)])
             self.assertRaises(SystemExit, self.ui.run_argv)
         finally:
             os.kill(pid, signal.SIGKILL)
@@ -788,8 +781,7 @@ class T(unittest.TestCase):
         else:
             self.skipTest("no kernel thread found")
 
-        sys.argv = ["ui-test", "-f", "-P", str(pid)]
-        self.ui = TestSuiteUserInterface()
+        self.ui = TestSuiteUserInterface(["ui-test", "-f", "-P", str(pid)])
         self.ui.present_details_response = {
             "report": True,
             "blacklist": False,
@@ -812,8 +804,8 @@ class T(unittest.TestCase):
         os.mkdir(d)
         reportfile = os.path.join(d, "bashisbad.apport")
 
-        sys.argv = ["ui-test", "-f", "-p", "bash", "--save", reportfile]
-        self.ui = TestSuiteUserInterface()
+        argv = ["ui-test", "-f", "-p", "bash", "--save", reportfile]
+        self.ui = TestSuiteUserInterface(argv)
         self.assertEqual(self.ui.run_argv(), True)
 
         self.assertEqual(self.ui.msg_severity, None)
@@ -833,8 +825,7 @@ class T(unittest.TestCase):
         self.assertEqual(r["ProblemType"], "Bug")
 
         # report it
-        sys.argv = ["ui-test", "-c", reportfile]
-        self.ui = TestSuiteUserInterface()
+        self.ui = TestSuiteUserInterface(["ui-test", "-c", reportfile])
         self.ui.present_details_response = {
             "report": True,
             "blacklist": False,
@@ -1058,8 +1049,8 @@ class T(unittest.TestCase):
         self.report["Package"] = "bash"
         self.update_report_file()
 
-        sys.argv = ["ui-test", "-c", self.report_file.name]
-        self.ui = TestSuiteUserInterface()
+        argv = ["ui-test", "-c", self.report_file.name]
+        self.ui = TestSuiteUserInterface(argv)
         self.ui.present_details_response = {
             "report": True,
             "blacklist": False,
@@ -1081,8 +1072,8 @@ class T(unittest.TestCase):
         )
         self.update_report_file()
 
-        sys.argv = ["ui-test", "-c", self.report_file.name]
-        self.ui = TestSuiteUserInterface()
+        argv = ["ui-test", "-c", self.report_file.name]
+        self.ui = TestSuiteUserInterface(argv)
         self.ui.present_details_response = {
             "report": True,
             "blacklist": False,
@@ -1100,8 +1091,8 @@ class T(unittest.TestCase):
         self.assertEqual(self.ui.msg_severity, "info")
 
         # should not die with an exception on an invalid name
-        sys.argv = ["ui-test", "-c", "/nonexisting.crash"]
-        self.ui = TestSuiteUserInterface()
+        argv = ["ui-test", "-c", "/nonexisting.crash"]
+        self.ui = TestSuiteUserInterface(argv)
         self.assertEqual(self.ui.run_argv(), True)
         self.assertEqual(self.ui.msg_severity, "error")
 
@@ -1911,8 +1902,7 @@ class T(unittest.TestCase):
 
     def test_run_update_report_nonexisting_package_from_bug(self):
         """run_update_report() on a nonexisting package (from bug)"""
-        sys.argv = ["ui-test", "-u", "1"]
-        self.ui = TestSuiteUserInterface()
+        self.ui = TestSuiteUserInterface(["ui-test", "-u", "1"])
 
         self.assertEqual(self.ui.run_argv(), False)
         self.assertIn("No additional information collected.", self.ui.msg_text)
@@ -1920,8 +1910,7 @@ class T(unittest.TestCase):
 
     def test_run_update_report_nonexisting_package_cli(self):
         """run_update_report() on a nonexisting package (CLI argument)"""
-        sys.argv = ["ui-test", "-u", "1", "-p", "bar"]
-        self.ui = TestSuiteUserInterface()
+        self.ui = TestSuiteUserInterface(["ui-test", "-u", "1", "-p", "bar"])
 
         self.assertEqual(self.ui.run_argv(), False)
         self.assertIn("No additional information collected.", self.ui.msg_text)
@@ -1929,8 +1918,7 @@ class T(unittest.TestCase):
 
     def test_run_update_report_existing_package_from_bug(self):
         """run_update_report() on an existing package (from bug)"""
-        sys.argv = ["ui-test", "-u", "1"]
-        self.ui = TestSuiteUserInterface()
+        self.ui = TestSuiteUserInterface(["ui-test", "-u", "1"])
         self.ui.present_details_response = {
             "report": True,
             "blacklist": False,
@@ -1955,8 +1943,8 @@ class T(unittest.TestCase):
     def test_run_update_report_existing_package_cli_tags(self):
         """run_update_report() on an existing package (CLI argument)
         with extra tag"""
-        sys.argv = ["ui-test", "-u", "1", "-p", "bash", "--tag", "foo"]
-        self.ui = TestSuiteUserInterface()
+        argv = ["ui-test", "-u", "1", "-p", "bash", "--tag", "foo"]
+        self.ui = TestSuiteUserInterface(argv)
         self.ui.present_details_response = {
             "report": True,
             "blacklist": False,
@@ -1979,8 +1967,7 @@ class T(unittest.TestCase):
 
     def test_run_update_report_existing_package_cli_cmdname(self):
         """run_update_report() on an existing package (-collect program)"""
-        sys.argv = ["apport-collect", "-p", "bash", "1"]
-        self.ui = TestSuiteUserInterface()
+        self.ui = TestSuiteUserInterface(["apport-collect", "-p", "bash", "1"])
         self.ui.present_details_response = {
             "report": True,
             "blacklist": False,
@@ -2002,8 +1989,7 @@ class T(unittest.TestCase):
 
     def test_run_update_report_noninstalled_but_hook(self):
         """run_update_report() on an uninstalled package with a source hook"""
-        sys.argv = ["ui-test", "-u", "1"]
-        self.ui = TestSuiteUserInterface()
+        self.ui = TestSuiteUserInterface(["ui-test", "-u", "1"])
         self.ui.present_details_response = {
             "report": True,
             "blacklist": False,
@@ -2036,8 +2022,8 @@ class T(unittest.TestCase):
         source_pkg = "shadow"
         self.assertRaises(ValueError, apport.packaging.get_version, source_pkg)
 
-        sys.argv = ["ui-test", "-p", source_pkg, "-u", "1"]
-        self.ui = TestSuiteUserInterface()
+        argv = ["ui-test", "-p", source_pkg, "-u", "1"]
+        self.ui = TestSuiteUserInterface(argv)
         self.ui.present_details_response = {
             "report": True,
             "blacklist": False,
@@ -2236,8 +2222,7 @@ class T(unittest.TestCase):
     def test_run_symptom(self, stderr_mock):
         """run_symptom()"""
         # unknown symptom
-        sys.argv = ["ui-test", "-s", "foobar"]
-        self.ui = TestSuiteUserInterface()
+        self.ui = TestSuiteUserInterface(["ui-test", "-s", "foobar"])
         self.ui.present_details_response = {
             "report": True,
             "blacklist": False,
@@ -2253,8 +2238,7 @@ class T(unittest.TestCase):
         self._write_symptom_script(
             "nopkg.py", "def run(report, ui):\n    pass\n"
         )
-        sys.argv = ["ui-test", "-s", "nopkg"]
-        self.ui = TestSuiteUserInterface()
+        self.ui = TestSuiteUserInterface(["ui-test", "-s", "nopkg"])
         stderr_mock.truncate(0)
         self.assertRaises(SystemExit, self.ui.run_argv)
         err = stderr_mock.getvalue()
@@ -2264,8 +2248,7 @@ class T(unittest.TestCase):
         self._write_symptom_script(
             "norun.py", "def something(x, y):\n    return 1\n"
         )
-        sys.argv = ["ui-test", "-s", "norun"]
-        self.ui = TestSuiteUserInterface()
+        self.ui = TestSuiteUserInterface(["ui-test", "-s", "norun"])
         stderr_mock.truncate(0)
         self.assertRaises(SystemExit, self.ui.run_argv)
         err = stderr_mock.getvalue()
@@ -2275,8 +2258,7 @@ class T(unittest.TestCase):
         self._write_symptom_script(
             "crash.py", "def run(report, ui):\n    return 1/0\n"
         )
-        sys.argv = ["ui-test", "-s", "crash"]
-        self.ui = TestSuiteUserInterface()
+        self.ui = TestSuiteUserInterface(["ui-test", "-s", "crash"])
         stderr_mock.truncate(0)
         self.assertRaises(SystemExit, self.ui.run_argv)
         err = stderr_mock.getvalue()
@@ -2290,8 +2272,7 @@ class T(unittest.TestCase):
             '  report["itch"] = "scratch"\n'
             '  return "bash"\n',
         )
-        sys.argv = ["ui-test", "-s", "itching"]
-        self.ui = TestSuiteUserInterface()
+        self.ui = TestSuiteUserInterface(["ui-test", "-s", "itching"])
         self.ui.present_details_response = {
             "report": True,
             "blacklist": False,
@@ -2311,8 +2292,8 @@ class T(unittest.TestCase):
         self.assertEqual(self.ui.report["ProblemType"], "Bug")
 
         # working noninteractive script with extra tag
-        sys.argv = ["ui-test", "--tag", "foo", "-s", "itching"]
-        self.ui = TestSuiteUserInterface()
+        argv = ["ui-test", "--tag", "foo", "-s", "itching"]
+        self.ui = TestSuiteUserInterface(argv)
         self.ui.present_details_response = {
             "report": True,
             "blacklist": False,
@@ -2340,8 +2321,7 @@ class T(unittest.TestCase):
                 """
             ),
         )
-        sys.argv = ["ui-test", "-s", "itching"]
-        self.ui = TestSuiteUserInterface()
+        self.ui = TestSuiteUserInterface(["ui-test", "-s", "itching"])
         self.ui.present_details_response = {
             "report": True,
             "blacklist": False,
@@ -2378,8 +2358,7 @@ class T(unittest.TestCase):
             "bar.py", 'def run(report, ui):\n  return "coreutils"\n'
         )
 
-        sys.argv = ["ui-test", "-f"]
-        self.ui = TestSuiteUserInterface()
+        self.ui = TestSuiteUserInterface(["ui-test", "-f"])
         self.ui.present_details_response = {
             "report": True,
             "blacklist": False,
@@ -2417,10 +2396,10 @@ class T(unittest.TestCase):
         """parse_args() option inference for a single argument"""
 
         def _chk(program_name, arg, expected_opts):
-            sys.argv = [program_name]
+            argv = [program_name]
             if arg:
-                sys.argv.append(arg)
-            ui = apport.ui.UserInterface()
+                argv.append(arg)
+            ui = apport.ui.UserInterface(argv)
             expected_opts["version"] = False
             self.assertEqual(ui.args.__dict__, expected_opts)
             self.assertEqual(stderr_mock.getvalue(), "")
@@ -2584,8 +2563,7 @@ class T(unittest.TestCase):
         """parse_args() option inference when invoked as *-bug"""
 
         def _chk(args, expected_opts):
-            sys.argv = ["apport-bug"] + args
-            ui = apport.ui.UserInterface()
+            ui = apport.ui.UserInterface(["apport-bug"] + args)
             expected_opts["version"] = False
             self.assertEqual(ui.args.__dict__, expected_opts)
             self.assertEqual(stderr_mock.getvalue(), "")
@@ -2823,8 +2801,7 @@ class T(unittest.TestCase):
 
         latest_id_before = self.ui.crashdb.latest_id()
 
-        sys.argv = ["ui-test", "-f", "-p", "bash"]
-        self.ui = TestSuiteUserInterface()
+        self.ui = TestSuiteUserInterface(["ui-test", "-f", "-p", "bash"])
 
         # Pretend it does not accept report
         self.ui.crashdb.accepts = lambda r: False

--- a/tests/integration/test_ui_cli.py
+++ b/tests/integration/test_ui_cli.py
@@ -10,7 +10,6 @@
 """Command line Apport user interface tests."""
 
 import os
-import sys
 import unittest
 
 import apport.report
@@ -40,11 +39,7 @@ class TestApportCli(unittest.TestCase):
         os.environ.update(cls.orig_environ)
 
     def setUp(self):
-        saved = sys.argv
-        sys.argv = [apport_cli_path]
-        self.app = apport_cli.CLIUserInterface()
-        sys.argv = saved
-
+        self.app = apport_cli.CLIUserInterface([apport_cli_path])
         self.app.report = apport.report.Report()
         self.app.report.add_os_info()
         self.app.report["ExecutablePath"] = "/bin/bash"

--- a/tests/system/test_ui_gtk.py
+++ b/tests/system/test_ui_gtk.py
@@ -12,7 +12,6 @@
 import os
 import shutil
 import subprocess
-import sys
 import tempfile
 import textwrap
 import unittest
@@ -73,12 +72,7 @@ class T(unittest.TestCase):
         os.environ["APPORT_IGNORE_OBSOLETE_PACKAGES"] = "1"
         os.environ["APPORT_DISABLE_DISTRO_CHECK"] = "1"
 
-        saved = sys.argv
-        # Work around GTKUserInterface using basename to find the GtkBuilder UI
-        # file.
-        sys.argv = [apport_gtk_path]
-        self.app = GTKUserInterface()
-        sys.argv = saved
+        self.app = GTKUserInterface([apport_gtk_path])
 
         # use in-memory crashdb
         self.app.crashdb = apport.crashdb_impl.memory.CrashDatabase(None, {})

--- a/tests/system/test_ui_kde.py
+++ b/tests/system/test_ui_kde.py
@@ -11,7 +11,6 @@
 # the full text of the license.
 import os
 import shutil
-import sys
 import tempfile
 import textwrap
 import unittest
@@ -50,12 +49,14 @@ else:
 )
 class T(unittest.TestCase):
     COLLECTING_DIALOG = unittest.mock.call(
+        os.path.dirname(apport_kde_path),
         "Collecting Problem Information",
         "Collecting problem information",
         "The collected information can be sent to the developers to improve "
         "the application. This might take a few minutes.",
     )
     UPLOADING_DIALOG = unittest.mock.call(
+        os.path.dirname(apport_kde_path),
         "Uploading Problem Information",
         "Uploading problem information",
         "The collected information is being sent to the bug tracking system. "
@@ -91,11 +92,7 @@ class T(unittest.TestCase):
         os.environ["APPORT_IGNORE_OBSOLETE_PACKAGES"] = "1"
         os.environ["APPORT_DISABLE_DISTRO_CHECK"] = "1"
 
-        self.orig_argv = sys.argv
-        # Work around MainUserInterface using basename to find the KDE UI file.
-        sys.argv = self.argv
-        self.app = MainUserInterface()
-
+        self.app = MainUserInterface(self.argv)
         # use in-memory crashdb
         self.app.crashdb = apport.crashdb_impl.memory.CrashDatabase(None, {})
 
@@ -123,7 +120,6 @@ class T(unittest.TestCase):
 
         shutil.rmtree(self.report_dir)
         shutil.rmtree(self.hook_dir)
-        sys.argv = self.orig_argv
 
     def test_close_button(self):
         """Clicking the close button on the window does not report the


### PR DESCRIPTION
The UI test cases need to save `sys.argv` and set them for testing. Instead of fiddling around with `sys.argv`, pass around the command line arguments and `argv` parameter. For `apport-kde` determine the UI data path once and pass it around as `ui_data_path`.