### PR TITLE
fix: Catch malformed problem report

### DIFF
--- a/bin/apport-unpack
+++ b/bin/apport-unpack
@@ -65,7 +65,7 @@ def main():
     bin_keys = []
     try:
         pr = load_report(args.report)
-    except OSError as error:
+    except (OSError, problem_report.MalformedProblemReport) as error:
         fatal(str(error))
     for key, value in pr.items():
         if value is None:

--- a/data/whoopsie-upload-all
+++ b/data/whoopsie-upload-all
@@ -26,6 +26,7 @@ import zlib
 
 import apport
 import apport.fileutils
+from problem_report import MalformedProblemReport
 
 
 def process_report(report):
@@ -75,7 +76,7 @@ def process_report(report):
                 return None
             r.load(f, binary="compressed")
             report_stat = os.stat(report)
-    except (OSError, zlib.error) as error:
+    except (MalformedProblemReport, OSError, zlib.error) as error:
         sys.stderr.write("ERROR: cannot load %s: %s\n" % (report, str(error)))
         return None
     if r.get("ProblemType", "") != "Crash" and "ExecutablePath" not in r:

--- a/tests/integration/test_whoopsie_upload_all.py
+++ b/tests/integration/test_whoopsie_upload_all.py
@@ -1,0 +1,49 @@
+# Copyright (C) 2022 Canonical Ltd.
+# Author: Benjamin Drung <benjamin.drung@canonical.com>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 2 of the License, or (at your
+# option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
+# the full text of the license.
+
+"""Integration tests for whoopsie-upload-all."""
+
+import io
+import os
+import shutil
+import tempfile
+import unittest
+import unittest.mock
+
+from tests.helper import import_module_from_file
+from tests.paths import get_data_directory
+
+whoopsie_upload_all = import_module_from_file(
+    os.path.join(get_data_directory(), "whoopsie-upload-all")
+)
+
+
+class TestWhoopsieUploadAll(unittest.TestCase):
+    """Integration tests for whoopsie-upload-all."""
+
+    def setUp(self):
+        self.report_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.report_dir)
+
+    def _write_report(self, content: bytes) -> str:
+        report = os.path.join(self.report_dir, "testcase.crash")
+        with open(report, "wb") as report_file:
+            report_file.write(content)
+        return report
+
+    @unittest.mock.patch("sys.stderr", new_callable=io.StringIO)
+    def test_process_report_malformed_report(self, stderr_mock):
+        """Test process_report() raises MalformedProblemReport."""
+        report = self._write_report(b"AB\xfc:CD\n")
+        self.assertEqual(whoopsie_upload_all.process_report(report), None)
+        self.assertIn(
+            "Malformed problem report: 'ascii' codec can't decode byte 0xfc"
+            " in position 2: ordinal not in range(128).",
+            stderr_mock.getvalue(),
+        )

--- a/tests/unit/test_problem_report.py
+++ b/tests/unit/test_problem_report.py
@@ -205,6 +205,16 @@ class T(unittest.TestCase):
         pr.load(io.BytesIO(b"ProblemType: Crash"))
         self.assertEqual(list(pr.keys()), ["ProblemType"])
 
+    def test_load_binary_blob(self):
+        """Throw exception when binary file (e.g. core) is loaded."""
+        report = problem_report.ProblemReport()
+        with io.BytesIO(b"AB\xfc:CD") as report_file:
+            with self.assertRaisesRegex(
+                problem_report.MalformedProblemReport,
+                "codec can't decode byte 0xfc in position 2",
+            ):
+                report.load(report_file)
+
     def test_write_fileobj(self):
         """Write a report with a pointer to a file-like object."""
         tempbin = io.BytesIO(bin_data)


### PR DESCRIPTION
When passing a core file, `apport-unpack` will crash:

```
Traceback (most recent call last):
  File "bin/apport-unpack", line 91, in <module>
    main()
  File "bin/apport-unpack", line 67, in main
    pr = load_report(args.report)
  File "bin/apport-unpack", line 47, in load_report
    pr.load(f, binary=False)
  File "problem_report.py", line 167, in load
    key = key.decode("ASCII")
UnicodeDecodeError: 'ascii' codec can't decode byte 0xfc in position 2: ordinal not in range(128)
```

Wrap `UnicodeDecodeError` in a `MalformedProblemReport` exception and catch this exception in `apport-unpack` to print nice error message.

Please review and merge the refactoring in #23 first.

Bug-Ubuntu: https://launchpad.net/bugs/1996040