### PR TITLE
refactor: Add add_tags() and get_tags() to ProblemReport

### DIFF
--- a/apport/crashdb_impl/launchpad.py
+++ b/apport/crashdb_impl/launchpad.py
@@ -361,7 +361,7 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
                     "cannot determine ProblemType from tags: " + str(b.tags)
                 )
 
-        report["Tags"] = " ".join(b.tags)
+        report.add_tags(b.tags)
 
         if "Title" in report:
             report["OriginalTitle"] = report["Title"]
@@ -1481,9 +1481,8 @@ and more
             self.assertEqual(
                 r.get("UserGroups"), self.ref_report.get("UserGroups")
             )
-            tags = set(r["Tags"].split())
             self.assertEqual(
-                tags,
+                r.get_tags(),
                 set(
                     [
                         self.crashdb.arch_tag,
@@ -1507,9 +1506,8 @@ and more
 
             # check tags
             r = self.crashdb.download(self.get_python_report())
-            tags = set(r["Tags"].split())
             self.assertEqual(
-                tags,
+                r.get_tags(),
                 set(
                     [
                         "apport-crash",

--- a/apport/hookutils.py
+++ b/apport/hookutils.py
@@ -948,7 +948,7 @@ def attach_mac_events(report, profiles=None):
         aa_re, report.get("KernLog", "") + report.get("AuditLog", "")
     ):
         if not profiles:
-            _add_tag(report, "apparmor")
+            report.add_tags(["apparmor"])
             break
 
         try:
@@ -963,16 +963,8 @@ def attach_mac_events(report, profiles=None):
 
         for search_profile in profiles:
             if re.match("^" + search_profile + "$", profile):
-                _add_tag(report, "apparmor")
+                report.add_tags(["apparmor"])
                 break
-
-
-def _add_tag(report, tag):
-    """Add or append a tag to the report."""
-    current_tags = report.get("Tags", "")
-    if current_tags:
-        current_tags += " "
-    report["Tags"] = current_tags + tag
 
 
 def attach_related_packages(report, packages):

--- a/apport/ui.py
+++ b/apport/ui.py
@@ -1558,11 +1558,7 @@ class UserInterface:
 
             # append snap tags, if this report is about the snap
             if "Snap" in self.report and "SnapTags" in self.report:
-                current_tags = self.report.get("Tags", "")
-                if current_tags:
-                    current_tags += " "
-                self.report["Tags"] = current_tags + self.report["SnapTags"]
-                del self.report["SnapTags"]
+                self.report.add_tags(self.report.pop("SnapTags").split(" "))
 
             # show a hint if we cannot auto report a snap bug via 'SnapSource'
             if (
@@ -1984,10 +1980,7 @@ class UserInterface:
         """Add extra tags to report specified with --tags on CLI."""
         assert self.report
         if self.args.tags:
-            tags = self.report.get("Tags", "")
-            if tags:
-                tags += " "
-            self.report["Tags"] = tags + " ".join(self.args.tags)
+            self.report.add_tags(self.args.tags)
 
     #
     # abstract UI methods that must be implemented in derived classes

--- a/data/apportcheckresume
+++ b/data/apportcheckresume
@@ -51,7 +51,7 @@ def main(argv=None):
 
         # Ensure we are appropriately tagged.
         if "Failure" in pr:
-            pr["Tags"] = "resume " + pr["Failure"]
+            pr.add_tags(["resume ", pr["Failure"]])
 
             # Record the failure mode.
             pr["Failure"] += "/resume"
@@ -60,7 +60,7 @@ def main(argv=None):
         # add an additional tag so we can pick these out.
         if os.path.exists(hanglog):
             attach_file_if_exists(pr, hanglog, "ResumeHangLog")
-            pr["Tags"] += " resume-late-hang"
+            pr.add_tags(["resume-late-hang"])
 
         # Generate a sensible report message.
         if pr.get("Failure") == "suspend/resume":

--- a/data/general-hooks/generic.py
+++ b/data/general-hooks/generic.py
@@ -82,15 +82,13 @@ Do you want to continue the report process anyway?
             ):
                 raise StopIteration
             report["LocalLibraries"] = " ".join(local_libs)
-            report["Tags"] = (report.get("Tags", "") + " local-libs").strip()
+            report.add_tags(["local-libs"])
 
     # using third-party packages?
     if "[origin:" in report.get("Package", "") or "[origin:" in report.get(
         "Dependencies", ""
     ):
-        report["Tags"] = (
-            report.get("Tags", "") + " third-party-packages"
-        ).strip()
+        report.add_tags(["third-party-packages"])
 
     # using ecryptfs?
     if os.path.exists(os.path.expanduser("~/.ecryptfs/wrapped-passphrase")):

--- a/data/package_hook
+++ b/data/package_hook
@@ -54,7 +54,10 @@ def parse_args():
         "--tags",
         help="Add the following tags to the bug report (comma separated)",
     )
-    return parser.parse_args()
+    args = parser.parse_args()
+    if args.tags:
+        args.tags = args.tags.split(",")
+    return args
 
 
 def main():
@@ -68,8 +71,7 @@ def main():
     pr["ErrorMessage"] = (sys.stdin, False)
 
     if options.tags:
-        tags = options.tags.replace(",", "")
-        pr["Tags"] = tags
+        pr.add_tags(options.tags)
 
     for line in options.logs or []:
         if os.path.isfile(line):

--- a/doc/package-hooks.md
+++ b/doc/package-hooks.md
@@ -104,10 +104,10 @@ Some bug tracking systems support tags to further categorize bug reports and
 make searching/duplication easier. Hooks can set tags with
 
 ```python
-report["Tags"] = "tag1 tag2"
+report.add_tags(["tag1", "tag2"])
 ```
 
-i. e. a space separated list of tag names.
+The `Tags` field contains a space separated list of tag names.
 
 Customize the crash DB to use
 =============================

--- a/problem_report.py
+++ b/problem_report.py
@@ -116,6 +116,12 @@ class ProblemReport(collections.UserDict):
         # keeps track of keys which were added since the last ctor or load()
         self.old_keys = set()
 
+    def add_tags(self, tags: typing.Iterable[str]) -> None:
+        """Add tags to the report. Duplicates are dropped."""
+        current_tags = self.get_tags()
+        new_tags = current_tags.union(tags)
+        self["Tags"] = " ".join(sorted(new_tags))
+
     def load(self, file, binary=True, key_filter=None):
         """Initialize problem report from a file-like object.
 
@@ -269,6 +275,12 @@ class ProblemReport(collections.UserDict):
                     if element is False
                 ]
             )
+
+    def get_tags(self) -> set[str]:
+        """Return the set of tags."""
+        if "Tags" not in self:
+            return set()
+        return set(self["Tags"].split(" "))
 
     def get_timestamp(self) -> typing.Optional[int]:
         """Get timestamp (seconds since epoch) from Date field.

--- a/tests/integration/test_hooks.py
+++ b/tests/integration/test_hooks.py
@@ -161,7 +161,7 @@ class T(unittest.TestCase):
             "-p",
             "bash",
             "-t",
-            "dist-upgrade, verybad",
+            "verybad,dist-upgrade",
         ]
         ph = subprocess.run(
             cmd, check=False, env=self.env, input=b"something is wrong"

--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -686,8 +686,7 @@ class T(unittest.TestCase):
         self.assertNotIn("ProcCmdline", self.ui.report)  # privacy!
         self.assertIn("ProcEnviron", self.ui.report)
         self.assertEqual(self.ui.report["ProblemType"], "Bug")
-        self.assertIn("Tags", self.ui.report)
-        self.assertIn("foo", self.ui.report["Tags"])
+        self.assertIn("foo", self.ui.report.get_tags())
 
         self.assertEqual(self.ui.msg_severity, None)
         self.assertEqual(self.ui.msg_title, None)
@@ -1964,7 +1963,7 @@ class T(unittest.TestCase):
         self.assertTrue(self.ui.report["Package"].startswith("bash "))
         self.assertIn("Dependencies", self.ui.report)
         self.assertIn("ProcEnviron", self.ui.report)
-        self.assertIn("foo", self.ui.report["Tags"])
+        self.assertIn("foo", self.ui.report.get_tags())
 
     def test_run_update_report_existing_package_cli_cmdname(self):
         """run_update_report() on an existing package (-collect program)"""
@@ -2308,7 +2307,7 @@ class T(unittest.TestCase):
         self.assertTrue(self.ui.present_details_shown)
 
         self.assertEqual(self.ui.report["itch"], "scratch")
-        self.assertIn("foo", self.ui.report["Tags"])
+        self.assertIn("foo", self.ui.report.get_tags())
 
         # working interactive script
         self._write_symptom_script(

--- a/tests/unit/test_problem_report.py
+++ b/tests/unit/test_problem_report.py
@@ -11,6 +11,22 @@ bin_data = b"ABABABABAB\0\0\0Z\x01\x02"
 
 
 class T(unittest.TestCase):
+    def test_add_tags(self):
+        """Test ProblemReport.add_tags()."""
+        report = problem_report.ProblemReport()
+        report.add_tags({"tag1"})
+        self.assertEqual(report["Tags"], "tag1")
+        report.add_tags(["tag2", "next_tag"])
+        self.assertEqual(report["Tags"], "next_tag tag1 tag2")
+
+    def test_add_tag_drop_duplicates(self):
+        """Test ProblemReport.add_tags() dropping duplicates."""
+        report = problem_report.ProblemReport()
+        report.add_tags({"same"})
+        self.assertEqual(report["Tags"], "same")
+        report.add_tags(["same"])
+        self.assertEqual(report["Tags"], "same")
+
     def test_basic_operations(self):
         """Basic creation and operation."""
         pr = problem_report.ProblemReport()


### PR DESCRIPTION
There are multiple Apport hooks that want to add tags to the report. Add `add_tags` and `get_tags` to `ProblemReport` to avoid code duplication.