### PR TITLE
test: Mark error case in test_get_file_package_diversion with no cover

### DIFF
--- a/tests/integration/test_packaging_apt_dpkg.py
+++ b/tests/integration/test_packaging_apt_dpkg.py
@@ -480,7 +480,7 @@ usr/bin/frob                                            foo/frob
             if len(fields) == 7:
                 # pick first diversion we have
                 break
-        else:
+        else:  # pragma: no cover
             self.fail(
                 f"No non-local diversion found. dpkg-divert output: {output}"
             )


### PR DESCRIPTION
Mark error case in `test_get_file_package_diversion` with no cover since this code path is only triggered in the test failure case.