### PR TITLE
tests: Determine source package dynamically in test_run_crash_kernel

### DIFF
--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -1502,13 +1502,12 @@ class T(unittest.TestCase):
 
     def test_run_crash_kernel(self):
         """run_crash() for a kernel error"""
-        sys_arch = apport.packaging.get_system_architecture()
-        if sys_arch in ["amd64", "arm64", "ppc64el", "s390x"]:
-            src_pkg = "linux-signed"
-        else:
+        package = apport.packaging.get_kernel_package()
+        try:
+            src_pkg = apport.packaging.get_source(package)
+        except ValueError:
+            # Kernel package not installed (e.g. in container)
             src_pkg = "linux"
-        if "azure" in os.uname().release:
-            src_pkg += "-azure"
 
         # set up hook
         with open(
@@ -1527,7 +1526,7 @@ class T(unittest.TestCase):
 
         # generate crash report
         r = apport.Report("KernelCrash")
-        r["Package"] = apport.packaging.get_kernel_package()
+        r["Package"] = package
         r["SourcePackage"] = src_pkg
 
         # write crash report


### PR DESCRIPTION
The autopkgtest for apport 2.23.1-0ubuntu1 fails on ppc64el:

```
======================================================================
FAIL: test_run_crash_kernel (tests.integration.test_ui.T)
run_crash() for a kernel error
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3.10/unittest/mock.py", line 1369, in patched
    return func(*newargs, **newkeywargs)
  File "tests/integration/test_ui.py", line 1617, in test_run_crash_kernel
    self.assertEqual(
AssertionError: 'http://linux.bugs.example.com/5' != 'http://linux-signed.bugs.example.com/5'
- http://linux.bugs.example.com/5
+ http://linux-signed.bugs.example.com/5
? +++++++

----------------------------------------------------------------------
```

Sometimes the Linux source package is `linux` and sometimes `linux-signed`. Instead of hard-coding the source package name, determine it dynamically on the running system.

Bug: https://launchpad.net/bugs/1992172