### PR TITLE
feat: Drop Python 2 support from unicode_gettext

### DIFF
--- a/apport/__init__.py
+++ b/apport/__init__.py
@@ -17,7 +17,4 @@ __all__ = [
 
 
 def unicode_gettext(message):
-    trans = gettext.gettext(message)
-    if isinstance(trans, bytes):
-        return trans.decode("UTF-8")
-    return trans
+    return gettext.gettext(message)

--- a/kde/apport-kde
+++ b/kde/apport-kde
@@ -64,8 +64,7 @@ def translate(self, prop):
         return self._cstring(prop)
     if prop.text is None:
         return ""
-    text = prop.text.encode("UTF-8")
-    return _(text)
+    return _(prop.text)
 
 
 uic.properties.Properties._string = translate


### PR DESCRIPTION
`gettext.gettext()` always returns Unicode strings in Python 3. Checking for type `bytes` was only needed for Python 2. The support for Python 2 has ended on beginning of 2020. So drop the Python 2 support from `unicode_gettext`.

`gettext.gettext()` needs to take a Unicode string as input. Otherwise it might return `bytes`.