### PR TITLE
tests: Close multiprocessing runner at end of the test case

### DIFF
--- a/tests/system/test_unkillable_shutdown.py
+++ b/tests/system/test_unkillable_shutdown.py
@@ -87,6 +87,7 @@ class TestUnkillableShutdown(unittest.TestCase):
             runner.join(60)
         finally:
             runner.kill()
+            runner.close()
 
     def _wait_for_process(
         self,


### PR DESCRIPTION
Sometimes `test_write_reports` fails in GitHub CI on Ubuntu 22.04 "jammy" with AssertionError: Process /usr/bin/sleep not started within 5 seconds. The reason is still unclear. Close the multiprocessing runner at end of the test case (to exclude one possible reason).