### PR TITLE
feat(crashdb/memory): Rename dummy_data to sample_data

### DIFF
--- a/apport/crashdb_impl/memory.py
+++ b/apport/crashdb_impl/memory.py
@@ -33,8 +33,8 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
         self.unretraced = set()
         self.dup_unchecked = set()
 
-        if "dummy_data" in options:
-            self.add_dummy_data()
+        if "sample_data" in options:
+            self.add_sample_data()
 
     def upload(self, report, progress_callback=None):
         """Store the report and return a handle number (starting from 0).
@@ -235,8 +235,8 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
         """Return the ID of the most recently filed report."""
         return len(self.reports) - 1
 
-    def add_dummy_data(self):
-        """Add some dummy crash reports.
+    def add_sample_data(self):
+        """Add some sample crash reports.
 
         This is mostly useful for test suites.
         """

--- a/doc/crashdb-conf.md
+++ b/doc/crashdb-conf.md
@@ -147,5 +147,5 @@ Crash database implementations
  * `memory` is a simple implementation of crash database interface which keeps
    everything in RAM. This is mainly useful for testing and debugging.
 
-   The only supported option is `dummy_data`; if set to a non-`False` value, it
+   The only supported option is `sample_data`; if set to a non-`False` value, it
    will populate the database with some example reports.

--- a/tests/integration/test_crash_digger.py
+++ b/tests/integration/test_crash_digger.py
@@ -22,7 +22,7 @@ from tests.paths import local_test_environment
 
 class T(unittest.TestCase):
     def setUp(self):
-        """Set up dummy config dir, crashdb.conf, and apport-retrace"""
+        """Set up config dir, crashdb.conf, and apport-retrace for testing"""
         self.env = os.environ | local_test_environment()
 
         self.workdir = tempfile.mkdtemp()
@@ -37,7 +37,7 @@ class T(unittest.TestCase):
                         "memory": {
                             "impl": "memory",
                             "distro": "Testux",
-                            "dummy_data": "1",
+                            "sample_data": "1",
                             "dupdb_url": "%s",
                         },
                         "empty": {"impl": "memory", "distro": "Foonux"},

--- a/tests/integration/test_dupdb_admin.py
+++ b/tests/integration/test_dupdb_admin.py
@@ -29,7 +29,7 @@ class TestDupdbAdmin(unittest.TestCase):
         self.env = os.environ | local_test_environment()
 
         self.crashes = CrashDatabase(
-            None, {"dummy_data": "1", "dupdb_url": f"file://{self.db_file}"}
+            None, {"sample_data": "1", "dupdb_url": f"file://{self.db_file}"}
         )
         self.crashes.init_duplicate_db(self.db_file)
 

--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -36,7 +36,7 @@ class TestSuiteUserInterface(apport.ui.UserInterface):
     """Concrete apport.ui.UserInterface suitable for automatic testing"""
 
     def __init__(self, argv: typing.Optional[list[str]] = None):
-        # use our dummy crashdb
+        # use our memory crashdb which is designed for testing
         # closed in __del__, pylint: disable=consider-using-with
         self.crashdb_conf = tempfile.NamedTemporaryFile()
         self.crashdb_conf.write(
@@ -65,7 +65,7 @@ class TestSuiteUserInterface(apport.ui.UserInterface):
         apport.ui.UserInterface.__init__(self, argv)
 
         self.crashdb = apport.crashdb_impl.memory.CrashDatabase(
-            None, {"dummy_data": 1, "dupdb_url": ""}
+            None, {"sample_data": 1, "dupdb_url": ""}
         )
 
         # state of progress dialogs

--- a/tests/unit/test_crashdb.py
+++ b/tests/unit/test_crashdb.py
@@ -14,7 +14,7 @@ class T(unittest.TestCase):
         self.workdir = tempfile.mkdtemp()
         self.dupdb_dir = os.path.join(self.workdir, "dupdb")
         self.crashes = CrashDatabase(
-            None, {"dummy_data": "1", "dupdb_url": "file://" + self.dupdb_dir}
+            None, {"sample_data": "1", "dupdb_url": "file://" + self.dupdb_dir}
         )
 
         self.assertEqual(
@@ -40,8 +40,8 @@ class T(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.workdir)
 
-    def test_no_dummy_data(self):
-        """No dummy data is added by default."""
+    def test_no_sample_data(self):
+        """No sample data is added by default."""
         self.crashes = CrashDatabase(None, {})
         self.assertEqual(self.crashes.latest_id(), -1)
         self.assertRaises(IndexError, self.crashes.download, 0)
@@ -53,7 +53,7 @@ class T(unittest.TestCase):
 
     def test_dynamic_crashdb_conf(self):
         """Dynamic code in crashdb.conf."""
-        # use our dummy crashdb
+        # use our memory crashdb
         with tempfile.NamedTemporaryFile(mode="w+") as crashdb_conf:
             crashdb_conf.write(
                 textwrap.dedent(


### PR DESCRIPTION
The word `dummy` in `dummy_data` may be insensitive. Therefore rename `dummy_data` to `sample_data`.