### PR TITLE
refactor(apport): Split sanity_checks out of process_crash

### DIFF
--- a/data/apport
+++ b/data/apport
@@ -859,31 +859,22 @@ def receive_arguments_via_socket() -> argparse.Namespace:
     )
 
 
-def process_crash(options: argparse.Namespace) -> int:
-    """Process crash and return exit code."""
-    pid = options.pid
-    signum = options.signal_number
-    core_ulimit = options.core_ulimit
-    dump_mode = options.dump_mode
-    coredump_fd = sys.stdin.fileno()
-
-    get_pid_info(pid)
-
+def sanity_checks(options: argparse.Namespace, process_start: int) -> bool:
+    """Run sanity checks and return True if all pass."""
     # Sanity check to make sure the process wasn't replaced after the crash
     # happened. The start time isn't fine-grained enough to be an adequate
     # security check.
     apport_start = get_apport_starttime()
-    process_start = get_process_starttime()
     if process_start > apport_start:
         error_log("process was replaced after Apport started, ignoring")
-        return 0
+        return False
 
     # Make sure the process uid/gid match the ones provided by the kernel
     # if available, if not, it may have been replaced
     if (options.uid is not None) and (options.gid is not None):
         if (options.uid != crash_uid) or (options.gid != crash_gid):
             error_log("process uid/gid doesn't match expected, ignoring")
-            return 0
+            return False
 
     # check if the executable was modified after the process started (e. g.
     # package got upgraded in between).
@@ -894,6 +885,23 @@ def process_crash(options: argparse.Namespace) -> int:
         or exe_mtime > process_mtime
     ):
         error_log("executable was modified after program start, ignoring")
+        return False
+
+    return True
+
+
+def process_crash(options: argparse.Namespace) -> int:
+    """Process crash and return exit code."""
+    pid = options.pid
+    signum = options.signal_number
+    core_ulimit = options.core_ulimit
+    dump_mode = options.dump_mode
+    coredump_fd = sys.stdin.fileno()
+
+    get_pid_info(pid)
+
+    process_start = get_process_starttime()
+    if not sanity_checks(options, process_start):
         return 0
 
     error_log(

--- a/tests/unit/test_signal_crashes.py
+++ b/tests/unit/test_signal_crashes.py
@@ -13,6 +13,7 @@ import os
 import pathlib
 import shutil
 import tempfile
+import time
 import unittest
 
 import apport.fileutils
@@ -109,6 +110,29 @@ class TestApport(unittest.TestCase):
             "/proc/sys/kernel/core_pipe_limit", "w", encoding="utf-8"
         )
         self.assertEqual(open_mock.call_count, 3)
+
+    def test_sanity_checks_replaced_process(self):
+        """Test sanity_checks() for a replaced crash process ID."""
+        options = apport_binary.parse_arguments(["-p", str(os.getpid())])
+        now = int(time.clock_gettime(time.CLOCK_BOOTTIME) * 100)
+        self.assertFalse(apport_binary.sanity_checks(options, now))
+
+    def test_sanity_checks_mismatching_uid(self):
+        """Test sanity_checks() for a mitmatching UID."""
+        pid = os.getpid()
+        options = apport_binary.parse_arguments(
+            [
+                "-p",
+                str(pid),
+                "-u",
+                str(os.getuid() + 1),
+                "-g",
+                str(os.getgid() + 1),
+            ]
+        )
+        # TODO: Get rid of global variables from get_pid_info
+        apport_binary.get_pid_info(pid)
+        self.assertFalse(apport_binary.sanity_checks(options, 1))
 
     def test_stop(self):
         """Test stopping Apport crash handler."""


### PR DESCRIPTION
To make the code more readable, split `sanity_checks` out of the `process_crash` function.

Add some unit tests for `sanity_checks` to increase the coverage of that function to 100% (when combined with the integration tests).