### PR TITLE
refactor: Rename Action.blacklist to Action.ignore

### DIFF
--- a/apport/ui.py
+++ b/apport/ui.py
@@ -226,8 +226,8 @@ def thread_collect_info(
 
 @dataclasses.dataclass
 class Action:
-    blacklist: bool = False
     examine: bool = False
+    ignore: bool = False
     remember: bool = False
     report: bool = False
     restart: bool = False
@@ -400,7 +400,7 @@ class UserInterface:
                 return
             if response.restart:
                 self.restart()
-            if response.blacklist:
+            if response.ignore:
                 self.report.mark_ignore()
             try:
                 if response.remember:
@@ -2004,8 +2004,8 @@ class UserInterface:
         Return the action and options as an Action object:
 
         - Valid attributes are: report the crash ('report'), restart
-          the crashed application ('restart'), or blacklist further crashes
-          ('blacklist').
+          the crashed application ('restart'), or ignore further crashes
+          ('ignore').
         """
         raise NotImplementedError(
             "this function must be overridden by subclasses"

--- a/bin/apport-cli
+++ b/bin/apport-cli
@@ -247,7 +247,7 @@ class CLIUserInterface(apport.ui.UserInterface):
             if response == complete:
                 return_value.report = True
             if response == ignore:
-                return_value.blacklist = True
+                return_value.ignore = True
             if response == view:
                 self.collect_info()
                 self.ui_update_view()

--- a/gtk/apport-gtk
+++ b/gtk/apport-gtk
@@ -437,7 +437,7 @@ class GTKUserInterface(apport.ui.UserInterface):
                 return_value.restart = True
 
             if self.w("ignore_future_problems").get_active():
-                return_value.blacklist = True
+                return_value.ignore = True
 
             return_value.remember = self.w(
                 "remember_send_report_choice"

--- a/kde/apport-kde
+++ b/kde/apport-kde
@@ -427,7 +427,7 @@ class MainUserInterface(apport.ui.UserInterface):
         if self.dialog.send_error_report.isChecked():
             return_value.report = True
         if self.dialog.ignore_future_problems.isChecked():
-            return_value.blacklist = True
+            return_value.ignore = True
         return return_value
 
     def ui_info_message(self, title, text):

--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -914,14 +914,14 @@ class T(unittest.TestCase):
             )
         )
 
-        # so far we did not blacklist, verify that
+        # so far we did not ignorelist, verify that
         self.assertTrue(not self.ui.report.check_ignored())
 
-        # cancel crash notification dialog and blacklist
+        # cancel crash notification dialog and ignorelist
         with open(report_file, "wb") as f:
             r.write(f)
         self.ui = UserInterfaceMock()
-        self.ui.present_details_response = apport.ui.Action(blacklist=True)
+        self.ui.present_details_response = apport.ui.Action(ignore=True)
         self.ui.run_crash(report_file)
         self.assertEqual(self.ui.msg_severity, None)
         self.assertEqual(self.ui.msg_title, None)


### PR DESCRIPTION
The word `blacklist` may be insensitive. Rename the `Action` property `blacklist` to  `ignore`.