### PR TITLE
refactor: Rename args.tag to args.tags

### DIFF
--- a/apport/ui.py
+++ b/apport/ui.py
@@ -934,6 +934,7 @@ class UserInterface:
             "--tag",
             action="append",
             default=[],
+            dest="tags",
             help=_(
                 "Add an extra tag to the report."
                 " Can be specified multiple times."
@@ -1066,6 +1067,7 @@ class UserInterface:
             "--tag",
             action="append",
             default=[],
+            dest="tags",
             help=_(
                 "Add an extra tag to the report."
                 " Can be specified multiple times."
@@ -1981,11 +1983,11 @@ class UserInterface:
     def add_extra_tags(self):
         """Add extra tags to report specified with --tags on CLI."""
         assert self.report
-        if self.args.tag:
+        if self.args.tags:
             tags = self.report.get("Tags", "")
             if tags:
                 tags += " "
-            self.report["Tags"] = tags + " ".join(self.args.tag)
+            self.report["Tags"] = tags + " ".join(self.args.tags)
 
     #
     # abstract UI methods that must be implemented in derived classes

--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -2418,7 +2418,7 @@ class T(unittest.TestCase):
                 "update_report": None,
                 "save": None,
                 "window": False,
-                "tag": [],
+                "tags": [],
                 "hanging": False,
             },
         )
@@ -2443,7 +2443,7 @@ class T(unittest.TestCase):
                 "update_report": None,
                 "save": None,
                 "window": False,
-                "tag": [],
+                "tags": [],
                 "hanging": False,
             },
         )
@@ -2471,7 +2471,7 @@ class T(unittest.TestCase):
                 "update_report": None,
                 "save": None,
                 "window": False,
-                "tag": [],
+                "tags": [],
                 "hanging": False,
             },
         )
@@ -2489,7 +2489,7 @@ class T(unittest.TestCase):
                 "update_report": None,
                 "save": None,
                 "window": False,
-                "tag": [],
+                "tags": [],
                 "hanging": False,
             },
         )
@@ -2508,7 +2508,7 @@ class T(unittest.TestCase):
                     "update_report": None,
                     "save": None,
                     "window": False,
-                    "tag": [],
+                    "tags": [],
                     "hanging": False,
                 },
             )
@@ -2526,7 +2526,7 @@ class T(unittest.TestCase):
                 "update_report": None,
                 "save": None,
                 "window": False,
-                "tag": [],
+                "tags": [],
                 "hanging": False,
             },
         )
@@ -2541,7 +2541,7 @@ class T(unittest.TestCase):
                 "crash_file": None,
                 "symptom": None,
                 "update_report": 1234,
-                "tag": [],
+                "tags": [],
                 "hanging": False,
             },
         )
@@ -2554,7 +2554,7 @@ class T(unittest.TestCase):
                 "crash_file": None,
                 "symptom": None,
                 "update_report": 1234,
-                "tag": [],
+                "tags": [],
                 "hanging": False,
             },
         )
@@ -2583,7 +2583,7 @@ class T(unittest.TestCase):
                 "update_report": None,
                 "save": None,
                 "window": False,
-                "tag": [],
+                "tags": [],
                 "hanging": False,
             },
         )
@@ -2604,7 +2604,7 @@ class T(unittest.TestCase):
                 "update_report": None,
                 "save": None,
                 "window": False,
-                "tag": [],
+                "tags": [],
                 "hanging": False,
             },
         )
@@ -2631,7 +2631,7 @@ class T(unittest.TestCase):
                 "update_report": None,
                 "save": None,
                 "window": False,
-                "tag": [],
+                "tags": [],
                 "hanging": False,
             },
         )
@@ -2649,7 +2649,7 @@ class T(unittest.TestCase):
                 "update_report": None,
                 "save": None,
                 "window": False,
-                "tag": [],
+                "tags": [],
                 "hanging": False,
             },
         )
@@ -2667,7 +2667,7 @@ class T(unittest.TestCase):
                     "update_report": None,
                     "save": None,
                     "window": False,
-                    "tag": [],
+                    "tags": [],
                     "hanging": False,
                 },
             )
@@ -2684,7 +2684,7 @@ class T(unittest.TestCase):
                 "update_report": None,
                 "save": None,
                 "window": False,
-                "tag": [],
+                "tags": [],
                 "hanging": False,
             },
         )
@@ -2705,7 +2705,7 @@ class T(unittest.TestCase):
                 "update_report": None,
                 "save": "foo.apport",
                 "window": False,
-                "tag": [],
+                "tags": [],
                 "hanging": False,
             },
         )
@@ -2722,7 +2722,7 @@ class T(unittest.TestCase):
                 "update_report": None,
                 "save": None,
                 "window": False,
-                "tag": ["foo"],
+                "tags": ["foo"],
                 "hanging": False,
             },
         )
@@ -2737,7 +2737,7 @@ class T(unittest.TestCase):
                 "update_report": None,
                 "save": None,
                 "window": False,
-                "tag": ["foo", "bar"],
+                "tags": ["foo", "bar"],
                 "hanging": False,
             },
         )


### PR DESCRIPTION
The attribute `UserInterface.args.tag` is singular, but it contains a list of tags. Rename `tag` to `tags` to reflect that to avoid confusion.