### PR TITLE
test: Fix test_deleted_working_directory for pytest-cov 4.0

### DIFF
--- a/tests/integration/test_python_crashes.py
+++ b/tests/integration/test_python_crashes.py
@@ -338,7 +338,8 @@ func(42)
         # Workaround for pytest bug.
         # See https://github.com/pytest-dev/pytest-cov/issues/541
         stderr = re.sub(
-            r"^Error processing [A-Za-z0-9 /-]*init_cov_core.pth:\n[\S\W]*\n"
+            r"^(Error processing [A-Za-z0-9 /-]*"
+            r"init_cov_core.pth:\n[\S\W]*\n)?"
             r"pytest-cov: Failed to setup subprocess coverage.*\n",
             "",
             process.stderr.decode(),


### PR DESCRIPTION
pytest-cov 4.0 does not print a stack trace in the `test_deleted_working_directory` test case any more, but only prints an one-liner:

```
pytest-cov: Failed to setup subprocess coverage. Environ: [...] Exception: FileNotFoundError(2, 'No such file or directory')
```

So extend `test_deleted_working_directory` to also only strip this one pytest-cov line from the stderr output.