### PR TITLE
refactor(apport): Avoid duplicate is_same_ns() check

### DIFF
--- a/data/apport
+++ b/data/apport
@@ -813,10 +813,10 @@ def main(args: list[str]) -> int:
     if options.global_pid is not None:
         host_pid = int(options.global_pid)
 
-        if not is_same_ns(host_pid, "pid") and not is_same_ns(host_pid, "mnt"):
-            forward_crash_to_container(host_pid, options)
-            return 0
         if not is_same_ns(host_pid, "mnt"):
+            if not is_same_ns(host_pid, "pid"):
+                forward_crash_to_container(host_pid, options)
+                return 0
             error_log(
                 "host pid %s crashed in a separate mount namespace, ignoring"
                 % host_pid

--- a/tests/unit/test_signal_crashes.py
+++ b/tests/unit/test_signal_crashes.py
@@ -52,6 +52,18 @@ class TestApport(unittest.TestCase):
             ["/usr/share/apport/kernel_crashdump"], check=False
         )
 
+    @unittest.mock.patch.object(
+        apport_binary,
+        "is_same_ns",
+        unittest.mock.MagicMock(return_value=False),
+    )
+    @unittest.mock.patch.object(apport_binary, "forward_crash_to_container")
+    def test_main_forward_crash_to_container(self, forward_mock):
+        """Test main() to forward crash to container."""
+        args = ["-p", "12345", "-P", "67890"]
+        self.assertEqual(apport_binary.main(args), 0)
+        forward_mock.assert_called_once()
+
     @unittest.mock.patch.object(apport_binary, "start_apport")
     def test_main_start(self, start_mock):
         """Test calling apport with --start."""


### PR DESCRIPTION
Avoid calling `is_same_ns(host_pid, "mnt")` twice.