### PR TITLE
fix: Catch UnicodeDecodeError on a malformed problem report

### DIFF
--- a/problem_report.py
+++ b/problem_report.py
@@ -175,7 +175,8 @@ class ProblemReport(collections.UserDict):
                     (key, value) = line.split(b":", 1)
                 except ValueError:
                     raise MalformedProblemReport(
-                        f"Malformed problem report: Line {line.decode()!r}"
+                        f"Malformed problem report: Line"
+                        f" {line.decode(errors='backslashreplace')!r}"
                         f" does not contain a colon for separating"
                         f" the key from the value."
                     ) from None

--- a/tests/unit/test_problem_report.py
+++ b/tests/unit/test_problem_report.py
@@ -225,6 +225,16 @@ class T(unittest.TestCase):
             ):
                 report.load(report_file)
 
+    def test_load_invalid_utf8(self):
+        """Throw exception when binary file is invalid UTF-8."""
+        report = problem_report.ProblemReport()
+        with io.BytesIO(b"\x7fELF\x02\x01\xb0j") as report_file:
+            with self.assertRaisesRegex(
+                problem_report.MalformedProblemReport,
+                r"Line '\\x7fELF\\x02\\x01\\\\xb0j' does not contain a colon",
+            ):
+                report.load(report_file)
+
     def test_load_incorrect_padding(self):
         """Throw exception when base64 encoded data has incorrect padding."""
         report = problem_report.ProblemReport()


### PR DESCRIPTION
apport-unpack will crash when passing a binary file that is not valid UTF-8:

```
$ apport-unpack /bin/ls unpack
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/problem_report.py", line 175, in load
    (key, value) = line.split(b":", 1)
    ^^^^^^^^^^^^
ValueError: not enough values to unpack (expected 2, got 1)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/bin/apport-unpack", line 91, in <module>
    main()
  File "/usr/bin/apport-unpack", line 67, in main
    pr = load_report(args.report)
         ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/bin/apport-unpack", line 47, in load_report
    pr.load(f, binary=False)
  File "/usr/lib/python3/dist-packages/problem_report.py", line 178, in load
    f"Malformed problem report: Line {line.decode()!r}"
                                      ^^^^^^^^^^^^^
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xc0 in position 24: invalid start byte
```

When wrapping the `ValueError` into an `MalformedProblemReport`, do not expect the causing line to be valid UTF-8. Replace the invalid characters with backslashed escape sequences.

Bug: https://launchpad.net/bugs/1996040