### PR TITLE
feat: Split bash completions by command

### DIFF
--- a/data/bash-completion/apport-bug
+++ b/data/bash-completion/apport-bug
@@ -1,7 +1,4 @@
-# 
-# Apport bash-completion
-#
-###############################################################################
+# Apport bash-completion for apport-bug and apport-cli
 
 # get available symptoms
 _apport_symptoms ()
@@ -204,65 +201,7 @@ _apport-cli ()
     esac
 }
 
-# apport-unpack completion
-_apport-unpack ()
-{
-    local cur prev
-
-    COMPREPLY=()
-    cur=`_get_cword`
-    prev=${COMP_WORDS[COMP_CWORD-1]}
-
-    case "$prev" in
-    apport-unpack)
-        # only show *.apport *.crash files
-        COMPREPLY=( $( compgen -G "${cur}*.apport"
-                       compgen -G "${cur}*.crash" ) )
-
-    ;;
-    esac
-}
-
-# apport-collect completion
-_apport-collect ()
-{
-    local cur prev
-
-    COMPREPLY=()
-    cur=`_get_cword`
-    prev=${COMP_WORDS[COMP_CWORD-1]}
-
-    case "$prev" in 
-    apport-collect)
-        COMPREPLY=( $( compgen -W "-p --package --tag" -- $cur) )
-
-    ;;
-    -p | --package)
-        # list package names
-        COMPREPLY=( $( apt-cache pkgnames $cur 2> /dev/null ) )
-
-    ;;
-    --tag)
-        # standalone parameter
-        return 0
-    ;;
-    *)
-        # only complete -p/--package once
-        if [[ "${COMP_WORDS[*]}" =~ .*\ -p.* || "${COMP_WORDS[*]}" =~ .*--package.* ]]; then
-            COMPREPLY=( $( compgen -W "--tag" -- $cur) )
-        else
-            COMPREPLY=( $( compgen -W "-p --package --tag" -- $cur) )
-        fi
-        
-    ;;
-    esac
-}
-
 # bind completion to apport commands
 complete -F _apport-bug -o filenames -o dirnames ubuntu-bug
 complete -F _apport-bug -o filenames -o dirnames apport-bug
 complete -F _apport-cli -o filenames -o dirnames apport-cli
-complete -F _apport-unpack -o filenames -o dirnames apport-unpack
-complete -F _apport-collect apport-collect
-
-# vi: syntax=bash

--- a/data/bash-completion/apport-cli
+++ b/data/bash-completion/apport-cli
@@ -1,0 +1,1 @@
+apport-bug

--- a/data/bash-completion/apport-collect
+++ b/data/bash-completion/apport-collect
@@ -1,0 +1,37 @@
+# Apport bash-completion for apport-collect
+
+_apport-collect ()
+{
+    local cur prev
+
+    COMPREPLY=()
+    cur=`_get_cword`
+    prev=${COMP_WORDS[COMP_CWORD-1]}
+
+    case "$prev" in
+    apport-collect)
+        COMPREPLY=( $( compgen -W "-p --package --tag" -- $cur) )
+
+    ;;
+    -p | --package)
+        # list package names
+        COMPREPLY=( $( apt-cache pkgnames $cur 2> /dev/null ) )
+
+    ;;
+    --tag)
+        # standalone parameter
+        return 0
+    ;;
+    *)
+        # only complete -p/--package once
+        if [[ "${COMP_WORDS[*]}" =~ .*\ -p.* || "${COMP_WORDS[*]}" =~ .*--package.* ]]; then
+            COMPREPLY=( $( compgen -W "--tag" -- $cur) )
+        else
+            COMPREPLY=( $( compgen -W "-p --package --tag" -- $cur) )
+        fi
+
+    ;;
+    esac
+}
+
+complete -F _apport-collect apport-collect

--- a/data/bash-completion/apport-unpack
+++ b/data/bash-completion/apport-unpack
@@ -1,0 +1,21 @@
+# Apport bash-completion for apport-unpack
+
+_apport-unpack ()
+{
+    local cur prev
+
+    COMPREPLY=()
+    cur=`_get_cword`
+    prev=${COMP_WORDS[COMP_CWORD-1]}
+
+    case "$prev" in
+    apport-unpack)
+        # only show *.apport *.crash files
+        COMPREPLY=( $( compgen -G "${cur}*.apport"
+                       compgen -G "${cur}*.crash" ) )
+
+    ;;
+    esac
+}
+
+complete -F _apport-unpack -o filenames -o dirnames apport-unpack


### PR DESCRIPTION
The bash completions directory `/etc/bash_completion.d` is obsolete and the completions should be installed into
`/usr/share/bash-completion/completions`, which has stricter filename requirements.

Therefore move the bash completions into `data/bash-completion` and split each command into a separate file that matches the command name. Keep `apport-bug` and `apport-cli` in one file because they share the same helper functions.

Please review https://github.com/canonical/apport/pull/33 first to fix the missing code coverage for `setup.py`.