### PR TITLE
test: Skip tests when required binaries are missing

### DIFF
--- a/tests/integration/test_hooks.py
+++ b/tests/integration/test_hooks.py
@@ -350,13 +350,18 @@ class T(unittest.TestCase):
         )
         self.assertEqual(apport.fileutils.get_new_reports(), [])
 
-    @staticmethod
-    def _gcc_version_path():
+    def _gcc_version_path(self):
         """Determine a valid version and executable path of gcc and return it
         as a tuple."""
-        gcc = subprocess.run(
-            ["gcc", "--version"], check=True, stdout=subprocess.PIPE, text=True
-        )
+        try:
+            gcc = subprocess.run(
+                ["gcc", "--version"],
+                check=True,
+                stdout=subprocess.PIPE,
+                text=True,
+            )
+        except FileNotFoundError as error:
+            self.skipTest(f"{error.filename} not available")
 
         ver_fields = gcc.stdout.splitlines()[0].split()[3].split(".")
         # try major/minor first

--- a/tests/integration/test_hookutils.py
+++ b/tests/integration/test_hookutils.py
@@ -10,6 +10,7 @@ import unittest.mock
 
 import apport.hookutils
 import apport.report
+from tests.helper import skip_if_command_is_missing
 
 
 class T(unittest.TestCase):
@@ -19,6 +20,7 @@ class T(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.workdir)
 
+    @skip_if_command_is_missing("/usr/bin/as")
     def test_module_license_evaluation(self):
         """Module licenses can be validated correctly."""
         # pylint: disable=protected-access
@@ -61,6 +63,7 @@ class T(unittest.TestCase):
         self.assertNotIn(good_ko, nonfree)
         self.assertIn(bad_ko, nonfree)
 
+    @skip_if_command_is_missing("/sbin/modinfo")
     def test_real_module_license_evaluation(self):
         """Module licenses can be validated correctly for real module."""
         # pylint: disable=protected-access

--- a/tests/integration/test_packaging_apt_dpkg.py
+++ b/tests/integration/test_packaging_apt_dpkg.py
@@ -546,6 +546,7 @@ deb http://secondary.mirror tuxy extra
         self.assertNotEqual(arch, "")
         self.assertNotIn("\n", arch)
 
+    @skip_if_command_is_missing("dpkg-architecture")
     def test_get_library_paths(self):
         """get_library_paths()."""
         paths = impl.get_library_paths()

--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -22,7 +22,7 @@ import apport.report
 import apport.ui
 import problem_report
 from apport.ui import _
-from tests.helper import pidof
+from tests.helper import pidof, skip_if_command_is_missing
 from tests.paths import (
     local_test_environment,
     patch_data_dir,
@@ -1011,6 +1011,7 @@ class T(unittest.TestCase):
         self.assertEqual(self.ui.msg_severity, None)
         self.assertTrue(self.ui.present_details_shown)
 
+    @skip_if_command_is_missing("gdb")
     def test_run_crash_broken(self):
         """run_crash() for an invalid core dump"""
         # generate broken crash report

--- a/tests/system/test_packaging_apt_dpkg.py
+++ b/tests/system/test_packaging_apt_dpkg.py
@@ -836,6 +836,7 @@ class T(unittest.TestCase):
             "unexpected version: " + res.split("/")[-1],
         )
 
+    @skip_if_command_is_missing("gpg")
     @unittest.skipUnless(has_internet(), "online test")
     def test_create_sources_for_a_named_ppa(self):
         """Add sources.list entries for a named PPA."""
@@ -891,6 +892,7 @@ class T(unittest.TestCase):
         apt_keys = gpg.stdout.decode()
         self.assertIn("Launchpad PPA for Daisy Pluckers", apt_keys)
 
+    @skip_if_command_is_missing("gpg")
     @unittest.skipUnless(has_internet(), "online test")
     def test_create_sources_for_an_unnamed_ppa(self):
         """Add sources.list entries for an unnamed PPA."""


### PR DESCRIPTION
Some test cases need some binaries for their test which might not be installed. Check for the presence and skip if the binaries are missing.