### PR TITLE
refactoring(apport): Return boolean directly in is_closing_session()

### DIFF
--- a/data/apport
+++ b/data/apport
@@ -434,10 +434,7 @@ def is_closing_session() -> bool:
         os.setresgid(real_gid, real_gid, -1)
 
     error_log("debug: session gdbus call: " + out.decode("UTF-8"))
-    if out.startswith(b"(false,"):
-        return True
-
-    return False
+    return out.startswith(b"(false,")
 
 
 def is_systemd_watchdog_restart(signum):


### PR DESCRIPTION
Return boolean directly in `is_closing_session()` instead of wrapping it in an useless if-statement.