### PR TITLE
feat: Already add package info during crash

### DIFF
--- a/apport/report.py
+++ b/apport/report.py
@@ -446,8 +446,10 @@ class Report(problem_report.ProblemReport):
         if not version:
             return
 
-        self["PackageArchitecture"] = packaging.get_architecture(package)
-        self["Dependencies"] = self._get_transitive_dependencies(package)
+        if "PackageArchitecture" not in self:
+            self["PackageArchitecture"] = packaging.get_architecture(package)
+        if "Dependencies" not in self:
+            self["Dependencies"] = self._get_transitive_dependencies(package)
 
     def add_snap_info(self, snap):
         """Add info about an installed Snap.
@@ -1124,6 +1126,7 @@ class Report(problem_report.ProblemReport):
         if ui is None:
             ui = NoninteractiveHookUI()
         ret = self._add_hooks_info(ui, package, srcpackage)
+        self.pop("_HooksRun", None)
         kill_pkttyagent()
         return ret
 

--- a/data/apport
+++ b/data/apport
@@ -1097,6 +1097,9 @@ def process_crash(options: argparse.Namespace) -> int:
 
     info.add_user_info()
     info.add_os_info()
+    with contextlib.suppress(SystemError, ValueError):
+        info.add_package_info()
+    info["_HooksRun"] = "no"
 
     try:
         info.write(reportfile)

--- a/data/whoopsie-upload-all
+++ b/data/whoopsie-upload-all
@@ -82,7 +82,7 @@ def process_report(report):
     if r.get("ProblemType", "") != "Crash" and "ExecutablePath" not in r:
         logging.info("  skipping, not a crash")
         return None
-    if "Dependencies" in r:
+    if "Dependencies" in r and r.get("_HooksRun") != "no":
         logging.info("%s already has info collected", report)
     else:
         logging.info("Collecting info for %s...", report)
@@ -126,7 +126,7 @@ def process_report(report):
         try:
             fd = os.open(
                 report,
-                os.O_NOFOLLOW | os.O_WRONLY | os.O_APPEND | os.O_NONBLOCK,
+                os.O_NOFOLLOW | os.O_WRONLY | os.O_NONBLOCK,
             )
         except FileNotFoundError:
             # The crash report was deleted. Nothing left to do.
@@ -135,7 +135,7 @@ def process_report(report):
         if stat.S_ISREG(st.st_mode):
             with os.fdopen(fd, "wb") as f:
                 os.fchmod(fd, 0)
-                r.write(f, only_new=True)
+                r.write(f)
                 os.fchmod(fd, 0o640)
 
     # now tell whoopsie to upload the report


### PR DESCRIPTION
The package info is added to the crash report when the report is reported by the user or when it is uploaded. There can be quite some time delay and the list of installed packages could have change since then. There are crashes on errors.ubuntu.com where the reported version is newer than the code in the Python stack trace. So this kind of discrepancy happens in the real world.

So try to add the package info during crash. Add a `HooksRun` entry to the report to document that the hooks were not run (for `whoopsie-upload-all`). Change `add_package_info` to not overwrite existing entries.