### PR TITLE
test: Skip tests if Python dependencies or required binaries are missing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -193,6 +193,35 @@ jobs:
           fail_ci_if_error: true
           files: ./coverage.xml,./coverage-setup.xml
 
+  skip-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        container:
+          - ubuntu:jammy
+          - ubuntu:kinetic
+    container:
+      image: ${{ matrix.container }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: >
+          apt-get update
+          && apt-get install --no-install-recommends --yes
+          python3 python3-apt python3-psutil python3-pytest python3-pytest-cov
+      - name: Run all tests (to check if they are skipped or succeed)
+        run: python3 -m pytest -ra --cov=$(pwd) --cov-report=xml tests/
+      - name: Install dependencies for Codecov
+        run: >
+          apt-get install --no-install-recommends --yes
+          ca-certificates curl git
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          fail_ci_if_error: true
+          files: ./coverage.xml
+
   system-tests:
     runs-on: ubuntu-latest
     strategy:

--- a/tests/integration/test_hooks.py
+++ b/tests/integration/test_hooks.py
@@ -349,13 +349,18 @@ class T(unittest.TestCase):
         )
         self.assertEqual(apport.fileutils.get_new_reports(), [])
 
-    @staticmethod
-    def _gcc_version_path():
+    def _gcc_version_path(self):
         """Determine a valid version and executable path of gcc and return it
         as a tuple."""
-        gcc = subprocess.run(
-            ["gcc", "--version"], check=True, stdout=subprocess.PIPE, text=True
-        )
+        try:
+            gcc = subprocess.run(
+                ["gcc", "--version"],
+                check=True,
+                stdout=subprocess.PIPE,
+                text=True,
+            )
+        except FileNotFoundError as error:
+            self.skipTest(f"{error.filename} not available")
 
         ver_fields = gcc.stdout.splitlines()[0].split()[3].split(".")
         # try major/minor first

--- a/tests/integration/test_hookutils.py
+++ b/tests/integration/test_hookutils.py
@@ -11,6 +11,7 @@ import unittest.mock
 import apport.hookutils
 import apport.report
 import problem_report
+from tests.helper import skip_if_command_is_missing
 
 
 class T(unittest.TestCase):
@@ -20,6 +21,7 @@ class T(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.workdir)
 
+    @skip_if_command_is_missing("/usr/bin/as")
     def test_module_license_evaluation(self):
         """Module licenses can be validated correctly."""
         # pylint: disable=protected-access
@@ -62,6 +64,7 @@ class T(unittest.TestCase):
         self.assertNotIn(good_ko, nonfree)
         self.assertIn(bad_ko, nonfree)
 
+    @skip_if_command_is_missing("/sbin/modinfo")
     def test_real_module_license_evaluation(self):
         """Module licenses can be validated correctly for real module."""
         # pylint: disable=protected-access

--- a/tests/integration/test_packaging_apt_dpkg.py
+++ b/tests/integration/test_packaging_apt_dpkg.py
@@ -546,6 +546,7 @@ deb http://secondary.mirror tuxy extra
         self.assertNotEqual(arch, "")
         self.assertNotIn("\n", arch)
 
+    @skip_if_command_is_missing("dpkg-architecture")
     def test_get_library_paths(self):
         """get_library_paths()."""
         paths = impl.get_library_paths()

--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -22,7 +22,7 @@ import apport.report
 import apport.ui
 import problem_report
 from apport.ui import _
-from tests.helper import pidof
+from tests.helper import pidof, skip_if_command_is_missing
 from tests.paths import (
     local_test_environment,
     patch_data_dir,
@@ -957,6 +957,7 @@ class T(unittest.TestCase):
         self.assertEqual(self.ui.msg_severity, None)
         self.assertTrue(self.ui.present_details_shown)
 
+    @skip_if_command_is_missing("gdb")
     def test_run_crash_broken(self):
         """run_crash() for an invalid core dump"""
         # generate broken crash report

--- a/tests/system/test_packaging_apt_dpkg.py
+++ b/tests/system/test_packaging_apt_dpkg.py
@@ -823,6 +823,7 @@ class T(unittest.TestCase):
             "unexpected version: " + res.split("/")[-1],
         )
 
+    @skip_if_command_is_missing("gpg")
     @unittest.skipUnless(has_internet(), "online test")
     def test_create_sources_for_a_named_ppa(self):
         """Add sources.list entries for a named PPA."""
@@ -878,6 +879,7 @@ class T(unittest.TestCase):
         apt_keys = gpg.stdout.decode()
         self.assertIn("Launchpad PPA for Daisy Pluckers", apt_keys)
 
+    @skip_if_command_is_missing("gpg")
     @unittest.skipUnless(has_internet(), "online test")
     def test_create_sources_for_an_unnamed_ppa(self):
         """Add sources.list entries for an unnamed PPA."""

--- a/tests/system/test_python_crashes.py
+++ b/tests/system/test_python_crashes.py
@@ -18,13 +18,19 @@ import tempfile
 import textwrap
 import unittest
 
-import dbus
+try:
+    import dbus
+
+    HAS_DBUS = True
+except ImportError:
+    HAS_DBUS = False
 
 import apport.fileutils
 import apport.report
 from tests.paths import local_test_environment
 
 
+@unittest.skipUnless(HAS_DBUS, "dbus Python module not installed")
 class T(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/tests/system/test_ui_gtk.py
+++ b/tests/system/test_ui_gtk.py
@@ -17,26 +17,38 @@ import textwrap
 import unittest
 import unittest.mock
 
-import gi
-
-gi.require_version("Gtk", "3.0")  # noqa: E402, pylint: disable=C0413
-from gi.repository import GLib, GObject, Gtk
-
 import apport.crashdb_impl.memory
 import apport.report
 from apport import unicode_gettext as _
 from tests.helper import import_module_from_file
 from tests.paths import get_data_directory, local_test_environment
 
-GLib.log_set_always_fatal(
-    GLib.LogLevelFlags.LEVEL_WARNING | GLib.LogLevelFlags.LEVEL_CRITICAL
-)
+try:
+    import gi
+
+    gi.require_version("Gtk", "3.0")  # noqa: E402, pylint: disable=C0413
+    from gi.repository import GLib, GObject, Gtk
+
+    GLib.log_set_always_fatal(
+        GLib.LogLevelFlags.LEVEL_WARNING | GLib.LogLevelFlags.LEVEL_CRITICAL
+    )
+
+    GI_IMPORT_ERROR = None
+except ImportError as error:
+    GI_IMPORT_ERROR = error
 
 apport_gtk_path = get_data_directory("gtk") / "apport-gtk"
-apport_gtk = import_module_from_file(apport_gtk_path)
-GTKUserInterface = apport_gtk.GTKUserInterface
+if not GI_IMPORT_ERROR:
+    apport_gtk = import_module_from_file(apport_gtk_path)
+    GTKUserInterface = apport_gtk.GTKUserInterface
+else:
+    apport_gtk = None
+    GTKUserInterface = None
 
 
+@unittest.skipIf(
+    GI_IMPORT_ERROR, f"gi Python module not available: {GI_IMPORT_ERROR}"
+)
 class T(unittest.TestCase):
     POLLING_INTERVAL_MS = 10
 

--- a/tests/unit/test_signal_crashes.py
+++ b/tests/unit/test_signal_crashes.py
@@ -72,6 +72,12 @@ class TestApport(unittest.TestCase):
 
     def test_receive_arguments_via_socket_invalid_socket(self):
         """Test receive_arguments_via_socket with invalid socket."""
+        try:
+            # pylint: disable=import-outside-toplevel
+            from systemd.daemon import listen_fds
+        except ImportError:
+            self.skipTest("systemd Python module not available")
+        assert listen_fds
         self.assertNotIn("LISTEN_FDS", os.environ)
         with self.assertRaisesRegex(SystemExit, "^1$"):
             apport_binary.receive_arguments_via_socket()


### PR DESCRIPTION
The Python crashes system tests need `dbus`, the GTK UI system tests need GI and the Glib/GTK libraries, and `test_receive_arguments_via_socket_invalid_socket` needs the systemd library. Check for the presence and skip if the libraries are missing.

Some test cases need some binaries for their test which might not be installed. Check for the presence and skip if the binaries are missing.

Run all tests in a minimal container to check if they are skipped or succeed.