### PR TITLE
ci: Run woke on the source code

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -286,3 +286,15 @@ jobs:
         with:
           fail_ci_if_error: true
           files: ./coverage.xml,./coverage-setup.xml
+
+  woke:
+    name: woke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: woke
+        uses: get-woke/woke-action@v0
+        with:
+          # Cause the check to fail on any broke rules
+          fail-on-error: true

--- a/.pylintrc
+++ b/.pylintrc
@@ -4,7 +4,7 @@
 # be loaded. Extensions are loading into the active Python interpreter and may
 # run arbitrary code. (This is an alternative name to extension-pkg-allow-list
 # for backward compatibility.)
-extension-pkg-whitelist=apt_pkg
+extension-pkg-whitelist=apt_pkg  # wokeignore:rule=whitelist
 
 # Pickle collected data for later comparisons.
 persistent=no

--- a/NEWS.md
+++ b/NEWS.md
@@ -2078,8 +2078,9 @@ Improvements:
    these traces from the client-side application, you need the actual exception
    in the D-Bus server backend instead.
    ([LP: #914220](https://launchpad.net/bugs/914220))
- - Support /etc/apport/whitelist.d/ similarly to /etc/apport/blacklist.d/, for
-   cases like installer environments where only crashes of a few selected
+ - Support /etc/apport/whitelist.d/ <!-- wokeignore:rule=whitelist -->
+   similarly to /etc/apport/blacklist.d/, <!-- wokeignore:rule=blacklist -->
+   for cases like installer environments where only crashes of a few selected
    programs should be reported.
 
 1.90 (2011-11-24):


### PR DESCRIPTION
Run `woke` on the source code in the CI to avoid regressions.