### PR TITLE
fix: Catch FileNotFoundError for missing desktop files

### DIFF
--- a/apport/fileutils.py
+++ b/apport/fileutils.py
@@ -110,9 +110,12 @@ def find_package_desktopfile(package):
                 return None  # more than one
 
             # only consider visible ones
-            with open(line, "rb") as f:
-                if b"NoDisplay=true" not in f.read():
-                    desktopfile = line
+            try:
+                with open(line, "rb") as f:
+                    if b"NoDisplay=true" not in f.read():
+                        desktopfile = line
+            except FileNotFoundError:
+                continue
 
     return desktopfile
 

--- a/tests/unit/test_fileutils.py
+++ b/tests/unit/test_fileutils.py
@@ -1,12 +1,24 @@
 import io
 import time
 import unittest
+import unittest.mock
 
 import apport.fileutils
 import apport.packaging
 
 
 class T(unittest.TestCase):
+    @unittest.mock.patch("apport.fileutils.packaging.get_files")
+    def test_find_package_desktopfile_deleted(self, get_files_mock):
+        """find_package_desktopfile() for a deleted desktop file."""
+        get_files_mock.return_value = [
+            "/usr/share/applications/non-existing/blueman.desktop"
+        ]
+        self.assertEqual(
+            apport.fileutils.find_package_desktopfile("blueman"), None
+        )
+        get_files_mock.assert_called_once_with("blueman")
+
     def test_likely_packaged(self):
         """likely_packaged()"""
         self.assertEqual(apport.fileutils.likely_packaged("/bin/bash"), True)


### PR DESCRIPTION
Desktop files shipped by Debian packages can be removed, which lets Apport crash:

```
Traceback (most recent call last):
  File "/usr/lib/python3.10/unittest/mock.py", line 1369, in patched
    return func(*newargs, **newkeywargs)
  File "tests/unit/test_fileutils.py", line 18, in test_find_package_desktopfile_deleted
    apport.fileutils.find_package_desktopfile("blueman"), None
  File "apport/fileutils.py", line 113, in find_package_desktopfile
    with open(line, "rb") as f:
FileNotFoundError: [Errno 2] No such file or directory: '/usr/share/applications/non-existing/blueman.desktop'
```

Bug: https://launchpad.net/bugs/1997753