### PR TITLE
fix: Catch ValueError: not enough values to unpack

### DIFF
--- a/problem_report.py
+++ b/problem_report.py
@@ -170,7 +170,14 @@ class ProblemReport(collections.UserDict):
                     else:
                         self.data[key] = self._try_unicode(value)
 
-                (key, value) = line.split(b":", 1)
+                try:
+                    (key, value) = line.split(b":", 1)
+                except ValueError:
+                    raise MalformedProblemReport(
+                        f"Malformed problem report: Line {line.decode()!r}"
+                        f" does not contain a colon for separating"
+                        f" the key from the value."
+                    ) from None
                 try:
                     key = key.decode("ASCII")
                 except UnicodeDecodeError as error:

--- a/tests/unit/test_problem_report.py
+++ b/tests/unit/test_problem_report.py
@@ -215,6 +215,16 @@ class T(unittest.TestCase):
             ):
                 report.load(report_file)
 
+    def test_load_missing_colon(self):
+        """Throw exception when key-value line misses a colon as separator."""
+        report = problem_report.ProblemReport()
+        with io.BytesIO(b"\n") as report_file:
+            with self.assertRaisesRegex(
+                problem_report.MalformedProblemReport,
+                r"Line '\\n' does not contain a colon",
+            ):
+                report.load(report_file)
+
     def test_write_fileobj(self):
         """Write a report with a pointer to a file-like object."""
         tempbin = io.BytesIO(bin_data)


### PR DESCRIPTION
The problem report might be malformed which lets `whoopsie-upload-all` crash:

```
Traceback (most recent call last):
  File "data/whoopsie-upload-all", line 250, in <module>
    main()
  File "data/whoopsie-upload-all", line 232, in main
    stamps = collect_info()
  File "data/whoopsie-upload-all", line 163, in collect_info
    res = process_report(r)
  File "data/whoopsie-upload-all", line 77, in process_report
    r.load(f, binary="compressed")
  File "problem_report.py", line 173, in load
    (key, value) = line.split(b":", 1)
ValueError: not enough values to unpack (expected 2, got 1)
```

Catch the `ValueError` and raise a `MalformedProblemReport` exception instead (which is catched by `whoopsie-upload-all` and `apport-unpack`).

Bug: https://launchpad.net/bugs/1995100