### PR TITLE
test: Add unit tests for is_closing_session()

### DIFF
--- a/data/apport
+++ b/data/apport
@@ -363,7 +363,7 @@ def _run_with_output_limit_and_timeout(
     return stdout, stderr
 
 
-def is_closing_session():
+def is_closing_session() -> bool:
     """Check if pid is in a closing user session.
 
     During that, crashes are common as the session D-BUS and X.org are going

--- a/data/apport
+++ b/data/apport
@@ -369,10 +369,6 @@ def is_closing_session():
     During that, crashes are common as the session D-BUS and X.org are going
     away, etc. These crash reports are mostly noise, so should be ignored.
     """
-    # consistency check, don't do anything for root processes
-    if crash_uid == 0 or crash_gid == 0:
-        return False
-
     with open("environ", "rb", opener=proc_pid_opener) as e:
         env = e.read().split(b"\0")
     for e in env:
@@ -1034,7 +1030,8 @@ def process_crash(options: argparse.Namespace) -> int:
     # write out the user coredumps
     recover_privileges()
 
-    if is_closing_session():
+    # Do not check closing session for root processes
+    if crash_uid != 0 and crash_gid != 0 and is_closing_session():
         error_log("happens for shutting down session, ignoring")
         return 0
 


### PR DESCRIPTION
Checking for root processes does not belong into `is_closing_session`.

Add unit tests for `is_closing_session()` to increase code coverage to ease future refactoring.