### PR TITLE
fix: Replace deprecated distutils for report test

### DIFF
--- a/tests/integration/test_report.py
+++ b/tests/integration/test_report.py
@@ -502,10 +502,10 @@ class T(unittest.TestCase):
             pr = apport.report.Report()
             pr["ExecutablePath"] = "/usr/bin/python3"
             pr["ProcStatus"] = "Name:\tpython3"
-            pr["ProcCmdline"] = "python\0-m\0distutils.cmd\0foo"
+            pr["ProcCmdline"] = "python3\0-m\0http.server\08080"
             pr._check_interpreted()
             self.assertEqual(pr["InterpreterPath"], "/usr/bin/python3")
-            self.assertIn("distutils/cmd.py", pr["ExecutablePath"])
+            self.assertIn("http/server.py", pr["ExecutablePath"])
 
             # Python script through -m, non-existent module
             pr = apport.report.Report()


### PR DESCRIPTION
The test case `test_check_interpreted` triggers a deprecation warning: "The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives"

`Report._python_module_path` uses `importlib.util.find_spec` which tries to find the spec for the module (but does not execute the module).

Replace `distutils.cmd` by `http.server` in the test, which is a real world example:

```
python3 -m http.server 8080
```