### PR TITLE
fix: Let _command_output return str instead of bytes

### DIFF
--- a/apport/report.py
+++ b/apport/report.py
@@ -151,9 +151,7 @@ def _read_maps(proc_pid_fd):
     return maps
 
 
-def _command_output(  # pylint: disable=redefined-builtin
-    command, input=None, env=None
-):
+def _command_output(command, env=None):
     """Run command and capture its output.
 
     Try to execute given command (argv list) and return its stdout, or return
@@ -166,7 +164,6 @@ def _command_output(  # pylint: disable=redefined-builtin
             command,
             check=False,
             env=env,
-            input=input,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             timeout=1800,

--- a/tests/integration/test_report.py
+++ b/tests/integration/test_report.py
@@ -1906,10 +1906,18 @@ int main() { return f(42); }
             timestamp, time.mktime(time.strptime("2014-01-01", "%Y-%m-%d"))
         )
 
+    def test_command_output(self):
+        out = apport.report._command_output(["echo", "hello"])
+        self.assertEqual(out, "hello\n")
+
     def test_command_output_passes_env(self):
         fake_env = {"GCONV_PATH": "/tmp"}
         out = apport.report._command_output(["env"], env=fake_env)
-        self.assertIn(b"GCONV_PATH", out)
+        self.assertIn("GCONV_PATH", out)
+
+    def test_command_output_raises_error(self):
+        with self.assertRaisesRegex(OSError, "failed with exit code 1"):
+            apport.report._command_output(["false"])
 
     def test_extrapath_preferred(self):
         """If extrapath is passed it is preferred."""


### PR DESCRIPTION
The fields `Snap.Changes`, `Snap.Connections`, `Snap.Info.*` contain binary instead of a string. Let `_command_output` return `str` instead of `bytes`.