### PR TITLE
refactor(apport): Return early in init_error_log

### DIFF
--- a/data/apport
+++ b/data/apport
@@ -157,27 +157,29 @@ def recover_privileges():
     assert os.geteuid() == os.getuid()
 
 
-def init_error_log():
+def init_error_log() -> None:
     """Open a suitable error log if sys.stderr is not a tty."""
 
-    if not os.isatty(2):
-        log = os.environ.get("APPORT_LOG_FILE", "/var/log/apport.log")
-        try:
-            f = os.open(log, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
-        except OSError:  # on a permission error, don't touch stderr
-            return
+    if os.isatty(2):
+        return
 
-        # if group adm doesn't exist, just leave it as root
-        with contextlib.suppress(KeyError, OSError):
-            admgid = grp.getgrnam("adm")[2]
-            os.chown(log, -1, admgid)
-            os.chmod(log, 0o640)
+    log = os.environ.get("APPORT_LOG_FILE", "/var/log/apport.log")
+    try:
+        f = os.open(log, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+    except OSError:  # on a permission error, don't touch stderr
+        return
 
-        os.dup2(f, 1)
-        os.dup2(f, 2)
-        sys.stderr = os.fdopen(2, "wb")
-        sys.stderr = io.TextIOWrapper(sys.stderr)
-        sys.stdout = sys.stderr
+    # if group adm doesn't exist, just leave it as root
+    with contextlib.suppress(KeyError, OSError):
+        admgid = grp.getgrnam("adm")[2]
+        os.chown(log, -1, admgid)
+        os.chmod(log, 0o640)
+
+    os.dup2(f, 1)
+    os.dup2(f, 2)
+    sys.stderr = os.fdopen(2, "wb")
+    sys.stderr = io.TextIOWrapper(sys.stderr)
+    sys.stdout = sys.stderr
 
 
 def error_log(msg):


### PR DESCRIPTION
Return early in `init_error_log` to reduce the indentation level and make the function more readable.