### PR TITLE
tests: Fix path for installed apport-cli and fix test_run_crash_kernel on Azure

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,6 +67,46 @@ jobs:
           fail_ci_if_error: true
           files: ./coverage.xml
 
+  unit-tests-installed:
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+      - name: Remove system installed Apport
+        run: >
+          sudo apt-get remove --purge --yes
+          apport python3-apport python3-problem-report
+      - name: Install dependencies
+        run: >
+          sudo apt-get update
+          && sudo apt-get install --no-install-recommends --yes
+          locales python3 python3-apt python3-distutils-extra python3-pytest
+          python3-pytest-cov
+      - name: Enable German locale
+        run: >
+          sudo sed -i 's/^# de_DE/de_DE/g' /etc/locale.gen
+          && sudo locale-gen
+      - name: Install
+        run: sudo ./setup.py install --install-layout=deb --prefix=/usr --root=/
+      - name: Run unit tests
+        run: >
+          WORKDIR=$(mktemp -d -t apport.XXXXXXXXXX)
+          && cp -r tests "$WORKDIR"
+          && cd "$WORKDIR"
+          && python3 -m pytest -ra --cov=$(pwd) --cov-report=xml tests/unit/
+          && cd -
+          && cp "$WORKDIR/coverage.xml" .
+      - name: Install dependencies for Codecov
+        run: >
+          sudo apt-get install --no-install-recommends --yes
+          ca-certificates curl git
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v2
+        with:
+          fail_ci_if_error: true
+          files: ./coverage.xml
+
   integration-tests:
     runs-on: ubuntu-latest
     strategy:
@@ -96,6 +136,45 @@ jobs:
       - name: Install dependencies for Codecov
         run: >
           apt-get install --no-install-recommends --yes
+          ca-certificates curl git
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v2
+        with:
+          fail_ci_if_error: true
+          files: ./coverage.xml
+
+  integration-tests-installed:
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+      - name: Remove system installed Apport
+        run: >
+          sudo apt-get remove --purge --yes
+          apport python3-apport python3-problem-report
+      - name: Install dependencies
+        run: >
+          sudo apt-get update
+          && sudo apt-get install --no-install-recommends --yes
+          bash binutils default-jdk-headless dpkg-dev gcc gdb iputils-ping kmod
+          libc6-dev pkg-config python3 python3-apt python3-distutils-extra
+          python3-launchpadlib python3-psutil python3-pytest python3-pytest-cov
+          python3-systemd valgrind
+      - name: Install
+        run: sudo ./setup.py install --install-layout=deb --prefix=/usr --root=/
+      - name: Run integration tests
+        run: >
+          WORKDIR=$(mktemp -d -t apport.XXXXXXXXXX)
+          && cp -r tests "$WORKDIR"
+          && cd "$WORKDIR"
+          && python3 -m pytest -ra --cov=$(pwd) --cov-report=xml
+          tests/integration/
+          && cd -
+          && cp "$WORKDIR/coverage.xml" .
+      - name: Install dependencies for Codecov
+        run: >
+          sudo apt-get install --no-install-recommends --yes
           ca-certificates curl git
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2

--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -1507,6 +1507,8 @@ class T(unittest.TestCase):
             src_pkg = "linux-signed"
         else:
             src_pkg = "linux"
+        if "azure" in os.uname().release:
+            src_pkg += "-azure"
 
         # set up hook
         with open(

--- a/tests/integration/test_ui_cli.py
+++ b/tests/integration/test_ui_cli.py
@@ -19,9 +19,7 @@ from tests.paths import is_local_source_directory, local_test_environment
 if is_local_source_directory():
     apport_cli_path = "bin/apport-cli"
 else:
-    apport_cli_path = os.path.join(
-        os.environ.get("APPORT_DATA_DIR", "/usr/share/apport"), "apport-cli"
-    )
+    apport_cli_path = "/usr/bin/apport-cli"
 apport_cli = import_module_from_file(apport_cli_path)
 
 


### PR DESCRIPTION
Running the CLI UI tests against the install Apport fails:

```
Traceback (most recent call last):
[...]
  File "tests/integration/test_ui_cli.py", line 25, in <module>
    apport_cli = import_module_from_file(apport_cli_path)
  File "tests/helper.py", line 48, in import_module_from_file
    spec.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 879, in exec_module
  File "<frozen importlib._bootstrap_external>", line 1016, in get_code
  File "<frozen importlib._bootstrap_external>", line 1073, in get_data
FileNotFoundError: [Errno 2] No such file or directory: '/usr/share/apport/apport-cli'
```

The CLI is installed in `/usr/bin/apport-cli`.

The UI integration test case `test_run_crash_kernel` fails on Azure:

```
>       self.assertEqual(
            self.ui.opened_url,
            "http://%s.bugs.example.com/%i"
            % (src_pkg, self.ui.crashdb.latest_id()),
        )
E       AssertionError: 'http://linux-signed-azure.bugs.example.com/5' != 'http://linux-signed.bugs.example.com/5'
E       - http://linux-signed-azure.bugs.example.com/5
E       ?                    ------
E       + http://linux-signed.bugs.example.com/5

tests/integration/test_ui.py:1574: AssertionError
```

The kernel source package is named `linux-signed-azure` on Azure.

Ubuntu's autopkgtest runs the unit and integration tests against the installed system. Test this scenario in the CI as well.