### PR TITLE
style: Format Python code with black -C

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,6 @@ jobs:
       fail-fast: false
       matrix:
         container:
-          - debian:bullseye-slim
           - debian:testing-slim
           - ubuntu:jammy
           - ubuntu:kinetic

--- a/data/whoopsie-upload-all
+++ b/data/whoopsie-upload-all
@@ -124,10 +124,7 @@ def process_report(report):
         # /proc/sys/fs/protected_regular is set to 1 (LP: #1848064)
         # make sure the file isn't a FIFO or symlink
         try:
-            fd = os.open(
-                report,
-                os.O_NOFOLLOW | os.O_WRONLY | os.O_NONBLOCK,
-            )
+            fd = os.open(report, os.O_NOFOLLOW | os.O_WRONLY | os.O_NONBLOCK)
         except FileNotFoundError:
             # The crash report was deleted. Nothing left to do.
             return None

--- a/tests/integration/test_github.py
+++ b/tests/integration/test_github.py
@@ -41,10 +41,7 @@ class T(unittest.TestCase):
     # }
 
     def test__format_report(self):
-        data = {
-            "bold1": "normal1",
-            "bold2": "normal2",
-        }
+        data = {"bold1": "normal1", "bold2": "normal2"}
         expected_body = "**bold1**\nnormal1\n\n**bold2**\nnormal2\n\n"
 
         result = self.crashdb._format_report(data)

--- a/tests/run-linters
+++ b/tests/run-linters
@@ -19,7 +19,7 @@ PYTHON_SCRIPTS=$(find bin data gtk kde -type f -executable ! -name apport-bug ! 
 
 if type black >/dev/null 2>&1; then
     echo "Running black..."
-    black --check --diff ${PYTHON_FILES} ${PYTHON_SCRIPTS}
+    black -C --check --diff ${PYTHON_FILES} ${PYTHON_SCRIPTS}
 else
     echo "Skipping black tests, black is not installed"
 fi


### PR DESCRIPTION
Run black with `--skip-magic-trailing-comma` to not use trailing commas as a reason to split lines. This will fold lines that became short enough.