### PR TITLE
fix: Fix test failures with Python 3.11

### DIFF
--- a/tests/integration/test_report.py
+++ b/tests/integration/test_report.py
@@ -493,10 +493,10 @@ class T(unittest.TestCase):
             pr = apport.report.Report()
             pr["ExecutablePath"] = "/usr/bin/python3"
             pr["ProcStatus"] = "Name:\tpython3"
-            pr["ProcCmdline"] = "python\0-m\0re\0install"
+            pr["ProcCmdline"] = "python3\0-m\0re\0install"
             pr._check_interpreted()
             self.assertEqual(pr["InterpreterPath"], "/usr/bin/python3")
-            self.assertIn("re.py", pr["ExecutablePath"])
+            self.assertRegex(pr["ExecutablePath"], r"re(\.py|/__init__.py)$")
 
             # python script through -m, with dot separator; sub-level module
             pr = apport.report.Report()

--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -764,7 +764,7 @@ class T(unittest.TestCase):
 
         self.assertEqual(self.ui.msg_severity, "error")
 
-    @unittest.mock.patch("apport.packaging.get_version")
+    @unittest.mock.patch("apport.packaging_impl.impl.get_version")
     def test_run_report_bug_kernel_thread(self, get_version_mock):
         """run_report_bug() for a pid of a kernel thread"""
         # The kernel package might not be installed in chroot environments.

--- a/tests/unit/test_rethread.py
+++ b/tests/unit/test_rethread.py
@@ -52,7 +52,7 @@ class T(unittest.TestCase):
             exc[-1].startswith("ZeroDivisionError"),
             "not a ZeroDivisionError:" + str(exc),
         )
-        self.assertTrue(exc[-2].endswith("return x / y\n"))
+        self.assertIn("\n    return x / y\n", exc[-2])
 
     def test_exc_raise(self):
         """exc_raise() raises caught thread exception."""
@@ -68,7 +68,7 @@ class T(unittest.TestCase):
             raised = True
             error = sys.exc_info()
             exc = traceback.format_exception(error[0], error[1], error[2])
-            self.assertTrue(exc[-2].endswith("return x / y\n"))
+            self.assertIn("\n    return x / y\n", exc[-2])
         self.assertTrue(raised)
 
     def test_exc_raise_complex(self):


### PR DESCRIPTION
Following changes in Python 3.11 causes some tests to fail:

* PEP 657 (Fine-grained error locations in tracebacks) changes the traceback strings.
* `re.py` was split into a directory with multiple files.

`apport/__init__.py` imports `impl` from `apport.packaging_impl` as `packaging`. So `apport.packaging` refers to
`apport.packaging_impl.impl`. Some change in Python 3.11 cause mocking the former fail. Therefore mock the real location of the object.