### PR TITLE
refactor(apport): Split receive_arguments_via_socket out of main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,6 +53,7 @@ jobs:
           apt-get update
           && apt-get install --no-install-recommends --yes
           locales python3 python3-apt python3-pytest python3-pytest-cov
+          python3-systemd
       - name: Enable German locale
         run: sed -i 's/^# de_DE/de_DE/g' /etc/locale.gen && locale-gen
       - name: Run unit tests

--- a/data/apport
+++ b/data/apport
@@ -724,78 +724,7 @@ def main(args: list[str]) -> int:
 
     # systemd socket activation
     if "LISTEN_FDS" in os.environ:
-        try:
-            # pylint: disable=import-outside-toplevel
-            from systemd.daemon import listen_fds
-        except ImportError:
-            error_log(
-                "Received a crash via apport-forward.socket,"
-                " but systemd python module is not installed"
-            )
-            return 0
-
-        # Extract and validate the fd
-        fds = listen_fds()
-        if len(fds) < 1:
-            error_log("Invalid socket activation, no fd provided")
-            return 1
-
-        # Open the socket
-        sock = socket.fromfd(int(fds[0]), socket.AF_UNIX, socket.SOCK_STREAM)
-        atexit.register(sock.shutdown, socket.SHUT_RDWR)
-
-        # Replace stdin by the socket activation fd
-        sys.stdin.close()
-
-        fds = array.array("i")
-        ucreds = array.array("i")
-        msg, ancdata, _unused_flags, _unused_addr = sock.recvmsg(4096, 4096)
-        for cmsg_level, cmsg_type, cmsg_data in ancdata:
-            if (
-                cmsg_level == socket.SOL_SOCKET
-                and cmsg_type == socket.SCM_RIGHTS
-            ):
-                fds.frombytes(
-                    cmsg_data[
-                        : len(cmsg_data) - (len(cmsg_data) % fds.itemsize)
-                    ]
-                )
-            elif (
-                cmsg_level == socket.SOL_SOCKET
-                and cmsg_type == socket.SCM_CREDENTIALS
-            ):
-                ucreds.frombytes(
-                    cmsg_data[
-                        : len(cmsg_data) - (len(cmsg_data) % ucreds.itemsize)
-                    ]
-                )
-
-        sys.stdin = os.fdopen(int(fds[0]), "r")
-
-        # Replace args by the arguments received over the socket
-        args = msg.decode().split()
-        if len(ucreds) >= 3:
-            args[0] = "%d" % ucreds[0]
-
-        if len(args) != 4:
-            error_log(
-                "Received a bad number of arguments from forwarder,"
-                " received %d, expected 4, aborting." % len(args)
-            )
-            return 1
-
-        options = argparse.Namespace(
-            pid=args[0],
-            signal_number=args[1],
-            core_ulimit=args[2],
-            dump_mode=args[3],
-            global_pid=None,
-            uid=None,
-            gid=None,
-            executable_path=None,
-            start=False,
-            stop=False,
-        )
+        options = receive_arguments_via_socket()
     else:
         options = parse_arguments(args)
 
@@ -1109,6 +1038,77 @@ def main(args: list[str]) -> int:
         error_log("environment: %s" % str(os.environ))
 
     return 0
+
+
+def receive_arguments_via_socket() -> argparse.Namespace:
+    """Receive arguments from the host via a socket."""
+    try:
+        # pylint: disable=import-outside-toplevel
+        from systemd.daemon import listen_fds
+    except ImportError:
+        error_log(
+            "Received a crash via apport-forward.socket,"
+            " but systemd python module is not installed"
+        )
+        sys.exit(0)
+
+    # Extract and validate the fd
+    fds = listen_fds()
+    if len(fds) < 1:
+        error_log("Invalid socket activation, no fd provided")
+        sys.exit(1)
+
+    # Open the socket
+    sock = socket.fromfd(int(fds[0]), socket.AF_UNIX, socket.SOCK_STREAM)
+    atexit.register(sock.shutdown, socket.SHUT_RDWR)
+
+    # Replace stdin by the socket activation fd
+    sys.stdin.close()
+
+    fds = array.array("i")
+    ucreds = array.array("i")
+    msg, ancdata, _unused_flags, _unused_addr = sock.recvmsg(4096, 4096)
+    for cmsg_level, cmsg_type, cmsg_data in ancdata:
+        if cmsg_level == socket.SOL_SOCKET and cmsg_type == socket.SCM_RIGHTS:
+            fds.frombytes(
+                cmsg_data[: len(cmsg_data) - (len(cmsg_data) % fds.itemsize)]
+            )
+        elif (
+            cmsg_level == socket.SOL_SOCKET
+            and cmsg_type == socket.SCM_CREDENTIALS
+        ):
+            ucreds.frombytes(
+                cmsg_data[
+                    : len(cmsg_data) - (len(cmsg_data) % ucreds.itemsize)
+                ]
+            )
+
+    sys.stdin = os.fdopen(int(fds[0]), "r")
+
+    # Replace args by the arguments received over the socket
+    args = msg.decode().split()
+    if len(ucreds) >= 3:
+        args[0] = "%d" % ucreds[0]
+
+    if len(args) != 4:
+        error_log(
+            "Received a bad number of arguments from forwarder,"
+            " received %d, expected 4, aborting." % len(args)
+        )
+        sys.exit(1)
+
+    return argparse.Namespace(
+        pid=args[0],
+        signal_number=args[1],
+        core_ulimit=args[2],
+        dump_mode=args[3],
+        global_pid=None,
+        uid=None,
+        gid=None,
+        executable_path=None,
+        start=False,
+        stop=False,
+    )
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_signal_crashes.py
+++ b/tests/unit/test_signal_crashes.py
@@ -52,6 +52,21 @@ class TestApport(unittest.TestCase):
             ["/usr/share/apport/kernel_crashdump"], check=False
         )
 
+    @unittest.mock.patch("builtins.__import__")
+    def test_receive_arguments_via_socket_import_error(self, import_mock):
+        """Test receive_arguments_via_socket() fail to import systemd."""
+        import_mock.side_effect = ModuleNotFoundError(
+            "No module named 'systemd'"
+        )
+        with self.assertRaisesRegex(SystemExit, "^0$"):
+            apport_binary.receive_arguments_via_socket()
+
+    def test_receive_arguments_via_socket_invalid_socket(self):
+        """Test receive_arguments_via_socket with invalid socket."""
+        self.assertNotIn("LISTEN_FDS", os.environ)
+        with self.assertRaisesRegex(SystemExit, "^1$"):
+            apport_binary.receive_arguments_via_socket()
+
     @unittest.mock.patch.object(
         apport_binary,
         "is_same_ns",


### PR DESCRIPTION
To make the code more readable, split `receive_arguments_via_socket` out of the `main` function.

Add some unit test cases for `receive_arguments_via_socket` to test failure cases (to increase test coverage).