### PR TITLE
fix: Fix ignoring SIGXCPU and SIGXFSZ

### DIFF
--- a/data/apport
+++ b/data/apport
@@ -446,7 +446,7 @@ def is_closing_session():
 def is_systemd_watchdog_restart(signum):
     """Check if this is a restart by systemd's watchdog"""
 
-    if signum != str(signal.SIGABRT) or not os.path.isdir(
+    if signum != str(int(signal.SIGABRT)) or not os.path.isdir(
         "/run/systemd/system"
     ):
         return False
@@ -979,7 +979,7 @@ def main(args: list[str]) -> int:
 
         # ignore SIGXCPU and SIGXFSZ since this indicates some external
         # influence changing soft RLIMIT values when running programs.
-        if signum in [str(signal.SIGXCPU), str(signal.SIGXFSZ)]:
+        if signum in (str(int(signal.SIGXCPU)), str(int(signal.SIGXFSZ))):
             error_log(
                 "Ignoring signal %s (caused by exceeding soft RLIMIT)" % signum
             )

--- a/tests/integration/test_signal_crashes.py
+++ b/tests/integration/test_signal_crashes.py
@@ -339,6 +339,10 @@ class T(unittest.TestCase):
         """Apport ignores SIGQUIT."""
         self.do_crash(sig=signal.SIGQUIT, expect_report=False)
 
+    def test_ignore_sigxcpu(self):
+        """Apport ignores CPU time limit exceeded (SIGXCPU)."""
+        self.do_crash(sig=signal.SIGXCPU, expect_report=False)
+
     def test_leak_inaccessible_files(self):
         """Existence of user-inaccessible files do not leak."""
         local_exe = os.path.join(self.workdir, "myscript")


### PR DESCRIPTION
`str(signal.SIGXCPU)` returns `Signals.SIGXCPU` instead of the string representation of the signal number `24`. Therefore the comparison with the signal number string will never match.