### PR TITLE
feat: Deprecate apport.unicode_gettext()

### DIFF
--- a/apport/__init__.py
+++ b/apport/__init__.py
@@ -1,4 +1,5 @@
 import gettext
+import warnings
 
 from apport.logging import error, fatal, log, memdbg, warning
 from apport.packaging_impl import impl as packaging
@@ -17,4 +18,10 @@ __all__ = [
 
 
 def unicode_gettext(message):
+    warnings.warn(
+        "apport.unicode_gettext() is deprecated."
+        " Please use gettext.gettext() directly instead.",
+        PendingDeprecationWarning,
+        stacklevel=2,
+    )
     return gettext.gettext(message)

--- a/apport/ui.py
+++ b/apport/ui.py
@@ -37,12 +37,12 @@ import typing
 import urllib.error
 import webbrowser
 import zlib
+from gettext import gettext as _
 
 import apport.crashdb
 import apport.fileutils
 import apport.logging
 import apport.REThread
-from apport import unicode_gettext as _
 from apport.packaging_impl import impl as packaging
 
 __version__ = "2.24.0"

--- a/bin/apport-cli
+++ b/bin/apport-cli
@@ -22,9 +22,9 @@ import subprocess
 import sys
 import tempfile
 import termios
+from gettext import gettext as _
 
 import apport.ui
-from apport import unicode_gettext as _
 
 
 class CLIDialog:

--- a/bin/apport-retrace
+++ b/bin/apport-retrace
@@ -23,11 +23,11 @@ import tempfile
 import termios
 import tty
 import zlib
+from gettext import gettext as _
 
 import apport
 import apport.fileutils
 import apport.sandboxutils
-from apport import unicode_gettext as _
 from apport.crashdb import get_crashdb
 
 

--- a/bin/apport-unpack
+++ b/bin/apport-unpack
@@ -17,10 +17,10 @@ import gettext
 import gzip
 import os
 import sys
+from gettext import gettext as _
 
 import problem_report
 from apport import fatal
-from apport import unicode_gettext as _
 
 
 def parse_args():

--- a/bin/apport-valgrind
+++ b/bin/apport-valgrind
@@ -20,11 +20,11 @@ import os
 import shutil
 import subprocess
 import sys
+from gettext import gettext as _
 
 import apport
 import apport.fileutils
 import apport.sandboxutils
-from apport import unicode_gettext as _
 
 #
 # functions

--- a/data/apportcheckresume
+++ b/data/apportcheckresume
@@ -12,9 +12,9 @@
 import datetime
 import os
 import sys
+from gettext import gettext as _
 
 import apport.report
-from apport import unicode_gettext as _
 from apport.hookutils import attach_file_if_exists
 from apport.packaging_impl import impl as packaging
 

--- a/data/kernel_oops
+++ b/data/kernel_oops
@@ -13,9 +13,9 @@
 
 import os
 import sys
+from gettext import gettext as _
 
 import apport.fileutils
-from apport import unicode_gettext as _
 
 checksum = None
 if len(sys.argv) > 1:

--- a/gtk/apport-gtk
+++ b/gtk/apport-gtk
@@ -15,10 +15,10 @@ import os
 import re
 import subprocess
 import sys
+from gettext import gettext as _
 
 import apport
 import apport.ui
-from apport import unicode_gettext as _
 
 try:
     import gi

--- a/kde/apport-kde
+++ b/kde/apport-kde
@@ -16,10 +16,10 @@ import os
 import shutil
 import subprocess
 import sys
+from gettext import gettext as _
 
 import apport.logging
 import apport.ui
-from apport import unicode_gettext as _
 
 try:
     from PyQt5 import uic

--- a/tests/system/test_ui_gtk.py
+++ b/tests/system/test_ui_gtk.py
@@ -16,10 +16,10 @@ import tempfile
 import textwrap
 import unittest
 import unittest.mock
+from gettext import gettext as _
 
 import apport.crashdb_impl.memory
 import apport.report
-from apport import unicode_gettext as _
 from tests.helper import import_module_from_file
 from tests.paths import get_data_directory, local_test_environment
 

--- a/tests/system/test_ui_kde.py
+++ b/tests/system/test_ui_kde.py
@@ -15,6 +15,7 @@ import tempfile
 import textwrap
 import unittest
 import unittest.mock
+from gettext import gettext as _
 
 try:
     from PyQt5.QtCore import QCoreApplication, QTimer
@@ -27,7 +28,6 @@ except ImportError as error:
 
 import apport.crashdb_impl.memory
 import apport.report
-from apport import unicode_gettext as _
 from tests.helper import import_module_from_file, wrap_object
 from tests.paths import get_data_directory, local_test_environment
 

--- a/tests/unit/test_deprecation.py
+++ b/tests/unit/test_deprecation.py
@@ -1,0 +1,24 @@
+# Copyright (C) 2023 Canonical Ltd.
+# Author: Benjamin Drung <benjamin.drung@canonical.com>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 2 of the License, or (at your
+# option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
+# the full text of the license.
+
+"""Unit tests for apport.unicode_gettext."""
+
+import unittest
+import unittest.mock
+
+from apport import unicode_gettext
+
+
+class TestDeprecation(unittest.TestCase):
+    """Unit tests for apport.unicode_gettext."""
+
+    def test_unicode_gettext(self) -> None:
+        """unicode_gettext() throws a deprecation warning."""
+        with self.assertWarns(PendingDeprecationWarning):
+            self.assertEqual(unicode_gettext("untranslated"), "untranslated")


### PR DESCRIPTION
Use `gettext.gettext()` directly and deprecate `apport.unicode_gettext()`. Use `PendingDeprecationWarning` for now, because it is not shown by default. Please change that to `DeprecationWarning` once no package in the Ubuntu archive uses `unicode_gettext` any more.