### PR TITLE
fix(whoopsie-upload-all): Use NoninteractiveHookUI for add_hooks_info

### DIFF
--- a/apport/report.py
+++ b/apport/report.py
@@ -39,6 +39,7 @@ import apport.logging
 import problem_report
 from apport.hookutils import kill_pkttyagent
 from apport.packaging_impl import impl as packaging
+from apport.ui import HookUI, NoninteractiveHookUI
 
 _data_dir = os.environ.get("APPORT_DATA_DIR", "/usr/share/apport")
 GENERAL_HOOK_DIR = f"{_data_dir}/general-hooks/"
@@ -1082,7 +1083,12 @@ class Report(problem_report.ProblemReport):
                 depth += 1
         self["StacktraceTop"] = "\n".join(toptrace).strip()
 
-    def add_hooks_info(self, ui, package=None, srcpackage=None):
+    def add_hooks_info(
+        self,
+        ui: typing.Optional[HookUI] = None,
+        package: typing.Optional[str] = None,
+        srcpackage: typing.Optional[str] = None,
+    ):
         """Run hook script for collecting package specific data.
 
         A hook script needs to be in PACKAGE_HOOK_DIR/<Package>.py or in
@@ -1093,12 +1099,18 @@ class Report(problem_report.ProblemReport):
         return True if the hook requested to stop the report filing process,
         False otherwise.
         """
-        assert ui is not None
+        if ui is None:
+            ui = NoninteractiveHookUI()
         ret = self._add_hooks_info(ui, package, srcpackage)
         kill_pkttyagent()
         return ret
 
-    def _add_hooks_info(self, ui, package, srcpackage):
+    def _add_hooks_info(
+        self,
+        ui: HookUI,
+        package: typing.Optional[str],
+        srcpackage: typing.Optional[str],
+    ):
         # determine package names, unless already given as arguments
         # avoid path traversal
         if not package:

--- a/apport/ui.py
+++ b/apport/ui.py
@@ -2246,6 +2246,9 @@ class NoninteractiveHookUI(HookUI):
     def __init__(self):
         super().__init__(None)
 
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}()"
+
     def information(self, text):
         return None
 

--- a/data/whoopsie-upload-all
+++ b/data/whoopsie-upload-all
@@ -97,7 +97,7 @@ def process_report(report):
             return None
         # add information from package specific hooks
         try:
-            r.add_hooks_info(None)
+            r.add_hooks_info()
         except Exception as error:  # pylint: disable=broad-except
             sys.stderr.write(
                 "WARNING: hook failed for processing %s: %s\n"

--- a/tests/integration/test_report.py
+++ b/tests/integration/test_report.py
@@ -851,26 +851,26 @@ int main() { return f(42); }
             with open(rep.name, "rb") as f:
                 pr.load(f)
             pr["Signal"] = "1"
-            pr.add_hooks_info("fake_ui")
+            pr.add_hooks_info()
             self.assertNotIn("SegvAnalysis", pr)
 
             pr = apport.report.Report()
             with open(rep.name, "rb") as f:
                 pr.load(f)
-        pr.add_hooks_info("fake_ui")
+        pr.add_hooks_info()
         self.assertIn(
             'Skipped: missing required field "Architecture"',
             pr["SegvAnalysis"],
         )
 
         pr.add_os_info()
-        pr.add_hooks_info("fake_ui")
+        pr.add_hooks_info()
         self.assertIn(
             'Skipped: missing required field "ProcMaps"', pr["SegvAnalysis"]
         )
 
         pr.add_proc_info()
-        pr.add_hooks_info("fake_ui")
+        pr.add_hooks_info()
         if pr["Architecture"] in ["amd64", "i386"]:
             # data/general-hooks/parse_segv.py only runs for x86 and x86_64
             self.assertIn(
@@ -1358,7 +1358,7 @@ int main() { return f(42); }
             r = apport.report.Report()
             r["Package"] = "bar"
             # should not throw any exceptions
-            self.assertEqual(r.add_hooks_info("fake_ui"), False)
+            self.assertEqual(r.add_hooks_info(), False)
             self.assertEqual(
                 set(r.keys()),
                 set(
@@ -1377,7 +1377,7 @@ int main() { return f(42); }
             r = apport.report.Report()
             r["Package"] = "baz 1.2-3"
             # should not throw any exceptions
-            self.assertEqual(r.add_hooks_info("fake_ui"), False)
+            self.assertEqual(r.add_hooks_info(), False)
             self.assertEqual(
                 set(r.keys()),
                 set(
@@ -1395,7 +1395,7 @@ int main() { return f(42); }
 
             r = apport.report.Report()
             r["Package"] = "foo"
-            self.assertEqual(r.add_hooks_info("fake_ui"), False)
+            self.assertEqual(r.add_hooks_info(), False)
             self.assertEqual(
                 set(r.keys()),
                 set(
@@ -1416,11 +1416,11 @@ int main() { return f(42); }
             self.assertEqual(r["Field2"], "Field 2\nBla")
             self.assertEqual(r["CommonField1"], "CommonField 1")
             self.assertEqual(r["CommonField2"], "CommonField 2")
-            self.assertEqual(r["CommonField3"], "fake_ui")
+            self.assertEqual(r["CommonField3"], "NoninteractiveHookUI()")
 
             r = apport.report.Report()
             r["Package"] = "foo 4.5-6"
-            self.assertEqual(r.add_hooks_info("fake_ui"), False)
+            self.assertEqual(r.add_hooks_info(), False)
             self.assertEqual(
                 set(r.keys()),
                 set(
@@ -1444,10 +1444,10 @@ int main() { return f(42); }
 
             # test hook abort
             r["Spethial"] = "1"
-            self.assertEqual(r.add_hooks_info("fake_ui"), True)
+            self.assertEqual(r.add_hooks_info(), True)
             r = apport.report.Report()
             r["Package"] = "commonspethial"
-            self.assertEqual(r.add_hooks_info("fake_ui"), True)
+            self.assertEqual(r.add_hooks_info(), True)
 
             # source package hook
             with open(
@@ -1469,7 +1469,7 @@ int main() { return f(42); }
             r = apport.report.Report()
             r["SourcePackage"] = "foo"
             r["Package"] = "libfoo 3"
-            self.assertEqual(r.add_hooks_info("fake_ui"), False)
+            self.assertEqual(r.add_hooks_info(), False)
             self.assertEqual(
                 set(r.keys()),
                 set(
@@ -1491,11 +1491,11 @@ int main() { return f(42); }
             self.assertEqual(r["Field2"], "Field 2\nBla")
             self.assertEqual(r["CommonField1"], "CommonField 1")
             self.assertEqual(r["CommonField2"], "CommonField 2")
-            self.assertEqual(r["CommonField3"], "fake_ui")
+            self.assertEqual(r["CommonField3"], "NoninteractiveHookUI()")
 
             # test hook abort
             r["Package"] = "spethial"
-            self.assertEqual(r.add_hooks_info("fake_ui"), True)
+            self.assertEqual(r.add_hooks_info(), True)
 
         finally:
             shutil.rmtree(apport.report.GENERAL_HOOK_DIR)
@@ -1553,7 +1553,7 @@ int main() { return f(42); }
                 "%s/foolabs.example.com/foo/bin/frob" % apport.report._opt_dir
             )
 
-            self.assertEqual(r.add_hooks_info("fake_ui"), False)
+            self.assertEqual(r.add_hooks_info(), False)
             self.assertEqual(r["SourceHook"], "1")
         finally:
             shutil.rmtree(apport.report.GENERAL_HOOK_DIR)
@@ -1607,7 +1607,7 @@ int main() { return f(42); }
             r["SourcePackage"] = "foo"
             r["ExecutablePath"] = "/bin/foo-cli"
 
-            self.assertEqual(r.add_hooks_info("fake_ui"), False)
+            self.assertEqual(r.add_hooks_info(), False)
 
             # should have the data until the crash
             self.assertEqual(r["BinHookBefore"], "1")


### PR DESCRIPTION
Commit f8edc7280d492e710218c193e53542f1f86cfa91 introduces a regression: The package specific hooks are not run in `whoopsie-upload-all` because `add_hooks_info` is called with `ui=None`. `add_hooks_info` will raise an `AssertionError` for `ui=None`.

Use `NoninteractiveHookUI()` when `ui` is set to `None`.

Bug: https://launchpad.net/bugs/2003098