### PR TITLE
Add GitHub backend for WSL and snaps

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
           black gir1.2-gtk-3.0 gir1.2-wnck-3.0 isort pycodestyle pydocstyle
           pyflakes3 pylint python3 python3-apt python3-dbus
           python3-distutils-extra python3-gi python3-launchpadlib
-          python3-psutil python3-rpm python3-yaml
+          python3-psutil python3-rpm python3-yaml python3-requests
       - name: Run linter tests
         run: tests/run-linters
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -135,7 +135,7 @@ jobs:
           bash binutils default-jdk-headless dpkg-dev gcc gdb iputils-ping kmod
           libc6-dev pkg-config python3 python3-apt python3-distutils-extra
           python3-launchpadlib python3-psutil python3-pytest python3-pytest-cov
-          python3-systemd valgrind
+          python3-requests python3-systemd valgrind
       - name: Build Java subdir
         run: >
           python3 -m coverage run ./setup.py build_java_subdir

--- a/apport/crashdb_impl/github.py
+++ b/apport/crashdb_impl/github.py
@@ -1,0 +1,318 @@
+"""Crash database implementation for Github."""
+
+# Copyright (C) 2022 - 2022 Canonical Ltd.
+# Author: Eduard Gómez Escanell <edu.gomez.escandell@canonical.com>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 2 of the License, or (at your
+# option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
+# the full text of the license.
+
+import json
+import time
+from dataclasses import dataclass
+
+import requests
+
+import apport
+import apport.crashdb
+
+
+class Github:
+    """Wrapper around Github API, used to log in and post issues."""
+
+    __last_request: float = time.time()
+
+    def __init__(self, client_id, message_callback):
+        self.__client_id = client_id
+        self.__authentication_data = None
+        self.__access_token = None
+        self.__cooldown = None
+        self.__expiry = None
+        self.message_callback = message_callback
+
+    @staticmethod
+    def _stringify(data: dict) -> str:
+        """Takes a dict and returns it as a string for POSTing."""
+        string = ""
+        for key, value in data.items():
+            string = f"{string}&{key}={value}"
+        return string
+
+    def _post(self, url: str, data: str):
+        """Posts the given data to the given URL.
+        Uses auth token if available"""
+        headers = {"Accept": "application/vnd.github.v3+json"}
+        if self.__access_token:
+            headers["Authorization"] = f"token {self.__access_token}"
+        try:
+            result = requests.post(
+                url, headers=headers, data=data, timeout=5.0
+            )
+        except requests.RequestException as err:
+            self.message_callback(
+                "Failed connection",
+                f"Failed connection to {url}.\n"
+                + "Please check your internet connection and try again.",
+            )
+            raise err
+        finally:
+            self.__last_request = time.time()
+
+        result.raise_for_status()  # Not using UI: the user can't do much here
+        return json.loads(result.text)
+
+    def api_authentication(self, url: str, data: dict):
+        return self._post(url, self._stringify(data))
+
+    def api_open_issue(self, owner: str, repo: str, data: dict):
+        url = f"https://api.github.com/repos/{owner}/{repo}/issues"
+        return self._post(url, json.dumps(data))
+
+    def __enter__(self):
+        """Enters login process. At exit, login process ends."""
+        data = {"client_id": self.__client_id, "scope": "public_repo"}
+        url = "https://github.com/login/device/code"
+        response = self.api_authentication(url, data)
+
+        prompt = (
+            "Posting an issue requires a Github account. If you have "
+            "one, please follow these steps to log in.\n"
+            "\n"
+            "Open the following URL. When requested, write this code "
+            "to enable apport to open an issue.\n"
+            "URL:  {url}\n"
+            "Code: {code}"
+        )
+
+        url = response["verification_uri"]
+        code = response["user_code"]
+
+        self.message_callback(
+            "Login required", prompt.format(url=url, code=code)
+        )
+
+        self.__authentication_data = {
+            "client_id": self.__client_id,
+            "device_code": f'{response["device_code"]}',
+            "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+        }
+        self.__cooldown = response["interval"]
+        self.__expiry = int(response["expires_in"]) + time.time()
+
+        return self
+
+    def __exit__(self, *_) -> None:
+        self.__authentication_data = None
+        self.__cooldown = 0
+        self.__expiry = 0
+
+    def authentication_complete(self) -> bool:
+        """Asks Github if the user has logged in already.
+        It respects the wait-time requested by Github.
+        """
+        if not self.__authentication_data:
+            raise RuntimeError(
+                "Authentication not started. Use a with statement to do so"
+            )
+
+        t = time.time()
+        waittime = self.__cooldown - (t - self.__last_request)
+        if t + waittime > self.__expiry:
+            self.message_callback(
+                "Failed login",
+                "Github authentication expired. Please try again.",
+            )
+            raise RuntimeError("Github authentication expired")
+        if waittime > 0:
+            time.sleep(waittime)  # Avoids spamming the API
+
+        url = "https://github.com/login/oauth/access_token"
+        response = self.api_authentication(url, self.__authentication_data)
+
+        if "error" in response:
+            if response["error"] == "authorization_pending":
+                return False
+            if response["error"] == "slow_down":
+                self.__cooldown = int(response["interval"])
+                return False
+            raise RuntimeError(f"Unknown error from Github: {response}")
+        if "access_token" in response:
+            self.__access_token = response["access_token"]
+            return True
+        raise RuntimeError(f"Unknown response from Github: {response}")
+
+
+@dataclass(frozen=True)
+class IssueHandle:
+    url: str
+
+
+class CrashDatabase(apport.crashdb.CrashDatabase):
+    """Github crash database.
+    This is a Apport CrashDB implementation for interacting with Github issues
+    """
+
+    def __init__(self, auth_file, options):
+        """Initialize some variables. Login is delayed until necessary."""
+        apport.crashdb.CrashDatabase.__init__(self, auth_file, options)
+        self.repository_owner = options["repository_owner"]
+        self.repository_name = options["repository_name"]
+        self.app_id = options["github_app_id"]
+        self.labels = set(options["labels"])
+        self.issue_url = None
+        self.github = None
+
+    def _format_report(self, report: apport.Report) -> dict:
+        """Formats report info as markdown and creates Github issue JSON."""
+        body_markdown = ""
+        for key, value in report.items():
+            body_markdown += f"**{key}**\n{value}\n\n"
+
+        return {
+            "title": "Issue submitted via apport",
+            "body": body_markdown,
+            "labels": list(self.labels),
+        }
+
+    def _github_login(self, user_message_callback):
+        with Github(self.app_id, user_message_callback) as github:
+            while not github.authentication_complete():
+                pass
+            return github
+
+    def upload(
+        self,
+        report: apport.Report,
+        progress_callback=None,
+        user_message_callback=None,
+    ) -> IssueHandle:
+        """Upload given problem report return a handle for it.
+        In Github, we open an issue.
+        """
+        assert self.accepts(report)
+
+        self.github = self._github_login(user_message_callback)
+
+        if self.github is None:
+            raise RuntimeError("Failed to login to Github")
+
+        data = self._format_report(report)
+        if not (
+            self.repository_name is None and self.repository_owner is None
+        ):
+            response = self.github.api_open_issue(
+                self.repository_owner, self.repository_name, data
+            )
+        elif "SnapGitOwner" in report and "SnapGitName" in report:
+            response = self.github.api_open_issue(
+                report["SnapGitOwner"], report["SnapGitName"], data
+            )
+        else:
+            raise RuntimeError(
+                "Couldn't determine which repository to file the report in"
+            )
+
+        return IssueHandle(url=response["html_url"])
+
+    def get_comment_url(
+        self, report: apport.Report, handle: IssueHandle
+    ) -> str:
+        """Return a URL that should be opened after report has been uploaded
+        and upload() returned handle.
+        """
+        return handle.url
+
+    def _mark_dup_checked(self, crash_id, report):
+        raise NotImplementedError(
+            "This method is not relevant for Github database implementation."
+        )
+
+    def can_update(self, crash_id):
+        raise NotImplementedError(
+            "This method is not relevant for Github database implementation."
+        )
+
+    def close_duplicate(self, report, crash_id, master_id):
+        raise NotImplementedError(
+            "This method is not relevant for Github database implementation."
+        )
+
+    def download(self, crash_id):
+        raise NotImplementedError(
+            "This method is not relevant for Github database implementation."
+        )
+
+    def duplicate_of(self, crash_id):
+        raise NotImplementedError(
+            "This method is not relevant for Github database implementation."
+        )
+
+    def get_affected_packages(self, crash_id):
+        raise NotImplementedError(
+            "This method is not relevant for Github database implementation."
+        )
+
+    def get_distro_release(self, crash_id):
+        raise NotImplementedError(
+            "This method is not relevant for Github database implementation."
+        )
+
+    def get_dup_unchecked(self):
+        raise NotImplementedError(
+            "This method is not relevant for Github database implementation."
+        )
+
+    def get_fixed_version(self, crash_id):
+        raise NotImplementedError(
+            "This method is not relevant for Github database implementation."
+        )
+
+    def get_id_url(self, report, crash_id):
+        raise NotImplementedError(
+            "This method is not relevant for Github database implementation."
+        )
+
+    def get_unfixed(self):
+        raise NotImplementedError(
+            "This method is not relevant for Github database implementation."
+        )
+
+    def get_unretraced(self):
+        raise NotImplementedError(
+            "This method is not relevant for Github database implementation."
+        )
+
+    def is_reporter(self, crash_id):
+        raise NotImplementedError(
+            "This method is not relevant for Github database implementation."
+        )
+
+    def mark_regression(self, crash_id, master):
+        raise NotImplementedError(
+            "This method is not relevant for Github database implementation."
+        )
+
+    def mark_retrace_failed(self, crash_id, invalid_msg=None):
+        raise NotImplementedError(
+            "This method is not relevant for Github database implementation."
+        )
+
+    def mark_retraced(self, crash_id):
+        raise NotImplementedError(
+            "This method is not relevant for Github database implementation."
+        )
+
+    def update(
+        self,
+        crash_id,
+        report,
+        comment,
+        change_description=False,
+        attachment_comment=None,
+        key_filter=None,
+    ):
+        raise NotImplementedError(
+            "This method is not relevant for Github database implementation."
+        )

--- a/apport/report.py
+++ b/apport/report.py
@@ -500,6 +500,7 @@ class Report(problem_report.ProblemReport):
         (e.g. 'ubuntu/+source/gnome-calculator') from snap 'contact'.
         Additionaly, extract any tag/tags defined in the contact URL.
         """
+        # Launchpad
         p = (
             r"^https?:\/\/.*launchpad\.net\/"
             r"((?:[^\/]+\/\+source\/)?[^\/]+)(?:.*field\.tags?=([^&]+))?"
@@ -509,6 +510,14 @@ class Report(problem_report.ProblemReport):
             self["SnapSource"] = m.group(1)
             if m.group(2):
                 self["SnapTags"] = m.group(2)
+
+        # Github
+        p = r"^https?://.*github\.com/([^/]+)/([^/]+)"
+        m = re.search(p, urllib.parse.unquote(snap_contact))
+        if m:
+            self["SnapGitOwner"] = m.group(1)
+            self["SnapGitName"] = m.group(2)
+            self["CrashDB"] = "snap-github"
 
     def add_os_info(self):
         """Add operating system information.

--- a/apport/ui.py
+++ b/apport/ui.py
@@ -1573,7 +1573,10 @@ class UserInterface:
             # show a hint if we cannot auto report a snap bug via 'SnapSource'
             if (
                 "Snap" in self.report
-                and "SnapSource" not in self.report
+                and (
+                    "SnapSource" not in self.report
+                    and "SnapGitName" not in self.report
+                )
                 and "UnreportableReason" not in self.report
                 and self.specified_a_pkg
             ):

--- a/doc/crashdb-conf.md
+++ b/doc/crashdb-conf.md
@@ -149,3 +149,21 @@ Crash database implementations
 
    The only supported option is `sample_data`; if set to a non-`False` value, it
    will populate the database with some example reports.
+
+ * `github` files bug reports as issues in Github using its [device flow][1].
+
+   **Options**:
+   - `repository_owner`: Name of the owner of the repository. In terms of URL:
+     github.com/repository\_owner/repository\_name.
+   - `repository_name`: Name of the repository. In terms of URL:
+     github.com/repository\_owner/repository\_name.
+   - `labels`: List of labels to add to the Github issue.
+   - `github_app_id`: The client ID obtained by registering the OAuth
+     application.
+
+   The special case of both `repository_owner` and `repository_name` being
+   `None` is reserved for snap reporting, whereby the repository to which the
+   bug is filed is determined from the `contact:` field of the snap (as listed
+   by `snap info <snap-name>`).
+
+[1]: https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#device-flow

--- a/etc/apport/crashdb.conf
+++ b/etc/apport/crashdb.conf
@@ -24,6 +24,13 @@ databases = {
         'recipient': 'submit@bugs.debian.org',
         'sender': ''
     },
+    'snap-github': {
+        'impl': 'github',
+        'repository_owner': None,
+        'repository_name': None,
+        'github_app_id': 'bb74ee9268c04aeca4fa',
+        'labels': ['apport'],
+    },
     'ubuntu-wsl': {
         'impl': 'github',
         'repository_owner': 'ubuntu',

--- a/etc/apport/crashdb.conf
+++ b/etc/apport/crashdb.conf
@@ -24,6 +24,13 @@ databases = {
         'recipient': 'submit@bugs.debian.org',
         'sender': ''
     },
+    'ubuntu-wsl': {
+        'impl': 'github',
+        'repository_owner': 'ubuntu',
+        'repository_name': 'WSL',
+        'github_app_id': 'bb74ee9268c04aeca4fa',
+        'labels': ['apport'],
+    },
     'debug': {
         # for debugging
         'impl': 'memory',

--- a/tests/integration/test_github.py
+++ b/tests/integration/test_github.py
@@ -1,0 +1,173 @@
+# Copyright (C) 2022 Canonical Ltd.
+# Author: Nathan Pratta Teodosio
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 2 of the License, or (at your
+# option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
+# the full text of the license.
+
+import unittest
+from unittest.mock import ANY, Mock, patch
+
+try:
+    import apport.crashdb_impl.github
+
+    IMPORT_ERROR = None
+except ImportError as error:
+    IMPORT_ERROR = error
+
+
+@unittest.skipIf(IMPORT_ERROR, f"module not available: {IMPORT_ERROR}")
+class T(unittest.TestCase):
+    # pylint: disable=protected-access
+
+    def setUp(self):
+        self.crashdb = self._get_gh_database("Lorem", "Ipsum")
+        self.crashdb_barren = self._get_gh_database(None, None)
+
+        self.message_cb = Mock()
+        self.github = apport.crashdb_impl.github.Github(
+            self.crashdb.app_id, self.message_cb
+        )
+
+    # Sample response:
+    # {
+    #     'device_code': '35fe1f072913d46c00ad3e4a83e57facfb758f67',
+    #     'user_code': '5A5D-7210',
+    #     'verification_uri': 'https://github.com/login/device',
+    #     'expires_in': 899,
+    #     'interval': 5
+    # }
+
+    def test__format_report(self):
+        data = {
+            "bold1": "normal1",
+            "bold2": "normal2",
+        }
+        expected_body = "**bold1**\nnormal1\n\n**bold2**\nnormal2\n\n"
+
+        result = self.crashdb._format_report(data)
+        self.assertTrue("body" in result and result["body"] == expected_body)
+        self.assertTrue("title" in result)
+        self.assertTrue(self.crashdb.labels == set(result["labels"]))
+
+    @patch("apport.crashdb_impl.github.Github.api_open_issue")
+    @patch("apport.crashdb_impl.github.Github.authentication_complete")
+    def test_upload(self, mock_auth, mock_api):
+        mock_api.return_value = {"html_url": "doesntmatterhere"}
+        mock_auth.return_value = True
+        nodata = {}
+        snapdata = {"SnapGitOwner": "gimli", "SnapGitName": "axe"}
+
+        with self.github as g:
+            self.crashdb.github = g
+            self.crashdb_barren.github = g
+
+            # Snap fields are not set and the database specifies no
+            # norepository_{owner,name}
+            self.assertRaises(
+                RuntimeError,
+                self.crashdb_barren.upload,
+                nodata,
+                None,
+                self.message_cb,
+            )
+
+            # Snap fields are not set and the database specifies
+            # norepository_{owner,name}
+            self.crashdb.upload(nodata, None, self.message_cb)
+            mock_api.assert_called_with(
+                self.crashdb.repository_owner,
+                self.crashdb.repository_name,
+                ANY,
+            )
+
+            # Snap fields are set and the database specifies
+            # norepository_{owner,name}
+            self.crashdb_barren.upload(snapdata, None, self.message_cb)
+            mock_api.assert_called_with(
+                snapdata["SnapGitOwner"], snapdata["SnapGitName"], ANY
+            )
+
+            # Snap fields are set and the database specifies
+            # repository_{owner,name}: The database specs takes precedence.
+            self.crashdb.upload(snapdata, None, self.message_cb)
+            mock_api.assert_called_with(
+                self.crashdb.repository_owner,
+                self.crashdb.repository_name,
+                ANY,
+            )
+
+    @patch("apport.crashdb_impl.github.Github.api_authentication")
+    def test_authentication_complete(self, mock_api):
+        base_response = {
+            "verification_uri": None,
+            "user_code": 123,
+            "device_code": "d123",
+            "interval": 1,
+            "expires_in": 20,
+        }
+        mocked = [base_response.copy() for i in range(7)]
+        mocked[2]["error"] = "foo"
+        mocked[3]["error"] = "authorization_pending"
+        mocked[4]["error"] = "slow_down"
+        mocked[5]["access_token"] = "token"
+        mocked[6]["expires_in"] = -100
+        mock_api.side_effect = mocked
+
+        # No __enter__, no authentication data
+        self.assertRaises(RuntimeError, self.github.authentication_complete)
+        self.message_cb.assert_not_called()
+        with self.github as g:
+            # Error message missing
+            self.assertRaises(RuntimeError, g.authentication_complete)
+            self.message_cb.assert_called_with("Login required", ANY)
+            # Error message awry
+            self.assertRaises(RuntimeError, g.authentication_complete)
+            # Still not authorized
+            self.assertFalse(g.authentication_complete())
+            # Slow down!
+            self.assertFalse(g.authentication_complete())
+            # Access token OK
+            self.assertTrue(g.authentication_complete())
+        with self.github as g:
+            # Expired (requires __enter__ again to update __expiry).
+            self.assertRaises(RuntimeError, g.authentication_complete)
+            self.message_cb.assert_called_with(
+                "Failed login",
+                "Github authentication expired. Please try again.",
+            )
+
+    def test_not_implemented_methods(self):
+        ni = NotImplementedError
+        self.assertRaises(ni, self.crashdb._mark_dup_checked, None, None)
+        self.assertRaises(ni, self.crashdb.can_update, None)
+        self.assertRaises(ni, self.crashdb.close_duplicate, None, None, None)
+        self.assertRaises(ni, self.crashdb.download, None)
+        self.assertRaises(ni, self.crashdb.duplicate_of, None)
+        self.assertRaises(ni, self.crashdb.get_affected_packages, None)
+        self.assertRaises(ni, self.crashdb.get_distro_release, None)
+        self.assertRaises(ni, self.crashdb.get_dup_unchecked)
+        self.assertRaises(ni, self.crashdb.get_fixed_version, None)
+        self.assertRaises(ni, self.crashdb.get_id_url, None, None)
+        self.assertRaises(ni, self.crashdb.get_unfixed)
+        self.assertRaises(ni, self.crashdb.get_unretraced)
+        self.assertRaises(ni, self.crashdb.is_reporter, None)
+        self.assertRaises(ni, self.crashdb.mark_regression, None, None)
+        self.assertRaises(ni, self.crashdb.mark_retrace_failed, None, None)
+        self.assertRaises(ni, self.crashdb.mark_retraced, None)
+        self.assertRaises(ni, self.crashdb.update, None, None, None, None)
+
+    @staticmethod
+    def _get_gh_database(repository_owner, repository_name):
+        return apport.crashdb_impl.github.CrashDatabase(
+            None,
+            {
+                "impl": "github",
+                "repository_owner": repository_owner,
+                "repository_name": repository_name,
+                "github_app_id": "a654870577ad2a2ab5b1",
+                "labels": ["apport"],
+            },
+        )

--- a/tests/unit/test_report.py
+++ b/tests/unit/test_report.py
@@ -1098,3 +1098,15 @@ No symbol table info available.
         pr.add_snap_contact_info(snap)
         self.assertEqual("ubuntu/+source/chromium-browser", pr["SnapSource"])
         self.assertEqual("snap", pr["SnapTags"])
+
+    def test_add_snap_contact_info_github(self):
+        """add_snap_contact_info()
+
+        Test that report is against Github
+        """
+        pr = apport.report.Report()
+        snap = "https://github.com/lxc/lxd/issues"
+        pr.add_snap_contact_info(snap)
+        self.assertEqual("lxc", pr["SnapGitOwner"])
+        self.assertEqual("lxd", pr["SnapGitName"])
+        self.assertEqual("snap-github", pr["CrashDB"])


### PR DESCRIPTION
This builds on Edu's work on https://github.com/canonical/apport/pull/1, to add this functionality: If a snap contact: field points to Github, report it there.

The snap report can be tested by installing [this snap](https://github.com/canonical/snap-for-apport-reports/) and then running `apport-bug apport-target`.