### PR TITLE
test: Assert _run_test_executable runner is alive

### DIFF
--- a/tests/system/test_unkillable_shutdown.py
+++ b/tests/system/test_unkillable_shutdown.py
@@ -79,6 +79,8 @@ class TestUnkillableShutdown(unittest.TestCase):
         runner = multiprocessing.Process(target=_run_test_executable)
         runner.start()
         try:
+            self.assertTrue(runner.is_alive(), runner)
+            self.assertIsNone(runner.exitcode, runner)
             pid = self._wait_for_process(self.TEST_EXECUTABLE, existing_pids)
             try:
                 yield runner


### PR DESCRIPTION
Sometimes `test_write_reports` fails in GitHub CI with AssertionError: Process /usr/bin/sleep not started within 5 seconds. In that case the runner was not started. Add assertions for future cases.