### PR TITLE
test(apport-gtk): Cover destroy code path in ui_update_view

### DIFF
--- a/tests/system/test_ui_gtk.py
+++ b/tests/system/test_ui_gtk.py
@@ -1274,6 +1274,11 @@ class T(unittest.TestCase):
             f'Für Hilfe gehen Sie über <a href="{url}">{url}</a>.',
         )
 
+    def test_ui_update_view_destroyed(self):
+        """Test ui_update_view if the dialog is already destroyed."""
+        self.app.w("details_treeview").destroy()
+        self.app.ui_update_view()
+
     @staticmethod
     def has_click_event_connected(widget):
         signal_id = GObject.signal_lookup("clicked", widget)


### PR DESCRIPTION
The code path in `ui_update_view` if the dialog is already destroyed is sometime covered. Add a test case for it to always cover it and stabilize the test coverage report.