### PR TITLE
CI: Remove system installed Apport

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -165,7 +165,7 @@ jobs:
           python3-pyqt5 python3-pytest python3-pytest-cov ubuntu-dbgsym-keyring
           ubuntu-keyring valgrind xvfb
       - name: Install
-        run: sudo ./setup.py install --install-layout=deb --prefix=/usr
+        run: sudo ./setup.py install --install-layout=deb --prefix=/usr --root=/
       - name: Enable Apport
         run: >
           echo "|/usr/share/apport/apport "

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -153,6 +153,10 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
+      - name: Remove system installed Apport
+        run: >
+          sudo apt-get remove --purge --yes
+          apport python3-apport python3-problem-report
       - name: Enable 'deb-src' URIs in /etc/apt/sources.list
         run: sudo sed -i '/^#\sdeb-src /s/^#\s//' /etc/apt/sources.list
       - name: Install dependencies


### PR DESCRIPTION
Installing Apport with layout `deb` and prefix `/usr` installs the `etc` directory into the local directory instead of `/`.

Set `--root` to `/` to install all files into the system.

Remove system installed Apport to avoid mixing the Apport version to test and the system installed Apport.