### PR TITLE
refactor: Introduce get_process_environ

### DIFF
--- a/apport/fileutils.py
+++ b/apport/fileutils.py
@@ -516,6 +516,25 @@ def get_boot_id():
     return boot_id
 
 
+def get_process_environ(proc_pid_fd: int) -> dict[str, str]:
+    """Get the process environ from a proc directory file descriptor.
+
+    Raises an OSError in case the environ file could not been read.
+    """
+
+    def opener(path, flags: int) -> int:
+        return os.open(path, flags, dir_fd=proc_pid_fd)
+
+    with open(
+        "environ", encoding="utf-8", errors="replace", opener=opener
+    ) as environ_fd:
+        environ = environ_fd.read().rstrip("\0 ")
+
+    if not environ:
+        return {}
+    return dict([entry.split("=", 1) for entry in environ.split("\0")])
+
+
 def get_process_path(proc_pid_fd=None):
     """Get the process path from a proc directory file descriptor."""
     if proc_pid_fd is None:

--- a/apport/report.py
+++ b/apport/report.py
@@ -288,6 +288,31 @@ def _which_extrapath(command, extra_path):
     return shutil.which(command, path=path)
 
 
+class _Environment(dict[str, str]):
+    """Wrapper around an environment dictionary."""
+
+    def anonymize_path(self) -> None:
+        """Anonymize PATH environment variable if present."""
+        path = self.get("PATH")
+        if path is None:
+            return
+        if (
+            path == "/usr/local/sbin:/usr/local/bin"
+            ":/usr/sbin:/usr/bin:/sbin:/bin:/usr/games"
+        ):
+            del self["PATH"]
+        elif "/home" in path or "/tmp" in path:
+            self["PATH"] = "(custom, user)"
+        else:
+            self["PATH"] = "(custom, no user)"
+
+    def anonymize_vars(self, keys: typing.Iterable[str]) -> None:
+        """Anonymize given environment variables if present."""
+        for key in keys:
+            if key in self:
+                self[key] = "<set>"
+
+
 #
 # Report class
 #
@@ -763,7 +788,8 @@ class Report(problem_report.ProblemReport):
           plus the ones mentioned in extraenv)
         - CurrentDesktop: Value of $XDG_CURRENT_DESKTOP, if present
         """
-        safe_vars = [
+        anonymize_vars = {"LD_LIBRARY_PATH", "LD_PRELOAD", "XDG_RUNTIME_DIR"}
+        safe_vars = anonymize_vars | {
             "SHELL",
             "TERM",
             "LANGUAGE",
@@ -781,9 +807,10 @@ class Report(problem_report.ProblemReport):
             "LC_MEASUREMENT",
             "LC_IDENTIFICATION",
             "LOCPATH",
-        ]
+            "PATH",
+        }
         if extraenv:
-            safe_vars += extraenv
+            safe_vars |= set(extraenv)
 
         if not proc_pid_fd:
             if not pid:
@@ -793,43 +820,26 @@ class Report(problem_report.ProblemReport):
                 "/proc/%s" % pid, os.O_RDONLY | os.O_PATH | os.O_DIRECTORY
             )
 
-        self["ProcEnviron"] = ""
-        env = _read_proc_file("environ", pid, proc_pid_fd).replace("\n", "\\n")
-        if env.startswith("Error:"):
-            self["ProcEnviron"] = env
-        else:
-            for line in env.split("\0"):
-                if line.split("=", 1)[0] in safe_vars:
-                    if self["ProcEnviron"]:
-                        self["ProcEnviron"] += "\n"
-                    self["ProcEnviron"] += line
-                elif line.startswith("PATH="):
-                    p = line.split("=", 1)[1]
-                    if "/home" in p or "/tmp" in p:
-                        if self["ProcEnviron"]:
-                            self["ProcEnviron"] += "\n"
-                        self["ProcEnviron"] += "PATH=(custom, user)"
-                    elif (
-                        p != "/usr/local/sbin:/usr/local/bin"
-                        ":/usr/sbin:/usr/bin:/sbin:/bin:/usr/games"
-                    ):
-                        if self["ProcEnviron"]:
-                            self["ProcEnviron"] += "\n"
-                        self["ProcEnviron"] += "PATH=(custom, no user)"
-                elif line.startswith("XDG_RUNTIME_DIR="):
-                    if self["ProcEnviron"]:
-                        self["ProcEnviron"] += "\n"
-                    self["ProcEnviron"] += "XDG_RUNTIME_DIR=<set>"
-                elif line.startswith("LD_PRELOAD="):
-                    if self["ProcEnviron"]:
-                        self["ProcEnviron"] += "\n"
-                    self["ProcEnviron"] += "LD_PRELOAD=<set>"
-                elif line.startswith("LD_LIBRARY_PATH="):
-                    if self["ProcEnviron"]:
-                        self["ProcEnviron"] += "\n"
-                    self["ProcEnviron"] += "LD_LIBRARY_PATH=<set>"
-                elif line.startswith("XDG_CURRENT_DESKTOP="):
-                    self["CurrentDesktop"] = line.split("=", 1)[1]
+        try:
+            environ = _Environment(
+                apport.fileutils.get_process_environ(proc_pid_fd)
+            )
+        except OSError as error:
+            self["ProcEnviron"] = f"Error: {error}"
+            return
+
+        environ.anonymize_path()
+        environ.anonymize_vars(anonymize_vars)
+
+        if "XDG_CURRENT_DESKTOP" in environ:
+            self["CurrentDesktop"] = environ["XDG_CURRENT_DESKTOP"]
+        self["ProcEnviron"] = "\n".join(
+            [
+                f"{key}=" + value.replace("\n", "\\n")
+                for key, value in sorted(environ.items())
+                if key in safe_vars
+            ]
+        )
 
     def add_kernel_crash_info(self):
         """Add information from kernel crash.

--- a/data/apport
+++ b/data/apport
@@ -369,13 +369,9 @@ def is_closing_session() -> bool:
     During that, crashes are common as the session D-BUS and X.org are going
     away, etc. These crash reports are mostly noise, so should be ignored.
     """
-    with open("environ", "rb", opener=proc_pid_opener) as e:
-        env = e.read().split(b"\0")
-    for e in env:
-        if e.startswith(b"DBUS_SESSION_BUS_ADDRESS="):
-            dbus_addr = e.split(b"=", 1)[1].decode()
-            break
-    else:
+    env = apport.fileutils.get_process_environ(proc_pid_fd)
+    dbus_addr = env.get("DBUS_SESSION_BUS_ADDRESS")
+    if dbus_addr is None:
         error_log(
             "is_closing_session(): no DBUS_SESSION_BUS_ADDRESS in environment"
         )

--- a/tests/unit/test_fileutils.py
+++ b/tests/unit/test_fileutils.py
@@ -37,6 +37,25 @@ class T(unittest.TestCase):
             apport.fileutils.likely_packaged("/var/lib/foo"), False
         )
 
+    def test_get_process_environ(self) -> None:
+        open_mock = unittest.mock.mock_open(
+            read_data="SHELL=/bin/bash\0TERM=xterm-256color\0LANGUAGE=en\0"
+        )
+        with unittest.mock.patch("builtins.open", open_mock):
+            environ = apport.fileutils.get_process_environ(1337)
+        open_mock.assert_called_once()
+        self.assertEqual(
+            environ,
+            {"LANGUAGE": "en", "SHELL": "/bin/bash", "TERM": "xterm-256color"},
+        )
+
+    def test_get_process_environ_empty(self) -> None:
+        open_mock = unittest.mock.mock_open(read_data="")
+        with unittest.mock.patch("builtins.open", open_mock):
+            environ = apport.fileutils.get_process_environ(1337)
+        open_mock.assert_called_once()
+        self.assertEqual(environ, {})
+
     def test_get_recent_crashes(self):
         """get_recent_crashes()"""
         # incomplete fields


### PR DESCRIPTION
Reduce duplicate code by introducing `apport.fileutils.get_process_environ` which reads and parses the process environ. Also make `Report.add_proc_environ` more readable by move some logic into a new `_Environment` object.