### PR TITLE
test: Test wait_for_report() helper method

### DIFF
--- a/tests/integration/test_recoverable_problem.py
+++ b/tests/integration/test_recoverable_problem.py
@@ -15,6 +15,7 @@ import subprocess
 import tempfile
 import time
 import unittest
+import unittest.mock
 
 import apport.report
 from tests.paths import get_data_directory, local_test_environment
@@ -42,6 +43,17 @@ class T(unittest.TestCase):
             f"timeout while waiting for .crash file to be created"
             f" in {self.report_dir}."
         )
+
+    @unittest.mock.patch("os.listdir")
+    @unittest.mock.patch("time.sleep")
+    def test_wait_for_report_timeout(self, sleep_mock, listdir_mock):
+        """Test wait_for_report() helper runs into timeout."""
+        listdir_mock.return_value = []
+        with unittest.mock.patch.object(self, "fail") as fail_mock:
+            self.wait_for_report()
+        fail_mock.assert_called_once()
+        sleep_mock.assert_called_with(0.1)
+        self.assertEqual(sleep_mock.call_count, 101)
 
     def call_recoverable_problem(self, data):
         cmd = ["%s/recoverable_problem" % self.datadir]


### PR DESCRIPTION
The `wait_for_report` helper method can success on the first try. Then the "sleep and retry" part of the function is not used which leads to a reduced code coverage.

Write test cases for the `wait_for_report` helper method to have full code coverage for it.