### PR TITLE
fix: Strip trailing whitespaces from Snap* values

### DIFF
--- a/apport/report.py
+++ b/apport/report.py
@@ -175,13 +175,13 @@ def _command_output(
     except subprocess.TimeoutExpired as error:
         raise OSError(
             f"Error: command {str(error.cmd)} timed out"
-            f" after {error.timeout} seconds: {error.stdout}"
+            f" after {error.timeout} seconds: {error.stdout.rstrip()}"
         ) from error
     if sp.returncode == 0:
-        return sp.stdout
+        return sp.stdout.rstrip()
     raise OSError(
         "Error: command %s failed with exit code %i: %s"
-        % (str(command), sp.returncode, sp.stdout)
+        % (str(command), sp.returncode, sp.stdout.rstrip())
     )
 
 

--- a/tests/integration/test_report.py
+++ b/tests/integration/test_report.py
@@ -1908,7 +1908,7 @@ int main() { return f(42); }
 
     def test_command_output(self):
         out = apport.report._command_output(["echo", "hello"])
-        self.assertEqual(out, "hello\n")
+        self.assertEqual(out, "hello")
 
     def test_command_output_passes_env(self):
         fake_env = {"GCONV_PATH": "/tmp"}


### PR DESCRIPTION
Strip trailing whitespaces from Snap* values.