### PR TITLE
fix: Only sent UNIX credentials when having CAP_SYS_ADMIN

### DIFF
--- a/data/apport
+++ b/data/apport
@@ -510,7 +510,7 @@ def is_same_ns(pid, ns):
 
 
 def forward_crash_to_container(
-    host_pid: int, options: argparse.Namespace
+    host_pid: int, options: argparse.Namespace, has_cap_sys_admin: bool = True
 ) -> None:
     """Try to forward the crash to the container.
 
@@ -608,20 +608,23 @@ def forward_crash_to_container(
         options.core_ulimit,
         options.dump_mode,
     )
-    try:
-        sock.sendmsg(
-            [args.encode()],
-            [
-                # Send a ucred containing the global pid
-                (
-                    socket.SOL_SOCKET,
-                    socket.SCM_CREDENTIALS,
-                    struct.pack("3i", host_pid, 0, 0),
-                ),
-                # Send fd 0 (the coredump)
-                (socket.SOL_SOCKET, socket.SCM_RIGHTS, array.array("i", [0])),
-            ],
+    # Send fd 0 (the coredump)
+    ancillary = [
+        (socket.SOL_SOCKET, socket.SCM_RIGHTS, bytes(array.array("i", [0])))
+    ]
+    if has_cap_sys_admin:
+        # SCM_CREDENTIALS needs CAP_SYS_ADMIN for specifying another
+        # process ID. Checking os.geteuid() to be 0 is not enough.
+        # Send a ucred containing the global pid
+        ancillary.append(
+            (
+                socket.SOL_SOCKET,
+                socket.SCM_CREDENTIALS,
+                struct.pack("3i", host_pid, 0, 0),
+            )
         )
+    try:
+        sock.sendmsg([args.encode()], ancillary)
         sock.shutdown(socket.SHUT_RDWR)
     except TimeoutError:
         logger.error("Container apport failed to process crash within 30s")


### PR DESCRIPTION
Sending `SCM_CREDENTIALS` needs the capability `CAP_SYS_ADMIN` to send another process ID than its own. Since the sent `host_pid` differs from the apport process ID, `CAP_SYS_ADMIN` is needed.

Checking for `CAP_SYS_ADMIN` need the prctl() syscall which is currently only available in `python3-prctl`. Checking `os.geteuid() == 0` is not enough. So just allow specifying `has_cap_sys_admin` to `forward_crash_to_container`.

Convert `array.array` to `bytes` to make the `ancillary` consistently of type `list[typing.Tuple[int, int, bytes]]` to make mypy happy.