### PR TITLE
fix: Address complaints from pylint 2.15.5

### DIFF
--- a/apport/packaging.py
+++ b/apport/packaging.py
@@ -146,8 +146,7 @@ class PackageInfo:
             "this method must be implemented by a concrete subclass"
         )
 
-    @staticmethod
-    def get_modified_conffiles(package):
+    def get_modified_conffiles(self, package):
         """Return modified configuration files of a package.
 
         Return a file name -> file contents map of all configuration files of
@@ -156,7 +155,7 @@ class PackageInfo:
         allows filtering.
         """
         # Default implementation does nothing, i.e. no config files modified
-        # pylint: disable=unused-argument
+        # pylint: disable=no-self-use,unused-argument
         return {}
 
     def get_file_package(
@@ -183,7 +182,8 @@ class PackageInfo:
             "this method must be implemented by a concrete subclass"
         )
 
-    def get_system_architecture(self):
+    @staticmethod
+    def get_system_architecture():
         """Return the architecture of the system.
 
         This should use the notation of the particular distribution.
@@ -192,15 +192,14 @@ class PackageInfo:
             "this method must be implemented by a concrete subclass"
         )
 
-    @staticmethod
-    def get_library_paths():
+    def get_library_paths(self):
         """Return a list of default library search paths.
 
         The entries should be separated with a colon ':', like for
         $LD_LIBRARY_PATH. This needs to take any multiarch directories into
         account.
         """
-        # dummy default implementation
+        # dummy default implementation, pylint: disable=no-self-use
         return "/lib:/usr/lib"
 
     def set_mirror(self, url):
@@ -342,8 +341,7 @@ class PackageInfo:
             "this method must be implemented by a concrete subclass"
         )
 
-    @staticmethod
-    def is_native_origin_package(package):
+    def is_native_origin_package(self, package):
         """Check if a package is one which has been white listed.
 
         Return True for a package which came from an origin which is listed in
@@ -351,7 +349,7 @@ class PackageInfo:
         """
         # Default implementation does nothing, i. e. native origins are not
         # supported.
-        # pylint: disable=unused-argument
+        # pylint: disable=no-self-use,unused-argument
         return False
 
     def get_uninstalled_package(self):

--- a/bin/apport-cli
+++ b/bin/apport-cli
@@ -429,8 +429,7 @@ class CLIUserInterface(apport.ui.UserInterface):
         if answer == [0]:
             apport.ui.UserInterface.open_url(self, url)
 
-    @staticmethod
-    def ui_has_terminal():
+    def ui_has_terminal(self):
         # we are already running in a terminal, so this works by definition
         return True
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 
+# distutils-extra needs porting, pylint: disable=deprecated-module
 import distutils.command.build
 import distutils.command.clean
 import distutils.core

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -112,9 +112,9 @@ def wrap_object(
 
     def mocked_attribute(self, *args, **kwargs):
         if include_instance:
-            mock.__call__(self, *args, **kwargs)
+            mock(self, *args, **kwargs)
         else:
-            mock.__call__(*args, **kwargs)
+            mock(*args, **kwargs)
         return real_attribute(self, *args, **kwargs)
 
     with unittest.mock.patch.object(target, attribute, mocked_attribute):


### PR DESCRIPTION
pylint 2.15.5 complains:

```
************* Module apport.packaging_impl.apt_dpkg
apport/packaging_impl/apt_dpkg.py:248:4: W0221: Number of parameters was 1 in 'PackageInfo.is_native_origin_package' and is now 2 in overridden '__AptDpkgPackageInfo.is_native_origin_package' method (arguments-differ)
apport/packaging_impl/apt_dpkg.py:450:4: W0221: Number of parameters was 1 in 'PackageInfo.get_modified_conffiles' and is now 2 in overridden '__AptDpkgPackageInfo.get_modified_conffiles' method (arguments-differ)
apport/packaging_impl/apt_dpkg.py:580:4: W0221: Number of parameters was 1 in 'PackageInfo.get_system_architecture' and is now 0 in overridden '__AptDpkgPackageInfo.get_system_architecture' method (arguments-differ)
apport/packaging_impl/apt_dpkg.py:592:4: W0221: Number of parameters was 0 in 'PackageInfo.get_library_paths' and is now 1 in overridden '__AptDpkgPackageInfo.get_library_paths' method (arguments-differ)
************* Module setup
setup.py:3:0: W4901: Deprecated module 'distutils.command.build' (deprecated-module)
setup.py:4:0: W4901: Deprecated module 'distutils.command.clean' (deprecated-module)
setup.py:5:0: W4901: Deprecated module 'distutils.core' (deprecated-module)
setup.py:6:0: W4901: Deprecated module 'distutils.version' (deprecated-module)
************* Module tests.helper
tests/helper.py:115:12: C2801: Unnecessarily calls dunder method __call__. Invoke instance directly. (unnecessary-dunder-call)
tests/helper.py:117:12: C2801: Unnecessarily calls dunder method __call__. Invoke instance directly. (unnecessary-dunder-call)
************* Module bin.apport-cli
bin/apport-cli:433:4: W0221: Number of parameters was 1 in 'UserInterface.ui_has_terminal' and is now 0 in overridden 'CLIUserInterface.ui_has_terminal' method (arguments-differ)
```