### PR TITLE
test: Specify Python files for linters directly

### DIFF
--- a/tests/run-linters
+++ b/tests/run-linters
@@ -14,18 +14,19 @@
 
 set -eu
 
+PYTHON_FILES="apport apport_python_hook.py data problem_report.py setup.py tests"
 PYTHON_SCRIPTS=$(find bin data gtk kde -type f -executable ! -name apport-bug ! -name apport-collect ! -name is-enabled ! -name root_info_wrapper)
 
 if type black >/dev/null 2>&1; then
     echo "Running black..."
-    black --check --diff . ${PYTHON_SCRIPTS}
+    black --check --diff ${PYTHON_FILES} ${PYTHON_SCRIPTS}
 else
     echo "Skipping black tests, black is not installed"
 fi
 
 if type isort >/dev/null 2>&1; then
     echo "Running isort..."
-    isort --check-only --diff .
+    isort --check-only --diff ${PYTHON_FILES} ${PYTHON_SCRIPTS}
 else
     echo "Skipping isort tests, isort is not installed"
 fi
@@ -33,7 +34,7 @@ fi
 if type pycodestyle >/dev/null 2>&1; then
     echo "Running pycodestyle..."
     # . catches all *.py modules; we explicitly need to specify the programs
-    pycodestyle --max-line-length=79 -r --ignore=E203,W503 . ${PYTHON_SCRIPTS}
+    pycodestyle --max-line-length=79 -r --ignore=E203,W503 ${PYTHON_FILES} ${PYTHON_SCRIPTS}
 else
     echo "Skipping pycodestyle tests, pycodestyle is not installed"
 fi
@@ -43,7 +44,7 @@ if type pydocstyle >/dev/null 2>&1; then
     pydocstyle_major_version=$(echo "$pydocstyle_version" | cut -d. -f1)
     if test "$pydocstyle_major_version" -ge 6; then
         echo "Running pydocstyle..."
-        pydocstyle . ${PYTHON_SCRIPTS}
+        pydocstyle ${PYTHON_FILES} ${PYTHON_SCRIPTS}
     else
         echo "Skipping pydocstyle tests, pydocstyle $pydocstyle_version is too old"
     fi
@@ -54,14 +55,14 @@ fi
 # pyflakes3, if available
 if type pyflakes3 >/dev/null 2>&1; then
     echo "Running pyflakes3..."
-    pyflakes3 . ${PYTHON_SCRIPTS}
+    pyflakes3 ${PYTHON_FILES} ${PYTHON_SCRIPTS}
 else
     echo "Skipping pyflakes3 tests, pyflakes3 is not installed"
 fi
 
 if type pylint >/dev/null 2>&1; then
     echo "Running pylint..."
-    pylint $(find . -name '*.py') ${PYTHON_SCRIPTS}
+    pylint ${PYTHON_FILES} ${PYTHON_SCRIPTS}
 else
     echo "Skipping pylint tests, pylint is not installed"
 fi


### PR DESCRIPTION
Black and pylint might complain about Python files in `.pc` that were created by quilt containing pre-patch versions of the Python files. Pylint might also check files in `.pybuild`. All these files should not be checked by the linters.