### PR TITLE
refactor: Drop unused check for stderr output in _call()

### DIFF
--- a/tests/integration/test_unkillable_shutdown.py
+++ b/tests/integration/test_unkillable_shutdown.py
@@ -36,11 +36,7 @@ class TestUnkillableShutdown(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.report_dir)
 
-    def _call(
-        self,
-        omit: typing.Optional[list] = None,
-        expected_stderr: typing.Optional[str] = None,
-    ) -> None:
+    def _call(self, omit: typing.Optional[list] = None) -> None:
         cmd = [f"{self.data_dir}/unkillable_shutdown"]
         if omit:
             cmd += [arg for pid in omit for arg in ["-o", str(pid)]]
@@ -54,8 +50,6 @@ class TestUnkillableShutdown(unittest.TestCase):
         )
         self.assertEqual(process.returncode, 0, process.stderr)
         self.assertEqual(process.stdout, "")
-        if expected_stderr:
-            self.assertEqual(process.stderr, expected_stderr)
 
     @staticmethod
     def _get_all_pids():
@@ -63,5 +57,5 @@ class TestUnkillableShutdown(unittest.TestCase):
 
     def test_omit_all_processes(self):
         """unkillable_shutdown will write no reports."""
-        self._call(omit=self._get_all_pids(), expected_stderr="")
+        self._call(omit=self._get_all_pids())
         self.assertEqual(os.listdir(self.report_dir), [])

--- a/tests/system/test_unkillable_shutdown.py
+++ b/tests/system/test_unkillable_shutdown.py
@@ -41,11 +41,7 @@ class TestUnkillableShutdown(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.report_dir)
 
-    def _call(
-        self,
-        omit: typing.Optional[list] = None,
-        expected_stderr: typing.Optional[str] = None,
-    ) -> None:
+    def _call(self, omit: typing.Optional[list] = None) -> None:
         cmd = [f"{self.data_dir}/unkillable_shutdown"]
         if omit:
             cmd += [arg for pid in omit for arg in ["-o", str(pid)]]
@@ -59,8 +55,6 @@ class TestUnkillableShutdown(unittest.TestCase):
         )
         self.assertEqual(process.returncode, 0, process.stderr)
         self.assertEqual(process.stdout, "")
-        if expected_stderr:
-            self.assertEqual(process.stderr, expected_stderr)
 
     @staticmethod
     def _get_all_pids():
@@ -126,7 +120,7 @@ class TestUnkillableShutdown(unittest.TestCase):
         """unkillable_shutdown will write exactly one report."""
         existing_pids = self._get_all_pids()
         with self._launch_process_with_different_session_id() as runner:
-            self._call(omit=existing_pids + [runner.pid], expected_stderr="")
+            self._call(omit=existing_pids + [runner.pid])
         self.assertEqual(
             os.listdir(self.report_dir),
             [f"{self.TEST_EXECUTABLE.replace('/', '_')}.{os.geteuid()}.crash"],


### PR DESCRIPTION
The `_call` function only checks the stderr output if `expected_stderr` evaluates to `True`. This function is either called without setting `expected_stderr` or setting it to `""` (both evaluate to `False`).

Since all those test cases have log output on stderr, drop the checking code for the stderr output.