### PR TITLE
refactor: Replace TestCase.fail by TestCase.assert*

### DIFF
--- a/tests/integration/test_hooks.py
+++ b/tests/integration/test_hooks.py
@@ -143,8 +143,8 @@ class T(unittest.TestCase):
                 log1key = k
             elif k.endswith("Log2"):
                 log2key = k
-            elif "sub" in k:
-                self.fail("logsub should not go into log files")
+            else:
+                self.assertNotIn("sub", k)
 
         self.assertTrue(filekey)
         self.assertTrue(log1key)

--- a/tests/integration/test_signal_crashes.py
+++ b/tests/integration/test_signal_crashes.py
@@ -604,13 +604,14 @@ class T(unittest.TestCase):
             test_proc.kill()
             test_proc.wait()
 
-        if app.stdout != "" or app.stderr != "":
-            self.fail(
-                f"Apport wrote to stdout and/or stderr"
-                f" (exit code {app.returncode})."
-                f"\n*** stdout:\n{app.stdout.strip()}"
-                f"\n*** stderr:\n{app.stderr.strip()}"
-            )
+        self.assertEqual(
+            app.stdout + app.stderr,
+            "",
+            msg=f"Apport wrote to stdout and/or stderr"
+            f" (exit code {app.returncode})."
+            f"\n*** stdout:\n{app.stdout.strip()}"
+            f"\n*** stderr:\n{app.stderr.strip()}",
+        )
         self.assertEqual(app.returncode, 0, app.stderr)
         with open(log, encoding="utf-8") as f:
             logged = f.read()


### PR DESCRIPTION
Replace `TestCase.fail` with `TestCase.assert*` calls that are always executed to increase the code coverage.

The statements after `self.fail` in
`test_install_packages_permanent_sandbox` were indented incorrectly, because the code after `self.fail` is unreachable.