### PR TITLE
feat: Add local_path to get_data_directory()

### DIFF
--- a/tests/integration/test_java_crashes.py
+++ b/tests/integration/test_java_crashes.py
@@ -16,12 +16,7 @@ import unittest
 import apport.fileutils
 import apport.report
 from tests.helper import skip_if_command_is_missing
-from tests.paths import (
-    SRCDIR,
-    get_data_directory,
-    is_local_source_directory,
-    local_test_environment,
-)
+from tests.paths import get_data_directory, local_test_environment
 
 
 @skip_if_command_is_missing("java")
@@ -35,10 +30,7 @@ class T(unittest.TestCase):
         self.env["APPORT_JAVA_EXCEPTION_HANDLER"] = os.path.join(
             datadir, "java_uncaught_exception"
         )
-        if is_local_source_directory():
-            java_dir = os.path.join(SRCDIR, "java")
-        else:
-            java_dir = datadir
+        java_dir = get_data_directory("java")
         self.apport_jar_path = os.path.join(java_dir, "apport.jar")
         self.crash_jar_path = os.path.join(java_dir, "testsuite", "crash.jar")
         if not os.path.exists(self.apport_jar_path):

--- a/tests/paths.py
+++ b/tests/paths.py
@@ -7,19 +7,21 @@ CRASHDB_CONF = os.path.join(SRCDIR, "etc", "apport", "crashdb.conf")
 DATADIR = os.path.join(SRCDIR, "data")
 
 
-def get_data_directory() -> str:
+def get_data_directory(local_path: typing.Optional[str] = None) -> str:
     """Return absolute path for apport's data directory.
 
     If the tests are executed in the local source code directory,
-    return the path to the local source directory. Otherwise
-    return the path to the system installed version. The data
-    directory can be specified by setting the environment variable
-    APPORT_DATA_DIR.
+    return the absolute path to the local data directory or to the
+    given local path (if specified). Otherwise return the path to the
+    system installed data directory. The returned data directory can be
+    overridden by setting the environment variable APPORT_DATA_DIR.
     """
     if "APPORT_DATA_DIR" in os.environ:
         return os.environ["APPORT_DATA_DIR"]
     if is_local_source_directory():
-        return DATADIR
+        if local_path is None:
+            return DATADIR
+        return os.path.join(SRCDIR, local_path)
     return "/usr/share/apport"
 
 

--- a/tests/system/test_ui_gtk.py
+++ b/tests/system/test_ui_gtk.py
@@ -26,23 +26,15 @@ import apport.crashdb_impl.memory
 import apport.report
 from apport import unicode_gettext as _
 from tests.helper import import_module_from_file
-from tests.paths import is_local_source_directory, local_test_environment
+from tests.paths import get_data_directory, local_test_environment
 
 GLib.log_set_always_fatal(
     GLib.LogLevelFlags.LEVEL_WARNING | GLib.LogLevelFlags.LEVEL_CRITICAL
 )
 
 
-if is_local_source_directory():
-    apport_gtk_path = "gtk/apport-gtk"
-    kernel_oops_path = "data/kernel_oops"
-else:
-    apport_gtk_path = os.path.join(
-        os.environ.get("APPORT_DATA_DIR", "/usr/share/apport"), "apport-gtk"
-    )
-    kernel_oops_path = os.path.join(
-        os.environ.get("APPORT_DATA_DIR", "/usr/share/apport"), "kernel_oops"
-    )
+apport_gtk_path = os.path.join(get_data_directory("gtk"), "apport-gtk")
+kernel_oops_path = os.path.join(get_data_directory(), "kernel_oops")
 apport_gtk = import_module_from_file(apport_gtk_path)
 GTKUserInterface = apport_gtk.GTKUserInterface
 

--- a/tests/system/test_ui_kde.py
+++ b/tests/system/test_ui_kde.py
@@ -29,14 +29,9 @@ import apport.crashdb_impl.memory
 import apport.report
 from apport import unicode_gettext as _
 from tests.helper import import_module_from_file, wrap_object
-from tests.paths import is_local_source_directory, local_test_environment
+from tests.paths import get_data_directory, local_test_environment
 
-if is_local_source_directory():
-    apport_kde_path = "kde/apport-kde"
-else:
-    apport_kde_path = os.path.join(
-        os.environ.get("APPORT_DATA_DIR", "/usr/share/apport"), "apport-kde"
-    )
+apport_kde_path = os.path.join(get_data_directory("kde"), "apport-kde")
 if not PYQT5_IMPORT_ERROR:
     apport_kde = import_module_from_file(apport_kde_path)
     MainUserInterface = apport_kde.MainUserInterface


### PR DESCRIPTION
Add `local_path` parameter to `get_data_directory` to specify a subdirectory for the local source directory. This allows using `get_data_directory` without needing to differentiate between the local source directory and the installed data directory.