### PR TITLE
test: Skip tests if Python dependencies are missing

### DIFF
--- a/tests/system/test_python_crashes.py
+++ b/tests/system/test_python_crashes.py
@@ -18,13 +18,19 @@ import tempfile
 import textwrap
 import unittest
 
-import dbus
+try:
+    import dbus
+
+    HAS_DBUS = True
+except ImportError:
+    HAS_DBUS = False
 
 import apport.fileutils
 import apport.report
 from tests.paths import local_test_environment
 
 
+@unittest.skipUnless(HAS_DBUS, "dbus Python module not installed")
 class T(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/tests/unit/test_signal_crashes.py
+++ b/tests/unit/test_signal_crashes.py
@@ -63,6 +63,12 @@ class TestApport(unittest.TestCase):
 
     def test_receive_arguments_via_socket_invalid_socket(self):
         """Test receive_arguments_via_socket with invalid socket."""
+        try:
+            # pylint: disable=import-outside-toplevel
+            from systemd.daemon import listen_fds
+        except ImportError:
+            self.skipTest("systemd Python module not available")
+        assert listen_fds
         self.assertNotIn("LISTEN_FDS", os.environ)
         with self.assertRaisesRegex(SystemExit, "^1$"):
             apport_binary.receive_arguments_via_socket()


### PR DESCRIPTION
The Python crashes system tests need `dbus`, the GTK UI system tests need GI and the Glib/GTK libraries, and
`test_receive_arguments_via_socket_invalid_socket` needs the systemd library. Check for the presence and skip if the libraries are missing.