### PR TITLE
ui: upload-time messaging

### DIFF
--- a/apport/crashdb.py
+++ b/apport/crashdb.py
@@ -673,7 +673,9 @@ class CrashDatabase:
     # Abstract functions that need to be implemented by subclasses
     #
 
-    def upload(self, report, progress_callback=None):
+    def upload(
+        self, report, progress_callback=None, user_message_callback=None
+    ):
         """Upload given problem report return a handle for it.
 
         This should happen noninteractively.

--- a/apport/crashdb_impl/debian.py
+++ b/apport/crashdb_impl/debian.py
@@ -61,7 +61,9 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
 
         return apport.crashdb.CrashDatabase.accepts(self, report)
 
-    def upload(self, report, progress_callback=None):
+    def upload(
+        self, report, progress_callback=None, user_message_callback=None
+    ):
         """Upload given problem report return a handle for it.
 
         In Debian, we use BTS, which is heavily email oriented. This method

--- a/apport/crashdb_impl/launchpad.py
+++ b/apport/crashdb_impl/launchpad.py
@@ -213,7 +213,9 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
 
         return self.__lp_distro
 
-    def upload(self, report, progress_callback=None):
+    def upload(
+        self, report, progress_callback=None, user_message_callback=None
+    ):
         """Upload given problem report return a handle for it.
 
         This should happen noninteractively.

--- a/apport/crashdb_impl/memory.py
+++ b/apport/crashdb_impl/memory.py
@@ -36,16 +36,22 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
         self.dup_unchecked = set()
 
         self.upload_delay = 0
+        self.upload_msg = None
 
         if "sample_data" in options:
             self.add_sample_data()
 
-    def upload(self, report, progress_callback=None):
+    def upload(
+        self, report, progress_callback=None, user_message_callback=None
+    ):
         """Store the report and return a handle number (starting from 0).
 
         This does not support (nor need) progress callbacks.
         """
         assert self.accepts(report)
+
+        if user_message_callback and self.upload_msg:
+            user_message_callback(self.upload_msg[0], self.upload_msg[1])
 
         self.reports.append(
             {

--- a/apport/crashdb_impl/memory.py
+++ b/apport/crashdb_impl/memory.py
@@ -9,6 +9,8 @@
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
 
+import time
+
 import apport.crashdb
 import apport.report
 
@@ -33,6 +35,8 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
         self.unretraced = set()
         self.dup_unchecked = set()
 
+        self.upload_delay = 0
+
         if "sample_data" in options:
             self.add_sample_data()
 
@@ -56,6 +60,15 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
             self.dup_unchecked.add(crash_id)
         else:
             self.unretraced.add(crash_id)
+
+        # Simulate uploading some data
+        if self.upload_delay:
+            if progress_callback:
+                progress_callback(0, 100)
+            time.sleep(self.upload_delay)
+            if progress_callback:
+                progress_callback(100, 100)
+
         return crash_id
 
     def get_comment_url(self, report, handle):

--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -632,6 +632,29 @@ class T(unittest.TestCase):
         self.assertEqual(self.ui.run_argv(), True)
         self.assertEqual(stdout_mock.getvalue(), apport.ui.__version__ + "\n")
 
+    def test_file_report_nodelay(self):
+        """file_report() happy path without polling"""
+        self.ui = UserInterfaceMock()
+        self.ui.report = self.report
+        previous_id = self.ui.crashdb.latest_id()
+        self.ui.file_report()
+        self.assertNotEqual(self.ui.crashdb.latest_id(), previous_id)
+        self.assertEqual(self.ui.msg_severity, None)
+        self.assertEqual(self.ui.msg_title, None)
+        self.assertEqual(self.ui.msg_text, None)
+
+    def test_file_report_upload_delay(self):
+        """file_report() with some polling during upload"""
+        self.ui = UserInterfaceMock()
+        self.ui.report = self.report
+        self.ui.crashdb.upload_delay = 0.2  # Arbitrary value
+        previous_id = self.ui.crashdb.latest_id()
+        self.ui.file_report()
+        self.assertNotEqual(self.ui.crashdb.latest_id(), previous_id)
+        self.assertEqual(self.ui.msg_severity, None)
+        self.assertEqual(self.ui.msg_title, None)
+        self.assertEqual(self.ui.msg_text, None)
+
     def test_run_report_bug_package(self):
         """run_report_bug() for a package"""
         self.ui = UserInterfaceMock(["ui-test", "-f", "-p", "bash"])

--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -655,6 +655,18 @@ class T(unittest.TestCase):
         self.assertEqual(self.ui.msg_title, None)
         self.assertEqual(self.ui.msg_text, None)
 
+    def test_file_report_upload_message(self):
+        """file_report() with a message to the user"""
+        self.ui = UserInterfaceMock()
+        self.ui.report = self.report
+        self.ui.crashdb.upload_msg = ("test title", "test content")
+        previous_id = self.ui.crashdb.latest_id()
+        self.ui.file_report()
+        self.assertNotEqual(self.ui.crashdb.latest_id(), previous_id)
+        self.assertEqual(self.ui.msg_severity, "info")
+        self.assertEqual(self.ui.msg_title, "test title")
+        self.assertEqual(self.ui.msg_text, "test content")
+
     def test_run_report_bug_package(self):
         """run_report_bug() for a package"""
         self.ui = UserInterfaceMock(["ui-test", "-f", "-p", "bash"])


### PR DESCRIPTION
Some crashdb backends might need to display messages to the user, here's a safe API to do so.

See individual commit logs for more detailed descriptions of the changes.

This is an offshoot of #26 