### PR TITLE
Refactor apport-unpack

### DIFF
--- a/bin/apport-unpack
+++ b/bin/apport-unpack
@@ -35,48 +35,53 @@ def parse_args():
     return parser.parse_args()
 
 
-gettext.textdomain("apport")
-args = parse_args()
+def main():
+    gettext.textdomain("apport")
+    args = parse_args()
 
-# ensure that the directory does not yet exist or is empty
-try:
-    if os.path.isdir(args.target_directory):
-        if os.listdir(args.target_directory):
-            fatal(_("Destination directory exists and is not empty."))
+    # ensure that the directory does not yet exist or is empty
+    try:
+        if os.path.isdir(args.target_directory):
+            if os.listdir(args.target_directory):
+                fatal(_("Destination directory exists and is not empty."))
+        else:
+            os.mkdir(args.target_directory)
+    except OSError as error:
+        fatal(str(error))
+
+    bin_keys = []
+    pr = problem_report.ProblemReport()
+    if args.report == "-":
+        pr.load(sys.stdin, binary=False)
     else:
-        os.mkdir(args.target_directory)
-except OSError as error:
-    fatal(str(error))
-
-bin_keys = []
-pr = problem_report.ProblemReport()
-if args.report == "-":
-    pr.load(sys.stdin, binary=False)
-else:
+        try:
+            if args.report.endswith(".gz"):
+                with gzip.open(args.report, "rb") as f:
+                    pr.load(f, binary=False)
+            else:
+                with open(args.report, "rb") as f:
+                    pr.load(f, binary=False)
+        except OSError as error:
+            fatal(str(error))
+    for key, value in pr.items():
+        if value is None:
+            bin_keys.append(key)
+            continue
+        with open(os.path.join(args.target_directory, key), "wb") as f:
+            if isinstance(value, str):
+                f.write(value.encode("UTF-8"))
+            else:
+                f.write(value)
     try:
         if args.report.endswith(".gz"):
             with gzip.open(args.report, "rb") as f:
-                pr.load(f, binary=False)
+                pr.extract_keys(f, bin_keys, args.target_directory)
         else:
             with open(args.report, "rb") as f:
-                pr.load(f, binary=False)
+                pr.extract_keys(f, bin_keys, args.target_directory)
     except OSError as error:
         fatal(str(error))
-for key, value in pr.items():
-    if value is None:
-        bin_keys.append(key)
-        continue
-    with open(os.path.join(args.target_directory, key), "wb") as f:
-        if isinstance(value, str):
-            f.write(value.encode("UTF-8"))
-        else:
-            f.write(value)
-try:
-    if args.report.endswith(".gz"):
-        with gzip.open(args.report, "rb") as f:
-            pr.extract_keys(f, bin_keys, args.target_directory)
-    else:
-        with open(args.report, "rb") as f:
-            pr.extract_keys(f, bin_keys, args.target_directory)
-except OSError as error:
-    fatal(str(error))
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/apport-unpack
+++ b/bin/apport-unpack
@@ -35,6 +35,19 @@ def parse_args():
     return parser.parse_args()
 
 
+def load_report(report: str) -> problem_report.ProblemReport:
+    pr = problem_report.ProblemReport()
+    if report == "-":
+        pr.load(sys.stdin, binary=False)
+    elif report.endswith(".gz"):
+        with gzip.open(report, "rb") as f:
+            pr.load(f, binary=False)
+    else:
+        with open(report, "rb") as f:
+            pr.load(f, binary=False)
+    return pr
+
+
 def main():
     gettext.textdomain("apport")
     args = parse_args()
@@ -50,19 +63,10 @@ def main():
         fatal(str(error))
 
     bin_keys = []
-    pr = problem_report.ProblemReport()
-    if args.report == "-":
-        pr.load(sys.stdin, binary=False)
-    else:
-        try:
-            if args.report.endswith(".gz"):
-                with gzip.open(args.report, "rb") as f:
-                    pr.load(f, binary=False)
-            else:
-                with open(args.report, "rb") as f:
-                    pr.load(f, binary=False)
-        except OSError as error:
-            fatal(str(error))
+    try:
+        pr = load_report(args.report)
+    except OSError as error:
+        fatal(str(error))
     for key, value in pr.items():
         if value is None:
             bin_keys.append(key)

--- a/tests/integration/test_apport_unpack.py
+++ b/tests/integration/test_apport_unpack.py
@@ -53,10 +53,12 @@ class T(unittest.TestCase):
 
     def test_unpack(self):
         """apport-unpack for all possible data types"""
-        self.assertEqual(
-            self._call(["apport-unpack", self.report_file, self.unpack_dir]),
-            (0, "", ""),
+        process = self._call(
+            ["apport-unpack", self.report_file, self.unpack_dir]
         )
+        self.assertEqual(process.returncode, 0)
+        self.assertEqual(process.stderr, "")
+        self.assertEqual(process.stdout, "")
 
         self.assertEqual(self._get_unpack("utf8"), self.utf8_str)
         self.assertEqual(self._get_unpack("unicode"), self.utf8_str)
@@ -65,32 +67,32 @@ class T(unittest.TestCase):
 
     def test_help(self):
         """Call apport-unpack with --help."""
-        (ret, out, err) = self._call(["apport-unpack", "--help"])
-        self.assertEqual(ret, 0)
-        self.assertEqual(err, "")
-        self.assertTrue(out.startswith("usage:"), out)
+        process = self._call(["apport-unpack", "--help"])
+        self.assertEqual(process.returncode, 0)
+        self.assertEqual(process.stderr, "")
+        self.assertTrue(process.stdout.startswith("usage:"), process.stdout)
 
     def test_error(self):
         """Call apport-unpack with wrong arguments."""
-        (ret, out, err) = self._call(["apport-unpack"])
-        self.assertEqual(ret, 2)
-        self.assertEqual(out, "")
-        self.assertTrue(err.startswith("usage:"), out)
+        process = self._call(["apport-unpack"])
+        self.assertEqual(process.returncode, 2)
+        self.assertEqual(process.stdout, "")
+        self.assertTrue(process.stderr.startswith("usage:"), process.stderr)
 
-        (ret, out, err) = self._call(["apport-unpack", self.report_file])
-        self.assertEqual(ret, 2)
-        self.assertEqual(out, "")
-        self.assertTrue(err.startswith("usage:"), out)
+        process = self._call(["apport-unpack", self.report_file])
+        self.assertEqual(process.returncode, 2)
+        self.assertEqual(process.stdout, "")
+        self.assertTrue(process.stderr.startswith("usage:"), process.stderr)
 
-        (ret, out, err) = self._call(
+        process = self._call(
             ["apport-unpack", "/nonexisting.crash", self.unpack_dir]
         )
-        self.assertEqual(ret, 1)
-        self.assertIn("/nonexisting.crash", err)
-        self.assertEqual(out, "")
+        self.assertEqual(process.returncode, 1)
+        self.assertIn("/nonexisting.crash", process.stderr)
+        self.assertEqual(process.stdout, "")
 
-    def _call(self, argv):
-        process = subprocess.run(
+    def _call(self, argv: list) -> subprocess.CompletedProcess:
+        return subprocess.run(
             argv,
             check=False,
             encoding="UTF-8",
@@ -98,7 +100,6 @@ class T(unittest.TestCase):
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
-        return (process.returncode, process.stdout, process.stderr)
 
     def _get_unpack(self, fname):
         with open(os.path.join(self.unpack_dir, fname), "rb") as f:

--- a/tests/integration/test_apport_unpack.py
+++ b/tests/integration/test_apport_unpack.py
@@ -53,9 +53,7 @@ class T(unittest.TestCase):
 
     def test_unpack(self):
         """apport-unpack for all possible data types"""
-        process = self._call(
-            ["apport-unpack", self.report_file, self.unpack_dir]
-        )
+        process = self._call_apport_unpack([self.report_file, self.unpack_dir])
         self.assertEqual(process.returncode, 0)
         self.assertEqual(process.stderr, "")
         self.assertEqual(process.stdout, "")
@@ -67,33 +65,33 @@ class T(unittest.TestCase):
 
     def test_help(self):
         """Call apport-unpack with --help."""
-        process = self._call(["apport-unpack", "--help"])
+        process = self._call_apport_unpack(["--help"])
         self.assertEqual(process.returncode, 0)
         self.assertEqual(process.stderr, "")
         self.assertTrue(process.stdout.startswith("usage:"), process.stdout)
 
     def test_error(self):
         """Call apport-unpack with wrong arguments."""
-        process = self._call(["apport-unpack"])
+        process = self._call_apport_unpack([])
         self.assertEqual(process.returncode, 2)
         self.assertEqual(process.stdout, "")
         self.assertTrue(process.stderr.startswith("usage:"), process.stderr)
 
-        process = self._call(["apport-unpack", self.report_file])
+        process = self._call_apport_unpack([self.report_file])
         self.assertEqual(process.returncode, 2)
         self.assertEqual(process.stdout, "")
         self.assertTrue(process.stderr.startswith("usage:"), process.stderr)
 
-        process = self._call(
-            ["apport-unpack", "/nonexisting.crash", self.unpack_dir]
+        process = self._call_apport_unpack(
+            ["/nonexisting.crash", self.unpack_dir]
         )
         self.assertEqual(process.returncode, 1)
         self.assertIn("/nonexisting.crash", process.stderr)
         self.assertEqual(process.stdout, "")
 
-    def _call(self, argv: list) -> subprocess.CompletedProcess:
+    def _call_apport_unpack(self, argv: list) -> subprocess.CompletedProcess:
         return subprocess.run(
-            argv,
+            ["apport-unpack"] + argv,
             check=False,
             encoding="UTF-8",
             env=self.env,


### PR DESCRIPTION
Refactor `apport-unpack` and its test suite to avoid code duplication and making fixing https://launchpad.net/bugs/1996040 easier.