### PR TITLE
fix: Catch binascii.Error: Incorrect padding

### DIFF
--- a/problem_report.py
+++ b/problem_report.py
@@ -10,6 +10,7 @@
 # the full text of the license.
 
 import base64
+import binascii
 import collections
 import email.encoders
 import email.mime.base
@@ -293,7 +294,12 @@ class ProblemReport(collections.UserDict):
     @classmethod
     def _decompress_line(cls, line, decompressor, value=b""):
         """Decompress a Base64 encoded line of gzip compressed data."""
-        block = base64.b64decode(line)
+        try:
+            block = base64.b64decode(line)
+        except binascii.Error as error:
+            raise MalformedProblemReport(
+                f"Malformed problem report: {error}."
+            ) from None
         if decompressor:
             value += decompressor.decompress(block)
         else:

--- a/tests/unit/test_problem_report.py
+++ b/tests/unit/test_problem_report.py
@@ -225,6 +225,21 @@ class T(unittest.TestCase):
             ):
                 report.load(report_file)
 
+    def test_load_incorrect_padding(self):
+        """Throw exception when base64 encoded data has incorrect padding."""
+        report = problem_report.ProblemReport()
+        content = (
+            b"CoreDump: base64\n"
+            b" H4sICAAAAAAC/0NvcmVEdW1wAA==\n"
+            b" 7Z0LYFPV/cdP0rQ\n"
+        )
+        with io.BytesIO(content) as report_file:
+            with self.assertRaisesRegex(
+                problem_report.MalformedProblemReport,
+                "^Malformed problem report: Incorrect padding.$",
+            ):
+                report.load(report_file)
+
     def test_write_fileobj(self):
         """Write a report with a pointer to a file-like object."""
         tempbin = io.BytesIO(bin_data)


### PR DESCRIPTION
The problem report might be malformed which lets `whoopsie-upload-all` crash:

```
Traceback (most recent call last):
  File "data/whoopsie-upload-all", line 250, in <module>
    main()
  File "data/whoopsie-upload-all", line 232, in main
    stamps = collect_info()
  File "data/whoopsie-upload-all", line 163, in collect_info
    res = process_report(r)
  File "data/whoopsie-upload-all", line 77, in process_report
    r.load(f, binary="compressed")
  File "problem_report.py", line 147, in load
    bd, value = self._decompress_line(line, bd, value)
  File "problem_report.py", line 296, in _decompress_line
    block = base64.b64decode(line)
  File "/usr/lib/python3.10/base64.py", line 87, in b64decode
    return binascii.a2b_base64(s)
binascii.Error: Incorrect padding
```

Catch the `binascii.Error` and raise a `MalformedProblemReport` exception instead (which is catched by `whoopsie-upload-all` and `apport-unpack`).

Bug: https://launchpad.net/bugs/1997912