### PR TITLE
feat: Add apport.service

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -264,12 +264,7 @@ jobs:
           && sudo chown "$SUDO_UID:$SUDO_GID" .coverage
           && python3 -m coverage xml -o coverage-setup.xml
       - name: Enable Apport
-        run: >
-          echo "|/usr/share/apport/apport "
-          "-p%p -s%s -c%c -d%d -P%P -u%u -g%g -- %E"
-          | sudo tee /proc/sys/kernel/core_pattern
-          && echo 2 | sudo tee /proc/sys/fs/suid_dumpable
-          && echo 10 | sudo tee /proc/sys/kernel/core_pipe_limit
+        run: sudo /usr/share/apport/apport --start
       - name: Run system tests
         env:
           GDK_BACKEND: x11

--- a/data/apport
+++ b/data/apport
@@ -28,6 +28,7 @@ import inspect
 import io
 import os
 import pwd
+import re
 import signal
 import socket
 import struct
@@ -632,11 +633,51 @@ def forward_crash_to_container(
         error_log("Container apport failed to process crash within 30s")
 
 
+def check_kernel_crash() -> None:
+    """Check for kernel crash dump, convert it to apport report."""
+    kernel_crash_re = re.compile("^([0-9]{12}|vmcore)$")
+    for report in os.listdir(apport.fileutils.report_dir):
+        if kernel_crash_re.match(report):
+            subprocess.run(["/usr/share/apport/kernel_crashdump"], check=False)
+            return
+
+
+def create_directory(path: str, mode: int) -> None:
+    """Ensure the directory is created with the correct mode."""
+    os.makedirs(path, exist_ok=True)
+    os.chmod(path, mode)
+
+
+def write_to_proc_sys(path: str, value: str) -> None:
+    """Write value to /proc/sys."""
+    with open(os.path.join("/proc/sys", path), "w", encoding="utf-8") as proc:
+        proc.write(value)
+
+
+def start_apport() -> None:
+    """Start Apport crash handler."""
+    create_directory(apport.fileutils.report_dir, 0o1777)
+    write_to_proc_sys(
+        "kernel/core_pattern",
+        f"|{__file__} -p%p -s%s -c%c -d%d -P%P -u%u -g%g -- %E",
+    )
+    write_to_proc_sys("fs/suid_dumpable", "2")
+    write_to_proc_sys("kernel/core_pipe_limit", "10")
+    check_kernel_crash()
+
+
+def stop_apport() -> None:
+    """Stop Apport crash handler."""
+    write_to_proc_sys("kernel/core_pipe_limit", "0")
+    write_to_proc_sys("fs/suid_dumpable", "0")
+    write_to_proc_sys("kernel/core_pattern", "core")
+
+
 def parse_arguments(args: list[str]):
     parser = argparse.ArgumentParser()
 
     # TODO: Use type=int
-    parser.add_argument("-p", "--pid", required=True, help="process id (%%p)")
+    parser.add_argument("-p", "--pid", help="process id (%%p)")
     parser.add_argument("-s", "--signal-number", help="signal number (%%s)")
     parser.add_argument("-c", "--core-ulimit", help="core ulimit (%%c)")
     parser.add_argument("-d", "--dump-mode", help="dump mode (%%d)")
@@ -649,7 +690,21 @@ def parse_arguments(args: list[str]):
         "executable_path", nargs="*", help="path of executable (%%E)"
     )
 
+    parser.add_argument(
+        "--start",
+        action="store_true",
+        help="Start Apport crash handler and exit",
+    )
+    parser.add_argument(
+        "--stop",
+        action="store_true",
+        help="Stop Apport crash handler and exit",
+    )
+
     options = parser.parse_args(args)
+
+    if not options.pid and not options.start and not options.stop:
+        parser.error("the following arguments are required: -p/--pid")
 
     # In kernels before 5.3.0, an executable path with spaces may be split
     # into separate arguments. If options.executable_path is a list, join
@@ -738,9 +793,18 @@ def main(args: list[str]) -> int:
             uid=None,
             gid=None,
             executable_path=None,
+            start=False,
+            stop=False,
         )
     else:
         options = parse_arguments(args)
+
+    if options.stop:
+        stop_apport()
+        return 0
+    if options.start:
+        start_apport()
+        return 0
 
     # Check if we received a valid global PID (kernel >= 3.12). If we do,
     # then compare it with the local PID. If they don't match, it's an

--- a/data/systemd/apport.service
+++ b/data/systemd/apport.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=automatic crash report generation
+After=remote-fs.target
+ConditionVirtualization=!container
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/share/apport/apport --start
+ExecStop=/usr/share/apport/apport --stop
+
+[Install]
+WantedBy=multi-user.target

--- a/etc/init.d/apport
+++ b/etc/init.d/apport
@@ -35,13 +35,7 @@ do_start()
 	#   1 if daemon was already running
 	#   2 if daemon could not be started
 
-	[ -e /var/crash ] || mkdir -p /var/crash
-	chmod 1777 /var/crash
-
-	# check for kernel crash dump, convert it to apport report
-	if [ -e /var/crash/vmcore ] || [ -n "`ls /var/crash | egrep ^[0-9]{12}$`" ];then
-	    /usr/share/apport/kernel_crashdump || true
-	fi
+	$AGENT --start
 
 	# check for incomplete suspend/resume or hibernate
 	if [ -e /var/lib/pm-utils/status ]; then
@@ -49,10 +43,6 @@ do_start()
 		rm -f /var/lib/pm-utils/status
 		rm -f /var/lib/pm-utils/resume-hang.log
 	fi
-
-	echo "|$AGENT -p%p -s%s -c%c -d%d -P%P -u%u -g%g -- %E" > /proc/sys/kernel/core_pattern
-	echo 2 > /proc/sys/fs/suid_dumpable
-	echo 10 > /proc/sys/kernel/core_pipe_limit
 }
 
 #
@@ -66,20 +56,13 @@ do_stop()
 	#   2 if daemon could not be stopped
 	#   other if a failure occurred
 
-	echo 0 > /proc/sys/kernel/core_pipe_limit
-	echo 0 > /proc/sys/fs/suid_dumpable
-
 	# Check for a hung resume.  If we find one try and grab everything
 	# we can to aid in its discovery.
 	if [ -e /var/lib/pm-utils/status ]; then
 		ps -wwef >/var/lib/pm-utils/resume-hang.log
 	fi
 
-	if [ "`dd if=/proc/sys/kernel/core_pattern count=1 bs=1 2>/dev/null`" != "|" ]; then
-	    return 1
-	else
-	    echo "core" > /proc/sys/kernel/core_pattern
-	fi
+	$AGENT --stop
 }
 
 case "$1" in

--- a/tests/unit/test_signal_crashes.py
+++ b/tests/unit/test_signal_crashes.py
@@ -1,0 +1,85 @@
+# Copyright (C) 2022 Canonical Ltd.
+# Author: Benjamin Drung <benjamin.drung@canonical.com>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 2 of the License, or (at your
+# option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
+# the full text of the license.
+
+"""Unit tests for data/apport."""
+
+import os
+import pathlib
+import shutil
+import tempfile
+import unittest
+
+import apport.fileutils
+from tests.helper import import_module_from_file
+from tests.paths import get_data_directory
+
+apport_binary = import_module_from_file(
+    os.path.join(get_data_directory(), "apport")
+)
+
+
+class TestApport(unittest.TestCase):
+    """Unit tests for data/apport."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.orig_report_dir = apport.fileutils.report_dir
+
+    @classmethod
+    def tearDownClass(cls):
+        apport.fileutils.report_dir = cls.orig_report_dir
+
+    def setUp(self):
+        self.workdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.workdir)
+        apport.fileutils.report_dir = os.path.join(self.workdir, "crash")
+        self.report_dir = pathlib.Path(apport.fileutils.report_dir)
+
+    @unittest.mock.patch("subprocess.run")
+    def test_check_kernel_crash(self, run_mock):
+        """Test found kernel crash dump."""
+        self.report_dir.mkdir()
+        vmcore = self.report_dir / "vmcore"
+        vmcore.touch()
+        apport_binary.check_kernel_crash()
+        run_mock.assert_called_once_with(
+            ["/usr/share/apport/kernel_crashdump"], check=False
+        )
+
+    @unittest.mock.patch.object(apport_binary, "start_apport")
+    def test_main_start(self, start_mock):
+        """Test calling apport with --start."""
+        self.assertEqual(apport_binary.main(["--start"]), 0)
+        start_mock.assert_called_once_with()
+
+    @unittest.mock.patch.object(apport_binary, "stop_apport")
+    def test_main_stop(self, stop_mock):
+        """Test calling apport with --stop."""
+        self.assertEqual(apport_binary.main(["--stop"]), 0)
+        stop_mock.assert_called_once_with()
+
+    def test_start(self):
+        """Test starting Apport crash handler."""
+        open_mock = unittest.mock.mock_open()
+        with unittest.mock.patch("builtins.open", open_mock):
+            apport_binary.start_apport()
+        open_mock.assert_called_with(
+            "/proc/sys/kernel/core_pipe_limit", "w", encoding="utf-8"
+        )
+        self.assertEqual(open_mock.call_count, 3)
+
+    def test_stop(self):
+        """Test stopping Apport crash handler."""
+        open_mock = unittest.mock.mock_open()
+        with unittest.mock.patch("builtins.open", open_mock):
+            apport_binary.stop_apport()
+        open_mock.assert_called_with(
+            "/proc/sys/kernel/core_pattern", "w", encoding="utf-8"
+        )
+        self.assertEqual(open_mock.call_count, 3)


### PR DESCRIPTION
Move start and stop logic from init.d service into `data/apport` to ease adding a corresponding systemd service. Do not move the pm-utils check for incomplete suspend/resume or hibernate, because pm-utils is not used any more in Ubuntu.

Add an apport systemd service as alternative to the init.d script.