### PR TITLE
tests: Expect crash .class and .jar to be present

### DIFF
--- a/tests/integration/test_java_crashes.py
+++ b/tests/integration/test_java_crashes.py
@@ -43,8 +43,7 @@ class T(unittest.TestCase):
     def test_crash_class(self):
         """Crash in a .class file."""
         crash_class = self.crash_jar_path.with_suffix(".class")
-        if not crash_class.exists():
-            self.skipTest(f"{crash_class} missing")
+        self.assertTrue(crash_class.exists(), f"{crash_class} missing")
         java = subprocess.run(
             [
                 "java",
@@ -66,8 +65,9 @@ class T(unittest.TestCase):
 
     def test_crash_jar(self):
         """Crash in a .jar file."""
-        if not self.crash_jar_path.exists():
-            self.skipTest(f"{self.crash_jar_path} missing")
+        self.assertTrue(
+            self.crash_jar_path.exists(), f"{self.crash_jar_path} missing"
+        )
         java = subprocess.run(
             [
                 "java",


### PR DESCRIPTION
The Java crashes tests check that the `java` command is available and `setUp` checks that `apport.jar` is present. In that case `crash.class` and `crash.jar` should also have been built by `setup.py`. So convert these checks into assertions to increase code coverage.