### PR TITLE
fix: Catch AttributeError: 'NoneType' object has no attribute 'origins'

### DIFF
--- a/apport/packaging_impl/apt_dpkg.py
+++ b/apport/packaging_impl/apt_dpkg.py
@@ -230,17 +230,17 @@ class __AptDpkgPackageInfo(PackageInfo):
         if pkg.installed and pkg.installed.version is None:
             return False
 
-        distro_name = self.get_os_version()[0]
+        if not pkg.candidate:
+            return False
 
-        if pkg.candidate and pkg.candidate.origins:  # might be None
-            for o in pkg.candidate.origins:
-                if o.origin == distro_name:
-                    return True
+        origins = {o.origin for o in pkg.candidate.origins}
+
+        distro_name = self.get_os_version()[0]
+        if distro_name in origins:
+            return True
 
         # on Ubuntu system-image we might not have any /var/lib/apt/lists
-        if {o.origin for o in pkg.candidate.origins} == {
-            ""
-        } and os.path.exists("/etc/system-image/channel.ini"):
+        if origins == {""} and os.path.exists("/etc/system-image/channel.ini"):
             return True
 
         return False

--- a/tests/integration/test_packaging_apt_dpkg.py
+++ b/tests/integration/test_packaging_apt_dpkg.py
@@ -143,7 +143,6 @@ class T(unittest.TestCase):
         """is_distro_package()."""
         self.assertRaises(ValueError, impl.is_distro_package, "nonexisting")
         self.assertTrue(impl.is_distro_package("bash"))
-        # no False test here, hard to come up with a generic one
 
     def test_get_architecture(self):
         """get_architecture()."""

--- a/tests/unit/test_packaging_apt_dpkg.py
+++ b/tests/unit/test_packaging_apt_dpkg.py
@@ -1,0 +1,77 @@
+# Copyright (C) 2022 Canonical Ltd.
+# Author: Benjamin Drung <benjamin.drung@canonical.com>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 2 of the License, or (at your
+# option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
+# the full text of the license.
+
+"""Unit tests for apport.packaging_impl.apt_dpkg."""
+
+import unittest
+import unittest.mock
+
+import apt
+
+from apport.packaging_impl.apt_dpkg import impl
+
+
+@unittest.mock.patch(
+    "apport.packaging_impl.apt_dpkg.__AptDpkgPackageInfo.get_os_version",
+    unittest.mock.MagicMock(return_value=("Ubuntu", "22.04")),
+)
+class TestPackagingAptDpkg(unittest.TestCase):
+    """Unit tests for apport.packaging_impl.apt_dpkg."""
+
+    @unittest.mock.patch("apt.Cache", spec=apt.Cache)
+    def test_is_distro_package_no_installed_version(self, apt_cache_mock):
+        """is_distro_package() for not installed package."""
+        getitem_mock = apt_cache_mock.return_value.__getitem__
+        getitem_mock.return_value = unittest.mock.MagicMock(
+            spec=apt.Package,
+            installed=unittest.mock.MagicMock(
+                spec=apt.package.Version, version=None
+            ),
+        )
+        self.assertEqual(impl.is_distro_package("7zip"), False)
+        getitem_mock.assert_called_once_with("7zip")
+
+    @unittest.mock.patch("apt.Cache", spec=apt.Cache)
+    def test_is_distro_package_ppa(self, apt_cache_mock):
+        """is_distro_package() for a PPA package."""
+        version = unittest.mock.MagicMock(
+            spec=apt.package.Version,
+            origins=[
+                unittest.mock.MagicMock(
+                    spec=apt.package.Origin, origin="LP-PPA"
+                )
+            ],
+            version="0.5.0-0ppa1",
+        )
+        getitem_mock = apt_cache_mock.return_value.__getitem__
+        getitem_mock.return_value = unittest.mock.MagicMock(
+            spec=apt.Package, candidate=version, installed=version
+        )
+        self.assertEqual(impl.is_distro_package("bdebstrap"), False)
+        getitem_mock.assert_called_once_with("bdebstrap")
+
+    @unittest.mock.patch("os.path.exists")
+    @unittest.mock.patch("apt.Cache", spec=apt.Cache)
+    def test_is_distro_package_system_image(self, apt_cache_mock, exists_mock):
+        """is_distro_package() for a system image without cache."""
+        version = unittest.mock.MagicMock(
+            spec=apt.package.Version,
+            origins=[
+                unittest.mock.MagicMock(spec=apt.package.Origin, origin="")
+            ],
+            version="2.23.1-0ubuntu4",
+        )
+        getitem_mock = apt_cache_mock.return_value.__getitem__
+        getitem_mock.return_value = unittest.mock.MagicMock(
+            spec=apt.Package, candidate=version, installed=version
+        )
+        exists_mock.return_value = True
+        self.assertEqual(impl.is_distro_package("apport"), True)
+        getitem_mock.assert_called_once_with("apport")
+        exists_mock.assert_called_once_with("/etc/system-image/channel.ini")

--- a/tests/unit/test_packaging_apt_dpkg.py
+++ b/tests/unit/test_packaging_apt_dpkg.py
@@ -25,6 +25,16 @@ class TestPackagingAptDpkg(unittest.TestCase):
     """Unit tests for apport.packaging_impl.apt_dpkg."""
 
     @unittest.mock.patch("apt.Cache", spec=apt.Cache)
+    def test_is_distro_package_no_candidate(self, apt_cache_mock):
+        """is_distro_package() for package that has no candidate."""
+        getitem_mock = apt_cache_mock.return_value.__getitem__
+        getitem_mock.return_value = unittest.mock.MagicMock(
+            spec=apt.Package, installed=None, candidate=None
+        )
+        self.assertEqual(impl.is_distro_package("adduser"), False)
+        getitem_mock.assert_called_once_with("adduser")
+
+    @unittest.mock.patch("apt.Cache", spec=apt.Cache)
     def test_is_distro_package_no_installed_version(self, apt_cache_mock):
         """is_distro_package() for not installed package."""
         getitem_mock = apt_cache_mock.return_value.__getitem__


### PR DESCRIPTION
`whoopsie-upload-all` might crash when there is no candidate in the APT cache for the Debian package:

```
Traceback (most recent call last):
  File "data/whoopsie-upload-all", line 250, in <module>
    main()
  File "data/whoopsie-upload-all", line 232, in main
    stamps = collect_info()
  File "data/whoopsie-upload-all", line 163, in collect_info
    res = process_report(r)
  File "data/whoopsie-upload-all", line 91, in process_report
    r.add_package_info()
  File "apport/report.py", line 371, in add_package_info
    version = self.add_package(package)
  File "apport/report.py", line 339, in add_package
    self._customized_package_suffix(package),
  File "apport/report.py", line 310, in _customized_package_suffix
    if not packaging.is_distro_package(package):
  File "apport/packaging_impl/apt_dpkg.py", line 241, in is_distro_package
    if {o.origin for o in pkg.candidate.origins} == {
AttributeError: 'NoneType' object has no attribute 'origins'
```

Also add unit tests for `is_distro_package` to increase the test coverage. Simulate an installed package that has no installed version in the APT cache, an installed PPA package, an package in a system image without the APT cache.

Bug: https://launchpad.net/bugs/1997973