### PR TITLE
Update translation template and import Ukrainian translation updata from Ubuntu 23.04 (lunar)

### DIFF
--- a/po/af.po
+++ b/po/af.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2020-05-24 20:31+0000\n"
 "Last-Translator: Bernard Stafford <Unknown>\n"
 "Language-Team: Afrikaans <af@li.org>\n"
@@ -40,11 +40,11 @@ msgstr ""
 "Sleutel asseblief jou wagwoord in om toegang te verkry tot probleemberigte "
 "van stelselprogramme"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "Dit lyk nie asof hierdie pakket korrek geïnstalleer is nie"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -55,7 +55,7 @@ msgstr ""
 "opdater die indekse van beskikbare pakkette, indien daardie doen nie werk "
 "dan verwyder verwante pakkette derde party en probeer weer."
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -68,21 +68,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "onbekende program"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Jammer, die program \"%s\" het onverwags gesluit"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Probleem in %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -90,65 +90,65 @@ msgstr ""
 "Jou rekenaar beskik nie oor genoegsame gratis geheue om die outomaties te "
 "probleem-analiseer en te raporteer aan die ontwikkelaars nie."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Ongeldige probleem verslag"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "Jy word nie toegelaat om toegang tot hierdie -probleem verslag."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Fout"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 "Daar -is nie genoeg skyfspasie beskikbare om die verwerking van dit verslag."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr "Geen PID gespesifiseerde"
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr "Jy behoefte om gespesifiseerde 'n PID. Sien --help vir meer inligting."
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "Ongeldige PID"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr "Die gespesifiseerde proses-ID bestaan nie."
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr "Nie u PID nie"
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr "Die gespesifiseerde proses-ID behoort nie aan u nie."
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "Geen pakket gespesifiseer nie"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Jy nodig het om 'n pakket of 'n PID spesifiseer. Sien --hulp vir meer "
 "inligting."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Toestemming gewyer"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -156,30 +156,30 @@ msgstr ""
 "Die spesifieke proses behoort nie aan jou nie. Laat die program loop as "
 "proseseienaar of as wortel."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "Die gespesifiseerde proses-ID behoort nie aan 'n program nie."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Simptometeks %s kon geen geaffekteerde pakket bepaal nie"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Pakket %s bestaan nie"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "Kan nie verslag skep nie"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "Opdateer probleemverslag"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -191,7 +191,7 @@ msgstr ""
 "\n"
 "Skep asseblief 'n nuwe verslag met behulp van \"apport-bug\"."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -212,24 +212,24 @@ msgstr ""
 "\n"
 "Wil jy regtig om voortgaan?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "Geen addisionele inligting ingesamel."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "Watter tipe probleem probeer jy rapporteer?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Onbekende simptoom"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Die simptoom \"%s\" is onbekend"
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -248,7 +248,7 @@ msgstr ""
 "voer. In die Prosesse-oortjie, scroll totdat jy die regte toepassing vind. "
 "Die proses-ID is die nommer wat in die ID-kolom gelys word."
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -256,32 +256,32 @@ msgstr ""
 "Nadat u hierdie boodskap gesluit het, klik op die toepassingsvenster om 'n "
 "probleem daaroor te rapporteer."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop nagelaat om proses bepaal ID van die venster"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr "%(prog)s <report number>"
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "Spesifiseer pakket naam."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Voeg 'n ekstra tag by die verslag. Kan verskeie kere gespesifiseer word."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -291,15 +291,15 @@ msgstr ""
 "pid. Indien geeneen verskaf word nie, vertoon 'n lys van bekende simptome. "
 "(By implkasie dat 'n enkele argument gegewe is."
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "Klik 'n venster as teiken vir indiening 'n probleem verslag."
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "Begin in bug opdatering modus. Kan 'n opsionele --pakket vat."
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -307,7 +307,7 @@ msgstr ""
 "Handig 'n bug rapport in oor 'n simptoom. (By implikasie dat 'n stelselnaam "
 "gegee word as die enigste argument.)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -316,7 +316,7 @@ msgstr ""
 "pid gespesifiseer is. (By implikasie dat 'n pakketnaam as die enogste "
 "argument gegee word.)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -326,11 +326,11 @@ msgstr ""
 "die bug verslag sal bevat meer inligting.\r\n"
 "(Geïmpliseer indien pid slegs as enigste argument.)"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "Die voorsien pid is 'n hang toepassing."
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -340,7 +340,7 @@ msgstr ""
 "van die afwagtende verlsae in %s. (By implikasie dat die lêer as enigste "
 "agrument gegee word.)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -350,36 +350,36 @@ msgstr ""
 "verslagdoening dit. Hierdie lêer kan dan wees berig later op van 'n "
 "verskillende masjien."
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Druk die Apport weergawe nommer."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Hierdie sal launch apport-retrace in 'n terminale venster te ondersoek die "
 "crash."
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "Hardloop gdb sessie"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Hardloop gdb sessie sonder aflaai debug simbole"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Opdateer %s met ten volle simboliese stapel spoor"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr "Kan nie onthou nie sturr verslag statusse instellings"
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -402,7 +402,7 @@ msgstr ""
 "Die probleem gebeur met die program %s watter verander sedert die crash het "
 "voorgekom."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Hierdie probleemverslag is beskadig en kan nie verwerk word nie."
 
@@ -433,13 +433,13 @@ msgstr "%s snap"
 msgid "%s deb package"
 msgstr "%s deb pakket"
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s is verskaf deur 'n snap gepubliseer deur %s. Kontak hulle via %s vir hulp."
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -448,41 +448,41 @@ msgstr ""
 "%s is verskaf deur 'n snap gepubliseer deur %s. Geen kontak adres het was "
 "verskaf; besoek die forum by https://forum.snapcraft.io/ vir hulp."
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "Kon nie die pakket of bronpakket naam bepaal nie."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "Kan nie die webblaaier begin nie"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Kan nie die webblaaier begin om oop %s."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Netwerkprobleem"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Kon nie verbind met die crash-databasis nie, gaan asseblief jou "
 "internetkonneksie na."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Geheue uitputting"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Jou stelsel het nie genoeg geheue beskikbaar om die ineenstortingsverslag te "
 "prosseseer nie."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -493,11 +493,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "Probleem reeds bekend"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -507,7 +507,7 @@ msgstr ""
 "webblaaier. Gaan asseblief na of enige verdere informasie bygevoeg kan word "
 "wat tot hulp van die ontwikkelaars kan wees."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Hierdie probleem is reeds aan ontwikkelaars gerapporteer. Dankie!"
 
@@ -871,7 +871,7 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Fout: %s is nie 'n uitvoerbare. Stop tans."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -879,7 +879,7 @@ msgstr ""
 "Hierdie het tydens 'n vorige opskort voorgekom en het verhoed dat die "
 "stelsel hervatting ordentlik."
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -887,7 +887,7 @@ msgstr ""
 "Dit het tydens 'n vorige winterslaap plaasgevind, en het verhoed dat die "
 "stelsel hervatting ordentlik."
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/am.po
+++ b/po/am.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2017-04-24 01:43+0000\n"
 "Last-Translator: samson <Unknown>\n"
 "Language-Team: Amharic <am@li.org>\n"
@@ -36,11 +36,11 @@ msgstr "የ ስርአት ችግር መግለጫ"
 msgid "Please enter your password to access problem reports of system programs"
 msgstr "እባክዎን የ እርስዎን የ መግቢያ ቃል ያስገቡ የ ስርአቱ ፕሮግራም ችግር ጋር ለ መድረስ"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "ይህ ጥቅል በ ትክክል አልተገጠመም"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -61,112 +61,112 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "ያልታወቀ ፕሮግራም"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "አዝናለሁ ፕሮግራሙ \"%s\" በድንገት ተዘግቷል"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "ችግር በ %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
 msgstr ""
 "የ እርስዎ ኮምፒዩተር በቂ የሆነ ነፃ ቦታ የለውም ራሱ በራሱ ችግሩን ለ መመርመር እና መግለጫ ለ አበልፃጊዎች ለ መላክ"
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "ዋጋ የሌለው የ ችግር መግለጫ"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "እርስዎ እዚህ የ ችግር መግለጫ ጋር ለ መድረስ አይችሉም"
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "ስህተት"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "ይህን መግለጫ ለማስኬድ ዝግጁ የሆነ በቂ የሆነ የ ዲስክ ቦታ የለም"
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "ዋጋ የሌለው PID"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "ምንም ጥቅል አልተመረጠም"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "ፍቃድ ተከልክሏል"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 msgstr ""
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr ""
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "ጥቅሉ %s አልተገኘም"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "መግለጫ መፍጠር አልተቻለም"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "የ ችግር መግለጫ ማሻሻያ"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -174,7 +174,7 @@ msgid ""
 "Please create a new report using \"apport-bug\"."
 msgstr ""
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -186,24 +186,24 @@ msgid ""
 "Do you really want to proceed?"
 msgstr ""
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "የተሰበሰበ ተጨማሪ መረጃ የለም"
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "ምን አይነት ችግር ነው ማሳወቅ የሚፈልጉት?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "ያልታወቀ ምልክት"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "ምልክቱ \"%s\" አይታወቅም"
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -214,115 +214,115 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "የጥቅሉን ስም ይግለጹ"
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "ተጨማሪ ማብራሪያ ከ መግለጫ ጋር ይጨምሩ: በርካታ ጊዜ መግለጽ ይቻላል"
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "መስኮቱን ይጫኑ እንደ ኢላማ የ ችግሩን መግለጫ ለ መሙላት"
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr ""
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr ""
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -339,7 +339,7 @@ msgid ""
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr ""
 
@@ -367,49 +367,49 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr ""
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "ድር መቃኛውን ማስጀመር አልተቻለም"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "የ ዌብ መቃኛ ማስጀመር አልተቻለም ለ መክፈት %s."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "የኔትዎርክ ችግር"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr "ከ ግጭት ዳታቤዝ ጋር መገናኘት አልተቻለም: እባክዎን የ እርስዎን ኢንተርኔት ግንኙነት ይመርምሩ"
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr ""
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "የ እርስዎ ስርአት ይህን የ ግጭት መግለጫ ለመላክ በቂ ማስታወሻ የለውም"
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -420,18 +420,18 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "ይህ ችግር ቀደም ብሎ የታወቀ ነው"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 msgstr ""
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "ይህ ችግር ቀደም ብሎ ለ አበልፃጊዎች ተልኳል: እናመሰግናለን!"
 
@@ -744,19 +744,19 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "ስህተት: %s ይህን መፈጸም አይቻልም: በማስቆም ላይ"
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/an.po
+++ b/po/an.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2011-05-03 12:15+0000\n"
 "Last-Translator: Daniel Martinez <entaltoaragon@gmail.com>\n"
 "Language-Team: Aragonese <an@li.org>\n"
@@ -36,11 +36,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr ""
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -57,111 +57,111 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "programa desconoxiu"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr ""
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Problema en %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
 msgstr ""
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr ""
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr ""
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Error"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "PID incorrecto"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr ""
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr ""
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 msgstr ""
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr ""
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr ""
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr ""
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr ""
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -169,7 +169,7 @@ msgid ""
 "Please create a new report using \"apport-bug\"."
 msgstr ""
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -181,24 +181,24 @@ msgid ""
 "Do you really want to proceed?"
 msgstr ""
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr ""
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr ""
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr ""
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr ""
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -209,115 +209,115 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr ""
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr ""
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr ""
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -334,7 +334,7 @@ msgid ""
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr ""
 
@@ -362,49 +362,49 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr ""
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "No ye posible encetar o navegador web"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "No ye posible encetar o navegador web ta ubrir %s."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Problemas con o rete"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr ""
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -412,18 +412,18 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr ""
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 msgstr ""
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 
@@ -735,19 +735,19 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr ""
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/apport.pot
+++ b/po/apport.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -35,11 +35,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr ""
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -47,7 +47,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -56,111 +56,111 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr ""
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr ""
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr ""
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
 msgstr ""
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr ""
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr ""
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr ""
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr ""
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr ""
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr ""
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 msgstr ""
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr ""
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr ""
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr ""
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr ""
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -168,7 +168,7 @@ msgid ""
 "Please create a new report using \"apport-bug\"."
 msgstr ""
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -180,24 +180,24 @@ msgid ""
 "Do you really want to proceed?"
 msgstr ""
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr ""
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr ""
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr ""
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr ""
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -208,115 +208,115 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr ""
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr ""
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr ""
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -333,7 +333,7 @@ msgid ""
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr ""
 
@@ -361,49 +361,49 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr ""
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr ""
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr ""
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr ""
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr ""
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -411,18 +411,18 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr ""
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 msgstr ""
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 
@@ -734,19 +734,19 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr ""
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2012-09-25 10:51+0000\n"
 "Last-Translator: Ibrahim Saed <ibraheem5000@gmail.com>\n"
 "Language-Team: Arabic <ar@li.org>\n"
@@ -36,11 +36,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr "برجاء إدخال كلمة سرك للنفاذ إلى تقارير المشاكل لبرامج النظام"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "هذه الحزمة لا تبدو مثبّتة بشكل صحيح"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -61,84 +61,84 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "برنامج مجهول"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "عُذرًا، أُغلق برنامج \"%s\" فجأة"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "مشكلة في %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
 msgstr ""
 "لا توجد ذاكرة خالية كافية على الجهاز لتحليل المشكلة وإبلاغ المطورين آليا."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "بلاغ مشكلة غير صالح"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "غير مسموح لك بالنفاذ إلى بلاغ المشكلة هذا."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "خطأ"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "لا توجد مساحة قرص كافية لمعالجة هذا البلاغ."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "رقم عملية(PID)غير صحيح"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "لم تُحدد حزمة"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "تحتاج إلى تحديد حزمة أو معرف عملية (PID). أطلع على --help لمزيد من المعلومات."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "رُفض التّصريح"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -146,30 +146,30 @@ msgstr ""
 "العملية المحددة لا تخصك. من فضلك شغل هذا البرنامج بنفس المستخدم مالك العملية "
 "أو كجذر."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "رقم تعريف العملية المحدد لا ينتمي ﻷي برنامج."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "الحزمة %s غير موجودة"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "تعذّر إنشاء التقرير"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "يُحدّث تقرير المشكلة"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -181,7 +181,7 @@ msgstr ""
 "\n"
 "من فضلك أنشئ تقريرًا جديدًا باستخدام \"apport-bug\"."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -200,24 +200,24 @@ msgstr ""
 "\n"
 "هل تود المتابعة حقًا؟"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "لم تُجمع معلومات إضافية."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "ما نوع المشكلة التي تود الإبلاغ عنها؟"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "عَرَض غير معروف"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "العَرَض\"%s\" غير معروف."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -228,7 +228,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -236,75 +236,75 @@ msgstr ""
 "بعد إغلاق هذه الرسالة رجاءً انقر على نافذة التطبيق للإبلاغ عن المشكلة "
 "المتعلقة بذلك."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "حدد  اسم الحزمة."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "انقر على النافذة كهدف لتقديم بلاغ عن مشكلة."
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -313,34 +313,34 @@ msgstr ""
 "في نمط الإبلاغ عن علّة، احفظ المعلومات المُجمّعة في ملف بدلًا من إرسالها. هذا "
 "الملف يمكن إرساله لاحقًا من جهاز حاسوب آخر."
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr ""
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr "هذا سينفّذ أمر apport-retrace في نافذة طرفية لتحليل الانهيار."
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr ""
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -357,7 +357,7 @@ msgid ""
 "occurred."
 msgstr "حدثت المشكلة مع برنامج '%s' الذي تغير منذ حدوث الانهيار."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "بلاغ المشكلة هذا  تالف ولا يمكن معالجته."
 
@@ -385,50 +385,50 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "تعذّر تحديد اسم الحزمة أو اسم الحزمة المصدر."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "تعذّر تشغيل المتصفح"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "تعذّر تشغيل المتصفح لفتح %s."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "مشكلة في الشبكة"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "لا يمكن الاتصال بقاعدة بيانات الانهيارات. من فضلك تحقق من اتصالك بالإنترنت."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "نفذت الذاكرة"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "لا توجد ذاكرة كافية في النظام لمعالجة بلاغ الانهيار هذا."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -439,11 +439,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "المشكلة معروفة"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -452,7 +452,7 @@ msgstr ""
 "بُلّغ عن هذه المشكلة مسبقًا في بلاغ العِلة المعروض في المتصفح، تحقق من فضلك مما "
 "إذا كان باستطاعتك إضافة معلومات أخرى قد تساعد المطورين."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "بُلّغ عن هذه المشكلة مُسبقًا. شكرًا لك!"
 
@@ -770,19 +770,19 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr ""
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/arn.po
+++ b/po/arn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2022-02-06 03:15+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Mapudungun <arn@li.org>\n"
@@ -36,11 +36,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr ""
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -57,111 +57,111 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr ""
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr ""
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr ""
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
 msgstr ""
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr ""
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr ""
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Welukawvn"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr ""
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr ""
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr ""
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 msgstr ""
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr ""
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr ""
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr ""
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr ""
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -169,7 +169,7 @@ msgid ""
 "Please create a new report using \"apport-bug\"."
 msgstr ""
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -181,24 +181,24 @@ msgid ""
 "Do you really want to proceed?"
 msgstr ""
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr ""
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr ""
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr ""
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr ""
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -209,115 +209,115 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr ""
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr ""
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr ""
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -334,7 +334,7 @@ msgid ""
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr ""
 
@@ -362,49 +362,49 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr ""
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr ""
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr ""
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr ""
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr ""
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -412,18 +412,18 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr ""
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 msgstr ""
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 
@@ -735,19 +735,19 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr ""
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/ast.po
+++ b/po/ast.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2020-10-20 11:42+0000\n"
 "Last-Translator: Xandru Martino <Unknown>\n"
 "Language-Team: Asturian <alministradores@softastur.org>\n"
@@ -35,11 +35,11 @@ msgstr ""
 "Escribi la to contraseña p'acceder a los informes de problemes de programes "
 "del sistema"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "Esti paquete nun paez tar instaláu correcho"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -50,7 +50,7 @@ msgstr ""
 "d'anova los índices de paquetes disponibles; si nun furrula esto, desistala "
 "los paquetes de terceros venceyaos y reinténtalo."
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -63,21 +63,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "programa desconocíu"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Sentímoslo; el programa «%s» zarróse inesperadamente"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Problema en %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -85,65 +85,65 @@ msgstr ""
 "El to equipu nun tien memoria llibre suficiente p'analizar el problema "
 "automáticamente y unviar un informe a los desendolcadores."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Informe de problema incorreutu"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "Nun tienes permitíu acceder a esti informe de problema."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Fallu"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 "Nun hai suficiente espaciu de discu disponible pa procesar esti informe."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr "Nun s'especificó dengún PID"
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr "Hai qu'especificar un PID. Mira --help pa obtener más información."
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "PID incorreutu"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr "La ID del procesu especificáu nun esiste."
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr "Nun ye'l to PID"
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr "La ID del procesu especificáu nun te pertenez."
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "Nun s'especificó dengún paquete"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Necesites especificar un paquete o un PID. Consulta --help pa más "
 "información."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Permisu denegáu"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -151,30 +151,30 @@ msgstr ""
 "El procesu especificáu nun te pertenez. Executa esti programa como "
 "propietariu del procesu o como superusuariu."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "El ID de procesu especificáu nun pertenez a dengún programa."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "El script de síntomes %s nun determinó dengún paquete afeutáu"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "El paquete %s nun esiste"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "Nun puede crease l'informe"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "Anovando informe de fallu"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -186,7 +186,7 @@ msgstr ""
 "\n"
 "Crea un informe nuevu usando «apport-bug»."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -206,24 +206,24 @@ msgstr ""
 "\n"
 "¿Daveres quies siguir?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "Nun se collechó información adicional."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "¿De qué triba de problema quier informar?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Síntoma desconocíu"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "El síntoma «%s» ye desconocíu"
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -234,7 +234,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -242,30 +242,30 @@ msgstr ""
 "Dempués de zarrar esti mensaxe calca nuna ventana d'aplicación pa informar "
 "tocante a esti problema."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop falló al determinar la ID de procesu de la ventana"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "Especifica'l nome del paquete."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "Amiesta una etiqueta estra al informe. Pue especificase delles vegaes."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -275,18 +275,18 @@ msgstr ""
 "opcional, o sólo un --pid. Si nun s'apurre dengún, amuesa una llista de "
 "síntomes conocíos. (Implícitu si s'apurre un únicu argumentu.)"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 "Fai click nuna ventana como oxetivu pa rellenar un informe de problema."
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "Aniciar en mou d'anovamientu d'errores. Almite un parámetru --package "
 "opcional."
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -294,7 +294,7 @@ msgstr ""
 "Rellenar un informe de fallu sobre un síntoma. (Implícitu si s'apurre un "
 "nome de síntoma como únicu argumentu.)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -303,7 +303,7 @@ msgstr ""
 "pid s'especifica. (Implícitu si se dió un nome de paquete como un únicu "
 "argumentu)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -313,11 +313,11 @@ msgstr ""
 "l'informe de fallu contendrá más información.  (Implica si pid se da como un "
 "argumentu solu.)"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "El pid proporcionáu ye una aplicación colgada."
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -327,7 +327,7 @@ msgstr ""
 "llugar de los pendientes en %s. (Implícitu si s'indica el ficheru como únicu "
 "argumentu.)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -337,34 +337,34 @@ msgstr ""
 "cuenta d'unviala. Esti ficheru pue unviase más sero, dende una máquina "
 "diferente."
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Amosar el númberu de versión d'Apport"
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr "Esto executará apport-retrace nuna terminal pa desaminar el fallu."
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "Executar una sesión gdb"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Executar una sesión gdb ensin descargar símbolos de depuración"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Anovar %s con una pila de siguimientu completamente simbólica"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr "Nun se recuerda la preferencia sobro unviar estaos d'informes"
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -384,7 +384,7 @@ msgid ""
 msgstr ""
 "El problema ocurrió col programa %s, que camudó dende qu'asocedió'l fallu."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "L'informe del problema ta frayáu y nun puede procesase."
 
@@ -414,14 +414,14 @@ msgstr "«Snap» de %s"
 msgid "%s deb package"
 msgstr "Paquete .deb de %s"
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s ufiértase como «snap», qu'espubliza %s. Ponte en contautu con ellos per "
 "aciu de %s (n'inglés) pa obtener ayuda."
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -431,41 +431,41 @@ msgstr ""
 "de contautu; visita'l foru en https://forum.snapcraft.io (n'inglés) pa "
 "obtener ayuda."
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "Nun pudo determinase'l nome del paquete binariu o fonte."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "Nun puede arrancase'l restolador web"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Nun puede arrancase'l restolador web p'abrir %s."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Problemes cola rede"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Nun puede afitase la conexón cola base de datos d'errores, por favor, "
 "verifique la so conexón a Internet."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Memoria escosada"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "El to sistema nun tien la memoria suficiente pa procesar esti informe de "
 "fallu."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -476,11 +476,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "Problema yá conocíu"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -490,7 +490,7 @@ msgstr ""
 "restolador web. Por favor, comprueba si puedes amestar cualesquier "
 "información adicional que pudieres resultar d'utilidá a los desendolcadores."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Ya s'informó d'esti problema a los desendolcadores. ¡Gracies!"
 
@@ -855,7 +855,7 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Fallu: %s nun ye un executable. Parando."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -863,7 +863,7 @@ msgstr ""
 "Esto asocedió demientres una suspensión anterior y torgó que'l sistema "
 "remaneciera correutamente."
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -871,7 +871,7 @@ msgstr ""
 "Esto asocedió demientres una hibernación anterior y torgó que'l sistema "
 "remaneciera correutamente."
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/az.po
+++ b/po/az.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2014-07-01 14:13+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Azerbaijani <az@li.org>\n"
@@ -36,11 +36,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr ""
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -57,111 +57,111 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr ""
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr ""
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr ""
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
 msgstr ""
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr ""
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr ""
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr ""
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr ""
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr ""
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr ""
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 msgstr ""
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr ""
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr ""
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr ""
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr ""
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -169,7 +169,7 @@ msgid ""
 "Please create a new report using \"apport-bug\"."
 msgstr ""
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -181,24 +181,24 @@ msgid ""
 "Do you really want to proceed?"
 msgstr ""
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr ""
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr ""
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr ""
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr ""
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -209,115 +209,115 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr ""
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr ""
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr ""
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -334,7 +334,7 @@ msgid ""
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr ""
 
@@ -362,49 +362,49 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr ""
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr ""
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr ""
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr ""
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr ""
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -412,18 +412,18 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr ""
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 msgstr ""
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 
@@ -735,19 +735,19 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr ""
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/be.po
+++ b/po/be.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2015-09-17 07:37+0000\n"
 "Last-Translator: Mikola Tsekhan <mail@tsekhan.com>\n"
 "Language-Team: Belarusian <be@li.org>\n"
@@ -40,11 +40,11 @@ msgstr ""
 "Калі ласка, увядзіце пароль для доступу да справаздач пра памылкі ў "
 "сістэмных праграмах"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "Падобна на тое, што гэты пакет усталяваны неправільна"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -52,7 +52,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -65,21 +65,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "невядомая праграма"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Прабачце, праграма «%s» аварыйна завяршыла сваю работу"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Праблема ў %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -87,64 +87,64 @@ msgstr ""
 "На Вашым кампутары недастаткова вольнай памяці для таго, каб аўтаматычна "
 "прааналізаваць няспраўнасць і даслаць справаздачу распрацоўшчыкам."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Няправільная справаздача аб памылцы"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "У Вас не хапае правоў, каб паведамляць аб праблемах."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Памылка"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "Недастаткова месца на дыску для апрацоўкі дадзенай справаздачы."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "Памылковы PID"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "Не пазначаны пакет"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Неабходна пазначыць пакет альбо PID. Запусціце праграму з параметрам --help "
 "каб атрымаць дадатковую інфармацыю."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Доступ забаронены"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -152,30 +152,30 @@ msgstr ""
 "Пазначаны працэс запушчэны іншым карыстальнікам. Запусціце дадзеную праграму "
 "з правамі ўладальніка працэса альбо адміністратара сістэмы."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "Пазначаны PID належыць іншаму працэсу."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Сімптаматычны скрыпт %s ня можа вызначыць закрануты пакет"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Пакет %s не існуе"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "Нельга стварыць справаздачу"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "Абнаўленне справаздачы аб праблеме"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -185,7 +185,7 @@ msgstr ""
 "Вы не з'яўляецеся аўтарам альбо атрымальнікам гэтай справаздачы аб праблеме, "
 "магчыма яна ўжо існуе ці была зачыненая."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -205,24 +205,24 @@ msgstr ""
 "\n"
 "Вы сапраўды хочаце працягнуць?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "Не сабрана ніякай дадатковай інфармацыі."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "Пра які тып праблемы Вы хочаце паведаміць?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Невядомы сімптом"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Сімптом  \"%s\" невядомы."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -233,7 +233,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -241,31 +241,31 @@ msgstr ""
 "Пасля закрыцця гэтага паведамлення, калі ласка, націсніце на вакно "
 "прыкладання, каб паведаміць аб праблеме."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop не ўдалося вызначыць ID працэсу акна"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "Пазначце імя пакета."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Дадаць дадатковы тэг да справаздачы. Можа быць паказаны некалькі разоў."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -276,16 +276,16 @@ msgstr ""
 "адлюстроўвае спіс вядомых сімптомаў. (Ужываецца, калі перададзены адзіны "
 "параметр.)"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "Цокніце па намечаным акне каб запоўніць справаздачу аб праблеме."
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "Запусціць у рэжыме абнаўлення памылкі. Можа прымаць дадатковы ключ - package."
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -293,7 +293,7 @@ msgstr ""
 "Адправіць справаздачу аб памылцы з сімптомам. (Ужываецца, калі назва "
 "сімптома перададзена ў якасці адзінага параметра.)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -301,7 +301,7 @@ msgstr ""
 "Пазначыць імя пакета ў рэжыме --file-bug. Неабавязкова, калі пазначаны --"
 "pid. (Ужываецца, калі імя пакета перададзена ў якасці адзінага праметра.)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -311,11 +311,11 @@ msgstr ""
 "справаздача аб памылцы будзе ўтрымліваць больш інфармацыі. (Маецца на ўвазе, "
 "што пазначаны адзіны аргумент - pid.)"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "Згаданы ідэнтыфікатар належыць працэсу, які не адказвае."
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -325,7 +325,7 @@ msgstr ""
 "ччакаемых у %s. (Ужываецца, калі файл перададзены ў якасці адзінага "
 "параметра.)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -335,36 +335,36 @@ msgstr ""
 "файле замест яе адпраўкі. Гэты файл можна будзе адправіць пазней, ці з "
 "іншага кампутара."
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Раздрукаваць нумар версіі Apport ."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Будзе ажыццёўлены запуск «apport-retrace» у акне тэрміналу для праверкі "
 "аварыйнага завяршэння працы."
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "Запусціць сеанс gdb"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Запусціць сеанс gdb, абыходзячы загрузкі адладкавых сімвалаў"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Абнавіць %s з поўным адсочваннем сімвалічнага стэку"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -383,7 +383,7 @@ msgstr ""
 "Праблема ў праграме %s, да якой былі ўнесены змены з моманту аварыйнага "
 "завяршэння яе работы."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Дадзеная справаздача аб непаладцы пашкоджана і не можа апрацоўвацца."
 
@@ -411,52 +411,52 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "Немагчыма вызначыць імя пакету альбо крыніцы."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "Не атрымалася запусціць вэб-браўзэр"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Немагчыма запусціць вэб-браўзэр, каб адчыніць %s."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Праблема з сеткай"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Не атрымоўваецца падлучыцца да базы дадзеных па збоях, калі ласка, праверце "
 "падлучэнне да Інтэрнэту."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Нястача памяці"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "У сістэме недастаткова памяці для апрацоўкі дадзенай справаздачы аб памылцы."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -467,11 +467,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "Праблема ўжо вядомая"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -481,7 +481,7 @@ msgstr ""
 "Вашым браўзэры. Калі ласка, праверце, ці можаце Вы дадаць да яе карысную "
 "інфармацыю, якая магла бы дапамагчы распрацоўшчыкам."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Аб гэтай праблеме распрацоўнікам ужо вядома. Дзякуй!"
 
@@ -835,7 +835,7 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Памылка: %s - не выканальны файл. Прыпынак."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -843,7 +843,7 @@ msgstr ""
 "Гэта адбылося падчас папярэдняга сеансу прыпынення працы і прывяло да "
 "немагчымасці належнага аднаўлення працы сістэмы."
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -851,7 +851,7 @@ msgstr ""
 "Гэта адбылося падчас папярэдняга сеансу ўсыплення і прывяло да немагчымасці "
 "належнага аднаўлення працы сістэмы."
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2014-02-18 15:58+0000\n"
 "Last-Translator: Atanas Kovachki <Unknown>\n"
 "Language-Team: Bulgarian <bg@li.org>\n"
@@ -40,11 +40,11 @@ msgstr ""
 "Моля, въведете паролата си за достъп до докладите за проблеми на системни "
 "програми"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "Този пакет не изглежда да е инсталиран правилно"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -52,7 +52,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -65,21 +65,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "неизвестна програма"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Извинете, програмата «%s» аварийно се затвори"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Проблем в %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -87,62 +87,62 @@ msgstr ""
 "Вашият компютър няма достатъчно свободна памет, за да се анализира "
 "автоматично проблема и да изпрати доклада на разработчиците."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Невалиден доклад с проблем"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "Нямате достъп до този доклад за проблем."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Грешка"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "Няма достатъчно свободно място за обработка на този доклад."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "Невалиден PID"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "Не е указан пакет"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr "Трябва да укажете пакет или PID. Вижте --help за повече информация."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Достъпа е отказан"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -150,30 +150,30 @@ msgstr ""
 "Указаният процес не ви принадлежи. Моля, стартирайте тази програма от името "
 "на собственика на процеса или като root потребител."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "Указания идентификатор не принадлежи на програма."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Симптомният скрипт %s не може да определи засегнат пакет"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Пакета %s не съществува"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "Не може да бъде създаден доклад"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "Актуализиране на доклада за проблема"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -184,7 +184,7 @@ msgstr ""
 "доклада да е дублиран или вече е затворен.\n"
 "Моля създайте нов доклад като използвате «apport-bug»."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -204,24 +204,24 @@ msgstr ""
 "\n"
 "Наистина ли искате да продължите?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "Не е събрана допълнителна информация."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "Какъв вид проблем искате да докладвате?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Неизвестен симптом"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Симптомът «%s» е неизвестен."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -232,7 +232,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -240,32 +240,32 @@ msgstr ""
 "След като затворите това съобщение, моля кликнете на прозореца на "
 "приложението, за да докладвате за този проблем."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop неуспя да определи идентификатора на процеса за прозореца"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "Посочете име на пакета."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Добавете допълнителен етикет към доклада си. Може да бъде указан няколко "
 "пъти."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -275,17 +275,17 @@ msgstr ""
 "pid, или само --pid. Ако не е подаден аргумент се показва списък с известни "
 "симптоми. (Стандартно ако е подаден единствен аргумент.)"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "Кликнете на целевият прозорец, за да попълните доклад за грешка."
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "Стартиране в режим на обновяване на грешка. Приема се аргумент по избор --"
 "package."
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -293,7 +293,7 @@ msgstr ""
 "Регистриране на доклад за грешка относно симптом. (Стандартно ако името на "
 "симптома е подадено като единствен аргумент.)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -301,7 +301,7 @@ msgstr ""
 "Посочете името на пакета в --file-bug режима. Това е по избор ако --pid e "
 "посочен. (Стандартно ако името на пакета е подадено като единствен аргумент.)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -311,11 +311,11 @@ msgstr ""
 "доклада за грешка ще съдържа повече информация. (Стандартно ако pid е даден "
 "като единствен аргумент.)"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "Посоченият идентификатор принадлежи на процес, който не отговаря."
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -324,7 +324,7 @@ msgstr ""
 "Докладване на срив от даден .apport или .crash файл вместо от висящите в %s. "
 "(Стандартно ако файла е подаден като единствен аргумент.)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -334,38 +334,38 @@ msgstr ""
 "вместо да я докладвате. Този файл може да бъде докладван по-късно от друг "
 "компютър."
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Отпечатай номера на версията на Apport."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Ще се стартира «apport-retrace» в терминален прозорец и ще извърши проверка "
 "на аварийното завършване на работата."
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "Стартирай gdb сесия"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 "Стартирай gdb сесия без изтегляне на символите за отстраняване на грешки"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 "Актуализирай %s с пълно проследяване на символичното трасиране на стека"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -384,7 +384,7 @@ msgstr ""
 "Проблемът възникна с програмата %s, в която са внесени промени след нейното "
 "аварийно завършване на работа."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Този доклад за проблем е повреден и не може да бъде обработен."
 
@@ -412,54 +412,54 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr ""
 "Не може да бъде определено името на пакета или на пакета с изходния код."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "Не може да се стартира уеб браузъра"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Не може да се стартира уеб браузъра, за да се отвори %s."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Мрежов проблем"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Не може да се свърже с базата данни за сривове, моля проверете връзката с "
 "интернет."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Изчерпване на паметта"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Вашата система не разполага с достатъчно памет, за да обработи този доклад "
 "за срив."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -470,11 +470,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "Проблемът вече е известен"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -484,7 +484,7 @@ msgstr ""
 "браузъра ви. Моля, проверете дали можете да добавите друга полезна "
 "информация, която може да помогне на разработчиците."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Този проблем вече е бил докладван на разработчиците. Благодарим ви!"
 
@@ -840,19 +840,19 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Грешка: %s не е изпълним файл. Спиране."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/bn.po
+++ b/po/bn.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2022-07-03 18:34+0000\n"
 "Last-Translator: Tushar <Unknown>\n"
 "Language-Team: Bengali <ankur-bd-l10n@googlegroups.com>\n"
@@ -37,11 +37,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "এই প্যাকেজ সঠিকরূপে ইনস্টল করা যাবেনা বলে মনে হচ্ছে"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -49,7 +49,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -62,21 +62,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "অজানা প্রোগ্রাম"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "দুঃখিত, \"%s\" প্রোগ্রামটি অপ্রত্যাশিতভাবে বন্ধ হয়ে গেল"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "%s এ সমস্যা"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -84,64 +84,64 @@ msgstr ""
 "স্বয়ংক্রিয়ভাবে সমস্যাটি পর্যালোচনা করা এবং ডেভেলপারকে প্রতিবেদন করার জন্য আপনার "
 "কম্পিউটারে পর্যাপ্ত পরিমাণ খালি মেমোরি নেই।"
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "অবৈধ সমস্যা প্রতিবেদন"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "এই সমস্যার প্রতিবেদনটিতে আপনার প্রবেশাধিকার নেই।"
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "ত্রুটি"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "এই প্রতিবেদন প্রক্রিয়া করতে যথেষ্ট ডিস্কের জায়গা বিদ্যমান নেই।"
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "অকার্যকর PID"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "কোন প্যাকেজ নির্দিষ্ট করা হয় নি"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "আপনার প্যাকেজ অথবা PID সুনির্দিষ্টভাবে উল্লেখ করা প্রয়োজন। দেখুন --আরও তথ্যের জন্য "
 "সহায়তা।"
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "অনুমতি প্রত্যাখ্যাত"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -149,30 +149,30 @@ msgstr ""
 "নির্ধারিত প্রক্রিয়াটি আপনার অন্তর্ভুক্ত নয়। অনুগ্রহ করে প্রক্রিয়ার মালিক অথবা মূল হিসেবে "
 "এই প্রোগ্রামটি সচল রাখুন।"
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "নির্ধারিত প্রক্রিয়াধীন ID প্রোগ্রামের অন্তর্ভুক্ত নয়।"
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "উপসর্গ স্ক্রিপ্ট %s প্রভাবিত প্যাকেজ নির্ধারণ করেনি"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "%s প্যাকেজের অস্তিত্ব নেই"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "প্রতিবেদন তৈরি করা যাবে না"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "সমস্যার প্রতিবেদন হালনাগাদ করা হচ্ছে"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -184,7 +184,7 @@ msgstr ""
 "\n"
 "অনুগ্রহ করে \"অ্যাপোর্ট-বাগ\" ব্যবহার করে নতুন প্রতিবেদন তৈরি করুন।"
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -203,24 +203,24 @@ msgstr ""
 "\n"
 "আপনি কি সত্যিই অগ্রসর হতে চান?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "কোনো অতিরিক্ত তথ্য সংগ্রহ হয়নি।"
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "কি ধরণের সমস্যা আপনি প্রতিবেদন করতে চান?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "অজানা লক্ষণ"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "\"%s\" লক্ষণটি পরিচিত নয়।"
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -231,7 +231,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -239,32 +239,32 @@ msgstr ""
 "এই বার্তা বন্ধের পরে অনুগ্রহ করে এটি সংক্রান্ত সমস্যা প্রতিবেদন করতে অ্যাপ্লিকেশন "
 "উইন্ডোতে ক্লিক করুন।"
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "উইন্ডোর প্রক্রিয়া ID নির্ধারণ করতে xprop ব্যর্থ"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "প্যাকেজের নাম সুনির্দিষ্টভাবে উল্লেখ করুন।"
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "প্রতিবেদনে একটি অতিরিক্ত ট্যাগ সংযুক্ত করুন। একাধিক সময় সুনির্দিষ্টভাবে উল্লেখিত হতে "
 "পারে।"
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -274,15 +274,15 @@ msgstr ""
 "যদি একটিও দেয়া না থাকে, পরিচিত উপসর্গের তালিকা প্রদর্শন করুন। (যদি একক যুক্তি দেয়া "
 "হয় সূচিত করা হবে।)"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "সমস্যার প্রতিবেদন পূরণের জন্য একটি লক্ষ্য হিসেবে উইন্ডোতে ক্লিক করুন।"
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "বাগ হালনাগাদ মোডে আরম্ভ করুন। ঐচ্ছিক --প্যাকেজ নিতে পারেন।"
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -290,7 +290,7 @@ msgstr ""
 "উপসর্গ সম্পর্কিত একটি বাগ প্রতিবেদন ফাইল করুন। (যদি উপসর্গ নাম শুধুমাত্র যুক্তি হিসাবে "
 "দেওয়া হয় তাহলে সূচিত করা হবে।)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -298,7 +298,7 @@ msgstr ""
 "সুনির্দিষ্টভাবে উল্লেখ করুন প্যাকেজের নাম --ফাইল-বাগ মোডে। এটি ঐচ্ছিক যদি --pid "
 "সুনির্দিষ্ট হয়। (যদি উপসর্গ নাম শুধুমাত্র যুক্তি হিসাবে দেওয়া হয় তাহলে সূচিত করা হবে।)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -308,11 +308,11 @@ msgstr ""
 "প্রতিবেদন আরও তথ্য ধারণ করবে। (যদি pid শুধুমাত্র যুক্তি হিসাবে দেওয়া হয় তাহলে সূচিত "
 "করা হবে।)"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -321,7 +321,7 @@ msgstr ""
 "%s তে অমীমাংসিত একটির পরিবর্তে given .apport অথবা .crash ফাইল থেকে ক্র্যাশ "
 "প্রতিবেদন দিন। (যদি ফাইল যুক্তি হিসেবে দেয়া হয় তাহলে সূচিত করা হবে।)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -330,34 +330,34 @@ msgstr ""
 "বাগ পূরণ মোডে, এটি প্রতিবেদন দেওয়ার পরিবর্তে সংগৃহীত তথ্য ফাইলে সংরক্ষণ করুন। এই "
 "ফাইলটি তখন ভিন্ন মেশিন থেকে পরবর্তীতে প্রতিবেদন করা হতে পারে।"
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "অ্যাপোর্ট সংস্করণ সংখ্যা মুদ্রণ করুন।"
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr "ক্র্যাশ পরীক্ষা করতে টার্মিনালের উইন্ডোর অ্যাপোর্ট-অনুসন্ধান চালু করা হবে।"
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "gdb সেশনে সচল"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "ডিবাগ প্রতীকে ডাউনলোড করা ছাড়া gdb সেশনে সচল"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "সম্পূর্ণ প্রতীকী স্ট্যাক ট্রেস দ্বারা %s হালনাগাদ করুন"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -376,7 +376,7 @@ msgid ""
 "occurred."
 msgstr "প্রোগ্রাম %s দ্বারা সমস্যা ঘটেছে, ক্র্যাশ সংঘটন হতে যা পরিবর্তিত হয়েছে।"
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "এই সমস্যা প্রতিবেদন ক্ষতিগ্রস্ত এবং প্রক্রিয়াধীন করা যাবে না।"
 
@@ -404,51 +404,51 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "প্যাকেজ অথবা উৎস প্যাকেজের নাম নির্ধারণ করা যায় নি।"
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "ওয়েব ব্রাউজার চালু করতে অসমর্থ"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "%s খুলতে ওয়েব ব্রাউজার আরম্ভ করতে অসমর্থ।"
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "নেটওয়ার্ক সমস্যা"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "বিধস্ত ডাটাবেসে সংযোগ করতে পারছি না, অনুগ্রহ করে আপনার ইন্টারনেট সংযুক্তি পরীক্ষা "
 "করুন।"
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "মেমরি নিঃশেষিত"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "এই বিধস্ত প্রতিবেদন প্রক্রিয়াজাত করার জন্য আপনার সিস্টেমে পর্যাপ্ত মেমোরি নেই।"
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -459,11 +459,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "সমস্যাটি ইতঃপূর্ব জ্ঞাত"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -472,7 +472,7 @@ msgstr ""
 "এই সমস্যাটি ইতিমধ্যে বাগ প্রতিবেদন প্রতিবেদন করেছে যা ওয়েব ব্রাউজারে প্রদর্শিত "
 "হয়েছে। ডেভেলপারের জন্য সহায়ক হবে এমন আরো তথ্য অনুগ্রহ করে নির্বাচন করুন।"
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "এই সমস্যাটি ইতোমধ্যে ডেভেলপারকে প্রতিবেদন করা হয়েছে। আপনাকে ধন্যবাদ!"
 
@@ -807,19 +807,19 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr ""
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/br.po
+++ b/po/br.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2010-06-11 21:48+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Breton <br@li.org>\n"
@@ -36,11 +36,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr ""
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -57,21 +57,21 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "goulev dianav"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Digarezit, gant un doare dic'hortoz eo bet serret ar goulev \"%s\""
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Kudenn e %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -79,66 +79,66 @@ msgstr ""
 "N'eus ket memor diac'hub a-walc'h evit dielfennañ ent emgefreek ar gudenn ha "
 "kas un danevell da baotred an diorren."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Danevell a-fet kudennoù didalvoudek"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "N'hoc'h eus ket an aotre da haeziñ an danevell-mañ."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Fazi"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 "N'eus ket plas a-walc'h war ar gantenn a-benn keweriañ an danevell-mañ."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
 # PID : process ID
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "Naoudi an argerzh (PID) didalvoudek"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "Pakad erspizet ebet"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Ezhomm hoc'h eus erspizañ ur pakad pe un naoudi eus un argerzh (PID). Lennit "
 "--help evit gouzout hiroc'h."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Aotre nac'het"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -146,30 +146,30 @@ msgstr ""
 "Naoudi an argerzh (PID) erspizet n'eo ket deoc'h. Erounit ar goulev-mañ evel "
 "perc'henn an argerzh pe ardead gwrizienn (root)."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "Naoudi an argerzh (PID) erspizet n'eo ket d'ur goulev."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Skript an azon %s n'en deus ket despizet ar pakad tizhet"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Ar pakad %s n'eus ket anezhañ"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "N'hall ket krouiñ an danevell"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "O hizivaat an danevell a-zivout ar gudenn"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -177,7 +177,7 @@ msgid ""
 "Please create a new report using \"apport-bug\"."
 msgstr ""
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -189,24 +189,24 @@ msgid ""
 "Do you really want to proceed?"
 msgstr ""
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "Titouroù ouzhpenn ebet bet dastumet."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "Evit peseurt kudennoù a fell deoc'h kas un danevell ?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Azon dianav"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "N'eo ket anavezet an azon \"%s\"."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -217,115 +217,115 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr ""
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Moullañ niverenn handelv Apport."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr ""
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -342,7 +342,7 @@ msgid ""
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Mekaet eo an danevell a-zivout ar gudenn ha n'hall ket bezañ keweriet."
 
@@ -370,49 +370,49 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "N'hall ket despizañ ar pakad pe anv tarzh ar pakad."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "N'eo ket gouest da loc'hañ ar merdeer web"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "N'eo ket gouest da loc'hañ ar merdeer web a-benn digeriñ %s."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Kudenn gant ar rouedad"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr ""
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -423,18 +423,18 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "Anavezet eo ar gudenn endeo"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 msgstr ""
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 
@@ -748,19 +748,19 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr ""
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/bs.po
+++ b/po/bs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2018-04-07 22:09+0000\n"
 "Last-Translator: Anel Mandal <Unknown>\n"
 "Language-Team: Bosnian <bs@li.org>\n"
@@ -40,11 +40,11 @@ msgstr ""
 "Molimo unesite svoju šifru kako bi pristupili izvještaju o problemima "
 "nastalim u sistemskim programima"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "Izgleda da ovaj paket nije ispravno instaliran"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -52,7 +52,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -65,21 +65,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "nepoznat program"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Izvinite, program „%s“ je neočekivano zatvoren"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Problem u %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -87,62 +87,62 @@ msgstr ""
 "Vaš računar nema dovoljno slobodne memorije da automatski analizira problem "
 "i pošalje izvještaj autorima."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Neispravan izvještaj o problemu"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "Nemate prava pristupa izvještavanju o problemu."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Greška"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "Nema dovoljno prostora na disku za obradu ovog izvještaja."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "Nevažeći PID"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "Nije naveden paket."
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr "Morate navesti paket ili PID. Pogledajte --help za više informacija"
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Dozvola je odbijena"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -150,30 +150,30 @@ msgstr ""
 "Navedeni proces vam ne pripada. Molim pokrenite ovaj proces kao vlasnik ili "
 "root."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "Specificirani PID ne pripada programu."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Skripta simptoma %s nije odredio nijedan poduticajni paket"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Paket %s ne postoji"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "Ne mogu da napravim izvještaj"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "Slanje izveštaja o problemu"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -185,7 +185,7 @@ msgstr ""
 "\n"
 "Molim napravite novi izvještaj koristeći \"apport-bug\"."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -204,24 +204,24 @@ msgstr ""
 "\n"
 "Da li zaista želite da nastavite?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "Nema dodatno prikupljenih informacija."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "O kakvom problemu želite da izvijestite?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Nepoznati simptom"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Simptom \"%s\" nije poznat."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -232,7 +232,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -240,30 +240,30 @@ msgstr ""
 "Nakon zatvaranja ove poruke, kliknite na prozor aplikacije da prijavite "
 "problem u vezi toga."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop nije uspio da odredi ID procesa prozora"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "Navedite ime paketa."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "Dodajte dodatnu oznaku u izvještaju. Može biti navedeno više puta."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -273,15 +273,15 @@ msgstr ""
 "opcionalan --pid, ili samo  --pid. Ako nijedan nije dat, prikaži listu "
 "poznatih simptoma. (Podrazumijeva se ako ako je dat samo jedan argument.)"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "Kliknite na prozor kao odredište za podnošenje izvještaja o problemu."
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "Pokrenuti u režimu slanja greške. Može da sadrži opcionalni --package."
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -289,7 +289,7 @@ msgstr ""
 "Popunite izvještaj greške o simptomu. (Podrazumijeva se ako je ime simptoma "
 "dato kao jedini argument.)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -298,7 +298,7 @@ msgstr ""
 "specificiran --pid. (Podrazumijeva se ako je ime paketa dato kao jedini "
 "argument.)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -308,11 +308,11 @@ msgstr ""
 "izvještaj o greškama će sadržati više informacija. (ugrađeno ako je PID kao "
 "jedini argument.)"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "Navedeni pid je viseća aplikacija"
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -321,7 +321,7 @@ msgstr ""
 "Prijavite o padu iz date .apport ili .crash datoteke umjesto jednog "
 "pripravnog u %s. (Podrazumijeva se ako je datoteka data kao jedini argument.)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -331,34 +331,34 @@ msgstr ""
 "umjesto da izvještavanja. Ova datoteka se zatim može prijaviti kasnije s "
 "druge mašine."
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Prikaži broj verzije Apport-a."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr "Ovo će pokrenuti „apport-retrace“ u prozoru terminala da ispita pad."
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "Pokreni gdb sesiju"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Pokreni gdb sesiju bez preuzimanja simbola za uklanjanje grešaka"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Ažuriraj %s potpunom simboličkim tragom gomile"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -377,7 +377,7 @@ msgid ""
 msgstr ""
 "Problem se desio s programom %s koji je promijenjen nakon što se dogodio pad."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Ovaj izvještaj o greški je oštećen i ne može da se obradi."
 
@@ -405,52 +405,52 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "Ne mogu da utvrdim paket ili izvorno ime paketa."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "Ne mogu da pokrenem internet pretraživač"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Ne mogu da pokrenem internet pretraživač da bih otvorio %s."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Mrežni problem"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Ne mogu da uspostavim vezu sa bazom podataka o urušavanjima, molim "
 "provjerite vašu internet vezu."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Nedostatak memorije"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Vaš sistem nema dovoljno memorije da obradi ovaj izvještaj o padu sistema."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -461,11 +461,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "Problem je već poznat"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -475,7 +475,7 @@ msgstr ""
 "pretraživaču. Molim Vas provjerite da li možete da dodate bilo kakvu dodatnu "
 "informaciju koja bi mogla da bude od pomoći autorima."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Ovaj problem je već prijavljen programerima. Hvala vam!"
 
@@ -833,7 +833,7 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Greška: %s nije izvršni program. Prekidam."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -841,7 +841,7 @@ msgstr ""
 "Ovo se desilo prilikom prethodnog suspendovanja i spriječilo je sistem da se "
 "ispravno obnovi."
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -849,7 +849,7 @@ msgstr ""
 "Ovo se desilo prilikom prethodne hibernacije i spriječilo je sistem da se "
 "ispravno obnovi."
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2015-04-27 21:47+0000\n"
 "Last-Translator: David Planella <david.planella@gmail.com>\n"
 "Language-Team: Ubuntu Catalan Translators list <Ubuntu-l10n-ca@lists.ubuntu."
@@ -41,11 +41,11 @@ msgstr ""
 "Introduïu la vostra contrasenya per accedir als informes d'error dels "
 "programes del sistema"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "Sembla ser que aquest paquet no s'ha instal·lat correctament"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -56,7 +56,7 @@ msgstr ""
 "d'actualitzar els índexs dels paquets disponibles, si això no funciona, "
 "elimineu els paquets de tercers relacionats i torneu-ho a provar."
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -69,21 +69,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "programa desconegut"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "El programa «%s» s'ha tancat de manera inesperada"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Problema a %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -91,64 +91,64 @@ msgstr ""
 "El vostre sistema no té prou memòria disponible per a analitzar el problema "
 "de manera automàtica i enviar un informe d'error als desenvolupadors."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Informe d'error no vàlid"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "No teniu permís per a accedir a aquest informe d'error."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Error"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "No hi ha prou espai disponible per a processar aquest informe."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr "No s'ha especificat cap PID"
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr "Cal especificar un PID. Consulteu --help per obtenir més informació."
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "PID no vàlid"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr "L'ID de procés especificat no existeix."
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr "No és el vostre PID"
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr "L'ID del procés especificat no us pertany."
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "No s'ha especificat cap paquet"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Cal que especifiqueu un paquet o un PID. Consulteu --help per a obtenir més "
 "informació."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Se us ha denegat el permís"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -156,30 +156,30 @@ msgstr ""
 "El procés especificat no us pertany. Hauríeu d'executar aquest programa com "
 "a propietari del procés o bé com a superusuari."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "L'identificador de procés especificat no pertany a cap programa."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "L'script de símptomes %s no ha determinat cap paquet afectat"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "El paquet %s no existeix"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "No es pot crear l'informe"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "S'està actualitzant l'informe del problema"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -191,7 +191,7 @@ msgstr ""
 "\n"
 "Creeu un informe nou utilitzant l'«apport-bug»."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -212,24 +212,24 @@ msgstr ""
 "\n"
 "Segur que voleu continuar?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "No s'ha recollit informació addicional."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "Sobre quin tipus de problema voleu informar?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Símptoma desconegut"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Es desconeix el símptoma «%s»."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -248,7 +248,7 @@ msgstr ""
 "la pestanya Processos, desplaceu-vos fins a trobar l'aplicació correcta. "
 "L'ID del procés és el nombre llistat a la columna ID."
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -256,33 +256,33 @@ msgstr ""
 "Després de tancar aquest missatge feu clic a una finestra de l'aplicació per "
 "informar d'un problema sobre aquesta."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 "L'xprop ha fallat en determinat l'identificador de procés de la finestra"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "Especifiqueu el nom del paquet."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Afegeix una etiqueta addicional a l'informe. Es pot especificar diverses "
 "vegades."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -292,15 +292,15 @@ msgstr ""
 "opcional o només un --pid. Si no se'n proporciona cap, es mostrarà una "
 "llista de símptomes coneguts. (Implícit si només es proporciona un argument)"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "Feu clic a una finestra per associar-la a l'informe d'error."
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "Inicieu en mode d'actualització d'errors. Admet un --package opcional."
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -308,7 +308,7 @@ msgstr ""
 "Ompliu un informe d'error sobre un símptoma. (Implícit si només es "
 "proporciona el nom del símptoma com a argument)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -317,7 +317,7 @@ msgstr ""
 "s'ha especificat un --pid. (Implícit si només es proporciona el nom del "
 "paquet com a argument)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -327,11 +327,11 @@ msgstr ""
 "l'informe d'error contindrà més informació (en cas que el pid es doni com a "
 "únic argument)."
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "El PID proporcionat és una aplicació que es penja."
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -340,7 +340,7 @@ msgstr ""
 "Informeu de la fallada a partir d'un fitxer .apport o .crash en lloc dels "
 "pendents a %s. (Implícit si només es proporciona el fitxer com a argument)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -350,35 +350,35 @@ msgstr ""
 "en lloc d'enviar l'informe. Aquest fitxer es pot enviar més tard des d'una "
 "màquina diferent."
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Mostra el número de versió de l'Apport."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Això executarà l'Apport-retrace en un terminal per examinar la fallada."
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "Executa una sessió del Gdb"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Executa una sessió del Gdb sense descarregar els símbols de depuració"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Actualitza el fitxer %s amb la traça simbòlica completa de la pila."
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr "No es pot recordar la configuració de l'enviament d'informes"
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -401,7 +401,7 @@ msgstr ""
 "El problema ha passat amb el programa %s, el qual ha canviat des que es "
 "produí la fallada."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Aquest informe d'error està malmès i no es pot processar."
 
@@ -431,14 +431,14 @@ msgstr "Snap de %s"
 msgid "%s deb package"
 msgstr "Paquet .deb de %s"
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s és proporcionat com un snap publicat per %s. Contacteu-los a través de %s "
 "per obtenir ajuda."
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -448,43 +448,43 @@ msgstr ""
 "adreça de contacte; visiteu el fòrum a https://forum.snapcraft.io/ per "
 "obtenir ajuda."
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr ""
 "No s'ha pogut determinar el nom del paquet del programa o del paquet del "
 "codi font."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "No s'ha pogut iniciar el navegador web"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "No s'ha pogut iniciar el navegador web per a obrir %s."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Problema de la xarxa"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "No es pot connectar a la base de dades de fallades, comproveu la vostra "
 "connexió a Internet."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Exhauriment de la memòria"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "El vostre sistema no té prou memòria disponible per a processar aquest "
 "informe de fallada."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -495,11 +495,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "El problema ja és conegut"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -509,7 +509,7 @@ msgstr ""
 "al navegador web. Comproveu si podeu afegir cap informació addicional que "
 "pugui ser d'ajuda per als desenvolupadors."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 "Aquest problema ja fou enviat als desenvolupadors anteriorment. Us agraïm la "
@@ -877,7 +877,7 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "S'ha produït un error: %s no és un fitxer executable. S'aturarà."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -885,7 +885,7 @@ msgstr ""
 "Això va passar durant una aturada temporal prèvia, i va prevenir el sistema "
 "de continuar correctament."
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -893,7 +893,7 @@ msgstr ""
 "Això va passar durant una hibernació prèvia, i va prevenir el sistema de "
 "continuar correctament."
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/ca@valencia.po
+++ b/po/ca@valencia.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2014-04-13 00:15+0000\n"
 "Last-Translator: David Planella <david.planella@gmail.com>\n"
 "Language-Team: Ubuntu Catalan Translators list <Ubuntu-l10n-ca@lists.ubuntu."
@@ -41,11 +41,11 @@ msgstr ""
 "Introduïu la vostra contrasenya per accedir als informes d'error dels "
 "programes del sistema"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "Pareix ser que este paquet no s'ha instal·lat correctament"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -53,7 +53,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -66,21 +66,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "programa desconegut"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "El programa «%s» s'ha tancat de manera inesperada"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Problema a %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -88,64 +88,64 @@ msgstr ""
 "El vostre sistema no té prou memòria disponible per a analitzar el problema "
 "de manera automàtica i enviar un informe d'error als desenvolupadors."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Informe d'error no vàlid"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "No teniu permís per a accedir a este informe d'error."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Error"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "No hi ha prou espai disponible per a processar este informe."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "PID no vàlid"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "No s'ha especificat cap paquet"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Cal que especifiqueu un paquet o un PID. Consulteu --help per a obtindre més "
 "informació."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Se vos ha denegat el permís"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -153,30 +153,30 @@ msgstr ""
 "El procés especificat no vos pertany. Hauríeu d'executar este programa com a "
 "propietari del procés o bé com a superusuari."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "L'identificador de procés especificat no pertany a cap programa."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "L'script de símptomes %s no ha determinat cap paquet afectat"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "El paquet %s no existeix"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "No es pot crear l'informe"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "S'està actualitzant l'informe del problema"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -188,7 +188,7 @@ msgstr ""
 "\n"
 "Creeu un informe nou utilitzant l'«apport-bug»."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -208,24 +208,24 @@ msgstr ""
 "\n"
 "Segur que voleu continuar?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "No s'ha recollit informació addicional."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "Sobre quin tipus de problema voleu informar?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Símptoma desconegut"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Es desconeix el símptoma «%s»."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -236,7 +236,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -244,33 +244,33 @@ msgstr ""
 "Després de tancar este missatge feu clic a una finestra de l'aplicació per "
 "informar d'un problema sobre esta."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 "L'xprop ha fallat en determinat l'identificador de procés de la finestra"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "Especifiqueu el nom del paquet."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Afig una etiqueta addicional a l'informe. Es pot especificar diverses "
 "vegades."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -280,15 +280,15 @@ msgstr ""
 "opcional o només un --pid. Si no se'n proporciona cap, es mostrarà una "
 "llista de símptomes coneguts. (Implícit si només es proporciona un argument)"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "Feu clic a una finestra per associar-la a l'informe d'error."
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "Inicieu en mode d'actualització d'errors. Admet un --package opcional."
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -296,7 +296,7 @@ msgstr ""
 "Ompliu un informe d'error sobre un símptoma. (Implícit si només es "
 "proporciona el nom del símptoma com a argument)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -305,7 +305,7 @@ msgstr ""
 "s'ha especificat un --pid. (Implícit si només es proporciona el nom del "
 "paquet com a argument)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -315,11 +315,11 @@ msgstr ""
 "l'informe d'error contindrà més informació (en cas que el pid es doni com a "
 "únic argument)."
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "El PID proporcionat és una aplicació que es penja."
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -328,7 +328,7 @@ msgstr ""
 "Informeu de la fallada a partir d'un fitxer .apport o .crash en lloc dels "
 "pendents a %s. (Implícit si només es proporciona el fitxer com a argument)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -338,35 +338,35 @@ msgstr ""
 "en lloc d'enviar l'informe. Este fitxer es pot enviar més tard des d'una "
 "màquina diferent."
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Mostra el número de versió de l'Apport."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Això executarà l'Apport-retrace en un terminal per examinar la fallada."
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "Executa una sessió del Gdb"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Executa una sessió del Gdb sense descarregar els símbols de depuració"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Actualitza el fitxer %s amb la traça simbòlica completa de la pila."
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -387,7 +387,7 @@ msgstr ""
 "El problema ha passat amb el programa %s, el qual ha canviat des que es "
 "produí la fallada."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Este informe d'error està malmés i no es pot processar."
 
@@ -415,55 +415,55 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr ""
 "No s'ha pogut determinar el nom del paquet del programa o del paquet del "
 "codi font."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "No s'ha pogut iniciar el navegador web"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "No s'ha pogut iniciar el navegador web per a obrir %s."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Problema de la xarxa"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "No es pot connectar a la base de dades de fallades, comproveu la vostra "
 "connexió a Internet."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Exhauriment de la memòria"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "El vostre sistema no té prou memòria disponible per a processar este informe "
 "de fallada."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -474,11 +474,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "El problema ja és conegut"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -488,7 +488,7 @@ msgstr ""
 "al navegador web. Comproveu si podeu afegir cap informació addicional que "
 "puga ser d'ajuda per als desenvolupadors."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 "Este problema ja fou enviat als desenvolupadors anteriorment. Vos agraïm la "
@@ -852,19 +852,19 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "S'ha produït un error: %s no és un fitxer executable. S'aturarà."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/ceb.po
+++ b/po/ceb.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2018-08-22 11:00+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Cebuano <ceb@li.org>\n"
@@ -36,11 +36,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr ""
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -57,111 +57,111 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr ""
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr ""
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr ""
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
 msgstr ""
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr ""
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr ""
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr ""
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr ""
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr ""
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr ""
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 msgstr ""
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr ""
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr ""
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr ""
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr ""
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -169,7 +169,7 @@ msgid ""
 "Please create a new report using \"apport-bug\"."
 msgstr ""
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -181,24 +181,24 @@ msgid ""
 "Do you really want to proceed?"
 msgstr ""
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr ""
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr ""
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr ""
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr ""
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -209,115 +209,115 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr ""
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr ""
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr ""
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -334,7 +334,7 @@ msgid ""
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr ""
 
@@ -362,49 +362,49 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr ""
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr ""
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr ""
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr ""
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr ""
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -412,18 +412,18 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr ""
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 msgstr ""
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 
@@ -735,19 +735,19 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr ""
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/ckb.po
+++ b/po/ckb.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2020-02-26 15:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Kurdish (Sorani) <ckb@li.org>\n"
@@ -36,11 +36,11 @@ msgstr "تۆماری کێشەکانی سیستم"
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr ""
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -57,111 +57,111 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr ""
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr ""
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr ""
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
 msgstr ""
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr ""
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr ""
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "هەڵە"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr ""
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr ""
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "ڕێ پێدان ڕەتکرایەوە"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 msgstr ""
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr ""
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr ""
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr ""
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr ""
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -169,7 +169,7 @@ msgid ""
 "Please create a new report using \"apport-bug\"."
 msgstr ""
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -181,24 +181,24 @@ msgid ""
 "Do you really want to proceed?"
 msgstr ""
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr ""
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr ""
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr ""
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr ""
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -209,115 +209,115 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr ""
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr ""
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr ""
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -334,7 +334,7 @@ msgid ""
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr ""
 
@@ -362,49 +362,49 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr ""
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr ""
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr ""
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr ""
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr ""
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -412,18 +412,18 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr ""
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 msgstr ""
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 
@@ -735,19 +735,19 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "هەڵە: %s شیاوی جێبەجێبوون نیە. دەوەستێت.."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2022-10-05 19:59+0000\n"
 "Last-Translator: Tomáš Marný <tomik.marny@gmail.com>\n"
 "Language-Team: Czech <cs@li.org>\n"
@@ -39,11 +39,11 @@ msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 "Zadejte prosím své heslo, aby mohl být problém systémového programu oznámen."
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "Tento balíček zřejmě není nainstalován správně"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -54,7 +54,7 @@ msgstr ""
 "aktualizaci indexů dostupných balíčků, pokud to nebude fungovat, odeberte "
 "související balíčky třetích stran a zkuste to znovu."
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -67,21 +67,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "neznámý program"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Omlouváme se, program \"%s\" byl neočekávaně uzavřen"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Problém v %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -89,65 +89,65 @@ msgstr ""
 "Váš počítač nemá dostatek volné paměti pro automatickou analýzu problému a "
 "odeslání hlášení vývojářům."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Neplatné hlášení o problému"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "Nemáte oprávnění k přístupu k tomuto hlášení problému."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Chyba"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "Pro zpracování tohoto hlášení není na disku dost místa."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr "Žádné PID nebylo specifikováno"
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 "Musíte specifikovat PID. Více informací naleznete pomocí příkazu --help"
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "Neplatný PID"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr "Proces s daným identifikátorem neexistuje."
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr "Není vaše PID"
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr "Proces s daným identifikátorem vám nepatří."
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "Nebyl specifikován žádný balík"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Musíte určit, o který balík nebo PID se jedná. Pro více informací použijte "
 "přepínač --help."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Přístup odepřen"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -155,30 +155,30 @@ msgstr ""
 "Nejste vlastníkem vybraného procesu. Prosím, spusťte tuto aplikaci jako "
 "vlastník onoho procesu nebo jako root."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "Zadané ID procesu neodpovídá žádnému programu."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Skript %s neurčuje problematický balík"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Balík %s neexistuje"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "Nelze vytvořit hlášení"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "Probíhá aktualizace chybového hlášení"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -190,7 +190,7 @@ msgstr ""
 "\n"
 "Vytvořte prosím nové hlášení pomocí \"apport-bug\"."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -210,24 +210,24 @@ msgstr ""
 "\n"
 "Opravdu chcete pokračovat?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "Nebyly shromážděny žádné další informace."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "Jaký druh problému si přejete nahlásit?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Neznámý příznak"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Příznak \"%s\" je neznámý."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -245,36 +245,36 @@ msgstr ""
 "Procesy posouvejte, dokud nenajdete správnou aplikaci. ID procesu je číslo "
 "uvedené ve sloupci ID."
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr "Po uzavření této zprávy klikněte na okno s nahlášením problému."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop selhal při rozeznávávání ID procesu okna"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr "%(prog)s <číslo hlášení>"
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "Upřesněte název balíku."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "Přidejte do hlášení další tagy - může jich být více."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -284,15 +284,15 @@ msgstr ""
 "pid, nebo pouze --pid. Pokud není zadán ani jeden, zobrazí se seznam známých "
 "příznaků. (Použito, pokud je zadán jediný argument.)"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "Kliknutím vyberte okno pro vytvoření hlášení o chybě."
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "Spustit režim aktualizace chyb.  Může mít volbu --packages"
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -300,7 +300,7 @@ msgstr ""
 "Podat hlášení o chybě o příznaku. (Použito, pokud je zadán název příznaku "
 "jako jediný argument.)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -308,7 +308,7 @@ msgstr ""
 "Určit název balíku v režimu --file-bug. Toto je volitelné, pokud je určeno --"
 "pid. (Použito, pokud je zadán název balíku jako jediný argument.)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -318,11 +318,11 @@ msgstr ""
 "hlášení obsahovat více informací. (Je-li číslo procesu uvedeno jako jediný "
 "argument.)"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "Poskytnuté pid je zamrzlá aplikace."
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -332,7 +332,7 @@ msgstr ""
 "některých nevyřízených z %s. (Použito, pokud je zadán soubor jako jediný "
 "argument.)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -341,34 +341,34 @@ msgstr ""
 "Uložte hlášení do souboru namísto přímého oznámení. Tento soubor může být "
 "nahlášen později nebo z jiného počítače."
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Vypsat číslo verze Apport."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr "Tímto spustíte apport-retrace v terminálovém okně."
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "Spustit gdb"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Spustit gdb bez stahování debugovacích symbolů"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Aktualizovat %s pomocí úplného symbolického trasování zásobníku"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr "Nenalezeno nastavení stavu odeslání hlášení"
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -387,7 +387,7 @@ msgid ""
 "occurred."
 msgstr "Problém byl zaznamenán v programu %s, který byl od pádu změněn."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Toto hlášení o problému je poškozené a nemůže být zpracováno."
 
@@ -417,13 +417,13 @@ msgstr "%s snap"
 msgid "%s deb package"
 msgstr "%s deb balíček"
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s je poskytován skrze snap vydaný %s. Pro pomoc je kontaktujte přes %s."
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -432,40 +432,40 @@ msgstr ""
 "%s je poskytován skrze snap vydaný %s. Nejsou poskytnuty žádné kontaktní "
 "údaje; pro pomoc navštivte fórum na adrese https://forum.snapcraft.io/."
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "Nelze určit název balíku nebo zdrojového balíku."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "Nelze spustit webový prohlížeč"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Nelze spustit webový prohlížeč a otevřít %s."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Problém se sítí"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Nelze se připojit k databází havárií, prosím zkontrolujte své internetové "
 "připojení."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Vyčerpání paměti"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Váš systém nemá dostatek paměti pro zpracování tohoto hlášení o havárii."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -476,11 +476,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "Problém je již znám"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -490,7 +490,7 @@ msgstr ""
 "prohlížeči. Prosím zkontrolujte, zda můžete přidat další informace, které by "
 "mohly být vývojářům nápomocné."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Tato chyba byla vývojářům již ohlášena. Děkujeme!"
 
@@ -842,7 +842,7 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Chyba: %soubor není spustitelný. Ukončuji proces."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -850,7 +850,7 @@ msgstr ""
 "Toto se stalo v průběhu minulého uspání do paměti a zabránilo systému v "
 "probuzení."
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -858,7 +858,7 @@ msgstr ""
 "Toto se stalo v průběhu minulého uspání na disk a zabránilo systému v "
 "probuzení."
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/cv.po
+++ b/po/cv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2011-10-07 06:10+0000\n"
 "Last-Translator: Ali Savatar <Unknown>\n"
 "Language-Team: Chuvash <cv@li.org>\n"
@@ -36,11 +36,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr ""
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -57,111 +57,111 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr ""
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr ""
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr ""
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
 msgstr ""
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr ""
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr ""
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Jănăš"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "\"PID\" tĕrĕs mar"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr ""
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr ""
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 msgstr ""
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr ""
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr ""
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr ""
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr ""
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -169,7 +169,7 @@ msgid ""
 "Please create a new report using \"apport-bug\"."
 msgstr ""
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -181,24 +181,24 @@ msgid ""
 "Do you really want to proceed?"
 msgstr ""
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr ""
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr ""
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr ""
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr ""
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -209,115 +209,115 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr ""
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr ""
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr ""
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -334,7 +334,7 @@ msgid ""
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr ""
 
@@ -362,49 +362,49 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr ""
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr ""
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr ""
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Tetel jănăšĕ"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr ""
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -412,18 +412,18 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr ""
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 msgstr ""
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 
@@ -735,19 +735,19 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr ""
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/cy.po
+++ b/po/cy.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2022-09-29 14:03+0000\n"
 "Last-Translator: Rhoslyn Prys <Unknown>\n"
 "Language-Team: Welsh <cy@li.org>\n"
@@ -40,11 +40,11 @@ msgstr ""
 "Rhowch eich cyfrinair i gael mynediad at adroddiadau problemau rhaglenni "
 "system"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "Nid yw'n ymddangos bod y pecyn hwn wedi'i osod yn gywir"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -55,7 +55,7 @@ msgstr ""
 "ar ôl diweddaru mynegeion y pecynnau sydd ar gael, os nad yw hynny'n "
 "gweithio yna tynnwch becynnau trydydd parti cysylltiedig a cheisiwch eto."
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -68,21 +68,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "rhaglen anhysbys"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Mae'n ddrwg gennym, caeodd y rhaglen \"%s\" yn annisgwyl"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Problem yn %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -90,63 +90,63 @@ msgstr ""
 "Nid oes gan eich cyfrifiadur ddigon o gof am ddim i ddadansoddi'r broblem yn "
 "awtomatig ac anfon adroddiad at y datblygwyr."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Adroddiad problem annilys"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "Ni chaniateir i chi gael mynediad at yr adroddiad problem hwn."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Gwall"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "Nid oes digon o le ar ddisg ar gael i brosesu'r adroddiad hwn."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr "Dim PID wedi'i nodi"
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr "Mae angen i chi nodi PID. Gweler --help am ragor o wybodaeth."
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "PID annilys"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr "Nid yw'r ID proses penodedig yn bodoli."
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr "Nid eich PID"
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr "Nid yw'r ID proses penodedig yn perthyn i chi."
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "Dim pecyn wedi'i nodi"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Mae angen i chi nodi pecyn neu PID. Gweler --help am ragor o wybodaeth."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Gwrthodwyd caniatâd"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -154,30 +154,30 @@ msgstr ""
 "Nid yw'r broses benodedig yn perthyn i chi. Rhedwch y rhaglen hon fel "
 "perchennog y broses neu fel gwraidd."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "Nid yw'r ID proses penodedig yn perthyn i raglen."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Nid yw sgript symptom  wedi canfod y pecyn %s effeithiwyd arno"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Nid yw pecyn %s yn bodoli"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "Methu creu adroddiad"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "Wrthi'n diweddaru adroddiad problem"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -189,7 +189,7 @@ msgstr ""
 "\n"
 "Crëwch adroddiad newydd gan ddefnyddio \"apport-bug\"."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -209,24 +209,24 @@ msgstr ""
 "\n"
 "Ydych chi wir eisiau bwrw ymlaen?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "Dim gwybodaeth ychwanegol wedi'i chasglu."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "Pa fath o broblem ydych chi am roi gwybod amdani?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Symptom anhysbys"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Nid yw'r symptom \"%s\" yn hysbys."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -245,7 +245,7 @@ msgstr ""
 "tab Prosesau, sgroliwch nes i chi ddod o hyd i'r rhaglen gywir. ID y broses "
 "yw'r rhif sy'n cael ei restri yn y golofn ID."
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -253,32 +253,32 @@ msgstr ""
 "Ar ôl cau'r neges hon, cliciwch ar ffenestr y raglen i roi gwybod am broblem "
 "amdani."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop wedi methu pennu ID proses y ffenestr"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr "%(prog)s<report number>"
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "Nodwch enw'r pecyn."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Ychwanegwch dag ychwanegol at yr adroddiad. Mae modd ei nodi sawl gwaith."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -288,15 +288,15 @@ msgstr ""
 "neu dim ond --pid. Os na roddir y naill na'r llall, dangoswch restr o "
 "symptomau hysbys. (Goblygiad os oes ymresymiad sengl yn cael ei gynnig.)"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "Cliciwch ffenestr fel targed ar gyfer ffeilio adroddiad problem."
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "Dechreuwch yn y modd diweddaru gwall. Gall gymryd --package dewisol."
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -304,7 +304,7 @@ msgstr ""
 "Ffeiliwch adroddiad gwall am symptom. (Goblygir os rhoddir enw'r symptom fel "
 "dadl yn unig.)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -312,7 +312,7 @@ msgstr ""
 "Nodwch enw'r pecyn yn y modd --file-bug. Mae hyn yn ddewisol os nodir --pid. "
 "(Goblygiad os oes ymresymiad sengl yn cael ei gynnig.)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -322,11 +322,11 @@ msgstr ""
 "nam yn cynnwys mwy o wybodaeth. (Goblygiad os pid yw'r unig ymresymiad sy'n "
 "cael ei gynnig.)"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "Mae'r pid a ddarperir yn raglen sy'n oedi."
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -336,7 +336,7 @@ msgstr ""
 "rhai sydd ar y gweill yn %s. (Goblygiad os taw ffeil sy'n cael ei chynnig "
 "fel yr unig ymresymiad.)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -346,36 +346,36 @@ msgstr ""
 "hytrach na'i hadrodd. Yna bydd modd adrodd ar y ffeil hon yn ddiweddarach o "
 "beiriant gwahanol."
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Argraffwch y rhif fersiwn Apport."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Bydd hyn yn lansio appport-retrace mewn ffenestr derfynell i archwilio'r "
 "chwaliad."
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "Rhedeg sesiwn gdb"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Rhedeg sesiwn gdb heb lwytho I lawr symbolau dadfygio"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Diweddaru %s gydag olrhain stac symbolaidd llawn"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr "Methu cofio anfon gosodiadau statws adroddiad"
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -397,7 +397,7 @@ msgid ""
 msgstr ""
 "Digwyddodd y broblem gyda'r rhaglen %s a newidiodd ers i'r chwaliad ddigwydd."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr ""
 "Mae'r adroddiad problem hwn wedi'i ddifrodi ac nid oes modd ei brosesu."
@@ -428,14 +428,14 @@ msgstr "%s snap"
 msgid "%s deb package"
 msgstr "Pecyn deb %s"
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "Mae %s yn cael ei ddarparu gan snap a gyhoeddwyd gan %s. Cysylltwch â nhw "
 "trwy %s am gymorth."
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -445,39 +445,39 @@ msgstr ""
 "cyswllt wedi'i ddarparu; ewch i'r fforwm yn https://forum.snapcraft.io/ am "
 "help."
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "Methu pennu enw'r pecyn neu ffynhonnell y pecyn."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "Methu cychwyn porwr gwe"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Methu cychwyn porwr gwe i agor %s."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Problem rhwydwaith"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Methu cysylltu â chronfa ddata chwalfa, gwiriwch eich cysylltiad rhyngrwyd."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Cof wedi dod i ben"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Nid oes gan eich system ddigon o gof i brosesu'r adroddiad chwalfa hwn."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -488,11 +488,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "Problem eisoes yn hysbys"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -502,7 +502,7 @@ msgstr ""
 "yn y porwr gwe. Gwiriwch a allwch ychwanegu unrhyw wybodaeth bellach a allai "
 "fod o gymorth i'r datblygwyr."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Rhoddwyd gwybod i ddatblygwyr am y broblem hon eisoes. Diolch!"
 
@@ -863,7 +863,7 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Gwall: Nid yw %s yn weithredadwy. Yn stopio."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -871,7 +871,7 @@ msgstr ""
 "Digwyddodd hyn yn ystod ataliad blaenorol, ac ataliodd y system rhag "
 "ailddechrau'n iawn."
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -879,7 +879,7 @@ msgstr ""
 "Digwyddodd hyn yn ystod cysgu trwm blaenorol, ac ataliodd y system rhag "
 "ailddechrau'n iawn."
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/da.po
+++ b/po/da.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2022-10-08 21:37+0000\n"
 "Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Language-Team: Danish <dansk@dansk-gruppen.dk>\n"
@@ -40,11 +40,11 @@ msgstr ""
 "Angiv venligst din adgangskode for at se rapporter over problemer med "
 "systemprogrammer"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "Denne pakke synes ikke at være korrekt installeret"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -55,7 +55,7 @@ msgstr ""
 "tilgængelige pakker og prøv igen. Virker det ikke, så fjern relaterede "
 "tredjepartspakker og prøv igen."
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -67,21 +67,21 @@ msgstr ""
 "følgende pakker og se om problemet stadig opstår:\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "ukendt program"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Undskyld, programmet \"%s\" lukkede uventet"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Problem i %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -89,62 +89,62 @@ msgstr ""
 "Din computer har ikke nok ledig hukommelse til en automatisk analyse af "
 "problemet og afsendelse af en rapport til udviklerne."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Ugyldig problemrapport"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "Du har ikke tilladelse til at tilgå denne problemrapport."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Fejl"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "Der er ikke nok diskplads til rådighed til at behandle denne rapport."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr "Ingen PID angivet"
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr "Du skal angive en PID. Se --help for flere oplysninger."
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "Ugyldigt PID"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr "Det angivne proces-ID findes ikke."
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr "Ikke dit PID"
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr "Det angivne proces-ID tilhører ikke dig."
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "Ingen pakke angivet"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr "Du skal angive en pakke eller en PID. Se --help for mere information."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Tilladelse nægtet"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -152,30 +152,30 @@ msgstr ""
 "Den angivne proces tilhører ikke dig. Kør venligst dette program som ejer af "
 "processen eller som administrator."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "Det angivne proces-ID tilhører ikke et program."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Symptomskript %s udpegede ikke en berørt pakke"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Pakke %s eksisterer ikke"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "Kan ikke oprette rapport"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "Opdaterer problemrapport"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -187,7 +187,7 @@ msgstr ""
 "\n"
 "Opret venligst en ny rapport ved at bruge \"apport-bug\"."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -208,24 +208,24 @@ msgstr ""
 "\n"
 "Ønsker du at fortsætte?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "Ingen yderligere oplysninger indsamlet."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "Hvilken slags problem ønsker du at rapportere?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Ukendt symptom"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Symptomet \"%s\" er ikke kendt."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -243,7 +243,7 @@ msgstr ""
 "fanebladet Processer ruller du ned, indtil du finder det rigtige program. "
 "Proces-id'et er nummeret vist i id-kolonnen."
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -251,30 +251,30 @@ msgstr ""
 "Tryk venligst på et programvindue - efter du lukker denne besked - for at "
 "rapportere et problem med det."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop kunne ikke bestemme proces-id for vinduet"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr "%(prog)s <rapportnummer>"
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "Angiv pakkenavn."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "Tilføj et ekstra mærke til rapporten. Kan gives flere gange."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr "%(prog)s [tilvalg] [symptom|pid|pakke|programsti|.apport/.crash-fil]"
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -284,15 +284,15 @@ msgstr ""
 "eller blot et --pid. Fremvis en liste over kendte symptomer, hvis ingen af "
 "delene er angivet. (Underforstået hvis et enkelt argument er angivet.)"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "Klik på et vindue som et mål for indsendelse af en fejlrapport."
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "Start i fejlopdateringstilstand. Kan have et valgfrit --package."
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -300,7 +300,7 @@ msgstr ""
 "Opret en fejlrapport om et symptom. (Underforstået hvis symptomnavn er "
 "angivet som eneste argument.)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -308,7 +308,7 @@ msgstr ""
 "Angiv pakkenavn i --file-bug-tilstand. Dette er valgfrit hvis et --pid er "
 "angivet. (Underforstået hvis pakkenavn er angivet som eneste argument.)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -318,11 +318,11 @@ msgstr ""
 "fejlrapporten indeholde mere information. (Underforstået, hvis pid gives som "
 "eneste argument.)"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "Det angivne pid er et program som hænger."
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -332,7 +332,7 @@ msgstr ""
 "igangværende filer i %s. (Underforstået hvis fil er angivet som eneste "
 "argument.)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -342,36 +342,36 @@ msgstr ""
 "stedet for at rapportere den. Denne fil kan så rapporteres fra en anden "
 "maskine på et senere tidspunkt."
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Skriv Apport-versionnummer."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Dette vil køre apport-retrace i et terminalvindue for at undersøge "
 "nedbruddet."
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "Kør gdb-session"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Kør gdb-session uden at hente fejlsøgningssymboler"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Opdatér %s med fuldt symbolsk stakspor"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr "Kan ikke huske indstillinger for status for send-rapport"
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -391,7 +391,7 @@ msgid ""
 msgstr ""
 "Problemet opstod med programmet %s, som har ændret sig siden sidste nedbrud."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Denne problemrapport er beskadiget og kan ikke behandles."
 
@@ -421,13 +421,13 @@ msgstr "%s snap"
 msgid "%s deb package"
 msgstr "%s deb-pakke"
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s leveres af en snap som er udgivet af %s. Kontakt dem via %s for hjælp."
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -436,40 +436,40 @@ msgstr ""
 "%s leveres af en snap som er udgivet af %s. Der er ikke leveret nogen "
 "kontaktadresse. Besøg forummet på https://forum.snapcraft.io/ for hjælp."
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "Kunne ikke bestemme pakken eller kildepakkenavn."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "Kan ikke starte internetbrowser"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Kan ikke starte internetbrowser for at åbne %s."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Netværksproblem"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Kan ikke forbinde til nedbrudsdatabase. Kontrollér venligst din "
 "internetforbindelse."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Overbelastning af hukommelse"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Dit system har ikke hukommelse nok til at behandle denne nedbrudsrapport."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -480,11 +480,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "Problemet er allerede kendt"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -494,7 +494,7 @@ msgstr ""
 "din internetbrowser. Kontrollér venligst om du kan tilføje yderligere "
 "information, som kan være til hjælp for udviklerne."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 "Dette problem er allerede blevet rapporteret til udviklerne. Mange tak!"
@@ -849,7 +849,7 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Fejl: %s er ikke en eksekvérbar fil. Afbryder."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -857,7 +857,7 @@ msgstr ""
 "Dette skete under en tidligere hviletilstand, og forhindrede systemet i at "
 "vågne op korrekt."
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -865,7 +865,7 @@ msgstr ""
 "Dette skete under en tidligere dvaletilstand, og forhindrede systemet i at "
 "vågne op korrekt."
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/de.po
+++ b/po/de.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport 0.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2015-09-10 15:08+0000\n"
 "Last-Translator: Martin Pitt <martin@piware.de>\n"
 "Language-Team: German <de@li.org>\n"
@@ -39,11 +39,11 @@ msgstr ""
 "Bitte geben Sie Ihr Passwort ein, um zu den Problemberichten von "
 "Systemprogrammen zu gelangen"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "Dieses Paket scheint nicht richtig installiert zu sein"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -55,7 +55,7 @@ msgstr ""
 "funktioniert, entfernen Sie die entsprechenden Pakete von Drittanbietern und "
 "versuchen Sie es erneut."
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -69,21 +69,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "unbekanntes Programm"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Entschuldigung, das Programm »%s« wurde unerwartet beendet"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Problem in %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -91,66 +91,66 @@ msgstr ""
 "Ihr System besitzt nicht genug Speicher, um den Absturzbericht zu "
 "verarbeiten und einen Bericht an die Entwickler zu senden."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Ungültiger Problembericht"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "Sie haben keine Berechtigung für diesen Problembericht."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Fehler"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 "Ihr System besitzt nicht genug Festplattenplatz, um den Absturzbericht zu "
 "verarbeiten."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr "Keine PID angegeben"
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr "Sie müssen eine PID angeben. Siehe --help für weitere Informationen"
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "Ungültige Prozesskennung"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr "Die angegebene Prozesskennung existiert nicht."
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr "Nicht Ihre Prozesskennung (PID)"
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr "Die angegebene Prozesskennung gehört nicht Ihnen."
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "Kein Paket angegeben"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Sie müssen ein Paketnamen oder eine PID angeben. Versuchen Sie --help für "
 "weitere Informationen."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Zugriff verweigert"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -158,30 +158,30 @@ msgstr ""
 "Der angegebene Prozess gehört nicht Ihnen. Bitte starten Sie dieses Programm "
 "als den Prozesseigentümer oder als root."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "Die angegebene Prozesskennung gehört zu keinem Programm."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Symptom-Skript %s konnte kein betroffenes Paket finden"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Paket %s existiert nicht"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "Bericht kann nicht erstellt werden"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "Problembericht wird aktualisiert"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -194,7 +194,7 @@ msgstr ""
 "\n"
 "Bitte erstellen Sie mit »apport-bug« einen neuen Problembericht."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -215,24 +215,24 @@ msgstr ""
 "\n"
 "Möchten Sie wirklich fortfahren?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "Keine zusätzlichen Informationen gesammelt."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "Welche Art von Problem möchten Sie melden?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Unbekanntes Symptom"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Das Symptom »%s« ist nicht bekannt."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -252,7 +252,7 @@ msgstr ""
 "Anwendung finden. Die Prozess-ID ist die Nummer, die in der Spalte »Kennung« "
 "aufgeführt ist."
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -260,33 +260,33 @@ msgstr ""
 "Nachdem Sie diese Meldung geschlossen haben, klicken Sie bitte auf das "
 "Fenster der Anwendung, zu der Sie ein Problem melden möchten."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "Xprop konnte die Prozesskennung des Fensters nicht ermitteln"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr "%(prog)s <Berichtsnummer>"
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "Paketnamen angeben."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Eine zusätzliches Schlagwort zu dem Bericht hinzufügen. Kann mehrfach "
 "angegeben werden."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 "%(prog)s [Optionen] [Symptom|pid|Paket|Programmpfad|.apport/.crash-Datei]"
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -296,19 +296,19 @@ msgstr ""
 "nur --pid. Wenn keines angegeben wird, eine Liste bekannter Symptome "
 "anzeigen. (Implizit, wenn nur ein einzelnes Argument angegeben wird.)"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 "Klicken Sie bitte auf das Fenster der Anwendung, die im Bericht vorkommen "
 "soll."
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "Im Fehleraktualisierungsmodus starten. Option --package kann zusätzlich "
 "angegeben werden."
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -316,7 +316,7 @@ msgstr ""
 "Fehler als einen Bericht über ein Symptom melden. (Implizit, wenn der "
 "Symptom-Name als einziges Argument angegeben wird.)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -325,7 +325,7 @@ msgstr ""
 "optional, wenn --pid angegeben wird. (Implizit, wenn der Paketname als "
 "einziges Argument angegeben wurde.)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -335,11 +335,11 @@ msgstr ""
 "Fehlerbericht mehr Informationen enthalten. (Standard, wenn das einzige "
 "Argument eine PID ist.)"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "Die angegebene pid ist eine nicht reagierende Anwendung."
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -349,7 +349,7 @@ msgstr ""
 "anstatt aus einer der in %s wartenden. (Implizit, wenn ein Dateiname als "
 "einziges Argument angegeben wurde.)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -359,37 +359,37 @@ msgstr ""
 "Datei, anstatt sie direkt zu melden. Diese Datei kann später von einem "
 "anderen Rechner aus gesendet werden, um den Fehler zu melden."
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Die Versionsnummer von Apport ausgeben."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Hierdurch wird apport-retrace in einem Terminal ausgeführt, um die "
 "Absturzursache zu untersuchen."
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "Eine gdb-Sitzung ausführen"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Eine gdb-Sitzung ausführen ohne Fehlerdiagnosesymbole herunterzuladen"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "%s mit vollständig symbolischen Stapelspeicher aktualisieren"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 "Die Einstellungen des Sendereportstatus konnten nicht gespeichert werden"
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -411,7 +411,7 @@ msgstr ""
 "Das Problem trat in der Anwendung %s auf, die seit dem Absturz verändert "
 "wurde."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr ""
 "Dieser Problembericht ist beschädigt und kann nicht verarbeitet werden."
@@ -443,14 +443,14 @@ msgstr "%s Snap"
 msgid "%s deb package"
 msgstr "%s deb Paket"
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s wird durch einen von %s veröffentlichten Snap bereitgestellt. Für Hilfe "
 "gehen Sie über %s."
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -460,41 +460,41 @@ msgstr ""
 "keine Kontaktadresse angegeben; besuchen Sie das Forum unter https://forum."
 "snapcraft.io/, um Hilfe zu erhalten."
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "Paket- oder Quellpaketname konnten nicht bestimmt werden."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "Konnte Webbrowser nicht starten"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Konnte Webbrowser nicht starten um %s zu öffnen."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Netzwerkproblem"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Es konnte keine Verbindung zur Fehlerdatenbank aufgebaut werden. Bitte "
 "prüfen Sie Ihre Internetverbindung."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Kein Speicher mehr verfügbar"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Ihr System besitzt nicht genug Speicher, um den Absturzbericht zu "
 "verarbeiten."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -505,11 +505,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "Dieses Problem ist bereits bekannt"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -520,7 +520,7 @@ msgstr ""
 "weiteren Informationen, welche für die Entwickler hilfreich sein könnten, "
 "hinzufügen können."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Dieses Problem wurde den Entwicklern bereits gemeldet. Vielen Dank!"
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Fehler: %s ist keine ausführbare Datei. Abbruch."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -903,7 +903,7 @@ msgstr ""
 "Das geschah während eines vorhergehenden Bereitschaftsmodus und verhinderte "
 "ein ordnungsgemäßes Fortsetzen."
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -911,7 +911,7 @@ msgstr ""
 "Das geschah während eines vorhergehenden Ruhezustandes und verhinderte ein "
 "ordnungsgemäßes Fortsetzen."
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2015-04-27 21:47+0000\n"
 "Last-Translator: Nick Andrik <nick.andrik@gmail.com>\n"
 "Language-Team: Greek, Modern (1453-) <el@li.org>\n"
@@ -40,11 +40,11 @@ msgstr ""
 "Παρακαλώ εισάγετε το συνθηματικό σας για να αποκτήσετε πρόσβαση στις "
 "αναφορές προβλημάτων των προγραμμάτων συστήματος"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "Αυτό το πακέτο δεν φαίνεται να έχει εγκατασταθεί σωστά"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -52,7 +52,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -66,21 +66,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "άγνωστο πρόγραμμα"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Συγνώμη, το πρόγραμμα \"%s\" τερματίστηκε απροσδόκητα"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Πρόβλημα στο %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -88,66 +88,66 @@ msgstr ""
 "Ο υπολογιστής σας δεν έχει αρκετή ελεύθερη μνήμη για να αναλύσει αυτόματα το "
 "πρόβλημα και να στείλει μια αναφορά στους προγραμματιστές."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Μη έγκυρη αναφορά προβλήματος"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr ""
 "Δεν σας επιτρέπεται να αποκτήσετε πρόσβαση σε αυτή την αναφορά προβλήματος."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Σφάλμα"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 "Δεν υπάρχει αρκετός χώρος στον δίσκο για την επεξεργασία αυτής της αναφοράς."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "Άκυρος αριθμός αναγνώρισης της διεργασίας (PID)"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr "Το καθορισμένο αναγνωριστικό διαδικασίας δεν υπάρχει."
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr "Δεν είναι η ταυτότητα της διεργασίας σας"
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr "Το καθορισμένο αναγνωριστικό διεργασίας δεν ανήκει σε εσάς."
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "Δεν ορίστηκε πακέτο"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Χρειάζεται να ορίσετε ένα πακέτο ή ένα PID. Δείτε την --help για "
 "περισσότερες πληροφορίες."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Δεν επιτρέπεται η πρόσβαση"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -155,32 +155,32 @@ msgstr ""
 "Η συγκεκριμένη διεργασία δεν ανήκει σε εσάς. Παρακαλούμε τρέξτε το πρόγραμμα "
 "ως ιδιοκτήτης της διεργασίας ή ως root."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr ""
 "Αυτός ο αριθμός αναγνώρισης της διεργασίας (PID) δεν ανήκει σε κάποιο "
 "πρόγραμμα"
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Το σενάριο συμπτώματος %s δεν προσδιόρισε κανένα επηρεασμένο πακέτο"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Το πακέτο %s δεν υπάρχει"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "Αδυναμία δημιουργίας αναφοράς"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "Ενημέρωση αναφοράς προβλήματος"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -192,7 +192,7 @@ msgstr ""
 "\n"
 "Παρακαλούμε δημιουργήστε μια νέα αναφορά με τη χρήση του \"apport-bug\"."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -213,24 +213,24 @@ msgstr ""
 "\n"
 "Θέλετε σίγουρα να προχωρήσετε;"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "Δεν έχουν συλλεχθεί επιπλέον πληροφορίες."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "Τι είδους πρόβλημα θέλετε να αναφέρετε;"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Άγνωστο σύμπτωμα"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Το σύμπτωμα \"%s\" είναι άγνωστο."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -241,7 +241,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -249,31 +249,31 @@ msgstr ""
 "Αφού κλείσετε αυτό το μήνυμα παρακαλούμε κάντε κλικ στο παράθυρο μιας "
 "εφαρμογής για να αναφέρετε ένα πρόβλημα σχετικό με αυτήν."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "Το xprop απέτυχε να προσδιορίσει την ταυτότητα (PID) του παραθύρου."
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "Καθορίστε ένα όνομα πακέτου."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Προσθέστε μια επιπλέον ετικέτα στην αναφορά. Μπορεί να οριστεί πολλές φορές."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -284,19 +284,19 @@ msgstr ""
 "εμφανίστε έναν κατάλογο γνωστών συμπτωμάτων. ( Η εξ ορισμού επιλογή εάν "
 "δίνεται ένα και μοναδικό όρισμα.)"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 "Επιλέξτε ένα παράθυρο πατώντας το, για να συμπληρώσετε μια αναφορά "
 "προβλήματος."
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "Εκκίνηση σε λειτουργία ενημέρωσης σφάλματος. Δέχεται προαιρετικά την "
 "παράμετρο --package."
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -304,7 +304,7 @@ msgstr ""
 "Υποβάλετε αναφορά σφάλματος για ένα σύμπτωμα. (Στην περίπτωση που η ονομασία "
 "του συμπτώματος δίνεται ως μοναδικό όρισμα.)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -313,7 +313,7 @@ msgstr ""
 "έχει ήδη καθοριστεί ένα --pid. (Στην περίπτωση που το όνομα πακέτου δίνεται "
 "ως μοναδικό όρισμα.)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -323,13 +323,13 @@ msgstr ""
 "προσδιοριστεί, η αναφορά θα περιέχει περισσότερες πληροφορίες. (Όταν η "
 "ταυτότητα διεργασίας (PID) δίνεται ως η μόνη παράμετρος.)"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr ""
 "Το παρεχόμενο αναγνωριστικό διεργασίας (PID) είναι για μια εφαρμογή που έχει "
 "κολλήσει."
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -338,7 +338,7 @@ msgstr ""
 "Αναφέρετε την κατάρρευση από το δεδομένο αρχείο .apport ή .crash αντί αυτών "
 "στο %s. (Στην περίπτωση που το αρχείο δίδεται ως το μοναδικό όρισμα.)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -348,37 +348,37 @@ msgstr ""
 "πληροφορίες σε ένα αρχείο αντί να τις αναφέρετε. Το αρχείο αυτό μπορεί να "
 "αποσταλεί για αναφορά αργότερα από έναν διαφορετικό υπολογιστή."
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Τυπώστε τον αριθμό έκδοσης της εφαρμογής Apport."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Αυτό θα εκκινήσει το apport-retrace σε ένα παράθυρο τερματικού για να "
 "διερευνηθεί η σύγκρουση."
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "Εκτέλεση συνεδρίας gdb"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Εκτέλεση συνεδρίας gdb χωρίς λήψη συμβόλων εκφαλμάτωσης"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Ενημέρωση %s με πλήρως συμβολική παρακολούθηση στίβας"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 "Δεν μπορεί να αποθηκευθεί η ρύθμιση να μην στέλνονται αναφορές κατάστασης"
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -399,7 +399,7 @@ msgstr ""
 "Το πρόβλημα παρουσιάστηκε με το πρόγραμμα %s το οποίο έχει αλλάξει από τη "
 "στιγμή που συνέβη η κατάρρευση."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr ""
 "Αυτή η αναφορά προβλήματος έχει καταστραφεί και είναι αδύνατη η επεξεργασία "
@@ -431,54 +431,54 @@ msgstr "%s snap"
 msgid "%s deb package"
 msgstr "%s πακέτο deb"
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr ""
 "Αδύνατος ο καθορισμός του πακέτου ή του ονόματος του πακέτου πηγαίου κώδικα."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "Αδύνατη η εκκίνηση του περιηγητή"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Αδύνατη η εκκίνηση του περιηγητή για το άνοιγμα του %s."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Πρόβλημα δικτύου"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Αδυναμία σύνδεσης στη βάση δεδομένων καταρρεύσεων, παρακαλώ ελέγξτε τη "
 "σύνδεσή σας στο διαδίκτυο."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Εξάντληση μνήμης"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Το σύστημα δεν έχει αρκετή ελεύθερη μνήμη για τη διαδικασία αναφοράς "
 "κατάρρευσης."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -489,11 +489,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "Πρόβλημα ήδη γνωστό"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -503,7 +503,7 @@ msgstr ""
 "που βλέπετε. Παρακαλώ εξετάστε, αν μπορείτε να προσθέσετε κάποιες επιπλέον "
 "πληροφορίες, που να είναι χρήσιμες στους προγραμματιστές."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 "Αυτό το πρόβλημα έχει ήδη αναφερθεί στους συντελεστές της εφαρμογής. Σας "
@@ -881,7 +881,7 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Σφάλμα: το %s δεν είναι εκτελέσιμο. Διακοπή."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -889,7 +889,7 @@ msgstr ""
 "Αυτό προκλήθηκε από προηγούμενη αναστολή και απέτρεψε το σύστημα από το να "
 "συνεχίσει σωστά."
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -897,7 +897,7 @@ msgstr ""
 "Αυτό προκλήθηκε από προηγούμενη αδρανοποίηση και απέτρεψε το σύστημα από το "
 "να συνεχίσει σωστά."
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/en_AU.po
+++ b/po/en_AU.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2015-04-27 21:46+0000\n"
 "Last-Translator: Anthony Harrington <Unknown>\n"
 "Language-Team: English (Australia) <en_AU@li.org>\n"
@@ -39,11 +39,11 @@ msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 "Please enter your password to access problem reports of system programs"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "This package does not seem to be installed correctly"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -54,7 +54,7 @@ msgstr ""
 "the indexes of available packages, if that does not work then remove related "
 "third party packages and try again."
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -67,21 +67,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "unknown program"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Sorry, the program \"%s\" closed unexpectedly"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Problem in %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -89,63 +89,63 @@ msgstr ""
 "Your computer does not have enough free memory to automatically analyse the "
 "problem and send a report to the developers."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Invalid problem report"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "You are not allowed to access this problem report."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Error"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "There is not enough disk space available to process this report."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr "No PID specified"
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr "You need to specify a PID. See --help for more information."
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "Invalid PID"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr "The specified process ID does not exist."
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr "Not your PID"
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr "The specified process ID does not belong to you."
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "No package specified"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "You need to specify a package or a PID. See --help for more information."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Permission denied"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -153,30 +153,30 @@ msgstr ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "The specified process ID does not belong to a program."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Symptom script %s did not determine an affected package"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Package %s does not exist"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "Cannot create report"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "Updating problem report"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -188,7 +188,7 @@ msgstr ""
 "\n"
 "Please create a new report using \"apport-bug\"."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -208,24 +208,24 @@ msgstr ""
 "\n"
 "Do you really want to proceed?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "No additional information collected."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "What kind of problem do you want to report?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Unknown symptom"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "The symptom \"%s\" is not known."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -236,7 +236,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -244,30 +244,30 @@ msgstr ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop failed to determine process ID of the window"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "Specify package name."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "Add an extra tag to the report. Can be specified multiple times."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -277,15 +277,15 @@ msgstr ""
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "Click a window as a target for filing a problem report."
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "Start in bug updating mode. Can take an optional --package."
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -293,7 +293,7 @@ msgstr ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -301,7 +301,7 @@ msgstr ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -311,11 +311,11 @@ msgstr ""
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "The provided pid is a hanging application."
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -324,7 +324,7 @@ msgstr ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -334,35 +334,35 @@ msgstr ""
 "reporting it. This file can then be reported later on from a different "
 "machine."
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Print the Apport version number."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "Run gdb session"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Run gdb session without downloading debug symbols"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Update %s with fully symbolic stack trace"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr "Can't remember send report status settings"
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -383,7 +383,7 @@ msgstr ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "This problem report is damaged and cannot be processed."
 
@@ -413,13 +413,13 @@ msgstr "%s snap"
 msgid "%s deb package"
 msgstr "%s deb package"
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s is provided by a snap published by %s. Contact them via %s for help."
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -428,38 +428,38 @@ msgstr ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "Could not determine the package or source package name."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "Unable to start web browser"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Unable to start web browser to open %s."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Network problem"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Cannot connect to crash database, please check your Internet connection."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Memory exhaustion"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "Your system does not have enough memory to process this crash report."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -470,11 +470,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "Problem already known"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -484,7 +484,7 @@ msgstr ""
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "This problem was already reported to developers. Thank you!"
 
@@ -831,7 +831,7 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Error: %s is not an executable. Stopping."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -839,7 +839,7 @@ msgstr ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -847,7 +847,7 @@ msgstr ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/en_CA.po
+++ b/po/en_CA.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2020-07-10 14:15+0000\n"
 "Last-Translator: Marc Deslauriers <marc.deslauriers@canonical.com>\n"
 "Language-Team: English (Canada) <en_CA@li.org>\n"
@@ -39,11 +39,11 @@ msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 "Please enter your password to access problem reports of system programs"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "This package does not seem to be installed correctly"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -54,7 +54,7 @@ msgstr ""
 "the indexes of available packages, if that does not work then remove related "
 "third party packages and try again."
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -67,21 +67,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "unknown program"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Sorry, the program \"%s\" closed unexpectedly"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Problem in %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -89,63 +89,63 @@ msgstr ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Invalid problem report"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "You are not allowed to access this problem report."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Error"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "There is not enough disk space available to process this report."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr "No PID specified"
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr "You need to specify a PID. See --help for more information."
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "Invalid PID"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr "The specified process ID does not exist."
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr "Not your PID"
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr "The specified process ID does not belong to you."
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "No package specified"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "You need to specify a package or a PID. See --help for more information."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Permission denied"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -153,30 +153,30 @@ msgstr ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "The specified process ID does not belong to a program."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Symptom script %s did not determine an affected package"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Package %s does not exist"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "Cannot create report"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "Updating problem report"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -188,7 +188,7 @@ msgstr ""
 "\n"
 "Please create a new report using \"apport-bug\"."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -208,24 +208,24 @@ msgstr ""
 "\n"
 "Do you really want to proceed?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "No additional information collected."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "What kind of problem do you want to report?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Unknown symptom"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "The symptom \"%s\" is not known."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -243,7 +243,7 @@ msgstr ""
 "the Processes tab, scroll until you find the correct application. The "
 "process ID is the number listed in the ID column."
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -251,30 +251,30 @@ msgstr ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop failed to determine process ID of the window"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "Specify package name."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "Add an extra tag to the report. Can be specified multiple times."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -284,15 +284,15 @@ msgstr ""
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "Click a window as a target for filing a problem report."
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "Start in bug updating mode. Can take an optional --package."
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -300,7 +300,7 @@ msgstr ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -308,7 +308,7 @@ msgstr ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -318,11 +318,11 @@ msgstr ""
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "The provided pid is a hanging application."
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -331,7 +331,7 @@ msgstr ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -341,35 +341,35 @@ msgstr ""
 "reporting it. This file can then be reported later on from a different "
 "machine."
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Print the Apport version number."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "Run gdb session"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Run gdb session without downloading debug symbols"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Update %s with fully symbolic stack trace"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr "Can't remember send report status settings"
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -390,7 +390,7 @@ msgstr ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "This problem report is damaged and cannot be processed."
 
@@ -420,13 +420,13 @@ msgstr "%s snap"
 msgid "%s deb package"
 msgstr "%s deb package"
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s is provided by a snap published by %s. Contact them via %s for help."
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -435,38 +435,38 @@ msgstr ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "Could not determine the package or source package name."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "Unable to start web browser"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Unable to start web browser to open %s."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Network problem"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Cannot connect to crash database, please check your Internet connection."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Memory exhaustion"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "Your system does not have enough memory to process this crash report."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -477,11 +477,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "Problem already known"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -491,7 +491,7 @@ msgstr ""
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "This problem was already reported to developers. Thank you!"
 
@@ -840,7 +840,7 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Error: %s is not an executable. Stopping."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -848,7 +848,7 @@ msgstr ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -856,7 +856,7 @@ msgstr ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2022-10-05 00:36+0000\n"
 "Last-Translator: Stephan Woidowski <swoidowski@t-online.de>\n"
 "Language-Team: English (United Kingdom) <en_GB@li.org>\n"
@@ -39,11 +39,11 @@ msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 "Please enter your password to access problem reports of system programs"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "This package does not seem to be installed correctly"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -54,7 +54,7 @@ msgstr ""
 "the indexes of available packages. If that does not work, then remove "
 "related third party packages and try again."
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -67,21 +67,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "unknown program"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Sorry, the program \"%s\" closed unexpectedly"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Problem in %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -89,63 +89,63 @@ msgstr ""
 "Your computer does not have enough free memory to automatically analyse the "
 "problem and send a report to the developers."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Invalid problem report"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "You are not allowed to access this problem report."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Error"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "There is not enough disk space available to process this report."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr "No PID specified"
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr "You need to specify a PID. See --help for more information."
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "Invalid PID"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr "The specified process ID does not exist."
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr "Not your PID"
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr "The specified process ID does not belong to you."
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "No package specified"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "You need to specify a package or a PID. See --help for more information."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Permission denied"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -153,30 +153,30 @@ msgstr ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "The specified process ID does not belong to a program."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Symptom script %s did not determine an affected package"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Package %s does not exist"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "Cannot create report"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "Updating problem report"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -188,7 +188,7 @@ msgstr ""
 "\n"
 "Please create a new report using \"apport-bug\"."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -208,24 +208,24 @@ msgstr ""
 "\n"
 "Do you really want to proceed?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "No additional information collected."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "What kind of problem do you want to report?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Unknown symptom"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "The symptom \"%s\" is not known."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -243,7 +243,7 @@ msgstr ""
 "the Processes tab, scroll until you find the correct application. The "
 "process ID is the number listed in the ID column."
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -251,31 +251,31 @@ msgstr ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop failed to determine process ID of the window"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr "%(prog)s <report number>"
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "Specify package name."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "Add an extra tag to the report. Can be specified multiple times."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -285,15 +285,15 @@ msgstr ""
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "Click a window as a target for filing a problem report."
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "Start in bug updating mode. Can take an optional --package."
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -301,7 +301,7 @@ msgstr ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -309,7 +309,7 @@ msgstr ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -319,11 +319,11 @@ msgstr ""
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "The provided pid is a hanging application."
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -332,7 +332,7 @@ msgstr ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -342,35 +342,35 @@ msgstr ""
 "reporting it. This file can then be reported later on from a different "
 "machine."
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Print the Apport version number."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "Run gdb session"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Run gdb session without downloading debug symbols"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Update %s with fully symbolic stack trace"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr "Can't remember send report status settings"
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -391,7 +391,7 @@ msgstr ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "This problem report is damaged and cannot be processed."
 
@@ -421,13 +421,13 @@ msgstr "%s snap"
 msgid "%s deb package"
 msgstr "%s deb package"
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s is provided by a snap published by %s. Contact them via %s for help."
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -436,38 +436,38 @@ msgstr ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "Could not determine the package or source package name."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "Unable to start web browser"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Unable to start web browser to open %s."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Network problem"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Cannot connect to crash database, please check your Internet connection."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Memory exhaustion"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "Your system does not have enough memory to process this crash report."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -478,11 +478,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "Problem already known"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -492,7 +492,7 @@ msgstr ""
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "This problem has already been reported to developers. Thank you!"
 
@@ -841,7 +841,7 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Error: %s is not an executable. Stopping."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -849,7 +849,7 @@ msgstr ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -857,7 +857,7 @@ msgstr ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2015-04-27 21:47+0000\n"
 "Last-Translator: Michael Moroni <michaelmoroni@disroot.org>\n"
 "Language-Team: Esperanto <eo@li.org>\n"
@@ -36,11 +36,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "Ŝajnas, ke ĉi tiu pakaĵo ne estas korekte instalita"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -61,21 +61,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "nekonata programaro"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Bedaŭrinde la programaro \"%s\" fermiĝis neatendite"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Problemo en %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -83,62 +83,62 @@ msgstr ""
 "Via komputilo ne havas sufiĉe da libera memoro por analizi la problemon kaj "
 "sendi raporton al la evoluigantoj."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Nevalida problemraporto"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "Vi ne rajtas aliri ĉi tiun problemraporton."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Eraro"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "Spaco en disko ne sufiĉas por trakti ĉi tiun raporton."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "Nevalida PID"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "Neniu pakaĵo indikita."
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr "Vi devas indiki pakaĵon aŭ PID. Vidu --help por pliaj informoj."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Permeso malaprobita"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -146,30 +146,30 @@ msgstr ""
 "La indikita procezo ne apartenas al vi. Bonvole rulu ĉi tiun programaron "
 "kiel posedanto de la procezo aŭ kiel ĉefuzanto."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "La indikita procesa identigilo ne apartenas al iu programaro."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "La skripto por analizi problemon %s ne trovis koncernatan pakaĵon"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Pakaĵo %s ne ekzistas"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "La raporto ne kreeblas"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "Ĝisdatiganta problemraporton"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -181,7 +181,7 @@ msgstr ""
 "\n"
 "Bonvole kreu novan raporton per \"apport-bug\"."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -201,24 +201,24 @@ msgstr ""
 "\n"
 "Ĉu vi vere volas daŭrigi?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "Neniu aldonaj informoj estis kolektitaj."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "Kiuspecan problemon vi volas raporti?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "nekonata simptomo"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "La simptomo \"%s\" ne estas konata."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -229,7 +229,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -237,30 +237,30 @@ msgstr ""
 "Ferminte ĉi tiun mesaĝon, bonvole alklaku aplikaĵfenestron por raporti "
 "problemon pri ĝi."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop fiaskis en determinado de procesidentigilo de la fenestro"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "Specifi pakaĵnomon."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "Aldoni plian markon al la raporto. Tio plurfoje specifeblas."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -271,15 +271,15 @@ msgstr ""
 "simptomoj aperas. (Ĉi tiu reĝimo validas aŭtomate, se nur unu argumento "
 "estas specifita.)"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "Alklaku sur fenestro kiel celo, por sendi problemraporton."
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "Startigi en redakta reĝimo. La opcio --package aldoneblas."
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -287,7 +287,7 @@ msgstr ""
 "Sendu problemraporton pri simptomoj. (Ĉi tiu regimo validas aŭtomate, se la "
 "nomo de la simptomo estas donita kiel sola argumento.)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -296,7 +296,7 @@ msgstr ""
 "specifita. (Ĉi tiu regimo validas aŭtomate, se la nomo de la pakaĵo estas "
 "donita kiel sola argumento.)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -306,11 +306,11 @@ msgstr ""
 "cimraporto enhavos pli da informoj.  (Ĉi tiu regimo validas aŭtomate, se pid "
 "estas donita kiel sola argumento.)"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -320,7 +320,7 @@ msgstr ""
 "okazantaj en %s.  (Ĉi tiu regimo validas aŭtomate, se la dosiero estas "
 "donita kiel sola argumento.)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -329,35 +329,35 @@ msgstr ""
 "En cimpleniga reĝimo, konservi la kolektitajn informojn en dosieron anstataŭ "
 "ol raporti ĝin. Ĉi tiu dosiero povas poste esti raportata per alia maŝino."
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Eligi la numeron de versio de Aporto."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Tio rulos apport-retrace en fenestro de terminalo por testi la kolapson."
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "Ruli seancon de gdb"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Ruli seancon de gdb sen elŝuti sencimigsimbolojn"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Ĝisdatigi %s kun tute simbolika staka spuro"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -375,7 +375,7 @@ msgid ""
 msgstr ""
 "La problemo okazis kun la programaro %s, kiu ŝanĝis ekde la kolapso okazis."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "La raporto estas damaĝita kaj ne povas esti traktata."
 
@@ -403,51 +403,51 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "Ne eblis eltrovi la nomon de la pakaĵo aŭ de la fonta pakaĵo."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "Ne eblis startigi retfoliumilon."
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Ne eblis starti retfoliumilo por malfermi %s."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Reta problemo"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Ne eblas konekti al la datumbazo pri kolapsoj. Bonvole kontrolu vian "
 "retkonekton."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Memoro elĉerpita"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "Via sistemo ne havas sufiĉe da memoro por trakti la kolapsraporton."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -458,11 +458,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "Jam konata problemo."
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -472,7 +472,7 @@ msgstr ""
 "retfoliumilo. Bonvole kontrolu, ĉu vi povas aldoni pliajn eble utilajn "
 "informojn por la evoluigantoj."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Ĉi tiu problemo estas jam raportita al programistoj. Dankon!"
 
@@ -812,19 +812,19 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr ""
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2015-04-27 21:46+0000\n"
 "Last-Translator: Adolfo Jayme Barrientos <fitoschido@gmail.com>\n"
 "Language-Team: Spanish <es@li.org>\n"
@@ -40,11 +40,11 @@ msgstr ""
 "Escriba su contraseña para acceder a los informes de problemas de programas "
 "del sistema"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "Este paquete no parece haberse instalado correctamente"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -55,7 +55,7 @@ msgstr ""
 "actualizar los índices de paquetes disponibles; si eso no funciona, "
 "desinstale los paquetes de terceros relacionados y reintente."
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -68,21 +68,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "programa desconocido"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "El programa «%s» se cerró inesperadamente"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Problema en %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -90,65 +90,65 @@ msgstr ""
 "Su equipo no tiene memoria libre suficiente para analizar el problema "
 "automáticamente y enviar un informe a los desarrolladores."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Informe de problema no válido"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "No tiene permitido acceder a este informe de problema."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Error"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 "No hay suficiente espacio de disco disponible para procesar este informe."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr "No se ha especificado ningún PID"
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr "Debe especificar un PID. Vea --help para obtener más información."
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "PID no válido"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr "El ID de proceso especificado no existe."
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr "No es su PID"
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr "El ID de proceso especificado no le pertenece."
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "No se especificó ningún paquete"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Necesita especificar un paquete o un PID. Consulte --help para más "
 "información."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Permiso denegado"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -156,30 +156,30 @@ msgstr ""
 "El proceso especificado no le pertenece. Ejecute este programa como "
 "propietario del proceso o como superusuario."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "El ID de proceso especificado no pertenece a ningún programa."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "El script de síntomas %s no determinó ningún paquete afectado"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "El paquete %s no existe"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "No se puede crear el informe"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "Informe de problema con actualización"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -191,7 +191,7 @@ msgstr ""
 "\n"
 "Cree un informe nuevo usando «apport-bug»."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -212,24 +212,24 @@ msgstr ""
 "\n"
 "¿Está seguro de que quiere continuar?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "No se ha recopilado información adicional."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "¿De qué tipo de problema quiere informar?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Síntoma desconocido"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "El síntoma «%s» es desconocido."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -248,7 +248,7 @@ msgstr ""
 "En la pestaña Procesos, desplácese por la lista hasta hallar la aplicación "
 "correcta. El identificador es el número que se muestra en la columna Id."
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -256,25 +256,25 @@ msgstr ""
 "Después de cerrar este mensaje pulse en una ventana de aplicación para "
 "informar acerca de un problema con ella."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop falló al determinar la ID de proceso de la ventana"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr "%(prog)s <número de informe>"
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "Especifique el nombre del paquete."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Añade una etiqueta adicional al informe. Se puede especificar varias veces."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
@@ -282,7 +282,7 @@ msgstr ""
 "%(prog)s [opciones] [síntoma|pid|paquete|ruta del programa|archivo .apport/."
 "crash]"
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -293,17 +293,17 @@ msgstr ""
 "lista de síntomas conocidos. (Implícito si se proporciona un único "
 "argumento.)"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "Pulse una ventana como objetivo para rellenar un informe de problema."
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "Iniciar en modo de actualización de errores. Admite un parámetro --package "
 "opcional."
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -311,7 +311,7 @@ msgstr ""
 "Rellenar un informe de error acerca de un síntoma. (Implícito si se "
 "proporciona un nombre de síntoma como único argumento)."
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -320,7 +320,7 @@ msgstr ""
 "un --pid es especificado. (Implícito si se ha dado un nombre de paquete como "
 "un único argumento)."
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -330,11 +330,11 @@ msgstr ""
 "el informe de error contendrá más información. (Implica si pid se da como un "
 "argumento solo.)"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "El pid proporcionado es una aplicación colgada."
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -344,7 +344,7 @@ msgstr ""
 "lugar de los pendientes en %s. (Implícito si se indica el archivo como único "
 "argumento.)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -354,34 +354,34 @@ msgstr ""
 "archivo en vez de enviarla. Este archivo se puede enviar más tarde desde un "
 "equipo diferente."
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Mostrar el número de versión de Apport"
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr "Esto ejecutará apport-retrace en una terminal para examinar la falla."
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "Ejecutar una sesión gdb"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Ejecutar una sesión gdb sin descargar símbolos de depuración"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Actualizar %s con una pila de seguimiento completamente simbólica"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr "No se puede recordar la preferencia sobre enviar estados de informes"
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -402,7 +402,7 @@ msgid ""
 msgstr ""
 "El problema ocurrió con el programa %s, que ha sido modificado desde esa vez."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "El informe del problema está dañado y no puede procesarse."
 
@@ -432,14 +432,14 @@ msgstr "«Snap» de %s"
 msgid "%s deb package"
 msgstr "Paquete .deb de %s"
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s se ofrece como «snap», el cual publica %s. Póngase en contacto con ellos "
 "a través de %s (en inglés) para obtener ayuda."
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -449,41 +449,41 @@ msgstr ""
 "dirección de contacto; visite el foro en https://forum.snapcraft.io (en "
 "inglés) para obtener ayuda."
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "No se pudo determinar el nombre del paquete binario o fuente."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "No se puede arrancar el navegador web"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "No se puede arrancar el navegador web para abrir %s."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Problemas con la red"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "No es posible la conexión con la base de datos de errores, por favor, "
 "verifique su conexión a Internet."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Memoria agotada"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Su sistema no tiene la memoria suficiente para procesar este informe de "
 "fallo."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -494,11 +494,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "Problema ya conocido"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -508,7 +508,7 @@ msgstr ""
 "mostrado en el navegador web. Por favor, compruebe si puede añadir cualquier "
 "información adicional que pudiera resultar de utilidad a los desarrolladores."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Ya se ha informado de este problema a los desarrolladores. ¡Gracias!"
 
@@ -876,7 +876,7 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Error: %s no es un ejecutable. Parando."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -884,7 +884,7 @@ msgstr ""
 "El evento se produjo durante una suspensión anterior y evitó que el sistema "
 "se reanudara adecuadamente."
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -892,7 +892,7 @@ msgstr ""
 "El evento se produjo durante una hibernación anterior y evitó que el sistema "
 "se reanudara adecuadamente."
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/et.po
+++ b/po/et.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2013-08-28 23:23+0000\n"
 "Last-Translator: olavi tohver <Unknown>\n"
 "Language-Team: Estonian <et@li.org>\n"
@@ -36,11 +36,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr ""
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -61,21 +61,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "tundmatu programm"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Vabandust, programm \"%s\" sulgus ootamatult"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Probleem %s ga"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -83,62 +83,62 @@ msgstr ""
 "Sinu arvutil ei ole piisavalt vaba mälu probleemi automaatse analüüsi ja "
 "arendajate teavitamise jaoks."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Ebasobiv vearaport"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "Sul puudub ligipääs sellele vearaportile."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Viga"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "Vearaporti käsitsemiseks pole piisavalt vaba kettaruumi."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "Vigane PID"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "Pakett määramata"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr "Sa pead määrama paketi või PID-i. Vaata --help lisainfo jaoks."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Ligipääs keelatud"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -146,30 +146,30 @@ msgstr ""
 "Valitud protsess ei kuulu sulle. Palun käivita see programm protsessi "
 "omaniku või administraatorina."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "Protsessi ID ei kuulu ühelegi programmile."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Sümptomiskript %s ei tuvastanud seotud paketti"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Paketti %s ei leitud"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "Raportit ei õnnestu luua"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "Probleemiraporti uuendamine"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -181,7 +181,7 @@ msgstr ""
 "\n"
 "Palun luua uus raport kasutades \"apport-bug\" käsku."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -193,24 +193,24 @@ msgid ""
 "Do you really want to proceed?"
 msgstr ""
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "Täiendavaid andmeid ei kogutud."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "Mis liiki veast sa tahad raporteerida?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Tundmatu sümptom"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Sümptom \"%s\" pole teada."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -221,7 +221,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -229,109 +229,109 @@ msgstr ""
 "Probleemist teatamiseks vajuta peale selle sõnumi sulgemist probleemse "
 "rakenduse aknal."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "Täpsusta paketi nimi."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr ""
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "Käivita gdb sessioon"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -348,7 +348,7 @@ msgid ""
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "See vearaport on rikutud ja seetõttu ei ole võimalik seda käsitseda."
 
@@ -376,50 +376,50 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "Paketi või lähtekoodi paketi nime ei suudetud tuvastada."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "Veebisirvija käivitamine ebaõnnestus"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr ""
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Probleem võrguühendusega"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Ei saa ühendust krahhide andmebaasiga, palun kontrolli oma internetiühendust."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Mälu ammendatud"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "Sinu arvutil pole piisavalt mälu selle krahhirapordi käsitlemiseks."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -430,11 +430,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "Probleem on varasemast teada"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -443,7 +443,7 @@ msgstr ""
 "Sellest probleemist teavitati juba veebisirvijas nähaolevas vearaportis. "
 "Palun vaata, kas sul on arendajate jaoks olulist informatsiooni, mida lisada."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 
@@ -763,19 +763,19 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Viga: %s ei ole käivitusfail. Katkestan."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/eu.po
+++ b/po/eu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2020-03-25 16:37+0000\n"
 "Last-Translator: Ibai Oihanguren Sala <Unknown>\n"
 "Language-Team: Basque <eu@li.org>\n"
@@ -38,11 +38,11 @@ msgstr "Sistemako arazoaren jakinarazpena"
 msgid "Please enter your password to access problem reports of system programs"
 msgstr "Sartu pasahitza sistemako programen arazoen txostenak atzitzeko"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "Paketea ez dela behar bezala instalatu dirudi"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -50,7 +50,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -63,21 +63,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "programa ezezaguna"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Lastima, ustekabean itxi da \"%s\" programa"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Arazoa %s-n"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -85,63 +85,63 @@ msgstr ""
 "Zure ordenagailuak ez dauka memoria aske nahikorik arazoa automatikoki "
 "aztertu eta garatzaileei txosten bat bidaltzeko."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Arazoaren txosten baliogabea"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "Ez daukazu errore-txosten hau eskuratzeko baimenik."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Errorea"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "Diskoan ez dago txostena prozesatzeko leku libre nahikorik."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "PID baliogabea"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr "Zehazturiko prozesu-IDa ez da existitzen."
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr "Ez da zure PIDa"
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr "Ez zara zehazturiko prozesu-IDaren jabea."
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "Ez da paketerik zehaztu"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Pakete edo PID bat zehaztu behar duzu. Informazio gehiagorako, ikusi --help."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Baimena ukatuta"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -149,30 +149,30 @@ msgstr ""
 "Zehaztutako prozesua ez da zurea. Exekutatu programa hau  jabe moduan edo "
 "erro moduan."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "Zehaztutako prozesu-IDa ez dagokio inongo programari."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "%s script sintomak ez du determinatzen eraginda dagoen pakete bat"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "%s paketea ez da existitzen"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "Ezin da txostena sortu"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "Arazoaren txostena eguneratzen"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -184,7 +184,7 @@ msgstr ""
 "\n"
 "Sortu txosten berri bat \"apport-bug\" erabiliz."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -205,24 +205,24 @@ msgstr ""
 "\n"
 "Ziur aurrera jarraitu nahi duzula?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "Ez dago bilduta informazio gehiago."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "Zein arazo-motaren berri eman nahi duzu?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Sintoma ezezaguna"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "\"%s\" sintoma ezezaguna da."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -233,7 +233,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -241,31 +241,31 @@ msgstr ""
 "Mezu hau itxi ondoren egin klik aplikazioaren leiho baten gainean eta eman "
 "arazoaren berri."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop-ek ezin izan du leihoaren prozesu-IDa ebatzi"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "Zehaztu pakete-izena."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Gehitu etiketa gehigarri bat txostenari. Hainbat alditan zehaztu daiteke."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -275,18 +275,18 @@ msgstr ""
 "edo --pid bakarrik. Ezer ez zehaztuz gero, sintoma ezagunen zerrenda bat "
 "bistaratzen da. (Inplizitua argumentu bakarra zehaztuz gero.)"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 "Egin klik leiho baten gainean, leiho hori helburu gisa jartzeko arazoaren "
 "berri ematean."
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "Hasi erroreak eguneratzeko moduan. Aukerazko --package bat hartu dezake."
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -294,7 +294,7 @@ msgstr ""
 "Sintoma baten berri emateko txostena bete. (Inplizitua sintomaren izena "
 "zehaztuz gero argumentu bakar bezala.)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -303,18 +303,18 @@ msgstr ""
 "zehaztu bada. (Inplizitua pakete-izen bakarra zehaztuz gero argumentu bakar "
 "bezala.)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -324,41 +324,41 @@ msgstr ""
 "%s(e)koen ordez. (Inplizitua fitxategi bat zehaztuz gero argumentu bakar "
 "bezala.)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Apport bertsio-zenbakia erakutsi."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "Exekutatu gdb saioa"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Exekutatu gdb saioa arazte-sinboloak deskargatu gabe"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Eguneratu %s stack trace erabat sinbolikoarekin"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -376,7 +376,7 @@ msgid ""
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Txosten hau kalteturik dago eta ezin da prozesatua izan."
 
@@ -404,51 +404,51 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "Ezin izan da paketearen edo jatorrizko paketearen izena zehaztu."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "Ezin izan da web-arakatzailea abiarazi"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Ezin izan da web-arakatzailea abiarazi %s irekitzeko."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Sarearen arazoa"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Ezin kraskatze-datubasera konektatu, zure Internet-konexioa egiaztatu ezazu."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Memoriaren agortzea"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Zure sistemak ez dauka kraskatzearen txostena prozesatzeko memoria nahiko."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -459,11 +459,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "Arazoa ezaguna da jadanik"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -473,7 +473,7 @@ msgstr ""
 "garatzaileentzat lagungarria izan daitekeen informazio gehiago eman "
 "dezakezun egiaztatu ezazu."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Dagoeneko eman zaie arazoaren berri garatzaileei. Eskerrik asko!"
 
@@ -817,19 +817,19 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Errorea: %s ez da exekutagarria. Gelditzen."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2022-03-11 13:14+0000\n"
 "Last-Translator: Tuomas Lähteenmäki <Unknown>\n"
 "Language-Team: Finnish <fi@li.org>\n"
@@ -38,11 +38,11 @@ msgstr "Järjestelmän ongelmaraportit"
 msgid "Please enter your password to access problem reports of system programs"
 msgstr "Anna salasanasi nähdäksesi järjestelmäohjelmien ongelmaraportteja"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "Tätä pakettia ei ole asennettu oikein"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -53,7 +53,7 @@ msgstr ""
 "olevan pakettiluettelon päivittämisen jälkeen. Jos se ei auta, poista asiaan "
 "liittyvät kolmannen osapuolen paketit ja yritä uudelleen."
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -66,21 +66,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "tuntematon sovellus"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Ikävä kyllä ohjelma \"%s\" sulkeutui yllättäen"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Ongelma osan %s kanssa"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -88,64 +88,64 @@ msgstr ""
 "Muistia ei ole vapaana tarpeeksi ongelman automaattiseen analysointiin ja "
 "virheraportin lähettämiseen."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Virheellinen ongelmaraportti"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "Sinulla ei ole lukuoikeuksia tähän ongelmaraporttiin."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Virhe"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "Levyllä ei ole tarpeeksi tilaa raportin käsittelyyn."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr "PID:iä ei määritetty"
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr "Sinun tulee määrittää PID. Katso --help saadaksesi lisätietoja."
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "PID-numero ei kelpaa"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr "Määriteltyä prosessitunnistetta ei ole."
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr "Ei sinun PID"
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr "Määritelty prosessitunniste ei kuulu sinulle."
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "Pakettia ei ole määritelty"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Paketti tai PID-tunniste on annettava. Katso lisätietoja käyttämällä "
 "valitsinta --help."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Lupa evätty"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -153,30 +153,30 @@ msgstr ""
 "Kyseinen prosessi ei kuulu sinulle. Aja tämä ohjelma prosessin omistajana "
 "tai pääkäyttäjänä."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "Määritetty prosessin ID-numero ei kuulu kyseiselle ohjelmalle."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Oirekomentosarja %s ei määritellyt vaikuttanutta pakettia"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Pakettia %s ei ole olemassa"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "Raporttia ei voida luoda"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "Päivitetään ongelmaraporttia"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -188,7 +188,7 @@ msgstr ""
 "\n"
 "Ole hyvä, ja luo uusi raportti käyttäen \"apport-bug\" määrittelyä."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -209,24 +209,24 @@ msgstr ""
 "\n"
 "Haluatko todella jatkaa?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "Lisätietoja ei kerätty."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "Millainen ongelma raportoidaan?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Tuntematon ongelma"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Ongelmaa \"%s\" ei tunnistettu."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -245,7 +245,7 @@ msgstr ""
 "Prosessit-välilehteä, kunnes löydät oikean sovelluksen. Prosessin tunnus on "
 "ID-sarakkeessa oleva numero."
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -253,31 +253,31 @@ msgstr ""
 "Kun olet sulkenut tämän viestin napsauta sen sovelluksen ikkunaa, johon "
 "liittyvän virheraportin haluat tehdä."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop ei onnistunut selvittämään ikkunaan ID-tunnistenumeroa"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "Määritä paketin nimi."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Lisää raporttiin liittyvä tunniste. Tämä voidaan tehdä useampia kertoja."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -287,17 +287,17 @@ msgstr ""
 "pid:n, tai vain --pid:n. Jos kumpaakaan ei anneta, näytä lista tunnetuista "
 "oireista. (Epäsuora jos yksi argumentti on annettu.)"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "Napsauta ikkunaa, johon liittyvän virheraportin haluat tehdä."
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "Aloita ohjelmavirheiden päivitystilassa. Voi ottaa valinnaisen valitsimen --"
 "package."
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -305,7 +305,7 @@ msgstr ""
 "Arkistoi ohjelmavirheen raportti oireena. (Epäsuorasti jos oireen nimi on "
 "annettu vain argumenttina.)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -313,7 +313,7 @@ msgstr ""
 "Määritä paketin nimi --file-bug-tilassa. Tämä on valinnainen jos --pid on "
 "määritetty. (Epäsuorasti jos paketin nimi on annettu vain argumenttina.)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -323,11 +323,11 @@ msgstr ""
 "virheraportti sisältää enemmän tietoa.  (Epäsuorasti, jos pid on annettu "
 "ainoana argumenttina.)"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "Annettu pid on ohjelma, joka ei vastaa."
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -336,7 +336,7 @@ msgstr ""
 "Raportoi kaatuminen annetusta .apport tai .crash-tiedostosta odottavien "
 "sijaan kohdassa %s. (Epäsuora jos tiedosta on annettu vain argumenttina.)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -346,34 +346,34 @@ msgstr ""
 "raportoimisen sijaan. Tämä tiedosto voidaan raportoida myöhemmin toiselta "
 "koneelta."
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Tulosta Apport-versionumero."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr "Tämä käynnistää apport-retracen pääteikkunnassa ongelman tutkimiseksi."
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "Käynnistä gdb sessiossa"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Suorita gdb-istunto ilman virheenjäljityssymbolien lataamista"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Päivitä %s täysin symbolisella pinolistauksella"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr "Ei muisteta raportin lähetystilan asetuksia"
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -392,7 +392,7 @@ msgid ""
 "occurred."
 msgstr "Ongelma koskee ohjelmaa %s, joka on muuttunut kaatumisen jälkeen."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Tämä ongelman raportti on vahingoittunut, eikä sitä voida käsitellä."
 
@@ -422,14 +422,14 @@ msgstr "%s snap"
 msgid "%s deb package"
 msgstr "%s deb paketti"
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s tarjotaan snap-muodossa, ja sen julkaisija on %s. Ole yhteydessä käyttäen "
 "%s saadaksesi apua."
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -439,39 +439,39 @@ msgstr ""
 "ei ole määritetty; käy keskustelualueella osoitteessa https://forum."
 "snapcraft.io/ saadaksesi apua."
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "Paketin tai lähdekoodipaketin nimeä ei voi määrittää."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "Selaimen käynnistäminen epäonnistui"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Verkkoselainta ei saatu käynnistettyä avattaessa sivua %s."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Verkko-ongelma"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Kaatumistietokantaan ei voi yhdistää. Tarkista Internet-yhteyden toimivuus."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Muisti ei riitä"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Järjestelmässäsi ei ole tarpeeksi muistia tämän kaatumisraportin käsittelyyn."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -482,11 +482,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "Ongelma on jo tiedossa"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -495,7 +495,7 @@ msgstr ""
 "Tämä ongelma raportoitiin jo virheraportissa, joka on näkyvissä selaimessa. "
 "Tarkista, voisitko lisätä joitakin kehittäjiä auttavaa tietoa."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 "Tästä ongelmasta on jo ilmoitettu kehittäjille. Kiitos kuitenkin "
@@ -854,7 +854,7 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Virhe: %s ei ole suoritettava tiedosto. Lopetetaan."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -862,7 +862,7 @@ msgstr ""
 "Tämä tapahtui edellisen valmiustilan aikana ja esti järjestelmää "
 "palautumasta oikein."
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -870,7 +870,7 @@ msgstr ""
 "Tämä tapahtui edellisen lepotilan aikana ja esti järjestelmää palautumasta "
 "oikein."
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:45+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2015-12-23 11:09+0000\n"
 "Last-Translator: Anne017 <Unknown>\n"
 "Language-Team: French <fr@li.org>\n"
@@ -40,11 +40,11 @@ msgstr ""
 "Veuillez saisir votre mot de passe pour accéder à des rapports de problèmes "
 "de programmes système"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "Ce paquet ne semble pas installé correctement."
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -55,7 +55,7 @@ msgstr ""
 "à jour des index de paquets proposés. Si cela ne fonctionne pas, supprimez "
 "alors les paquets tiers associés et réessayez."
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -69,21 +69,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "programme inconnu"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Désolé, le programme « %s » a quitté de façon inattendue"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Problème dans %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -91,64 +91,64 @@ msgstr ""
 "Votre ordinateur ne possède pas suffisamment de mémoire libre pour analyser "
 "automatiquement le problème et envoyer un rapport aux développeurs."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Rapport d'anomalie non valide"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "Vous n'êtes pas autorisé à accéder à ce rapport d'anomalie."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Erreur"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "Il n'y a pas assez d'espace disque disponible pour traiter ce rapport."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr "Aucun PID n’est indiqué"
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr "Vous devez indiquer un PID. Voir --help pour plus de précisions"
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "PID non valide"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr "L'ID de processus indiqué n'existe pas."
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr "Pas votre PID"
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr "L’identifiant de processus indiqué ne vous appartient pas."
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "Aucun paquet spécifié"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Vous devez préciser un paquet ou un PID. Utilisez --help pour plus "
 "d'informations."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Autorisation refusée"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -157,30 +157,30 @@ msgstr ""
 "en tant que propriétaire du processus ou en tant que super-utilisateur "
 "(root)."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "L'ID de processus spécifié n'appartient à aucun programme."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Le script  %s n'a pas pu déterminer un paquet affecté"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Le paquet %s n'existe pas"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "Impossible de créer le rapport"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "Mise à jour du rapport d'anomalie"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -192,7 +192,7 @@ msgstr ""
 "\n"
 "Veuillez créer un nouveau rapport en utilisant « apport-bug »."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -213,24 +213,24 @@ msgstr ""
 "\n"
 "Voulez-vous vraiment continuer ?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "Aucune information supplémentaire n'a été collectée."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "Quel type de problème voulez-vous signaler ?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Symptôme inconnu"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Le symptôme « %s » est inconnu."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -241,7 +241,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -249,32 +249,32 @@ msgstr ""
 "Après avoir fermé ce message, veuillez cliquer sur la fenêtre de "
 "l'application pour laquelle vous voulez signaler un problème."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop n'a pas pu déterminer l'ID du processus de la fenêtre"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "Veuillez indiquer le nom du paquet."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Ajouter un marqueur supplémentaire pour le rapport. Peut être spécifié "
 "plusieurs fois."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -284,15 +284,15 @@ msgstr ""
 "pid en option, ou simplement --pid. Si aucun n'est fournit, affiche une "
 "liste de symptômes connus. (Implicite si un seul argument est fournit.)"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "Cliquez sur la fenêtre pour laquelle vous voulez signaler un problème."
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "Démarrer en mode de mise à jour de bogue. Accepte l’option --package."
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -300,7 +300,7 @@ msgstr ""
 "Rédiger un rapport de bogue concernant un symptôme. (Implicite si le nom du "
 "symptôme est donné comme unique argument.)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -309,7 +309,7 @@ msgstr ""
 "--pid est spécifié. (Implicite si le nom du paquet est donné comme unique "
 "argument.)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -319,11 +319,11 @@ msgstr ""
 "spécifié, le rapport de bogue contiendra davantage d'informations. "
 "(implicite si l’identifiant du processus est passé comme unique argument)"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "Le pid fourni est une application qui ne répond pas."
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -333,7 +333,7 @@ msgstr ""
 "qu'à partir de ceux en attente dans %s. (Implicite si le fichier est donné "
 "comme unique argument.)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -343,36 +343,36 @@ msgstr ""
 "un fichier au lieu de générer un rapport. Ce fichier pourra être utilisé "
 "plus tard à partir d'une autre machine pour envoyer un rapport."
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Afficher le numéro de version d'Apport."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Cela va lancer apport-retrace dans une fenêtre de terminal pour examiner le "
 "plantage."
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "Lancer une session gdb"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Exécuter la session gdb sans télécharger les symboles de débogage"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Mettre %s à jour avec une trace de pile entièrement symbolique"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr "Impossible de se souvenir des paramètres d'état du rapport d'envoi"
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -392,7 +392,7 @@ msgid ""
 "occurred."
 msgstr "Le problème concerne le programme %s qui a changé depuis le plantage."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Ce rapport d'anomalie est endommagé et ne peut pas être traité."
 
@@ -422,14 +422,14 @@ msgstr "Snap %s"
 msgid "%s deb package"
 msgstr "Paquet deb %s"
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s est fourni par un snap publié par %s. Contactez-les via %s pour obtenir "
 "de l'aide."
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -439,40 +439,40 @@ msgstr ""
 "indiquée ; visitez le forum à l’adresse https://forum.snapcraft.io/ pour "
 "obtenir de l’aide."
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "Impossible de déterminer le nom du paquet ou du paquet source."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "Impossible de lancer le navigateur Web"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Impossible de lancer le navigateur Web pour ouvrir %s."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Problème de réseau"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Impossible de se connecter à la base de données des plantages. Veuillez "
 "vérifier votre connexion Internet."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Mémoire saturée"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Votre système n'a pas assez de mémoire pour traiter ce rapport de plantage."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -483,11 +483,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "Problème déjà connu"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -497,7 +497,7 @@ msgstr ""
 "navigateur Web. Veuillez vérifier si vous pouvez ajouter des informations "
 "complémentaires susceptibles d'aider les développeurs."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Ce problème a déjà été signalé aux développeurs. Merci !"
 
@@ -865,7 +865,7 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Erreur : %s n'est pas un exécutable. Arrêt."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -873,7 +873,7 @@ msgstr ""
 "Cela s'est produit lors d'une mise en veille précédente et a empêché la "
 "bonne reprise du système."
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -881,7 +881,7 @@ msgstr ""
 "Cela s'est produit lors d'une mise en veille prolongée précédente et a "
 "empêché la bonne reprise du système."
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/fr_CA.po
+++ b/po/fr_CA.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2015-04-27 21:45+0000\n"
 "Last-Translator: Martin Pitt <martin@piware.de>\n"
 "Language-Team: French (Canada) <fr_CA@li.org>\n"
@@ -40,11 +40,11 @@ msgstr ""
 "Veuillez saisir votre mot de passe pour accéder aux relevés de problèmes des "
 "programmes système"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "Ce paquet ne semble pas être installé correctement."
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -55,7 +55,7 @@ msgstr ""
 "à jour des index de paquets proposés. Ssi cela ne fonctionne pas, supprimez "
 "alors les paquets tiers associés et réessayez."
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -69,21 +69,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "programme inconnu"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Désolé, le programme « %s » s'est fermé de façon inattendue"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Problème dans %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -91,64 +91,64 @@ msgstr ""
 "Votre ordinateur n’a pas assez de mémoire libre pour analyser "
 "automatiquement le problème et envoyer un relevé aux développeurs."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Le relevé de problème est invalide"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "Vous n’êtes pas autorisé à accéder à ce relever de problème."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Erreur"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "Il n’y a pas assez d’espace disque libre pour traiter ce relevé."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr "Aucun PID n’est indiqué"
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr "Vous devez indiquer un PID. Voir --help pour plus de précisions"
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "PID invalide"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr "L’ID de processus indiqué n’existe pas."
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr "N’est pas votre PID"
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr "L’ID de processus indiqué ne vous appartient pas."
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "Aucun paquet n’est indiqué"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Vous devez préciser un paquet ou un PID. Voir --help pour plus "
 "d'informations."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Permission refusée"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -156,30 +156,30 @@ msgstr ""
 "Le processus indiqué ne vous appartient pas. Veuillez exécuter ce programme "
 "en tant que propriétaire du processus ou en tant que root."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "L'ID de processus indiqué n’appartient à aucun programme."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Le script symptome %s n'a pas déterminé un paquet affecté"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Le paquet %s n'existe pas"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "Impossible de créer le relevé"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "Mise à jour du relevé de problème"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -191,7 +191,7 @@ msgstr ""
 "\n"
 "Veuillez créer un nouveau relevé en utilisant « apport-bug »."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -212,24 +212,24 @@ msgstr ""
 "\n"
 "Voulez-vous vraiment continuer ?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "Aucune autre information n'a été recueillie."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "Quel sorte de problème voulez-vous signaler?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Symptôme inconnu"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Le symptôme « %s » est inconnu."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -240,7 +240,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -248,32 +248,32 @@ msgstr ""
 "Après avoir fermé ce message, veuillez cliquer sur la fenêtre de "
 "l’application pour laquelle vous voulez signaler un problème."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop n'a pas pu déterminer l'ID du processus de la fenêtre"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "Indiquer le nom du paquet."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Ajouter une balise supplémentaire au relevé. Peut être indiquée plusieurs "
 "fois."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -283,15 +283,15 @@ msgstr ""
 "option, ou juste --pid. Si aucun n'est donné, afficher une liste de "
 "symptômes connus. (Implicite si un seul argument est donné.)"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "Cliquer sur une fenêtre qui sera la cible du relevé de problème."
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "Démarrer en mode de mise à jour de bogue. Accepte l’option --package."
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -299,7 +299,7 @@ msgstr ""
 "Rédiger un relevé de bogue relatif à un symptôme. (Implicite si le nom du "
 "symptôme est donné comme seul argument.)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -308,7 +308,7 @@ msgstr ""
 "--pid est indiqué. (Implicite si le nom du paquet est donné comme seul "
 "argument.)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -318,11 +318,11 @@ msgstr ""
 "relevé de bogue contiendra plus d’informations. (implicite si le pid est "
 "donné comme seul argument)"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "Le pid fourni est une application bloquée."
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -332,7 +332,7 @@ msgstr ""
 "qu’à partir de ceux en attente dans %s. (Implicite si le fichier est donné "
 "comme seul argument.)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -342,36 +342,36 @@ msgstr ""
 "un fichier au lieu de les signaler. Ce fichier pourra ensuite être signalé "
 "plus tard à partir d'une machine différente."
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Imprimer le numéro de version d'Apport."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "apport-retrace sera lancé dans une fenêtre de terminal pour examiner le "
 "plantage."
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "Exécuter une session gdb"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Exécuter une session gdb sans télécharger les symboles de débogage"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Mettre %s à jour avec une trace de pile entièrement symbolique"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr "Impossible de se souvenir des paramètres d'état du relevé d'envoi"
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -391,7 +391,7 @@ msgid ""
 msgstr ""
 "Le problème est survenu avec le programme %s qui a changé depuis le plantage."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Ce relevé de problème est endommagé et ne peut pas être traité."
 
@@ -421,14 +421,14 @@ msgstr "Snap %s"
 msgid "%s deb package"
 msgstr "Paquet deb %s"
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s est fourni par un snap publié par %s. Contactez-les par %s pour obtenir "
 "de l’aide."
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -438,40 +438,40 @@ msgstr ""
 "indiquée ; visitez le forum à l’adresse https://forum.snapcraft.io/ pour "
 "obtenir de l’aide."
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "Impossible de déterminer le nom du paquet ou du paquet source."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "Impossible de démarrer le navigateur Web"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Impossible de démarrer le navigateur Web pour ouvrir %s."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Problème de réseau"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Impossible de se connecter à la base de données des plantages. Veuillez "
 "vérifier votre connexion Internet."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Mémoire pleine"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Votre système n’a pas assez de mémoire pour traiter ce relevé de plantage."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -482,11 +482,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "Problème déjà connu"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -496,7 +496,7 @@ msgstr ""
 "navigateur Web. Veuillez vérifier si vous pouvez ajouter des renseignements "
 "complémentaires susceptibles d’aider les développeurs."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Ce problème a déjà été signalé aux développeurs. Merci!"
 
@@ -864,7 +864,7 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Erreur : %s n'est pas un exécutable. Arrêt."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -872,7 +872,7 @@ msgstr ""
 "Cela s'est produit lors d'une mise en veille précédente et a empêché la "
 "reprise correcte du système."
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -880,7 +880,7 @@ msgstr ""
 "Cela s'est produit lors d'une mise en veille prolongée précédente et a "
 "empêché la reprise correcte du système."
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/gd.po
+++ b/po/gd.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2016-01-29 01:13+0000\n"
 "Last-Translator: Akerbeltz <fios@akerbeltz.org>\n"
 "Language-Team: Gaelic; Scottish <gd@li.org>\n"
@@ -40,11 +40,11 @@ msgstr ""
 "Cuir a-steach am facal-faire agad gus cothrom fhaighinn air aithrisean mu "
 "dhèidhinn duilgheadas a bha aig prògraman a t-siostaim"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "Tha coltas nach deach a' phacaid seo a stàladh mar bu chòir"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -52,7 +52,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -65,21 +65,21 @@ msgstr ""
 "\n"
 " %s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "prògram neo-aithnichte"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Tha sinn duilich ach dhùin am prògram \"%s\" gu h-obann."
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Duilgheadas ann an %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -88,64 +88,64 @@ msgstr ""
 "dha an duilgheadas a sgrùdadh gu fèin-obrachail is aithris a chur dhan luchd-"
 "leasachaidh."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Aithris duilgheadais mhì-dhligheach"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "Chan eil cead-inntrigidh agad dhan aithris duilgheadais seo."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Mearachd"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "Chan eil àite gu leòr air an diosg gus an aithris seo a làimhseachadh."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "PID mì-dhligheach"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "Cha deach pacaid a shònrachadh"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Feumaidh tu pacaid no PID a shònrachadh. Faic --help airson barrachd "
 "fiosrachaidh."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Chaidh cead a dhiùltadh"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -153,30 +153,30 @@ msgstr ""
 "Chan eil am pròiseas a shònraich thu a' buntainn riut. Ruith am prògram seo "
 "mar shealbhadair a' phròiseis no mar root."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "Chan eil ID a' phròiseis a shònraich thu a' buntainn do phrògram."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Cha do lorg an sgriobt %s pacaid air a bheil buaidh"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Chan eil a' phacaid %s ann"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "Cha ghabh an aithris a chruthachadh"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "Ag ùrachadh aithris an duilgheadais"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -189,7 +189,7 @@ msgstr ""
 "\n"
 "Cruthaich aithris ùr le \"apport-bug\"."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -209,24 +209,24 @@ msgstr ""
 "\n"
 "A bheil thu cinnteach gu bheil thu airson leantainn air adhart?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "Cha deach fiosrachadh a bharrachd a chruinneachadh."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "Dè seòrsa duilgheadas tha thu airson aithris a dhèanamh air?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Buaidh nach aithne dhuinn"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Chan aithne dhuinn a' bhuaidh \"%s\"."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -237,7 +237,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -245,32 +245,32 @@ msgstr ""
 "An dèidh dhut an teachdaireachd seo a dhùnadh. briog air uinneag aplacaid "
 "gus aithris a dhèanamh air duilgheadas leis."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "Cha b' urrainn dha xprop ID pròiseas na h-uinneige a dhearbhadh"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "Sònraich ainm na pacaid."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Cuir taga a bharrachd ris an aithris. 'S urrainn dhut a shònrachadh iomadh "
 "turas."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -281,17 +281,17 @@ msgstr ""
 "de bhuaidhean air a bheil eòlas. (Tuigear dheth seo ma tha argamaid "
 "shingilte air a chur ann)."
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "Briog air uinneag mar thargaid gus aithris a dhèanamh air duilgheadas."
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "Tòisich sa mhodh ùrachadh bhugaichean. Gabhaidh seo ri --package ma tha feum "
 "air."
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -299,7 +299,7 @@ msgstr ""
 "Clàraich buga mu dhèidhinn buaidh. (Tuigear dheth seo mas e ainm na buaidhe "
 "an aon argamaid.)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -307,7 +307,7 @@ msgstr ""
 "Sònraich ainm na pacaid sa mhodh --file-bug. Tha seo roghainneil ma chaidh --"
 "pid a shònrachadh. (Tuigear dheth seo mas e ainm na pacaid an aon argamaid.)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -317,11 +317,11 @@ msgstr ""
 "shònrachadh, bidh barrachd fiosrachaidh san aithris. (Tuigear dheth seo mas "
 "e pid an aon argamaid.)"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "Tha am pid a shònraich thu 'na aplacaid chrochte."
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -331,7 +331,7 @@ msgstr ""
 "an fheadhainn a tha ri dhèiligeadh ann an %s. (Tuigear dheth seo mas e am "
 "faidhle an aon argamaid.)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -342,38 +342,38 @@ msgstr ""
 "urrainn dhut aithris a dhèanamh leis an fhaidhle às a dhèidh sin no o "
 "choimpiutair eile."
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Clò-bhuail àireamh an tionndaidh aig Apport."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Cuireadh seo air bhog apport-retrace ann an uinneag tèirmineil gus sgrùdadh "
 "a dhèanamh air an tuisleadh."
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "Ruith seisean gdb"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 "Ruith seisean gdb as aonais gun a bhith a' luchdadh a-nuas nan samhlaidhean "
 "dì-bhugachaidh"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Ùraich %s le Stack Trace a tha gu tur samhlach"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -394,7 +394,7 @@ msgstr ""
 "Thachair an duilgheadas leis a' phrògram %s ach chaidh atharrachadh on a "
 "thachair an tuisleadh."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Chaidh an aithris seo a dhochann is cha ghabh a làimhseachadh."
 
@@ -424,54 +424,54 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr ""
 "Cha b' urrainn dhuinn a' phacaid no ainm na pacaid thùsail a dhearbhadh."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "Chan urrainn dhuinn brabhsair-lìn a thòiseachadh"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Chan urrainn dhuinn brabhsair-lìn a thòiseachadh gus %s fhosgladh."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Duilgheadas leis an lìonra"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Chan urrainn dhuinn ceangal ri stòr-dàta nan tuisleadh, thoir sùil air a' "
 "cheangal agad ris an eadar-lìon."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Gainnead cuimhne"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Chan eil cuimhne gu leòr air an t-siostam agad is chan urrainn dha aithris "
 "an tuislidh seo a làimhseachadh."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -482,11 +482,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "Tha sinn eòlach air an duilgheadas seo mu thràth"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -496,7 +496,7 @@ msgstr ""
 "aithris a' bhuga sa bhrabhsair-lìn agad. Thoir sùil ach a bheil fiosrachadh "
 "ùr sam bith agad a dh'fhaodadh a bhith feumail dhan luchd-leasachaidh."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 "Fhuair an luchd-leasachaidh aithris air an duilgheadas seo mu thràth. Tapadh "
@@ -873,7 +873,7 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Mearachd: Chan eil %s 'na rud so-ghnìomhaichte. A' sgur dheth."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -881,7 +881,7 @@ msgstr ""
 "Thachair seo nuair a chaidh a chur ’na dhàil roimhe agus cha b’ urrainn dhan "
 "t-siostam leantainn air adhart mar bu chòir ri linn."
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -889,7 +889,7 @@ msgstr ""
 "Thachair seo nuair a chaidh a chur ’na chadal-geamhraidh roimhe agus cha b’ "
 "urrainn dhan t-siostam leantainn air adhart mar bu chòir ri linn."
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/gl.po
+++ b/po/gl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2017-03-15 22:17+0000\n"
 "Last-Translator: Xosé <Unknown>\n"
 "Language-Team: Galician <gl@li.org>\n"
@@ -40,11 +40,11 @@ msgstr ""
 "Introduza o seu contrasinal para acceder aos informes de problemas dos "
 "programas do sistema"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "Este paquete semella que non está instalado correctamente"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -55,7 +55,7 @@ msgstr ""
 "actualizar os índices dos paquetes dispoñibles; se isto non funciona, "
 "elimine os paquetes relacionados de terceiros e tente de novo."
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -68,21 +68,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "programa descoñecido"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Desculpe, o programa «%s» pechouse inesperadamente"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Problema en %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -90,64 +90,64 @@ msgstr ""
 "O seu computador non dispón de memoria libre abondo para analizar "
 "automaticamente o problema e enviarlle un informe aos desenvolvedores."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "O informe de problema non é válido"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "Non ten permiso para acceder a este informe de problema."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Erro"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "Non hai espazo abondo no disco para procesar este informe."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr "Non se indicou ningún PID"
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr "Hai que indicar un PID. Vexa --axuda para máis información."
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "O PID non é válido"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr "O identificador de proceso indicado non existe."
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr "Non é o seu PID"
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr "O identificador de proceso indicado non lle pertence a vostede."
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "Non se especificou ningún paquete"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Ten que especificar un paquete ou un PID. Vexa --axuda para obter máis "
 "información."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Permiso denegado"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -155,30 +155,30 @@ msgstr ""
 "O proceso especificado non lle pertence. Execute este programa como "
 "propietario do proceso ou como root."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "O ID de proceso especificado non pertence a ningún programa."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "O script «symptom» %s non determinou ningún paquete afectado"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "O paquete %s non existe"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "Non se pode crear o informe"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "Actualización de informe de problemas"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -190,7 +190,7 @@ msgstr ""
 "\n"
 "Por favor, cree un novo informe con «apport-bug»."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -210,24 +210,24 @@ msgstr ""
 "\n"
 "Desexa continuar?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "Non se recolleu información adicional."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "De que tipo de problema quere informar?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Síntoma descoñecida"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Non se coñece a síntoma «%s»."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -246,7 +246,7 @@ msgstr ""
 "Sistema. Na lapela Procesos, baixe até atopar a aplicación correcta. O "
 "identificador do proceso é o número que aparece na lista Identificador."
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -254,25 +254,25 @@ msgstr ""
 "Despois de pechar esta mensaxe, prema nunha xanela do aplicativo para "
 "informar sobre este problema."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "Produciuse un fallo en «xprop» ao determinar o ID de proceso da xanela"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr "%(prog)s <número de informe>"
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "Especifique o nome do paquete."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Engade unha etiqueta extra ao informe. Pódese especificar varias veces."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
@@ -280,7 +280,7 @@ msgstr ""
 "%(prog)s [opcións] [síntoma|pid|paquete|ruta ao programa| ficheiro .apport/."
 "crash]"
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -290,17 +290,17 @@ msgstr ""
 "opcional, ou só un --pid. Se non se fornece ningún, mostra unha lista de "
 "síntomas coñecidas. (Implícito se se fornece un único argumento.)"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "Prema nunha xanela como un obxectivo para informar do problema."
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "Iniciar en modo de actualización de erros. Pode aceptar un --package "
 "opcional."
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -308,7 +308,7 @@ msgstr ""
 "Ficheiro dun informe de erro dunha síntoma. (Implícito se se deu como único "
 "argumento o nome da síntoma)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -316,7 +316,7 @@ msgstr ""
 "Especificar un nome de paquete no modo --file-bug. Isto é opcional se se "
 "especifica un --pid. (Tamén se o nome do paquete foi dado só como argumento)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -326,11 +326,11 @@ msgstr ""
 "informe de erro conterá máis información.  (Implica se o PID se fornece só "
 "como un argumento.)"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "O pid fornecido é un aplicativo bloqueado."
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -339,7 +339,7 @@ msgstr ""
 "Informe sobre a falla no ficheiro dado .apport ou .crash en lugar de facelo "
 "nos pendentes en %s. (Tamén se o ficheiro foi dado só como argumento) ."
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -349,37 +349,37 @@ msgstr ""
 "no canto de enviala. Este ficheiro pódese enviar máis adiante desde unha "
 "máquina diferente."
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Imprimir o número da versión do Apport."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Isto iniciará apport-retrace nunha xanela de terminal para examinar o peche "
 "inesperado."
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "Executar sesión de gdb"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Executar sesión de gdb sen descargar os símbolos de depuración"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Actualizar %s coa pila de chamadas simbólicas completas"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 "Non é posíbel lembrar a preferencia sobre o envío do estado dos informes"
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -400,7 +400,7 @@ msgid ""
 msgstr ""
 "O problema aconteceu co programa %s, que mudou desde que se produciu o fallo."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "O informe de erro está danado e non pode ser procesado."
 
@@ -430,14 +430,14 @@ msgstr "%s snap"
 msgid "%s deb package"
 msgstr "%s paquete deb"
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s foi fornecido cun snap publicado por %s. Contacte con eles a través de %s "
 "se precisa axuda."
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -446,39 +446,39 @@ msgstr ""
 "%s foi fornecido cun snap publicado por %s. Non se forneceu ningún enderezo "
 "de contacto; visite o foro en https://forum.snapcraft.io/ se precisa axuda."
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "Non se puido determinar o paquete ou o nome do paquete fonte."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "Non é posíbel iniciar o navegador web"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Non é posíbel iniciar o navegador para abrir %s."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Erro de conexión"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "É imposíbel conectar coa base de datos de fallos. Verifique a conexión á "
 "Internet."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Memoria esgotada"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "O sistema non posúe memoria abondo para procesar este informe de erro,"
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -489,11 +489,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "Problema coñecido"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -503,7 +503,7 @@ msgstr ""
 "web. Comprobe se pode engadir información adicional que lle poida resultar "
 "de utilidade aos desenvolvedores."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Este problema xa foi informado ao desenvolvedores. Grazas!"
 
@@ -871,7 +871,7 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Erro: %s no né un executábel. Paramos."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -879,7 +879,7 @@ msgstr ""
 "Isto produciuse durante unha suspensión anterior do sistema e impediu que se "
 "retomase adecuadamente."
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -887,7 +887,7 @@ msgstr ""
 "Isto produciuse durante unha hibernación anterior do sistema e impediu que "
 "se retomase adecuadamente."
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/gu.po
+++ b/po/gu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2011-10-07 06:10+0000\n"
 "Last-Translator: raj <Unknown>\n"
 "Language-Team: Gujarati <gu@li.org>\n"
@@ -36,11 +36,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr ""
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -61,21 +61,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "અજાણયો પ્રોગ્રામ"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "માફ કરશો, પ્રોગ્રામ %s એકાએક બંધ થયો છે"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "%s માં તકલીફ છે"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -83,62 +83,62 @@ msgstr ""
 "તમારા કૉમ્પ્યૂટર માં મુશ્કેલીનુ આપોઆપ વિશ્લેષણ કરવા માટે અને ડેવલોપરોને રિપૉર્ટ (હકીકત) "
 "મોકલાવવા માટે પુરતા પ્રમાણ માં મુકત મેમરી નથી."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "અપ્રમાણ મુશ્કેલી રિપૉર્ટ"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "આપને મુશ્કેલી રિપૉર્ટ જોવાની પરવાનગી નથી."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr ""
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "આ રિપૉર્ટ ને આગળ વધારવા માટે પુરતી માત્રામાં ડિસ્ક સ્પેઇસ મોજુદ નથી."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "અમાન્ય પીઆઈડી"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "કોઈ પેકેજ જણાવેલ નથી"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr "તમારે ચોક્કસ પેકેજ અથવા પીઆઈડી નો ઉલ્લેખ કરવાની જરૂર છે. વધુ વિઞત માટે --મદદ જુઓ."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr ""
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -146,30 +146,30 @@ msgstr ""
 "જણાવેલ પ્રોસેસ તમારી સાથે જોડાયેલી નથી. મહેરબાની કરીને આ પ્રોગ્રામ તમે પ્રોસેસ ના માલિક "
 "અથવા રૂટ તરીકે ચલાવો."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "જણાવેલ પ્રોસેસ આઈડી પ્રોગ્રામ સાથે જોડાયેલું નથી."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "પેકેજ %s નુ અસ્તિત્વ નથી"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr ""
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr ""
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -177,7 +177,7 @@ msgid ""
 "Please create a new report using \"apport-bug\"."
 msgstr ""
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -189,24 +189,24 @@ msgid ""
 "Do you really want to proceed?"
 msgstr ""
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr ""
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "કયા પ્રકારનો પ્રશ્ન આપ રજૂ કરવા માગો છો?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "અજાણયુ ચિહ્ન"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "ચિહ્ન %s જાણીતુ નથી."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -217,57 +217,57 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr ""
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -275,18 +275,18 @@ msgstr ""
 "પેકેજ ના નામનો  --ફાઇલ-બગ મોડ માં ઉલ્લેખ કરો. આ વૈકલ્પિક છે જો --પીઆઈડી નો ઉલ્લેખ હોય. "
 "(સૂચિત જો ચિહ્ન નુ નામ ફકત આર્ગ્યૂમેન્ટ તરીકે આપેલ હોય.)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -295,41 +295,41 @@ msgstr ""
 "પતન વિશે ની રજુઆત નિકાલ ન થયેલા %s ના બદલે આપેલી .અપોર્ટ અથવા .ક્રૅશ ફાઈલ માંથી કરો. "
 "(સૂચિત જો એક આર્ગ્યૂમેન્ટ આપેલ હોય.)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "અપોર્ટ વર્ઝન નંબર ની નકલ કાઢો."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr ""
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -346,7 +346,7 @@ msgid ""
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "આ સમસ્યા રિપૉર્ટ નુકસાન પામેલ છે અને આગળ વધી નહી શકાય."
 
@@ -374,50 +374,50 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "પેકેજ અથવા સૉર્સ પેકેજ નુ નામ શોધી નથી શકાયુ."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "વેબ બ્રાઊઝર શરુ કરવામાં સમર્થ નથી."
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "%s ને ખોલવા માટે વેબ બ્રાઊઝર શરુ કરવામાં સમર્થ નથી."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "નેટવર્ક માં સમસ્યા"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "ક્રૅશ ડેટાબેઞ સાથે જોડાણ થઈ શકે તેમ નથી. મહેરબાની કરીને તમારા ઈનટરનેટનુ જોડાણ તપાશો."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "મેમરીની થકાવટ"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "આ ક્રૅશ રિપૉર્ટ ને પ્રોસેસ કરવા માટે તમારી સિસ્ટમમાં પૂરતી મેમરી નથી."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -428,11 +428,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "મુશ્કેલી પહેલાંથી જાણીતી છે."
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -441,7 +441,7 @@ msgstr ""
 "આ સમસ્યા વેબ બ્રાઊઝરમાં દેખાતા બગ રિપૉટમાં પહેલાંથી રજુ કરેલ છે. મહેરબાની કરીને ચકાસો કે "
 "તમે વધુ માહીતી ઊમેરી શકો છો કે જે ડેવલોપરો માટે ઊપયોગી થઈ શકે."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 
@@ -753,19 +753,19 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr ""
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2022-08-19 14:26+0000\n"
 "Last-Translator: Yaron <sh.yaron@gmail.com>\n"
 "Language-Team: Hebrew <he@li.org>\n"
@@ -36,11 +36,11 @@ msgstr "דיווחי תקלות במערכת"
 msgid "Please enter your password to access problem reports of system programs"
 msgstr "נא להזין את הססמה שלך כדי לגשת לדיווחים על תקלות שנמצאו בתכניות המערכת"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "מסתבר כי חבילה זו אינה מותקנת כראוי"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -51,7 +51,7 @@ msgstr ""
 "החבילות הזמינות, אם זה לא עובד אז יש להסיר את החבילות מגורמי צד־שלישי ולנסות "
 "שוב."
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -64,113 +64,113 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "תכנית בלתי מוכרת"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "התכנה „%s“  נסגרה במפתיע, עמך הסליחה"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "תקלה ב־%s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
 msgstr ""
 "למחשבך אין די זכרון פנוי כדי לנתח את התקלה אוטומטית ולשלוח דוח למפתחים."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "דוח תקלה שגוי"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "אין לך הרשאה לגשת לדוח תקלה זה."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "שגיאה"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "אין די שטח פנוי בכונן כדי לעבד דוח זה."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr "לא צוין מזהה תהליך"
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr "עליך לציין מזהה תהליך. פרטים נוספים עם ‎--help."
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "מזהה התהליך שגוי"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr "מזהה התהליך שצוין לא נמצא."
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr "לא מזהה התהליך שלך"
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr "מזהה התהליך שצוין לא שייך לך."
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "לא צוינה חבילה כלשהי"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr "עליך לציין חבילה או מזהה תהליך. ניתן לעיין ב־‎--help לקבלת מידע נוסף."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "הגישה נדחתה"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 msgstr ""
 "התהליך שצוין אינו שייך לך. נא להריץ תכנה זו כבעל התהליך או כמשתמש על (root)."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "מזהה התהליך שצוין אינו שייך לאף תכנית."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "סקריפט התסמינים %s לא איתר חבילות שנפגעו"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "החבילה %s אינה קיימת"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "לא ניתן ליצור דוח"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "דוח הבעיה מתעדכן"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -182,7 +182,7 @@ msgstr ""
 "\n"
 "יש ליצור דיווח חדש באמצעות \"apport-bug\"."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -201,24 +201,24 @@ msgstr ""
 "\n"
 "האם ברצונך להמשיך?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "לא נאסף מידע נוסף."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "מהי הבעיה עליה ברצונך לדווח?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "תסמין לא מוכר"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "התסמין „%s“ אינו מוכר."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -229,37 +229,37 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 "לאחר סגירת הודעה זו יש ללחוץ על חלון היישום כדי לדווח על בעיות בהפעלתו."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop לא הצליח לזהות את מזהה התהליך של החלון"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "נא לציין את שם החבילה."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "הוספת תגית נוספת לדיווח. ניתן לציין מספר פעמים."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -269,21 +269,21 @@ msgstr ""
 "אף אחד מאלה לא הוזן, תוצג רשימה של סימפטומים ידועים. (מרומז במקרה שצוין "
 "ארגומנט יחיד.)"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "יש ללחוץ על חלון כיעד לדיווח על תקלה."
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "הפעלה במצב עדכון. ניתן להוסיף ‎--package במידת הצורך."
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr "הגשת דיווח על תסמין. (מרומז אם שם התסמין ניתן רק כארגומנט.)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -291,7 +291,7 @@ msgstr ""
 "יש לציין את שם החבילה במצב ‎--file-bug. אין חובה לעשות כך אם צוין ה־‎--pid. "
 "(מרומז אם שם החבילה הוא הארגומנט היחיד שצוין.)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -300,11 +300,11 @@ msgstr ""
 "יש לציין תכנית פעילה במצב ‎--file-bug. אם פרמטר זה יתווסף דיווח הבאג יכיל "
 "מידע נוסף.  (כלומר שהמזהה התהליך, ה־pid, ניתן כארגומנט בלבד.)"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "ה־pid (מזהה היישום) שסופק מצביע על יישום תקוע."
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -313,7 +313,7 @@ msgstr ""
 "דיווח על התקלה מקובץ ‎.apport או ‎.crash נתון במקום אלו שממתינים ב־%s. (מרומז "
 "אם ניתן קובץ כארגומנט יחיד.)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -322,34 +322,34 @@ msgstr ""
 "במצב דיווח על באגים, יש לשמור את המידע שנאסף לקובץ במקום לדווח עליו. ניתן "
 "לדווח באמצעות קובץ זה בשלב מאוחר יותר דרך מחשב אחר."
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "הצגת מספר הגרסה של Apport."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr "פעולה זו תפעיל את apport-retrace בחלון מסוף כדי לנתח את הקריסה."
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "הפעלת gdb"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "הפעלת gdb מבלי להוריד סימני ניפוי שגיאות"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "עדכון %s במעקב ערימה בסמליות מלאה"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr "לא ניתן לשמור הגדרות מצב שליחת דיווח"
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -367,7 +367,7 @@ msgid ""
 "occurred."
 msgstr "התקלה אירעה בתכנית %s שהשתנתה מאז קריסתה האחרונה."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "דוח תקלה זה פגום ולכן לא ניתן לעבד אותו."
 
@@ -396,13 +396,13 @@ msgstr "%s snap"
 msgid "%s deb package"
 msgstr "חבילת deb %s"
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s מסופק על ידי snap שהופץ על ידי %s. יש ליצור אתם קשר דרך %s לקלבת עזרה."
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -411,37 +411,37 @@ msgstr ""
 "%s מסופק על ידי snap שהופץ על ידי %s. לא סופקה דרך ליצירת קשר, יש לבקר "
 "בפורום https://forum.snapcraft.io/‎ לקבלת עזרה."
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "לא ניתן לאתר את החבילה או את שם חבילת המקור."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "לא ניתן להפעיל את דפדפן האינטרנט."
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "לא ניתן להפעיל את דפדפן האינטרנט כדי לפתוח את %s."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "תקלת רשת"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr "לא ניתן להתחבר אל מסד נתוני הקריסות, יש לבדוק את החיבור לאינטרנט."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "תשישות הזכרון"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "למערכת שלך אין די זכרון פנוי כדי לעבד דוח תקלה זה."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -452,11 +452,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "התקלה כבר מוכרת"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -465,7 +465,7 @@ msgstr ""
 "תקלה זו כבר דווחה בדוח התקלה המוצג בדפדפן האינטרנט. נא לבדוק האם ניתן להוסיף "
 "מידע נוסף שעלול לעזור למפתחים בפתרון התקלה."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "תקלה זו כבר דווחה למתכנתים. תודה רבה!"
 
@@ -795,19 +795,19 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "שגיאה: %s זה לא קובץ שניתן להריץ. נעצר."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr "תקלה זו קרתה במהלך השהיה קודמת ומנעה מהמשך פעילות המערכת באופן תקין."
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr "זה קרה במהלך תרדמת קודמת ומנע מהמערכת להמשיך בפעילות כראוי."
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2011-12-27 13:13+0000\n"
 "Last-Translator: Vibhav Pant <vibhavp@gmail.com>\n"
 "Language-Team: Hindi <hi@li.org>\n"
@@ -36,11 +36,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "ऐसा लगता है कि इस पैकेज को सही ढंग से स्थापित नहीं करा गया है"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -61,21 +61,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "अज्ञात प्रोग्राम"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "क्षमा करें, %s प्रोग्राम अनपेक्षित ढंग से बंद हो गया।"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "%s में समस्या"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -83,63 +83,63 @@ msgstr ""
 "आपके कंप्युटर में समस्या का स्वतः विश्लेषण करने और विकासकर्ताओं को सूचित करने के लिये पर्याप्त "
 "रिक्त स्मृति नहीं है।"
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "अमान्य समस्या सूचना"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "इस समस्या रिपोर्ट में आपके पहुँच की अनुमति नहीं है."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "त्रुटी"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "इस रिपोर्ट को प्रक्रिया करने हेतु डिस्क में प्रर्याप्त जगह उपलब्ध नहीं है."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "अवैध पीआईडी"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "पैकेज का विशिष्ट निर्देश नहीं है"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "आपको पैकेज या PID का विशिष्ट निर्देश देना होगा. अधिक जानकारी के लिए  --help देखें."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "अनुमति निषेधित"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -147,30 +147,30 @@ msgstr ""
 "यह आपका विशिष्ट निर्देश नहीं है. कृपया इस प्रोग्राम को प्रक्रिया उत्तराधिकारी के रुप में या "
 "रुट में चलाएं."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "विशिष्ट निर्देश आईडी प्रोग्राम का हिस्सा नहीं है."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "सिनेप्टिक स्क्रिप्ट %s प्रभावित पैकेज का निर्धारण नहीं कर पा रहा है"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "पैकेज %s मोजूद नहीं है"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "रिपोर्ट बनाई नहीं जा सकती"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "समस्या रिपोर्ट को अद्यतन कर रहा है"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -182,7 +182,7 @@ msgstr ""
 "\n"
 "कृपया \"apport-bug\" का उपयोग कर एक नया रिपोर्ट बनाएं."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -201,24 +201,24 @@ msgstr ""
 "\n"
 "क्या आप आगे की प्रक्रिया करेंगें?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "अतरिक्त सूचना संगृहित नहीं की जाएगी."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "किस तरह की समस्या का आप रिपोर्ट करना चाहते हैं?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "अज्ञात लक्षण"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "यह लक्षण \"%s\" ज्ञात नहीं है."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -229,37 +229,37 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 "इस संदेश के बंद होने के पश्चात कृपया अनुप्रयोग विंडो पर क्लिक कर समस्या के बारे में रिपोर्ट करें."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop विंडो की प्रक्रिया आईडी को निर्धारित करने में असफल हो गया"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "संकुल नाम निर्दिष्ट करें."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "रिपोर्ट में एक अतरिक्त टैग जोड़े जिससे एकाधिक बार का उल्लेख हो सके."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -269,15 +269,15 @@ msgstr ""
 "एक --pid की. यदि कोई भी नहीं दिया हुआ हो, तो ज्ञात लक्षणों की सूची दिखाएं. (यदि एक "
 "ही तर्क दिया हो तो लागु करें.)"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "एक समस्या रपट दर्ज करने हेतु लक्ष्य विंडो पर क्लिक करें."
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "बग अद्यतन पद्धति में चालु करें. एक विकल्प --package ले सकते हैं ."
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -285,7 +285,7 @@ msgstr ""
 "लक्षण के बारे में एक बग रिपोर्ट दाखिल करें. (जब लक्षण के नाम केवल तर्क के रुप में दिया गया "
 "हो तो लागु करें.)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -293,7 +293,7 @@ msgstr ""
 "पैकेज का नाम --file-bug पद्धति में वर्णन करें. यह वैकल्पिक होगा यदि एक --pid का वर्णन "
 "होगा. (जब पैकेज का नाम केवल तर्क के रुप में दिया गया हो तो लागु करें.)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -302,11 +302,11 @@ msgstr ""
 "एक चल रहे प्रोग्राम --file-bug पद्धति में का उल्लेख करें. यदि इसका उल्लेख है, तो दोष रपट "
 "अधिक सूचनात्मक हो जाएगा.(यह लागू हो यदि pid में केवल तर्क दिया होगा.)"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -315,7 +315,7 @@ msgstr ""
 "विध्वंस रिपोर्ट को दिए गए .apport या .crash संचिका से करें बजाए %s में जो विचाराधीन "
 "है. (यदि तर्क के रुप में केवल संचिका दिया गया हो.)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -324,34 +324,34 @@ msgstr ""
 "बग भराई पद्धति में, संगृहित सूचना को रपट करने के बजाए एक फ़ाइल में सहेजें. यह फ़ाइल परवर्ति "
 "एक अन्य मशीन से रपट किया जा  सकता है."
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "एपोर्ट(Apport) संस्करण संख्या को छापे."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "जीडीबी सत्र चलाएँ"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "जीडीबी का सत्र बिना डिबग प्रतीकों डाउनलोड करें शुरु करें"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -368,7 +368,7 @@ msgid ""
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "यह समस्या सूचना क्षतिग्रस्त है तथा संसाधित नहीं की जा सकती."
 
@@ -396,49 +396,49 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "पैकेज या स्त्रोत पैकेज नाम को निर्धारित नहीं कर सका."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "वेब खंगालक(ब्राउजर) को शुरु करनें में असमर्थ"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "वेब खंगालक(ब्राउजर) खोलने में असमर्थ %s."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "संजाल समस्या"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr "विध्वंस समंंकआधार से जुड़ नहीं सका, कृपया अपने अंतरजाल संयोजन की जाँच करें."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "स्मरण समाप्त हो गया है"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "आपके तंत्र में पर्याप्त स्मरण नहीं है कि इस ध्वंस के रिपोर्ट की प्रक्रिया कर सके."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -449,11 +449,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "समस्या पूर्व से ज्ञात है"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -463,7 +463,7 @@ msgstr ""
 "कृपया जाँच करे कि यदि अन्य को अतिरिक्त सूचना जोड़ सकते है या नहीं जो कि विकासकर्ता को "
 "अधिक मददगार साबित हो."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "यह समस्या पहले से ही डेवलपर्स को  सूचित किया गया था. शुक्रिया!"
 
@@ -790,19 +790,19 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr ""
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/hr.po
+++ b/po/hr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2022-09-03 12:24+0000\n"
 "Last-Translator: gogo <trebelnik2@gmail.com>\n"
 "Language-Team: Croatian <hr@li.org>\n"
@@ -39,11 +39,11 @@ msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 "Upišite svoju lozinku za pristup izvještajima problema programa sustava"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "Izgleda da ovaj paket nije ispravno instaliran"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -54,7 +54,7 @@ msgstr ""
 "sadržaja dostupnih paketa, ako to ne uspije tada uklonite povezane pakete "
 "treće strane i pokušajte ponovno."
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -67,21 +67,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "nepoznati program"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Program \"%s\" se neočekivano zatvorio"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Problem u %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -89,92 +89,92 @@ msgstr ""
 "Vaše računalo nema dovoljno slobodne memorije za automatsku analizu problema "
 "i slanje izvještaja razvijateljima."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Neispravan izvještaj o problemu"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "Niste ovlašteni za pristup ovom izvještaju o problemu."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Greška"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "Nema dovoljno prostora na disku za obradu ovog izvještaja."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr "PID nije naveden"
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr "Morate navesti PID. Pogledajte --help za više informacija."
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "Neispravan PID"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr "Određeni ID procesa ne postoji."
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr "Nije vaš PID"
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr "Određeni ID procesa vam ne pripada."
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "Nema određenih paketa"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr "Morate odrediti paket ili PID. Pogledajte --help za više informacija."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Pristup odbijen"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 msgstr ""
 "Određeni proces vam ne pripada. Pokrenite ovaj program kao root korisnik."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "Određeni ID proces ne pripada programu."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Skripta simptoma %s nije odredila zahvaćeni paket"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Paket %s ne postoji"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "Ne mogu napraviti izvještaj"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "Nadopuna izvještaja problema"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -186,7 +186,7 @@ msgstr ""
 "\n"
 "Napravite novi izvještaj koristeći \"apport-bug\"."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -206,24 +206,24 @@ msgstr ""
 "\n"
 "Želite li stvarno nastaviti?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "Nisu prikupljene dodatne informacije."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "Kakav problem želite prijaviti?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Nepoznat simptom"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Simptom \"%s\" nije poznat."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -241,7 +241,7 @@ msgstr ""
 "Procesi, potražite odgovarajuću aplikaciju. ID procesa je broj prikazan u "
 "stupcu Identifikacija."
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -249,24 +249,24 @@ msgstr ""
 "Nakon zatvaranja ove poruke kliknite na prozor aplikacije za prijavu ovog "
 "problema."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop nije uspio odrediti proces ID prozora"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr "%(prog)s <broj izvještaja>"
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "Odredite naziv paketa."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "Dodajte dodatnu oznaku u izvještaj. Moguće je odrediti više puta."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
@@ -274,7 +274,7 @@ msgstr ""
 "%(prog)s [mogućnosti] [simptom|pid|paket|program putanja|.apport/.crash "
 "datoteka]"
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -284,15 +284,15 @@ msgstr ""
 "ukratko samo --pid. Ako ni jedno nije navedeno, prikaži popis poznatih "
 "simptoma. (Podrazumijeva se ako je jedan argument zadan.)"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "Kliknite na prozor kao cilj za podnošenje izvještaja o problemu."
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "Početak načina nadopune greške. Može se dodati po izboru --package."
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -300,7 +300,7 @@ msgstr ""
 "Prijavi izvještaj greške o simptomu. (Podrazumijeva ako je naziv simptoma "
 "naveden kao jedini argument.)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -308,7 +308,7 @@ msgstr ""
 "Navedite naziv paketa u --file-bug načinu. Ovo nije obavezno ako je --pid "
 "naveden. (Podrazumijeva se ako je naziv paketa naveden kao jedini argument.)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -318,11 +318,11 @@ msgstr ""
 "greške će sadržavati više informacija. (Podrazumijeva se ako je pid naveden "
 "kao jedini argument.)"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "Zadani pid prekida aplikaciju."
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -332,7 +332,7 @@ msgstr ""
 "nezavršenih u %s. (Podrazumijeva se ako je datoteka zadana kao jedini "
 "argument.)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -342,35 +342,35 @@ msgstr ""
 "da je prijavite. Ta datoteka se zatim kasnije može prijaviti s drugog "
 "računala."
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Ispiši broj Apport inačice."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "To će pokrenuti apport-retrace u prozoru terminala zbog ispitivanja rušenja."
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "Pokreni gdb sesiju"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Pokreni gdb sesiju bez preuzimanja simbola otklanjanja greške"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Nadopuni %s s potpunim simboličkim opširnim zapisom"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr "Nemoguće zapamtiti postavke stanja slanja izvještaja"
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -390,7 +390,7 @@ msgid ""
 "occurred."
 msgstr "Dogodio se problem s programom %s koji se promijenio otkada se srušio."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Ovaj izvještaj o problemu je oštećen i ne može biti obrađen."
 
@@ -420,14 +420,14 @@ msgstr "%s snap paket"
 msgid "%s deb package"
 msgstr "%s deb paket"
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s je omogućen putem snap paketa objavljen od strane %s. Kontaktirajte ih "
 "putem %s za pomoć."
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -436,41 +436,41 @@ msgstr ""
 "%s je omogućen putem snap paketa objavljen od strane %s. Nema adrese za "
 "kontakt, posjetite forum https://forum.snapcraft.io/ za pomoć."
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "Ne može se odrediti paket ili naziv izvornog paketa."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "Nemoguće pokretanje Internet preglednika"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Nemoguće pokretanje Internet preglednik za otvaranje %s."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Problem s mrežom"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Nemoguće povezivanje na bazu podataka rušenja. Provjerite vaš pristup "
 "Internetu."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Nedostatak memorije"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Vaš sustav nema dovoljno memorije za obradu ovog izvještaja o rušenju "
 "sustava."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -481,11 +481,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "Problem je već poznat"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -495,7 +495,7 @@ msgstr ""
 "internet pregledniku. Provjerite možete li dodati neke dodatne informacije "
 "koje mogu pomoći razvijateljima."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Ovaj problem je već prijavljen razvijateljima. Hvala Vam!"
 
@@ -856,7 +856,7 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Greška: %s nije izvršna datoteka. Zaustavljanje."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -864,7 +864,7 @@ msgstr ""
 "Ovo je nastalo tijekom prijašnje suspenzije i spriječilo je ispravno "
 "pokretanje sustava."
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -872,7 +872,7 @@ msgstr ""
 "Ovo je nastalo tijekom prijašnje hibernacije i spriječilo je ispravno "
 "pokretanje sustava."
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2020-04-03 16:38+0000\n"
 "Last-Translator: Úr Balázs <balazs@urbalazs.hu>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -38,11 +38,11 @@ msgstr "Rendszerhiba-jelentések"
 msgid "Please enter your password to access problem reports of system programs"
 msgstr "Adja meg jelszavát a rendszerprogramok hibáinak eléréséhez"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "Úgy tűnik, ez a csomag nincs megfelelően telepítve"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -50,7 +50,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -63,21 +63,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "ismeretlen program"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Elnézést, a(z) „%s” program váratlanul összeomlott."
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Probléma a következőben: %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -85,64 +85,64 @@ msgstr ""
 "A számítógépe nem rendelkezik elegendő szabad memóriával a probléma "
 "automatikus elemzéséhez és a jelentés elküldéséhez a fejlesztőknek."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Érvénytelen hibajelentés"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "A hibajelentés elérése nem engedélyezett"
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Hiba"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "Nincs elegendő lemezterület a hiba feldolgozásához."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "Érvénytelen PID"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr "A megadott folyamatazonosító nem létezik."
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr "Nem az Ön folyamatazonosítója"
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr "A megadott folyamatazonosító nem Önhöz tartozik."
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "Nincs megadva csomag"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Meg kell adnia egy csomagot vagy PID azonosítót. További információkért "
 "tekintse meg a --help kapcsoló kimenetét."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Hozzáférés megtagadva"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -150,30 +150,30 @@ msgstr ""
 "A megadott folyamat nem Önhöz tartozik. Ezt a programot a folyamat "
 "tulajdonosaként vagy rendszergazdaként futtassa."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "A megadott PID nem programhoz tartozik."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "A(z) %s tünetparancsfájl nem határozott meg érintett csomagot"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "A(z) %s csomag nem létezik"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "Nem készíthető jelentés"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "Hibajelentés frissítése"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -185,7 +185,7 @@ msgstr ""
 "\n"
 "Készítsen új jelentést az „apport-bug” használatával."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -206,24 +206,24 @@ msgstr ""
 "\n"
 "Biztosan folytatja?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "Nem került gyűjtésre további információ."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "Milyen problémát kíván jelenteni?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Ismeretlen tünet"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "A(z) „%s” tünet ismeretlen."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -234,7 +234,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -242,30 +242,30 @@ msgstr ""
 "Ezen üzenet bezárása után kattintson egy alkalmazásablakra az azzal "
 "kapcsolatos hiba jelentéséhez."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "Az xprop nem tudta meghatározni az ablak folyamatazonosítóját"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "Adja meg a csomagnevet."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "Extra címke hozzáadása a jelentéshez. Többször is megadható."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -275,16 +275,16 @@ msgstr ""
 "egy --pid kapcsolót igényel. Ha egyik sincs megadva, az ismert tünetek "
 "listáját jeleníti meg. (Egy paraméter megadása is ezt jelenti.)"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "Kattintson egy ablakra az azzal kapcsolatos hiba jelentéséhez."
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "Indítás hibafrissítés módban. Opcionálisan használható a --package kapcsoló."
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -292,7 +292,7 @@ msgstr ""
 "Hiba bejelentése egy tünetről. (Ha az egyetlen paraméter tünetnév, az is ezt "
 "jelenti.)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -300,7 +300,7 @@ msgstr ""
 "Csomagnév megadása --file-bug módban. Ez elhagyható, ha a --pid meg van "
 "adva. (Ha az egyetlen paraméter egy csomagnév, az is ezt jelenti.)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -309,11 +309,11 @@ msgstr ""
 "Futó program megadása --file-bug módban. Ha ez meg van adva, a hibajelentés "
 "több információt fog tartalmazni."
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "A megadott PID egy nem válaszoló alkalmazásra mutat."
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -323,7 +323,7 @@ msgstr ""
 "függőben lévők helyet. (Ha az egyetlen paraméter egy fájl, az is ezt "
 "jelenti.)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -332,36 +332,36 @@ msgstr ""
 "Hibajelentő módban az összegyűjtött információk mentése fájlba a bejelentés "
 "helyett. Ez a fájl később másik gépről beküldhető."
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Az Apport verziószámának megjelenítése."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Ez meg fogja nyitni az apport-retrace-t egy terminálban, hogy az "
 "megvizsgálja az összeomlást."
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "gdb folyamat futtatása"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "gdb folyamat futtatása a hibakeresési szimbólumok letöltése nélkül"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "%s frissítése teljes szimbolikus veremkiíratással"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr "Nem lehet megjegyezni a jelentés küldése állapot beállításait"
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -383,7 +383,7 @@ msgid ""
 msgstr ""
 "A hiba a(z) „%s” programmal lépett fel, amely megváltozott az összeomlás óta."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "A hibajelentés megsérült és nem dolgozható fel."
 
@@ -411,53 +411,53 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "A csomag vagy forrás neve nem állapítható meg."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "A webböngésző nem indítható."
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "A(z) „%s” megnyitásához nem lehet elindítani a webböngészőt."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Hálózati probléma"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Nem lehet kapcsolódni az összeomlás-adatbázishoz, ellenőrizze az "
 "internetkapcsolatát."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Elfogyott a memória"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "A rendszere nem rendelkezik elegendő memóriával ezen összeomlásjelentés "
 "feldolgozásához."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -468,11 +468,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "A probléma már ismert."
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -482,7 +482,7 @@ msgstr ""
 "hibajelentés. Ellenőrizze, hogy tud-e további információkkal szolgálni, "
 "amelyek hasznosak lehetnek a fejlesztők számára."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Ez a probléma már jelentve volt a fejlesztőknek. Köszönjük!"
 
@@ -842,7 +842,7 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Hiba: a(z) %s nem végrehajtható. Leállítás."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -850,7 +850,7 @@ msgstr ""
 "Ez egy korábbi felfüggesztés közben történt, és ezzel megakadályozta a "
 "rendszer megfelelő indulását."
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -858,7 +858,7 @@ msgstr ""
 "Ez egy korábbi hibernálás közben történt, és ezzel megakadályozta a rendszer "
 "megfelelő indulását."
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/hy.po
+++ b/po/hy.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2011-03-11 22:55+0000\n"
 "Last-Translator: Serj Safarian <serjsafarian@gmail.com>\n"
 "Language-Team: Armenian <hy@li.org>\n"
@@ -36,11 +36,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr ""
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -57,111 +57,111 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "անհայտ ծրագիր"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr ""
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Խնդիր %s֊ում"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
 msgstr ""
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr ""
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr ""
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr ""
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr ""
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr ""
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr ""
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 msgstr ""
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr ""
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr ""
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr ""
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr ""
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -169,7 +169,7 @@ msgid ""
 "Please create a new report using \"apport-bug\"."
 msgstr ""
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -181,24 +181,24 @@ msgid ""
 "Do you really want to proceed?"
 msgstr ""
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr ""
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr ""
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr ""
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr ""
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -209,115 +209,115 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr ""
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr ""
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr ""
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -334,7 +334,7 @@ msgid ""
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr ""
 
@@ -362,49 +362,49 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr ""
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr ""
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr ""
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr ""
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr ""
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -412,18 +412,18 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr ""
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 msgstr ""
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 
@@ -735,19 +735,19 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr ""
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/ia.po
+++ b/po/ia.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2018-05-09 23:32+0000\n"
 "Last-Translator: karm <melo@carmu.com>\n"
 "Language-Team: Interlingua <ia@li.org>\n"
@@ -40,11 +40,11 @@ msgstr ""
 "Per favor Inserer le contrasigno pro acceder la reporto de problemas del "
 "programmas del systema"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "Iste pacchetto non pare esser installate correctemente"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -52,7 +52,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -65,21 +65,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "programma incognite"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Displacente, le programma \"%s\" claudeva inexpectatemente"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Problema in %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -87,65 +87,65 @@ msgstr ""
 "Tu computer non ha bastante memoria libere pro analysar automaticamente le "
 "problema e inviar un reporto al disveloppatores."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Reporto de problema invalide"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "Tu es permittite acceder iste reporto de problema."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Error"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 "Il non ha bastante spatio del disco disponibile a processar iste reporto."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "PID invalide"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "Nulle pacchetto specificate"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Tu necessita specificar un pacchetto o un PID. Vider --help pro plus de "
 "informationes."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Permission negate"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -153,30 +153,30 @@ msgstr ""
 "Le processo specificate non pertine a te. Per favor flue iste programma como "
 "le proprietario del processo o como radice."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "Le ID del processo specificate non pertine a un programma."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Le script del symptoma %s non determina un pacchetto affligite"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Le pacchetto %s non existe"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "On non pote crear un reporto"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "Ajornamento del reporto del problema"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -188,7 +188,7 @@ msgstr ""
 "\n"
 "Per favor crear un nove reporto per \"apport-bug\"."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -209,24 +209,24 @@ msgstr ""
 "\n"
 "Desira tu realmente proceder?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "Nulle information additional colligite."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "Qual genere de problema desira tu reportar?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Symptoma incognite"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Le symptoma \"%s\" non es note."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -237,7 +237,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -245,30 +245,30 @@ msgstr ""
 "Post claudite iste message, cliccar per favor su un fenestra de application "
 "pro reportar un problema re illo."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop ha mancate a determinar le ID de processo del fenestra"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "Specificar le nomine del pacchetto."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "Adder un tag extra al reporto. Pote esser specificate multiple vices."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -278,17 +278,17 @@ msgstr ""
 "--pid, o sol un --pid. Si non es date, displicar un lista del symptomas "
 "notori. (Implicite si es date un argumento singule.)"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 "Cliccar un fenestra qual destination pro registrar un reporto del problema."
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "Initiar in modo ajornamento del defecto. Pote prender un --package optional."
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -296,7 +296,7 @@ msgstr ""
 "Registrar un reporto de defecto circa un symptoma. (Implicite si le nomine "
 "del symptoma es date qual argumento unic.)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -305,7 +305,7 @@ msgstr ""
 "es specificate un --pid. (Implicite si le nomine del pacchetto es date qual "
 "argumento unic.)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -315,11 +315,11 @@ msgstr ""
 "le reporto de defecto continera plus de informationes.  (Implicite si le pid "
 "es date qual argumento unic.)"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "Le pid supplite es un application suspendite."
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -328,7 +328,7 @@ msgstr ""
 "Reportar le crash per le file .apport o .crash date in vice de illos "
 "pendente in %s. (Implicite si le file es date qual argumento unic.)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -338,36 +338,36 @@ msgstr ""
 "file in vice de reportar lo. Iste file pote pois esser reportate ex un "
 "machina differente."
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Imprimer le numero de version de Apport."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Isto lanceara apport-retrace in un fenestra de terminal pro examinar le "
 "crash."
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "Facer fluer un session gdb"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Facer fluer un session gdb sin discargar symbolos del correction"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Ajornar %s con le tracia del pila plenmente symbolic"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -387,7 +387,7 @@ msgstr ""
 "Le problema ha occurrite con le programma %s que ha cambiate depois que le "
 "crash occurreva."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Iste reporto de problema is damnificate e non pote esser processate."
 
@@ -416,52 +416,52 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "Non poterea determinar le pacchetto o le nomine del pacchetto fonte."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "Incapace de lancear le navigator del web"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Incapace de lancear le navigator del web pro aperir %s."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Problema de rete"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "On non pote connecter al base de datos del crash, per favor controlar le "
 "connexion al Rete."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Exhaustion del memoria"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Tu systema non ha bastante memoria pro processar iste reporto de crash."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -472,11 +472,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "Problema ja note"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -486,7 +486,7 @@ msgstr ""
 "navigator del Web. Per favor controla si tu pote adder alcun information "
 "additional que pote esser auxilio al disveloppatores."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Iste problema esseva ja reportate al disveloppatores. Gratias!"
 
@@ -849,7 +849,7 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Error: %s non es un  executabile. Arresto."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -857,7 +857,7 @@ msgstr ""
 "Iato occurreva durante un previe suspension e ha prevenite le proprie "
 "reinitio del systema."
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -865,7 +865,7 @@ msgstr ""
 "Iato occurreva durante un previe hibernation e ha prevenite le proprie "
 "reinitio del systema."
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2015-04-27 21:46+0000\n"
 "Last-Translator: Cecep Mahbub <cecep.mahbub@gmail.com>\n"
 "Language-Team: Indonesian <id@li.org>\n"
@@ -38,11 +38,11 @@ msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 "Harap masukkan sandi Anda untuk mengakses laporan masalah dari program sistem"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "Paket ini nampaknya tak terpasang secara benar"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -53,7 +53,7 @@ msgstr ""
 "indeks dari paket yang tersedia, bila itu tidak bekerja maka hapuslah paket "
 "pihak ke tiga dan coba lagi."
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -66,21 +66,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "program tak dikenal"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Maaf, program \"%s\" ditutup tak disangka-sangka"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Masalah di %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -88,65 +88,65 @@ msgstr ""
 "Komputer anda sepertinya tidak memiliki cukup memori bebas untuk secara "
 "otomatis menganalisa masalah dan mengirimkan laporan pada pengembang."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Laporan masalah tidak valid"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "Anda tak diijinkan untuk mengakses laporan masalah ini."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Galat"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "Tak tersedia ruang cakram yang cukup untuk mengolah laporan ini."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr "Tidak ada PID yang dinyatakan"
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 "Anda perlu menyatakan suatu PID. Lihat --help untuk informasi lebih lanjut."
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "PID tak valid"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr "ID proses yang dinyatakan tidak ada."
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr "Bukan PID Anda"
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr "ID proses yang dinyatakan bukan milik Anda."
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "Tak ada paket yang dinyatakan"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Anda perlu menyatakan suatu paket atau sebuah PID. Lihat --help untuk "
 "informasi lebih."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Tak diijinkan"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -154,30 +154,30 @@ msgstr ""
 "Proses berikut tidak dimiliki oleh Anda. Silakan jalankan program ini dengan "
 "mengunakan root atau pemilik proses."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "ID proses yang dinyatakan bukan milik suatu program."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Skrip gejala %s tak menentukan paket yang terpengaruh"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Paket %s tidak ada"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "Tidak dapat membuat laporan"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "Sedang memperbarui laporan masalah"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -189,7 +189,7 @@ msgstr ""
 "\n"
 "Silakan membuat suatu laporan baru memakai \"apport-bug\"."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -210,24 +210,24 @@ msgstr ""
 "\n"
 "Apakah Anda yakin ingin meneruskan?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "Tidak ada informasi tambahan yang dikumpulkan"
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "Masalah macam apa yang ingin Anda laporkan?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Gejala tak dikenal"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Gejala '%s' tak dikenal."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -245,7 +245,7 @@ msgstr ""
 "tab Proses, gulir sampai Anda menemukan aplikasi yang tepat. ID proses "
 "adalah angka yang dicantumkan dalam kolom ID."
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -253,32 +253,32 @@ msgstr ""
 "Setelah menutup pesan ini silakan klik pada jendela aplikasi untuk "
 "melaporkan masalah tentang hal ini."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop gagal untuk menentukan ID proses dari jendela"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "Tentukan nama paket."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Tambahkan label tambahan untuk laporan. Dapat memasukkan beberapa label "
 "sekaligus."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -288,15 +288,15 @@ msgstr ""
 "atau hanya --pid. Bila keduanya tak diberikan, tampilkan daftar dari gejala "
 "yang telah diketahui. (Otomatis bila argumen tunggal diberikan.)"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "Klik jendela sebagai target untuk mengajukan laporan masalah."
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "Memulai mode memperbarui bug. Dapat mengambil optional --package."
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -304,7 +304,7 @@ msgstr ""
 "Laporkan kutu tentang suatu gejala. (Otomatis bila nama gejala diberikan "
 "sebagai argumen tunggal.)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -312,7 +312,7 @@ msgstr ""
 "Nyatakan nama paket dalam moda --file-bug. Ini opsional bila suatu --pid "
 "dinyatakan.  (Otomatis bila nama paket diberikan sebagai argumen tunggal.)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -322,11 +322,11 @@ msgstr ""
 "dinyatakan, laporan kutu akan memuat lebih banyak informasi. (diasumsikan "
 "bila pid diberikan sebagai satu-satunya argumen.)"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "Pid yang diberikan adalah aplikasi yang hang."
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -335,7 +335,7 @@ msgstr ""
 "Laporkan crash dari berkas .apport atau .crash alih-alih dari yang tertunda "
 "di %s. (Otomatis bila berkas diberikan sebagai argumen tunggal.)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -345,36 +345,36 @@ msgstr ""
 "berkas alih-alih melaporkannya. Berkas ini kemudian dapat dilaporkan nanti "
 "atau dari mesin lain."
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Cetak nomor versi Apport."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Ini akan meluncurkan apport-retrace dalam suatu jendela terminal untuk "
 "memeriksa crash."
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "Memulai sesi gdb"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Memulai sesi gdb tanpa mengunduh simbol debug"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Mutakhirkan %s dengan pelacakan stack simbol lengkap"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr "Tak bisa mengingat pengaturan status kirim laporan"
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -395,7 +395,7 @@ msgid ""
 msgstr ""
 "Terjadi masalah dengan program %s yang berubah semenjak terjadinya crash."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Laporan permasalah gagal dan tidak dapat diproses."
 
@@ -425,14 +425,14 @@ msgstr "%s snap"
 msgid "%s deb package"
 msgstr "%s paket deb"
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s disediakan oleh sebuah snap yang dipublikasikan oleh %s. Hubungi mereka "
 "melalui %s untuk bantuan."
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -442,41 +442,41 @@ msgstr ""
 "kontak yang disediakan; kunjungi forum pada https://forum.snapcraft.io/ "
 "untuk bantuan."
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "TIdak dapat menentukan nama paket atau nama paket sumber."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "TIdak dapat menjalankan perambah web"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "TIdak dapat menjalankan perambah web untuk membuka %s."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Masalah di jaringan"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Tak bisa menyambung ke basis data crash, silakan periksa sambungan Internet "
 "Anda."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Kehabisan memori"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Sistem Anda tidak memiliki memori yang cukup untuk memproses laporan crash "
 "ini."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -487,11 +487,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "Masalah sudah diketahui"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -501,7 +501,7 @@ msgstr ""
 "web. Silakan periksa apakah Anda dapat menambah informasi lebih lanjut yang "
 "mungkin berguna bagi para pengembang."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Masalah ini sudah dilaporkan ke pengembang. Terima kasih!"
 
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Galat: %s bukan executable. Menghentikan."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -866,7 +866,7 @@ msgstr ""
 "Ini terjadi saat suspensi sebelumnya, dan mencegah sistem melanjutkan secara "
 "benar."
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -874,7 +874,7 @@ msgstr ""
 "Ini terjadi saat hebernasi sebelumnya, dan mencegah sistem melanjutkan "
 "secara benar."
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/is.po
+++ b/po/is.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2021-10-18 22:33+0000\n"
 "Last-Translator: Sveinn í Felli <sv1@fellsnet.is>\n"
 "Language-Team: Icelandic <is@li.org>\n"
@@ -38,11 +38,11 @@ msgstr "Vandamálaskýrslur kerfis"
 msgid "Please enter your password to access problem reports of system programs"
 msgstr "Sláðu inn lykilorð til að fá aðgang að villuskýrslum kerfisforrita"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "Þessi pakki virðist ekki rétt upp settur"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -50,7 +50,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -63,21 +63,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "óþekkt forrit"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Fyrirgefðu, forritið \"%s\" hætti óvænt"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Vandamál í %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -85,63 +85,63 @@ msgstr ""
 "Tölvan þín hefur ekki nóg laust innra minni til að greina sjálfkrafa "
 "vandamálið og senda til forritaranna."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Ógild vandamálsskýrsla"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "Þú hefur ekki leyfi til að skoða þessa skýrslu."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Villa"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "Það er ekki nóg diskpláss til að vinna úr skýrslunni."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "Ógilt PID"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "Enginn pakki valinn"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Þú þarft að tilgreina pakka eða PID. Sjá --help fyrir meiri upplýsingar."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Aðgangur bannaður"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -149,30 +149,30 @@ msgstr ""
 "Tiltekið ferli tilheyrir þér ekki. Keyrðu þetta forrit sem eigandi ferlisins "
 "eða sem kerfisstjórnandi"
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "Þetta ID tilheyrir ekki neinu forriti."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Pakki %s er ekki til"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "Get ekki gert skýrslu"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "Uppfæri villuskýrslu"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -184,7 +184,7 @@ msgstr ""
 "\n"
 "Búðu til nýja skýrslu með ‚apport-bug‘."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -204,24 +204,24 @@ msgstr ""
 "\n"
 "Ertu alveg viss þú viljir halda áfram?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "Engum aukaupplýsingum er safnað"
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "Hvers konar forrit viltu senda skýrslu um?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Óþekkt einkenni"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Einkennið „%s“ er ekki þekkt."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -232,7 +232,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -240,109 +240,109 @@ msgstr ""
 "Eftir lokun þessa skilaboða, smelltu á forritsglugga til að skrá villu um "
 "hann."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "Tilgreindu pakkaheiti."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "Gefna PID-ið er forrit sem hangir."
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Gefa Apport útgáfunúmerið."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr ""
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -360,7 +360,7 @@ msgid ""
 msgstr ""
 "Vandamálið kom fyrir í forritunu %s sem er breytt síðan síðasta hrun varð."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Skýrslan er löskuð og ég get ekki unnið úr henni"
 
@@ -388,50 +388,50 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "Gat ekki ákveðið nafn pakka eða grunnpakka"
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "Gat ekki ræst vefvafra"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Gat ekki ræst vefvafra til að opna %s"
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Vandamál með nettengingu"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr "Get ekki tengst við gagnagrunn, athugaðu nettenginguna."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Minnisvandamál"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Kerfið þitt hefur ekki nóg vinnsluminni til að vinna úr þessari skýrslu."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -442,11 +442,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "Vandamál þegar þekkt"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -456,7 +456,7 @@ msgstr ""
 "vefvafranum. Athugaðu hvort þú getur bætt við einhverjum gagnlegum "
 "upplýsingum."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 "Þetta vandamál hefur nú þegar verið tilkynnt til þróunarteymis. Takk fyrir!"
@@ -783,19 +783,19 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Villa: %s er ekki keyranlegt forrit. Hætti."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2015-04-27 21:47+0000\n"
 "Last-Translator: Gianfranco Frisani <gfrisani@libero.it>\n"
 "Language-Team: Italian <it@li.org>\n"
@@ -40,11 +40,11 @@ msgstr ""
 "Inserire la propria password per accedere alle segnalazioni d'errore di "
 "programmi di sistema"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "Questo pacchetto non sembra installato correttamente"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -55,7 +55,7 @@ msgstr ""
 "aggiornato gli indici dei pacchetti disponibili, se non funziona rimuovere i "
 "relativi pacchetti di terze parti e riprovare."
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -69,21 +69,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "programma sconosciuto"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Chiusura inattesa del programma «%s»"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Problema in %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -91,66 +91,66 @@ msgstr ""
 "Nel computer non è presente abbastanza memoria libera per analizzare "
 "automaticamente il problema e inviare una segnalazione agli sviluppatori."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Segnalazione di problema non valida"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "Accesso non consentito alla segnalazione riguardo questo problema."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Errore"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 "Non c'è spazio sufficiente sul disco per elaborare questa segnalazione."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr "Nessun PID specificato"
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 "È necessario specificare un PID. Per maggiori informazioni consultare --help."
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "PID non valido"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr "L'ID di processo specificato non esiste."
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr "Non è un PID dell'utente attuale"
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr "L'ID di processo specificato non appartiene all'utente attuale."
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "Nessun pacchetto specificato"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "È necessario specificare un pacchetto o un PID. Per maggiori informazioni "
 "consultare --help."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Permesso negato"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -158,32 +158,32 @@ msgstr ""
 "Il processo specificato non appartiene all'utente corrente. Eseguire questo "
 "programma come il proprietario del processo o come root."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "L'identificatore di processo specificato non appartiene al programma"
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 "Lo script per l'analisi delle anomalie %s  non ha rilevato alcun pacchetto "
 "alterato"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Il pacchetto %s non esiste"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "Impossibile creare la segnalazione"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "Aggiornamento segnalazione del problema"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -195,7 +195,7 @@ msgstr ""
 "\n"
 "Creare una nuova segnalazione utilizzando «apport-bug»."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -215,24 +215,24 @@ msgstr ""
 "\n"
 "Procedere?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "Non è stata raccolta alcuna informazione aggiuntiva."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "Che tipo di problema segnalare?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Anomalia sconosciuta"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "L'anomalia «%s» è sconosciuta."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -251,7 +251,7 @@ msgstr ""
 "Monitor. Nella scheda Processi, scorri fino a trovare l'applicazione "
 "corretta. L'ID processo è il numero elencato nella colonna ID."
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -259,27 +259,27 @@ msgstr ""
 "Dopo aver chiuso questo messaggio, fare clic sulla finestra di "
 "un'applicazione per segnalarne un problema."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 "Recupero dell'identificativo del processo della finestra da parte di xprop "
 "non riuscito"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr "%(prog)s <numero rapporto>"
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "Specificare il nome del pacchetto."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Aggiunge un'etichetta alla segnalazione, può essere specificata più volte"
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
@@ -287,7 +287,7 @@ msgstr ""
 "%(prog)s [opzioni] [sintomo|pid|pacchetto|percorso programma|.apport/.crash "
 "file]"
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -297,16 +297,16 @@ msgstr ""
 "pid  oppure solo --pid: se non è indicato alcuno dei due, sarà visualizzato "
 "un elenco di anomalie (implicito se è indicato un singolo argomento)."
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "Fare clic su una finestra per completare i campi della segnalazione."
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "Avvia in modalità aggiornamento bug: è possibile usare l'opzione --package"
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -314,7 +314,7 @@ msgstr ""
 "Invia una segnalazione di bug riguardo un'anomalia (implicito se è indicato "
 "il nome di un'anomalia come unico argomento)."
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -323,7 +323,7 @@ msgstr ""
 "stato specificato (implicito se il nome del pacchetto è indicato come unico "
 "argomento)."
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -333,11 +333,11 @@ msgstr ""
 "specificato, la segnalazione conterrà maggiori informazioni (implicito se il "
 "PID è passato come argomento)"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "Il PID fornito è un'applicazione in attesa."
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -346,7 +346,7 @@ msgstr ""
 "Segnala il crash da un file .apport o .crash fornito, piuttosto che da "
 "quelli in attesa in %s (implicito se file è indicato come unico argomento)."
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -356,36 +356,36 @@ msgstr ""
 "invece di inviare la segnalazione; il file può poi essere inviato "
 "successivamente da un computer differente"
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Mostra il numero di versione del programma."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Questo eseguirà apport-retrace in una finestra di terminale per esaminare il "
 "crash."
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "Esegui una sessione gdb"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Esegui una sessione gdb senza scaricare i simboli di debug"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Aggiornare %s con uno stack trace completamente simbolico"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr "Impostazioni di invio rapporto non trovate o non memorizzate"
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -407,7 +407,7 @@ msgstr ""
 "Il problema si è verificato con il programma «%s», che risulta essere stato "
 "modificato rispetto al momento in cui si è verificato il crash."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr ""
 "Questa segnalazione di problema è danneggiata e non può essere elaborata."
@@ -439,14 +439,14 @@ msgstr "snap %s"
 msgid "%s deb package"
 msgstr "pacchetto deb %s"
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s è fornito da uno snap pubblicato da %s. Contattali tramite %s per "
 "assistenza."
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -456,42 +456,42 @@ msgstr ""
 "indirizzo di contatto; visita il forum all'indirizzo https://forum.snapcraft."
 "io/ per assistenza."
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr ""
 "Impossibile determinare il nome del pacchetto o del pacchetto sorgente."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "Impossibile avviare il browser web"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Impossibile avviare il browser web per aprire %s."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Problema di rete"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Impossibile connettersi al database dei crash, controllare la connessione "
 "Internet."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Memoria esaurita"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Il sistema non ha abbastanza memoria per elaborare questa segnalazione di "
 "crash."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -502,11 +502,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "Problema già noto"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -516,7 +516,7 @@ msgstr ""
 "mostrato nel browser web. Verificare se è possibile aggiungere ulteriori "
 "informazioni che potrebbero essere utili agli sviluppatori."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Il problema è già stato segnalato agli sviluppatori. Grazie."
 
@@ -883,7 +883,7 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Errore: %s non è eseguibile. Arresto."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -891,7 +891,7 @@ msgstr ""
 "Ciò si è verificato durante una precedente sospensione che non ha consentito "
 "il corretto ripristino del sistema."
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -899,7 +899,7 @@ msgstr ""
 "Ciò si è verificato durante una precedente ibernazione che non ha consentito "
 "il corretto ripristino del sistema."
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2021-10-19 10:21+0000\n"
 "Last-Translator: id:sicklylife <Unknown>\n"
 "Language-Team: Japanese <ja@li.org>\n"
@@ -38,11 +38,11 @@ msgstr ""
 "システムプログラムの問題レポートにアクセスするにはパスワードを入力してくださ"
 "い"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "このパッケージは恐らく正常にインストールされていません"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -53,7 +53,7 @@ msgstr ""
 "デックスを更新してから再度試してみてください。問題が解決しない場合、関連する"
 "サードパーティーのパッケージの削除も試してみてください。"
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -66,21 +66,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "不明なプログラム"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "残念ながら、プログラム \"%s\" が予期せず終了しました"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "%s に問題があります"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -88,65 +88,65 @@ msgstr ""
 "コンピューターに、問題を自動的に解析して開発者にレポートを送るための十分な空"
 "きメモリーがありません。"
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "無効な問題のレポートです"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "この問題を報告するための権限がありません。"
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "エラー"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "このレポートを作成するための空きスペースがディスクにありません。"
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr "PIDが指定されていません"
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 "PIDを指定する必要があります。詳細については --help の出力を確認してください。"
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "無効なプロセスID"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr "指定されたプロセスIDは存在しません。"
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr "プロセスIDの所有者ではありません"
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr "あなたは指定されたプロセスIDの所有者ではありません。"
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "パッケージが指定されていません"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "パッケージまたはプロセスIDを指定する必要があります。詳細については --help の"
 "出力を確認してください。"
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "許可がありません"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -154,30 +154,30 @@ msgstr ""
 "このプロセスを操作する権限がありません。プロセスの所有者もしくはrootユーザー"
 "として実行してください。"
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "指定されたプロセスIDはプログラムに属していません。"
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Symptomスクリプト %s は、影響を受けたパッケージを特定していません"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "パッケージ %s は存在しません"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "レポートを作成できません"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "問題点のレポートを更新中"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -189,7 +189,7 @@ msgstr ""
 "\n"
 "\"apport-bug\"を使って新規にレポートを作成してください。"
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -209,24 +209,24 @@ msgstr ""
 "\n"
 "本当に進めますか?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "収集する追加情報はありません。"
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "どのような種類の問題を報告しますか？"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "未知の現象"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "現象 \"%s\" は知られていません。"
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -237,7 +237,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -245,30 +245,30 @@ msgstr ""
 "このメッセージを閉じた後でアプリケーションウィンドウ上でクリックして、その問"
 "題について報告してください。"
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "xpropはウィンドウのプロセスIDを特定できませんでした"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "パッケージ名を指定"
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "レポートに追加タグを追加します。複数回指定できます。"
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -279,16 +279,16 @@ msgstr ""
 "ないときには、既知の現象のリストを表示します（暗黙の一つの引数が与えられた場"
 "合）。"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 "問題レポートを埋めるには、ターゲットとなるウィンドウをクリックしてください。"
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "バグ更新モードを開始します。オプション --package が使用できます。"
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -296,7 +296,7 @@ msgstr ""
 "SYMPTOM（症状）についてのバグを報告します（唯一の引数は症状の名前を意味しま"
 "す）。"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -304,7 +304,7 @@ msgstr ""
 "--file-bug モードで使用するパッケージ名を指定します。--pid が指定されている場"
 "合はオプション扱いになります（唯一の引数はパッケージ名を意味します）。"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -314,11 +314,11 @@ msgstr ""
 "指定した場合、バグ報告にはより多くの情報が含まれます（唯一の引数はプロセスID"
 "を意味します）。"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "指定されたpidはハングアップしたアプリケーションのものです。"
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -327,7 +327,7 @@ msgstr ""
 "クラッシュの報告を %s で保留中のプログラムのかわりに .apport または .crash "
 "ファイルで行う（ファイル名が引数のみで与えられた場合）。"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -336,34 +336,34 @@ msgstr ""
 "バグファイリングモードでは、収集した情報は報告する代わりにファイルに保存され"
 "ます。このファイルは、後で別のコンピューターから報告することができます。"
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Apportのバージョン番号を表示します。"
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr "クラッシュの解析を行うため端末ウィンドウでapport-retraceを起動します。"
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "gdbセッションを実行"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "デバッグシンボルをダウンロードせずgdbセッションを実行"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "%s を完全なシンボリックスタックトレースに更新する"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr "レポートの送信のステータス設定を記憶できません"
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -385,7 +385,7 @@ msgstr ""
 "この問題はプログラム %s に発生したものですが、このプログラムはクラッシュして"
 "から変更されています。"
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "この問題の報告は破損しており、処理することができません。"
 
@@ -415,14 +415,14 @@ msgstr "snapの %s"
 msgid "%s deb package"
 msgstr "debパッケージの %s"
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s は %s が公開しているsnapです。バグ報告や質問については %s に連絡してくださ"
 "い。"
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -431,41 +431,41 @@ msgstr ""
 "%s は %s が公開しているsnapです。連絡先のアドレスは提供されていないため、バグ"
 "報告や質問については https://forum.snapcraft.io/ にアクセスしてください。"
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "パッケージまたはソースパッケージ名を特定できませんでした。"
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "ウェブブラウザーを起動できません"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "%s を開くためのウェブブラウザーを起動できません"
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "ネットワークの問題"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "クラッシュデータベースに接続できませんでした。インターネット接続を確認してく"
 "ださい。"
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "メモリー不足"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "コンピューターには、このクラッシュレポートを処理するのに十分なメモリーがあり"
 "ません。"
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -476,11 +476,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "問題は既知のものです"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -489,7 +489,7 @@ msgstr ""
 "この問題は、ブラウザーに表示されたバグレポートですでに報告されています。開発"
 "者にとって役立つような、より詳しい情報を追加できるかどうか確認してください。"
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "この問題はすでに開発者に報告されています。ありがとうございます！"
 
@@ -847,7 +847,7 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "エラー: %s は実行ファイルではありません。中止します。"
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -855,7 +855,7 @@ msgstr ""
 "このことは前のサスペンド中に発生しており、システムが正常に復帰できませんでし"
 "た。"
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -863,7 +863,7 @@ msgstr ""
 "このことは前のハイバネーション中に発生しており、システムが正常に復帰できませ"
 "んでした。"
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/kab.po
+++ b/po/kab.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2011-10-07 06:10+0000\n"
 "Last-Translator: yugurten <yugurten1@hotmail.fr>\n"
 "Language-Team: Kabyle <kab@li.org>\n"
@@ -40,11 +40,11 @@ msgstr ""
 "Ttxil sekcem awal-ik uffir akken ad tkecmeḍ ɣer yineqqisen n wuguren n "
 "wahilen n unagraw"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "Akemmus ur d-ittban ara yettwasbedd akken ilaq"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -52,7 +52,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -65,21 +65,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "ahil arussin"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Suref-aɣ, ahil \"%s\" yemdel akka kan"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Agnu deg %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -87,62 +87,62 @@ msgstr ""
 "Aselkim-inek m ur yesɛi ara ddeqs n tkatut tilellit akken ad yesleḍ ugur s "
 "wudem awurman yerna ad yazen aneqqis i yisneflayen."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Aneqqis n wuguren mačči d ameɣtu"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "Ur tesɛiḍ ara tasiregt ad tkecmeḍ ɣer uneqqis-a n wuguren."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Tuccḍa"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "Ulac ddeqs n tallunt n uḍebsi iwejden akken ad yekker uneqqis-agi."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr "Ulac PID i d-ittunefken"
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr "Teḥwaǧeḍ ad d-tefkeḍ PID. Ẓer --help i wugar n telɣut."
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "PID mačči d ameɣtu"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr "ID i d-ittunefken ur yelli ara."
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr "Mačči PID inek m"
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr "ID n ukala i d-ittunefken mačči d ayla-k m."
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "Ulac akemmus i d-ittunefken"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr "Teḥwaǧed ad d-tefkeḍ akemmus neɣ ID. Ẓer --help i wugar n telɣut."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Tasiregt ur tettwaqbel ara"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -150,30 +150,30 @@ msgstr ""
 "Akala i d-ittnefken mačči d ayla-k. Ttxil-k m selkem ahil-agi am bab n ukala "
 "neɣ am root."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "ID n ukala i d-ittunefken mačči d ayla n wahil."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Akemmus %s ur yelli ara"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "Timerniwt n uneqqis d tawezɣit"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "Aleqqem n uneqqis n wuguren"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -181,7 +181,7 @@ msgid ""
 "Please create a new report using \"apport-bug\"."
 msgstr ""
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -193,24 +193,24 @@ msgid ""
 "Do you really want to proceed?"
 msgstr ""
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "Ulac tilɣa-nniḍen i d-yettwaleqḍen."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "Anwa anaw n wuguren i tebɣiḍ ad temleḍ?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Ccira ur nettwassen ara"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Ccira-nni %s\" ur tettwassen ara."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -221,7 +221,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -229,111 +229,111 @@ msgstr ""
 "Mi tmedleḍ izen-agi ttxil-k m ssit ɣef usfaylu n usnas akken ad tazneḍ "
 "aneqis fell-as."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop igguma ad d-yaf ID n ukala n usfaylu"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "Sbadu isem n ukemmus."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "Rnu ticreḍt-nniḍen i weneqqis. Tezmer ad d-ttunefk aṭas n tikkal."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "Ssit ɣef usfaylu amzun d anican aken ad yaččar uneqqis n wugur."
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Siggez uḍḍun n lqem n uneqqis."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Ayagi ad iskker apport-retrace deg usfaylu n tdiwent akken ad isekyed "
 "aɣelluy."
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "Senker tiɣimit gdb"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Selkem tiɣimit gdb war asader n yizamulen n useɣti"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr "Ur necfi ara nuzen iɣewwaṛen n waddad n uneqqis"
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -350,7 +350,7 @@ msgid ""
 "occurred."
 msgstr "Ugur yeḍra-d akked wahil %s i yebeddelen segmi d-yeḍra uɣelluy."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Aneqqis-agi n wugur yerreẓ yerna ulamek ara yettusekker."
 
@@ -380,53 +380,53 @@ msgstr "snap %s"
 msgid "%s deb package"
 msgstr "Akemmus deb %s"
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "Ulamek tifin n ukemmus neɣ aɣbalu n yisem n ukemmus."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "Ulamek asekker n yiminig n web"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Ulamek asekker n yiminig n web akken ad yeldi %s."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Ugur n uẓeṭṭa"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Ulamek tuqqna ɣer uzadur n yisefka n yiɣelluyen, ttxil-k m elken tuqqna "
 "internet inek m."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr ""
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Anagraw-inek m ur yesɛi ara ddeqs n tkatut akken ad isekker aneqqis-agi n "
 "uɣelluy."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -437,18 +437,18 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "Ugur yetwassen yakan"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 msgstr ""
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Ugur-a dayen yettwamla i yineflayen. Tanemmirt!"
 
@@ -776,19 +776,19 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Tuccḍa: %s mačči d aselkam. Seḥbes."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/kk.po
+++ b/po/kk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2011-04-13 06:20+0000\n"
 "Last-Translator: jmb_kz <Unknown>\n"
 "Language-Team: Kazakh <kk@li.org>\n"
@@ -36,11 +36,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr ""
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -61,21 +61,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "белгісіз бағдарлама"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Кешіріңіз, бірақ \"%s\" бағдарламасы апатты түрде жабылды"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Олқылық (неполадка) %s ішінде"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -84,64 +84,64 @@ msgstr ""
 "есепті жіберу, сіздің компьютеріңізде жады жеткіліксіз болғандықтан мүмкін "
 "емес."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Қате туралы есеп бұрыс"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "Сізде қате есебіне рұқсатыңыз жоқ."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Қате"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "Осы есепті өңдеу үшін дискілік орын жетіспейді."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "Бұрыс PID"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "Пакет көрсетілмеген"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Пакетті немесе PID көрсетуіңіз қажет. Қосымша ақпарат алу үшін бағдарламаны "
 "--help кілтпенен ашыңыз."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Рұқсат жоқ"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -149,30 +149,30 @@ msgstr ""
 "Көрсетілген үрдіс басқа пайдаланушымен орындалуда. Осы бағдарламаны сол "
 "пайдаланушы атынан не әкімшілік құқықтармен ашыңыз."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "Көрсетілген PID басқа үрдіске меншіктелген."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "%s пакеті жоқ"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "Есепті құру мүмкін емес"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "Қате есебі жаңартылуда"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -180,7 +180,7 @@ msgid ""
 "Please create a new report using \"apport-bug\"."
 msgstr ""
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -192,24 +192,24 @@ msgid ""
 "Do you really want to proceed?"
 msgstr ""
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "Қосымша ақпарат жиналынбады."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "Сіз қандай қате туралы хабарлағыңыз келіп тұр?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Белгісіз белгілеулер (симптомдар)"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "\"%s\" белгілеуі (симптомы) белгісіз."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -220,115 +220,115 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr ""
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Apport нұсқасын баспаға шығару."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr ""
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -345,7 +345,7 @@ msgid ""
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Олқылық жайлы есеп бұзылған және де өңделу мүмкін емес."
 
@@ -373,50 +373,50 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr ""
 "Пакеттің атын немесе бастапқы коды бар пакеттің атын анықтау мүмкін емес."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "Веб-шолғышты ашу мүмкін емес"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "%s ашу үшін веб-шолғышты ашу мүмкін емес."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Желілік мәселе"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Жады жетіспейді"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "Осы есепті өңдеу үшін жүйелік жады жетіспейді."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -427,11 +427,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "Қате сондай-ақ белгілі"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -441,7 +441,7 @@ msgstr ""
 "Сіз осы қате жайлы, өндірушілерге көмектесетін, қосымша қосатын "
 "мәліметтеріңіз бар болуын тексеріңіз."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 
@@ -764,19 +764,19 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr ""
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/km.po
+++ b/po/km.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2015-04-27 21:46+0000\n"
 "Last-Translator: Martin Pitt <martin@piware.de>\n"
 "Language-Team: Khmer <km@li.org>\n"
@@ -36,11 +36,11 @@ msgstr "របាយការណ៍​បញ្ហា​ប្រព័ន្ធ
 msgid "Please enter your password to access problem reports of system programs"
 msgstr "សូម​បញ្ចូល​ព័ត៌មាន​លម្អិត​របស់​អ្នក​ ដើម្បី​​ចូល​ដំណើរការ​​​របាយការណ៍​បញ្ហា​នៃ​កម្មវិធី​ប្រព័ន្ធ"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "កញ្ចប់​នេះ​ហាក់​បី​ដូច​ជា​ដំឡើង​មិន​ត្រឹមត្រូវ​ទេ"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -59,21 +59,21 @@ msgstr ""
 "អ្នកមាន​កំណែ​កញ្ចប់​ដែល​លែង​ប្រើ​បាន​ដំឡើង ។ សូម​ធ្វើ​វា​​ឲ្យ​កញ្ចប់​ដូច​ខាង​ក្រោម​ប្រសើរ​ឡើង​ ហើយ​ពិនិត្យ​មើល​ថាតើ​"
 "នៅ​តែ​មាន​បញ្ហា​កើត​ឡើង​ទៀត​ដែរឬទេ ៖ %s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "មិន​ស្គាល់​កម្មវិធី"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "សូម​ទោស កម្មវិធី \"%s\" មិន​ត្រឹមត្រូវ"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "បញ្ហា​នៅ​ក្នុង %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -81,62 +81,62 @@ msgstr ""
 "កម្មវិធី​កុំព្យូទ័រ​របស់​អ្នក​មិន​មាន​អង្គ​ចងចាំ​គ្រប់គ្រាន់ ដើម្បី​ធ្វើវិភាគ​ដោយស្វ័យប្រវត្តិ ហើយ​ផ្ញើ​របាយការណ៍​ទៅ​"
 "អ្នក​អភិវឌ្ឍន៍ ។"
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "របាយការណ៍​បញ្ហា​មិន​ត្រឹមត្រូវ"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "អ្នក​មិន​ត្រូវ​បាន​អនុញ្ញាត​ឲ្យ​ចូល​មើល​របាយការណ៍​បញ្ហា​នេះ ។"
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "កំហុស"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "មិនមាន​ទំហំ​គ្រប់គ្រាន់​ ដើម្បី​ដំណើរការ​របាយការណ៍​នេះ​ទេ ។"
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "PID មិន​ត្រឹមត្រូវ"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "គ្មាន​កញ្ចប់​បាន​បញ្ជាក់​ទេ"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr "អ្នក​ត្រូវ​តែ​បញ្ជាក់​កញ្ចប់ ឬ​ PID ។ ចំពោះ​ព័ត៌មាន​បន្ថែម សូម​មើល --help ។"
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "សិទ្ធិ​ត្រូវ​បាន​បដិសេធ"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -144,30 +144,30 @@ msgstr ""
 "ដំណើរការ​ដែល​បាន​បញ្ជាក់​មិនមែនជា​របស់​អ្នក​ទេ ។ សូម​ដំណើរការ​កម្មវិធី​នេះ​ជា​ម្ចាស់​ដំណើរការ ឬ​ដំណើរការ​"
 "ជា root ។"
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "លេខ​សម្គាល់​ដំណើរការ​ដែល​បាន​បញ្ជាក់ មិន​មែន​ជា​របស់​កម្មវិធី​​នេះ​ទេ ។"
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "ស្គ្រីប​សញ្ញា %s មិន​បាន​កំណត់​កញ្ចប់​ដែល​មាន​ប្រសិទ្ធភាព​ឡើយ"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "គ្មាន​កញ្ចប់ %s ឡើយ"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "មិន​អាច​ធ្វើ​របាយការណ៍​​បាន​ឡើយ"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "ធ្វើ​បច្ចុប្បន្នភាព​របាយការណ៍​​អំពី​បញ្ហា"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -179,7 +179,7 @@ msgstr ""
 "\n"
 "សូម​ធ្វើ​របាយការណ៍​ថ្មី \"apport-bug\" ។"
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -198,24 +198,24 @@ msgstr ""
 "\n"
 "តើ​អ្នក​ពិត​ជា​ចង់​ធ្វើ​បន្ត​ឬ ?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "គ្មាន​ព័ត៌មាន​បន្ថែម​​ដែល​បាន​ប្រមូល​ឡើយ ។"
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "តើ​ប្រភេទ​បញ្ហា​អ្វី​ដែល​អ្នក​ចង់​រាយការណ៍ ?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "មិន​ស្គាល់​សញ្ញា"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "មិន​ស្គាល់​សញ្ញា \"%s\" ។"
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -226,36 +226,36 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr "ក្រោយ​ពេល​​បិទ​សារ​នេះ សូម​ចុច​លើ​​បង្អួច​កម្មវិធី ដើម្បី​រាយការណ៍​អំពី​វា ។"
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "បាន​បរាជ័យ xprop ដើម្បី​កំណត់​លេខ​សម្គាល់​ដំណើរការ​របស់​បង្អួច"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "បញ្ជាក់​ឈ្មោះ​កញ្ចប់ ។"
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "បន្ថែម​ស្លាក​​ខាងក្រៅ​ដើម្បី​រាយការណ៍ ។ អាច​ត្រូវ​បាន​បញ្ជាក់​ពេលវេលា​ច្រើន ។"
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -265,22 +265,22 @@ msgstr ""
 "ប្រសិនបើ​ មិន​ត្រូវ​​បាន​ផ្ដល់​ឲ្យ​ទេ​នោះ បង្ហាញ​បញ្ជី​សញ្ញា​ដែល​មិន​ស្គាល់ ។  (បាន​បញ្ជាក់ ប្រសិនបើ​អាគុយម៉ង់​ត្រូវ​"
 "បាន​ផ្ដល់​ឲ្យ ។)"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "ចុច​លើ​បង្អួច​ដែល​ជា​គោលដៅ​សម្រាប់​បំពេញ​របាយការណ៍​អំពី​បញ្ហា ។"
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "ចាប់ផ្ដើម​ជា​របៀប​​ការ​ធ្វើ​បច្ចុប្បន្នភាព​កំហុស ។ អាច​យក​កញ្ចប់ --ជា​ជម្រើស ។"
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 "ឯកសារ​របាយការណ៍​កំហុស​អំពី​សញ្ញា ។ (បាន​បញ្ជាក់ ប្រសិនបើ​ឈ្មោះ​សញ្ញា​ត្រូវ​បាន​ផ្ដល់​ជា​អាគុយម៉ង់​តែមួយ ។)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -288,7 +288,7 @@ msgstr ""
 "បញ្ជាក់​ឈ្មោះ​កញ្ចប់​ជា​របៀប --កំហុស-ឯកសារ ។ វា​គឺ​ជា​ជម្រើស ប្រសិនបើ --pid ត្រូវ​បាន​បញ្ជាក់ ។ (បាន​"
 "បញ្ជាក់ ប្រសិនបើ​​ឈ្មោះ​កញ្ចប់​ត្រូវ​បាន​ផ្ដល់​ជា​អាគុយម៉ង់​តែមួយ ។)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -297,11 +297,11 @@ msgstr ""
 "បញ្ជាក់​ការ​ដំណើរការ​កម្មវិធី​ជា​របៀប --កំហុស-ឯកសារ ។ ប្រសិនបើ វា​ត្រូវ​បាន​បញ្ជាក់ របាយការណ៍​កំហុស​នឹង​"
 "មាន​ព័ត៌មាន​បន្ថែម ។  (បាន​បញ្ជាក់ ប្រសិនបើ pid ត្រូវ​បាន​ផ្ដល់​ជា​អាគុយម៉ង់​តែមួយ ។)"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "pid ដែល​បាន​ផ្ដល់​ជា​កម្ម​វិធី​ដែល​បាន​ព្យួរ។"
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -310,7 +310,7 @@ msgstr ""
 "របាយការណ៍​គាំង​​ដែល​បាន​ផ្ដល់​ពី​ឯកសារ .apport ឬ .crash ជំនួស​នៅ​ក្នុង%s. ( បាន​បញ្ជាក់​ ប្រសិនបើ​"
 "ឯកសារ​ត្រូវ​បាន​ផ្ដល់​​តែ​អាគុយម៉ង់ ។)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -319,34 +319,34 @@ msgstr ""
 "ជា​របៀប​បំពេញ​កំហុស រក្សាទុក​ព័ត៌មាន​ដែល​បាន​ប្រមូល​នៅ​ក្នុង​ឯកសារ​​ជំនួស​ការ​ធ្វើ​របាយការណ៍​​អំពី​វា ។ ឯកសារ​នេះ​​"
 "អាច​ត្រូវ​បាន​​រាយការណ៍​​ក្រោយ​ពេល​ពី​ម៉ាស៊ីន​ខុសគ្នា ។"
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "បោះពុម្ព​លេខ​កំណែ Apport ។"
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr "វា​នឹង​ចាប់ផ្ដើម apport-retrace នៅ​ក្នុង​បង្អួយ​ស្ថានីយ ដើម្បី​ត្រួតពិនិត្យ​​ភាគ​គាំង ។"
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "រត់​សម័យ  gdb"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "រត់​សម័យ gdb ដោយ​មិន​ទាញ​យក​និមិត្ត​សញ្ញា​បំបាត់​កំហុស"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "ធ្វើ​បច្ចុប្បន្ន %s ជា​មួយ​ដាន​​ជា​​​និមិត្ត​សញ្ញា​ពេញលេញ"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -363,7 +363,7 @@ msgid ""
 "occurred."
 msgstr "បញ្ហា​បានកើត​ឡើង​ជា​មួយ​កម្មវិធី %s ដែល​បាន​ផ្លាស់ប្ដូរ​តាំង​ពី​​មាន​ការ​គាំង ។"
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "របាយការណ៍​អំពី​បង្ហាញ​នេះ​ខូច ហើយ​មិន​អាច​ធ្វើ​បន្ត​បាន​ទេ ។"
 
@@ -391,49 +391,49 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "មិន​អាច​កំណត់​​ ឈ្មោះ​កញ្ចប់​ប្រភព ឬ​កញ្ចប់​បាន​ឡើយ ។"
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "មិន​អាច​ចាប់ផ្ដើម​កម្មវិធី​រុករក​បណ្ដាញ​បាន​ទេ"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "មិន​អាច​ចាប់ផ្ដើម​កម្មវិធី​រុករក​បណ្ដាញ ដើម្បី​បើក %s បាន​ទេ ។"
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "បញ្ហា​បណ្ដាញ"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr "មិន​អាច​តភ្ជាប់​ទៅកាន់​មូលដ្ឋាន​ទិន្នន័យ​គាំង​បាន​ទេ សូម​ពិនិត្យមើល​ការ​តភ្ជាប់​អ៊ីនធឺណិត​របស់​អ្នក ។"
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "ការ​ប្រើ​​​អស់​អង្គ​ចងចាំ"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "ប្រព័ន្ធ​របស់​អ្នក​មិន​មាន​អង្គ​ចងចាំ​គ្រប់គ្រាន់ ដើម្បី​ដំណើរការ​របាយការណ៍​គាំង​នេះ​ទេ ។"
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -444,11 +444,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "ស្គាល់​​​អំពី​បញ្ហា​ហើយ"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -457,7 +457,7 @@ msgstr ""
 "បញ្ហា​នេះ​ត្រូវ​បាន​រាយការណ៍​នៅ​ក្នុង​របាយការណ៍​កំហុស ដែល​បង្ហាញ​នៅ​ក្នុង​កម្មវិធី​រុករក​បណ្ដាញ ។ សូម​ពិនិត្យមើល "
 "ប្រសិនបើ​អ្នក​អាច​បន្ថែម​ព័ត៌មាន​បន្ថែម ​​ដែល​​​អា​ផ្ដល់​ជា​ប្រយោជន៍​សម្រាប់​​អ្នក​អ្នក​អភិវឌ្ឍន៍ ។"
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "បញ្ហា​នេះ​​អាច​ត្រូវ​បាន​រាយការណ៍​ទៅ​កាន់​​​អ្នក​អភិវឌ្ឍន៍ ។ អរគុណ !"
 
@@ -790,21 +790,21 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "កំហុស៖ %s មិន​អាន​ប្រតិបត្តិ​បាន បាន​បញ្ឈប់។"
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 "នេះបានកើតឡើងក្នុងអំឡុងពេលការផ្អាកដងមុន និងបានរារាំងប្រព័ន្ធពីការដំណើរការបន្តយ៉ាងត្រឹមត្រូវ ។"
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 "នេះបានកើតឡើងក្នុងអំឡុងពេលការសម្ងំដងមុន និងបានរារាំងប្រព័ន្ធពីការដំណើរការបន្តយ៉ាងត្រឹមត្រូវ ។"
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/kn.po
+++ b/po/kn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2016-03-26 09:34+0000\n"
 "Last-Translator: Neelavar <Unknown>\n"
 "Language-Team: Kannada <kn@li.org>\n"
@@ -36,11 +36,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr ""
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -61,85 +61,85 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "ಅಜ್ಜ್ನಾತ ಪ್ರೋಗ್ರಾಮ್"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "ಕ್ಷಮಿಸಿ %s ಪ್ರೋಗ್ರಾಮ್ ಅನಿರೀಕ್ಷಿತವಾಗಿ ಅಂತ್ಯಗೊಂಡಿದೆ"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "%s ನಲ್ಲಿ ತೊಂದರೆ"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
 msgstr ""
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "ಅಸಿಂಧುವಾದ ತೊಂದರೆ ವರದಿ"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "ನಿಮಗೆ ಈ ತೊಂದರೆ ವರದಿಯನ್ನು ಪರಿಶೀಲಿಸುವ ಅಧಿಕಾರವಿಲ್ಲ"
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "ದೋಷ"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 "ಈ ತೊಂದರೆ ವರದಿಯನ್ನು ಪರಿಶೀಲಿಸಲು ಬೇಕಾಗುವಷ್ಟು ಸ್ಥಳಾವಕಾಶ ನಿಮ್ಮ ಗಣಕಯಂತ್ರದ "
 "ಡಿಸ್ಕ್(ಮುದ್ರಿಕೆಯಲ್ಲಿ) ನಲ್ಲಿ ಇಲ್ಲ"
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "ಅಮಾನ್ಯವಾದ pid"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "ಯಾವುದೇ ಪ್ಯಾಕೆಜ್ ಹೇಳಲಾಗಿಲ್ಲ"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "ನೀವು ಪ್ಯಾಕೆಜ್ ಅಥವಾ PID ಯನ್ನು ಉಲ್ಲೇಖಿಸಬೇಕು. ಹೆಚ್ಚಿನ ಮಾಹಿತಿಗಾಗಿ --help ಅನ್ನು ನೋಡಿ"
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "ಅನುಮತಿಯು ನಿರಾಕರಿಸಲ್ಪಟ್ಟಿದೆ"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -147,30 +147,30 @@ msgstr ""
 "ಉಲ್ಲೇಖಿಸಿದ ಪ್ರಕ್ರಿಯೆಯು ನಿಮಗೆ ಸಂಬಂಧಿಸಿದಲ್ಲ. ದಯವಿಟ್ಟು ಈ ಅನ್ವಯವನ್ನು ಪ್ರಕ್ರಿಯೆಯ ಯಜಮಾನನಾಗಿ "
 "ಅಥವಾ root ಆಗಿ ಚಾಲನೆ ಮಾಡಿ."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "ಉಲ್ಲೇಖಿಸಿದ ಪ್ರಕ್ರಿಯೆಯ ID ಯಾವುದೇ ಅನ್ವಯಕ್ಕೆ ಸಂಬಂಧಿಸಿದ್ದಲ್ಲ"
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "%s ಪ್ಯಾಕೆಜ್  ಅಸ್ಥಿತ್ವದಲ್ಲಿಲ್ಲ"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "ವರದಿ ತಯಾರಿಸಲು ಸಾಧ್ಯವಿಲ್ಲ"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr ""
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -178,7 +178,7 @@ msgid ""
 "Please create a new report using \"apport-bug\"."
 msgstr ""
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -190,24 +190,24 @@ msgid ""
 "Do you really want to proceed?"
 msgstr ""
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "ಯಾವುದೇ ಹೆಚ್ಚಿನ ಮಾಹಿತಿಯನ್ನು ಸಂಗ್ರಹಿಸಲಾಗಿಲ್ಲ."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "ನೀವು ಯಾವ ವಿಧದ ತೊಂದರೆಯನ್ನು ವರದಿ ಮಾಡಲು ಬಯಸುತ್ತೀರಿ"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "ಅಜ್ಞಾತ ಕುರುಹು"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "\"%s\" ಕುರುಹಿನ ಬಗ್ಗೆ ತಿಳಿದಿಲ್ಲ."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -218,115 +218,115 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr ""
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Apport ನ ಆವೃತ್ತಿ ಸಂಖ್ಯೆಯನ್ನು ಮುದ್ರಿಸು."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr ""
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -343,7 +343,7 @@ msgid ""
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "ಈ ತೊಂದರೆ ವರದಿ ಹಾನಿಗೊಂಡಿದೆ ಆದುದರಿಂದ ಪರಿಷ್ಕರಣೆ ಮಾಡಲಾಗುತ್ತಿಲ್ಲ"
 
@@ -371,49 +371,49 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr ""
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "ಜಾಲ ವೀಕ್ಷಕವನ್ನು ಆರಂಭಿಸಲು ಸಾಧ್ಯವಾಗಿಲ್ಲ."
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "%s ಅನ್ನು ತೆರೆಯಲು ಜಾಲ ವೀಕ್ಷಕವನ್ನು ಆರಂಭಿಸಲು ಸಾಧ್ಯವಾಗಿಲ್ಲ."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr ""
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "ಮೆಮೊರಿ ಖಾಲಿಯಾಗಿದೆ"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -424,18 +424,18 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "ಈಗಾಗಲೆ ತಿಳಿದಿರುವ ತೊಂದರೆ."
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 msgstr ""
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 
@@ -751,19 +751,19 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr ""
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2021-01-23 02:37+0000\n"
 "Last-Translator: Catry <Unknown>\n"
 "Language-Team: Korean <ko@li.org>\n"
@@ -36,11 +36,11 @@ msgstr "시스템 문제 보고"
 msgid "Please enter your password to access problem reports of system programs"
 msgstr "시스템 프로그램의 문제 보고서에 접근하려면 암호를 입력해야 합니다."
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "이 패키지를 올바르게 설치하지 않았습니다."
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -51,7 +51,7 @@ msgstr ""
 "후 다시 시도하시오. 그래도 작동하지 않으면 관련 타사 패키지를 제거하고 다시 "
 "시도하시오."
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -64,21 +64,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "알 수 없는 문제"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "죄송합니다. \"%s\" 프로그램이 예상치 않게 끝났습니다."
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "%s 내의 문제"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -86,64 +86,64 @@ msgstr ""
 "컴퓨터에 자동으로 문제를 분석하여 개발자에게 보고서를 보낼 수 있을 정도의 여"
 "유 메모리가 없습니다."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "올바르지 않은 문제 보고서"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "이 문제 보고서에 접근할 수 있는 권한이 없습니다."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "오류"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "디스크 공간이 부족하여 보고서를 처리할 수 없습니다."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr "PID가 지정되지 않음"
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr "PID를 지정해야 합니다. 더 많은 정보는 --help를 통해 확인하시오."
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "유효하지 않은 PID"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr "지정된 프로세스 ID가 존재하지 않습니다."
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr "당신의 PID가 아님"
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr "지정된 프로세스 ID는 당신의 소유가 아닙니다."
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "패키지가 지정되지 않음"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "패키지 혹은 PID를 지정해야 합니다. --help 옵션으로 더 많은 정보를 확인할 수 "
 "있습니다."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "권한 없음"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -151,30 +151,30 @@ msgstr ""
 "선택한 프로세스는 여러분이 실행한 것이 아닙니다. 이 프로그램을 직접 실행하거"
 "나 root 사용자로 실행하십시오."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "확인된 프로세스 ID는 프로그램에 종속되지 않은 것입니다."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "증상 스크립트 %s에서 영향을 받는 패키지를 확인하지 않았습니다."
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "%s 패키지가 존재하지 않습니다"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "보고서를 만들 수 없습니다"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "문제 보고서 갱신"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -185,7 +185,7 @@ msgstr ""
 "거나 이미 닫힌 문제입니다.\n"
 "\"apport-bug\" 명령을 이용해 새 보고서를 만들어주십시오."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -202,24 +202,24 @@ msgstr ""
 "코멘트를 작성할 것을 권장합니다.\n"
 "정말로 이대로 진행하겠습니까?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "어떠한 추가 정보도 수집하지 않습니다."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "어떤 종류의 문제를 보고하시겠습니까?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "알려지지 않은 증상"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "\"%s\"은(는) 알려지지 않은 증상입니다."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -230,36 +230,36 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr "이 메시지를 닫은 후 문제를 보고할 프로그램의 창을 선택해주십시오."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop 프로그램이 창 프로세스 ID를 알아낼 수 없습니다."
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "패키지 이름을 지정합니다."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "보고서에 태그를 추가합니다. 여러 번 지정할 수 있습니다."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -269,16 +269,16 @@ msgstr ""
 "사용합니다. 어떤 것도 사용하지 않으면 알려진 증상의 목록을 표시합다. (하나의 "
 "인수가 주어진 PID가 유일한 인수일 경우 자동으로 실행합니다.)"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "문제를 보고할 프로그램의 창을 선택해주십시오."
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "버그 업데이트 모드로 시작. 추가적으로 --package 명령을 사용할 수 있습니다."
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -286,7 +286,7 @@ msgstr ""
 "문제 증상에 대한 버그 보고. (문제 증상만이 매개 변수로 주어진 경우 이 모드가 "
 "기본입니다)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -294,7 +294,7 @@ msgstr ""
 "--file-bug 모드에서 패키지 이름을 지정합니다. --pid 명령을 지정하면 사용하지 "
 "않을 수 있습니다.(패키지 이름이 유일한 인수일 경우 자동으로 실행합니다.)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -304,11 +304,11 @@ msgstr ""
 "면 버그 보고에 더 많은 정보를 포함하게 됩니다. (PID가 유일한 인수일 경우 자동"
 "으로 실행합니다.)"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "주어진 PID는 응답이 없는 프로그램입니다."
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -317,7 +317,7 @@ msgstr ""
 "%s에서 대기 중인 것 대신 주어진 .apport 혹은 .crash 파일의 충돌을 보고.(유일"
 "한 인수일 경우 자동으로 실행합니다.)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -326,34 +326,34 @@ msgstr ""
 "버그 정리 모드에서 문제를 보고하지 않고 수집한 정보를 파일로 저장합니다. 이 "
 "파일을 이용해 이후 다른 컴퓨터에서 문제를 보고할 수 있습니다."
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Apport 버전 번호를 출력합니다."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr "충돌을 분석하기 위해 터미널 창에서 apport-retrace 명령을 실행합니다."
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "GDB 세션 실행"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "디버그 심볼을 다운로드하지 않고 GDB 세션을 실행합니다."
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "%s을(를) 심볼릭 스택 트레이스로 업데이트합니다."
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr "보내는 리포트 상태 설정을 기억할 수 없습니다."
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -372,7 +372,7 @@ msgid ""
 "occurred."
 msgstr "충돌 발생 후 바뀐 프로그램 %s에서 문제가 발생했습니다."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "문제 보고서가 손상되어 처리할 수 없습니다."
 
@@ -402,13 +402,13 @@ msgstr "%s 스냅"
 msgid "%s deb package"
 msgstr "%s deb 패키지"
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s 은(는) %s  배포한 스냅에서 제공합니다. 도움이 필요하면 %s 연락하십시오."
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -417,37 +417,37 @@ msgstr ""
 "%s 은(는) %s 배포한 스냅에서 제공합니다. 연락처가 제공되지 않았습니다. 도움"
 "이 필요하면 https://forum.snapcraft.io/ 포럼을 방문하십시오."
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "패키지나 소스 패키지 이름을 알아낼 수 없습니다."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "웹 브라우저를 시작할 수 없습니다"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "웹 브라우저를 이용하여 %s을(를) 열 수 없습니다."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "네트워크 문제"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr "충돌한 데이터베이스에 연결할 수 없습니다. 인터넷 연결을 확인하세요."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "메모리 부족"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "시스템에 충돌 보고서를 처리할 수 있을 만큼의 여유 메모리가 없습니다."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -458,11 +458,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "이미 알려진 문제"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -471,7 +471,7 @@ msgstr ""
 "이 문제는 웹 브라우저에 표시된 버그 보고서에 이미 보고된 것입니다. 개발자에"
 "게 도움이 될 수 있는 추가 정보를 제공할 수 있는지 확인해 주십시오."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "이미 문제를 개발자에게 보고했습니다. 감사합니다!"
 
@@ -811,7 +811,7 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "오류: %s은(는) 실행할 수 없습니다. 멈춥니다."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -819,7 +819,7 @@ msgstr ""
 "이전에 절전을 했을 때 발생하였고 시스템이 정상적으로 계속 진행하는 것을 차단"
 "하고 있습니다."
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -827,7 +827,7 @@ msgstr ""
 "이전에 최대 절전을 했을 때 발생하였고 시스템이 정상적으로 계속 진행하는 것을 "
 "차단하고 있습니다."
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/ku.po
+++ b/po/ku.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2011-10-07 06:10+0000\n"
 "Last-Translator: rizoye-xerzi <rizoxerzi@gmail.com>\n"
 "Language-Team: Kurdish <ku@li.org>\n"
@@ -40,11 +40,11 @@ msgstr ""
 "Xêra xwe ji bo bigihîjî raporên pirsgirêkê yên bernameyên sîstemê şîfreya "
 "xwe têkeve"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "Ev pakêt wekî ku bi awayekî rast bar bûbe nayê xuyan"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -52,7 +52,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -65,21 +65,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "bernameya nenas"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Xemgînim, bernameya \"%s\" bi awayekî ne dihat hêvîkirin hat girtin."
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Pirsgirêk di %s de"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -87,64 +87,64 @@ msgstr ""
 "Komputera te ne xwediyê têr bîr e ku bixeber vê pirsgirêkê analîz bike û "
 "raporekê ji pisporan re bişîne."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Raporkirina pirsgirêkê ya ne derbasdar"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "Destûra te tune tu bigihîjî vê rapora pirsgirêkê."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Çewtî"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "Ji bo kirina vê raporê têr valahiya dîskê tune."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "PID'a nederbasdar"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "Pakêt nehatiye diyarkirin"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Divê tu pakêtekê yan jî PID'ekî dîyarbikî. Ji bo agahiya zêdetir li --help "
 "binêre."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Destûr nehate dayîn"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -152,30 +152,30 @@ msgstr ""
 "Kirara dîyarkirî ne aîdî te ye. Ji kerema xwe ra bernameyê wekî ku xwediyê "
 "kirarê root be bixebitînin."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "ID ya kirarê ku hatiye dîyarkirin ne aîdî bernameyekê ye."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Skrîpta symptomê %s pakêteke tesîrlêbûyî tesbît nekiriye"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Pakêta %s tune"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "Rapor nikare were çêkirin"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "Rapora pirsgirêkê tê rojanekirin"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -187,7 +187,7 @@ msgstr ""
 "\n"
 "Xêra xwe bi bikaranîna \"apport-bug\" raporeke nû çêbike."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -208,24 +208,24 @@ msgstr ""
 "\n"
 "Jidil dixwazî dewam bikî?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "Ti agahiyeke zêdetir nehate civandin."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "Pirsgirêkeke bi çi awayî tu dixwazî rapor bikî?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Nîşaneya nenas"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Nîşaneya \"%s\" nayê zanîn."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -236,7 +236,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -244,32 +244,32 @@ msgstr ""
 "Piştî ku te vê peyamê girt xêra xwe ji bo raporkirina pirsgirêka derbarê vê "
 "de bitikîne ser paceyeke sepanê."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop di tesbîtkirina IDya kirariyê ya paceyê de bi ser neket"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "Navê pakêtê diyar bike."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Etîketekî ekstra li raporê zêde bike. Ji yek caran zêdetir dikare were "
 "diyarkirin."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -279,17 +279,17 @@ msgstr ""
 "yek --pid, ya jîbi tenê --pid ek. Kû yek jî nê dayîn listeya nîşaneyên tên "
 "zanin nîşandide.(Tê wateya ku hebek arguman bê dayîn.)"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "Ji bo tijîkirina rapora pirsgirêkê wekî hedefek bitikîne paceyeke."
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "Di moda rojanekirina çewtiyê de bide destpêkirin. Eger bixwazî dikarî -"
 "package'ek hildî."
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -297,7 +297,7 @@ msgstr ""
 "Di dermafê nîşaneyê de raporeke çewtiyê bipel bike.(Tê wateya ku li şûna "
 "argumanê navê nîşaneyê bê dayîn.)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -306,7 +306,7 @@ msgstr ""
 "diyarkirin, ev girêdayî daxwazê ye. (Eger navê pakêtê wekî yek argumanek "
 "hatibe dayîn.)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -316,11 +316,11 @@ msgstr ""
 "nediyarkirî be, rapora pirsgirêkê wê zêdetir dêtayan bihewîne. (Tê qesdkirin "
 "ku eger PID wekî yek argumenek hatibe dayîn.)"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "Pid'a diyarkirî (id'ya bernameyê) sepanekî nexilasbûyî ye."
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -329,7 +329,7 @@ msgstr ""
 "Rapora çewtiyê li şûna yên ku di %s de li bendê ne ji peldankên .apport an ."
 "crash ragihîne. (Eger navê peldankê wekî yek argumenek be.)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -338,36 +338,36 @@ msgstr ""
 "Di moda tijîkirina çewtiyê de, li şûna ku wan ragihînî agahiyên berhevkirî "
 "qeydê peldankekî bike. Ev peldank paşê ji makîneyek din dikare bê raporkirin."
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Hejmara guhertoya Apport çap bike."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Ev wê ji bo lêkolîna hilweşînê, di paceya termînalê de fermana \"apport-"
 "retrace\" bide xebitandin."
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "Danişîna gdb bixebitîne"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Danişîna gdb'yê bêyî daxistina sembolên neqandina çewtiyan bixebitîne"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Temamiya peldanka %s bi şopa komikê ya sembolîk rojane bike"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr "Mîhengên 'rewşa şandina raportê' nayê bîranîn."
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -389,7 +389,7 @@ msgstr ""
 "Bernameya %s ji wexta hilweşînê û pê ve guherî û tê de pirsgirêkek derkete "
 "holê."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Ev rapora pirsgirêkê xerabe ye û nayê kirin."
 
@@ -417,51 +417,51 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "Nikare pakêtê destnîşan bike an jî navê pakêtê bibîne."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "Nikare geroka webê bide destpêkirin"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Nikare geroka webê bide destpêkirin ji bo vekirina %s."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Pirsgirêka torê"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Nikare bi danegeha hilweşînê ve bê girêdan, Girêdana xwe yê întenetê kontrol "
 "bike."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Têrnekirina bîrkanê"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "Di pergala te de têr bîr tuneye ku kirara vê rapora çewtiyê bike."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -472,11 +472,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "Pirsgirêk jixwe tê zanîn"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -486,7 +486,7 @@ msgstr ""
 "hatiye raporkirin. Xêra xwe kontrol bike gelo tu dikarî ji bo alîkarbûna "
 "pêşvebiran agahiyeke zêdetir lê zêde bikî an na."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Ev pirsgirêk ji pêşdebiran re jixwe hatiye raporkirin. Mala te ava!"
 
@@ -843,7 +843,7 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Çewtî: %s ne bikarbar e. Tê sekinandin."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -851,7 +851,7 @@ msgstr ""
 "Ev rewş ji ber rawestandinê derketiye holê û bûye asteng ku sîstem bi "
 "awayekî rast dewam bike xebitandinê."
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -859,7 +859,7 @@ msgstr ""
 "Ev hal ji ber xistina xewê ya beriya vê derketiye û nehiştiye ku sîstem rast "
 "dewam bike şixulandinê."
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/lt.po
+++ b/po/lt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2019-04-13 17:56+0000\n"
 "Last-Translator: Moo <hazap@hotmail.com>\n"
 "Language-Team: Lithuanian <lt@li.org>\n"
@@ -40,11 +40,11 @@ msgstr ""
 "Įveskite slaptažodį, kad prieitumėte prie sistemos programų pranešimų apie "
 "klaidas"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "Atrodo šis paketas įdiegtas neteisingai"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -52,7 +52,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -65,21 +65,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "nežinoma programa"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Atsiprašome, programa „%s“ netikėtai užsidarė"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "%s klaida"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -87,63 +87,63 @@ msgstr ""
 "Kompiuteris neturi pakankamai laisvos atminties, kad automatiškai "
 "išanalizuotų problemą ir išsiųstų ataskaitą kūrėjams."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Neteisinga ataskaita apie klaidą"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "Jums neleidžiama prieiti prie ataskaitos apie problemą."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Klaida"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "Nepakanka vietos diske šios ataskaitos apdorojimui."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "Neteisingas PID"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr "Nurodyto proceso ID nėra."
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr "Nėra jūsų PID"
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr "Nurodyto proceso ID nepriklauso jums."
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "Nenurodytas paketas"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Jums reikia nurodyti paketą arba PID. Daugiau informacijos gausite su --help."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Neturite teisės"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -151,30 +151,30 @@ msgstr ""
 "Nurodytas procesas jums nepriklauso. Paleiskite programą kaip proceso "
 "valdytojas ar pagrindinis naudotojas."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "Nurodytas proceso ID nepriklauso programai."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Simptomų scenarijus %s nenustatė paveikto paketo"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Paketas %s neegzistuoja"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "Ataskaitos sukurti nepavyko"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "Atnaujinama problemos ataskaita"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -186,7 +186,7 @@ msgstr ""
 "\n"
 "Prašome sukurti naują pranešimą naudojant „apport-bug“."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -206,24 +206,24 @@ msgstr ""
 "\n"
 "Ar tikrai norite tęsti?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "Jokios papildomos informacijos nesurinkta."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "Apie kokią problemų rūšį norite pranešti?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Nežinomas simptomas"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Simptomas „%s“ yra nežinomas."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -234,7 +234,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -242,31 +242,31 @@ msgstr ""
 "Kai uždarysite šį pranešimą, paspauskite ant programos lango, kad "
 "praneštumėte apie tai."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop nepavyko nustatyti lango proceso ID"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "Nurodykite paketo pavadinimą."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Prie ataskaitos pridėti papildomą žymę. Gali būti nurodyta kelis kartus."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -276,15 +276,15 @@ msgstr ""
 "arba tik --pid. Jei nė vienas neduotas, parodyti žinomų simptomų sąrašą. "
 "(Turima omeny, jei duotas tik vienas argumentas.)"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "Pranešti apie problemą, paspauskite ant lango."
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "Pradėti klaidos atnaujinimo režime. Gali prireikti nebūtino --package."
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -292,7 +292,7 @@ msgstr ""
 "Registruoti pranešimą apie simptomą. (Turima omeny, jei simptomo vardas "
 "duotas kaip vienintelis argumentas.)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -300,7 +300,7 @@ msgstr ""
 "Nurodyti paketo vardą --file-bug režime. Tai neprivaloma, jei nurodytas --"
 "pid. (Turima omeny, jei paketo vardas duotas kaip vienintelis argumentas.)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -310,11 +310,11 @@ msgstr ""
 "pranešimas apie klaidą turės daugiau informacijos. (Numanoma, jei pateiktas "
 "„pid“ kaip vienintelis argumentas.)"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "Pateiktas pid yra užstrigusi programa."
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -323,7 +323,7 @@ msgstr ""
 "Pranešti apie strigtį iš duoto apport ar .crash failo, o ne iš laukiančių "
 "%s. (Turima omeny, jei failas duotas kaip vienintelis argumentas.)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -332,35 +332,35 @@ msgstr ""
 "Pranešimo apie klaidą veiksenoje išsaugoti surinktą informaciją į failą "
 "vietoje perdavimo. Šis failas gali būti perduotas vėliau iš kito kompiuterio."
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Atspausdinti Apport versijos numerį."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Tai terminalo lange paleis „apport-retrace“ ir bus galima išanalizuoti lūžį."
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "Vykdyti gdb sesiją"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Vykdyti gdb sesiją, neparsiunčiant derinimo simbolių"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Atnaujinti %s su visiškai simboliniu dėklo pėdsaku"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -377,7 +377,7 @@ msgid ""
 "occurred."
 msgstr "Problema įvyko su programa %s, kuri pasikeitė nuo strigties įvykio."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Ši ataskaita apie klaidą yra pažeista ir negali būti apdorota."
 
@@ -405,52 +405,52 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "Nepavyko nustatyti paketo ar pirminio paketo vardo."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "Nepavyko paleisti žiniatinklio naršyklės"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Nepavyko paleisti žiniatinklio naršyklės %s atverti."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Tinklo problema"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Nepavyko prisijungti prie strigčių duomenų bazės, patikrinkite interneto "
 "ryšį."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Atminties išnaudojimas"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Jūsų sistema neturi pakankamai atminties ataskaitai apie strigtį apdoroti."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -461,11 +461,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "Problema jau žinoma"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -475,7 +475,7 @@ msgstr ""
 "rodomoje žiniatinklio naršyklėje. Patikrinkite ar galite pridėti daugiau "
 "informacijos, kuri galėtų būti naudinga kūrėjams."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Apie šią problemą jau buvo pranešta kūrėjams. Ačiū!"
 
@@ -826,7 +826,7 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Klaida: %s nėra vykdomasis. Stabdoma."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -834,7 +834,7 @@ msgstr ""
 "Tai įvyko ankstesnio pristabdymo metu ir neleido sistemai tinkamai pratęsti "
 "savo darbą."
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -842,7 +842,7 @@ msgstr ""
 "Tai įvyko ankstesnio užmigdymo metu ir neleido sistemai tinkamai pratęsti "
 "savo darbą."
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2018-04-11 17:57+0000\n"
 "Last-Translator: Rūdolfs Mazurs <Unknown>\n"
 "Language-Team: Latvian <lv@li.org>\n"
@@ -40,11 +40,11 @@ msgstr ""
 "Lūdzu, ievadiet savu paroli, lai piekļūtu sistēmas programmu "
 "problēmziņojumiem"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "Šī pakotne šķiet instalēta nekorekti"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -52,7 +52,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -65,21 +65,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "nezināma programma"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Piedod, bet programma „%s“ negaidīti beidza darboties"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Problēma ar %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -87,62 +87,62 @@ msgstr ""
 "Jūsu datoram trūkst brīvas atmiņas, lai veiktu automātisku problēmas analīzi "
 "un nosūtītu ziņojumu izstrādātājiem."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Nepareizs kļūdas ziņojums"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "Jums nav atļauts piekļūt kļūdas ziņojumam."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Kļūda"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "Nepietiek brīvas diska vietas, lai apstrādātu šo ziņojumu."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "Nepareizs PID"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "Nav norādīta pakotne"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr "Jums jānorāda pakotne vai PID. Apskatiet --help, lai uzzinātu vairāk."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Nav tiesību uz procesu"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -150,30 +150,30 @@ msgstr ""
 "Jums nepieder norādītais process. Lūdzu, palaidiet šo programmu kā procesa "
 "īpašnieks vai kā root lietotājs."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "Norādītais procesa ID nepieder programmai."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Simptoma skripts %s nenoteica ietekmēto pakotni"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Pakotne %s neeksistē"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "Neizdodas izveidot ziņojumu"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "Uzlabo ziņojumu par problēmu"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -185,7 +185,7 @@ msgstr ""
 "\n"
 "Lūdzu izveidojiet jaunu ziņojumu izmantojiet \"apport-bug\"."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -206,24 +206,24 @@ msgstr ""
 "\n"
 "Vai jūs patiešām vēlaties turpināt?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "Nekāda papildus informācija netika savākta."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "Par kāda veida problēmu jūs vēlaties ziņot?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Nezināms simptoms"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Simptoms \"%s\" nav zināms."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -234,7 +234,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -242,30 +242,30 @@ msgstr ""
 "Pēc šīs ziņas aizvēršanas, lūdzu, klikšķiniet uz lietotnes loga, lai ziņotu "
 "par tās problēmu."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop neizdevās noteikt loga procesa ID"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "Norādīt pakotnes nosaukumu."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "Pievienot papildu etiķeti atskaitei. Var norādīt vairākas reizes."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -275,16 +275,16 @@ msgstr ""
 "tikai --pid karodziņu. Ja neviens no tiem nav dots, parāda sarakstu ar "
 "zināmiem simptomiem (pieņemot, ka dots viens arguments)."
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "Klikšķiniet uz loga, kas ir problēmas ziņojuma mērķis."
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "Sākt kļūdas atjaunināšanas režīmā. Var pieņemt optionālu --package karodziņu."
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -292,7 +292,7 @@ msgstr ""
 "Aizpildīt kļūdas ziņojumu par simptomu (pieņemot, ka simptoma nosaukums ir "
 "dots kā vienīgais arguments)."
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -300,7 +300,7 @@ msgstr ""
 "Norādiet pakotnes nosaukumu --file-bug režīmā. Tas ir optionāli ja --pid ir "
 "norādīts (pieņemot, ka pakotnes nosaukums ir dots kā vienīgais arguments)."
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -310,11 +310,11 @@ msgstr ""
 "ziņojums saturēs vairāk informācijas. (Tiek pieņemts, ja pid ir padots kā "
 "vienīgais parametrs.)"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "Norādītais procesa identifikators (pid) ir \"uzkārusies\" lietotne"
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -324,7 +324,7 @@ msgstr ""
 "avārijām, kas gaida savu kārtu %s (pieņemot, ka fails ir dots kā vienīgais "
 "arguments)."
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -333,35 +333,35 @@ msgstr ""
 "Kļūdas iesniegšanas režīmā saglabājiet savākto informāciju failā, nevis "
 "ziņojiet par to. Pēc tam uz cita datora šo failu var noziņot."
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Drukāt Apport versijas numuru."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Tas palaidīs apport-retrace termināļa logā, lai sīkāk izpētītu avāriju."
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "Palaist gdb sesiju"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Palaist gdb sesiju bez atkļūdošanas simbolu lejupielādes"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Atjaunināt %s ar pilnīgu simbolisko izsekošanas pavedienu"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -380,7 +380,7 @@ msgid ""
 "occurred."
 msgstr "Problēma notika ar programmu %s, kura ir mainījusies kopš avārijas."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Problēmas ziņojums ir bojāts un to nevar apstrādāt."
 
@@ -408,52 +408,52 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "Neizdevās noteikt pakotnes vai pirmkoda pakotnes nosaukumu."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "Neizdevās palaist tīmekļa pārlūku"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Neizdevās palaist tīmekļa pārlūku, lai atvērtu %s."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Tīkla problēma"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Neizdodas savienoties ar avāriju datubāzi, lūdzu pārbaudiet jūsu Internet "
 "savienojumu."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Atmiņas pārtēriņš"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Jūsu sistēmai nepietiek atmiņas, lai apstrādātu šo ziņojumu par avāriju."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -464,11 +464,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "Jau zināma problēma"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -478,7 +478,7 @@ msgstr ""
 "Lūdzu pārbaudiet, vai jūs varat pievienot papildus informāciju, kas varētu "
 "būt noderīga izstrādātājiem."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Šī problēma jau ir ziņota izstrādātājiem. Paldies!"
 
@@ -832,7 +832,7 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Kļūda — %s nav izpildāms. Aptur."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -840,7 +840,7 @@ msgstr ""
 "Tas gadījās iepriekšējā iesnaudināšanas reizē un tas neļāva sistēmai normāli "
 "atsākt darbu."
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -848,7 +848,7 @@ msgstr ""
 "Tas gadījās iepriekšējā iemidzināšanas reizē un tas neļāva sistēmai normāli "
 "atsākt darbu."
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/mnw.po
+++ b/po/mnw.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2019-11-05 10:32+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Mon <mnw@li.org>\n"
@@ -36,11 +36,11 @@ msgstr "သၞောတ်လိက်ဒုၚ်စဳရေၚ်ပြဿန
 msgid "Please enter your password to access problem reports of system programs"
 msgstr "သွက်ဂွံလုပ်ကျောဝ်ဒုၚ်စဳရေၚ်ပြဿနာသၞောတ်စက်ဂှ်တက်စုတ်ကုဒ်ဒၠုက်ညိ"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr ""
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -57,111 +57,111 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr ""
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr ""
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr ""
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
 msgstr ""
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr ""
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr ""
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr ""
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr ""
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr ""
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr ""
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 msgstr ""
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr ""
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr ""
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr ""
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr ""
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -169,7 +169,7 @@ msgid ""
 "Please create a new report using \"apport-bug\"."
 msgstr ""
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -181,24 +181,24 @@ msgid ""
 "Do you really want to proceed?"
 msgstr ""
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr ""
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr ""
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr ""
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr ""
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -209,115 +209,115 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr ""
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr ""
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr ""
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -334,7 +334,7 @@ msgid ""
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr ""
 
@@ -362,49 +362,49 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr ""
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr ""
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr ""
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr ""
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr ""
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -412,18 +412,18 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr ""
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 msgstr ""
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 
@@ -735,19 +735,19 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "တၚ်ဗၠေတ် %s ဝွံစကာဟွံဂွံ၊ ဒေါံမံၚ်"
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2013-04-08 10:39+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Marathi <mr@li.org>\n"
@@ -36,11 +36,11 @@ msgstr "प्रणाली समस्या अहवाल"
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "हे संकुल योग्य प्रकारे स्थापित केलेले दिसत नाही"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -61,21 +61,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "अपरिचीत कार्यक्रम"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "क्षमस्व, कार्यक्रम \"%s\" अनपेक्षितपणे बंद पडला"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "%s यात समस्या"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -83,63 +83,63 @@ msgstr ""
 "आपल्या संगणकावर आपोआप समस्या विश्लेषण आणि विकसकांसाठी एक अहवाल पाठवण्यासाठी अतिरीक्त "
 "मोकळी जागा नाही."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "अवैध समस्या अहवाल"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "आपण हा समस्या अहवाल प्रवेश करण्याची परवानगी नाही."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "त्रुटी"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "या अहवालावर प्रक्रिया करण्यासाठी पुरेशी जागा उपलब्ध नाही."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "अवैध पीआयडी"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "पॅकेज निर्दिष्ट केले नाही"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "तुम्ही पॅकेज किंवा पी आय डी निर्देशीत करणे आवश्यक आहे. अधिक माहितीसाठी --help पहा."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "परवानगी नाही"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -147,30 +147,30 @@ msgstr ""
 "निर्दिष्ट प्रक्रिया आपणाशी संबंधित नाही. या कार्यक्रमात प्रक्रिया मालक म्हणून किंवा रूट "
 "म्हणून चालवा."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "निर्दिष्ट कार्यपध्दती ID एक कार्यक्रम संबंधित नाही."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "लक्षण स्क्रिप्ट %s ने प्रभावित पॅकेज निश्चित केले नाही"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "पेकेज %s अस्तित्वात नाही"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "अहवाल निर्माण करू शकत नाही"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "समस्या अहवाल अद्ययावत करत आहे"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -182,7 +182,7 @@ msgstr ""
 "\n"
 "\"apport-bug\" वापर करून नवीन अहवाल तयार करा."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -201,24 +201,24 @@ msgstr ""
 "\n"
 "आपण खरोखर पुढे जायचे?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "अधिक माहिती गोळा केली नाही."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "आपण काय प्रकारची समस्या तक्रार नोंदवू इच्छित आहात?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "अपरिचीत लक्षण"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "लक्षण \"%s\" ज्ञात नाही."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -229,36 +229,36 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr "हा संदेश बंद केल्यानंतर त्याबद्दल एक समस्या कळवण्याची खिडकी वर क्लिक करा."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop विंडो प्रक्रिया आयडी निर्धारित करण्यासाठी अयशस्वी झाले"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "पॅकेज नाव निर्देशित करा."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "अहवाल एक अतिरिक्त टॅग जोडा. अनेक वेळा निर्देशीत करणे शक्य आहे."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -268,21 +268,21 @@ msgstr ""
 "आवश्यक आहे. नाही दिली तर ओळखले लक्षणे यादी प्रदर्शित केली जाईल. (एकच आर्ग्युमेण्ट दिले असेल "
 "तर.)"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "एक समस्या अहवालासाठी लक्ष्य विंडो क्लिक करा."
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "बग अद्ययावत करणे मोडमध्ये सुरू. एक पर्यायी --package घेऊ शकता."
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr "एक लक्षणाबद्दल बग अहवाल. (जर लक्षण नाव एकमेव वितर्क म्हणून दिले जाते तर.)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -290,7 +290,7 @@ msgstr ""
 "--file-bug mode मध्ये पॅकेज नाव निर्देशीत करा. एक --pid निर्दिष्ट केले नसेल तर हे ऐच्छिक "
 "आहे. (जर संकुल नाव एकमेव वितर्क म्हणून दिले तर.)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -299,11 +299,11 @@ msgstr ""
 "--file-bug मोड मध्ये एक रनिंग कार्यक्रम निर्देशीत करा. हे निर्देशीत केल्यास, बग अहवाल "
 "अधिक माहिती असेल. (जर पी आय डी एकमेव वितर्क म्हणून दिले तर.)"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "प्रदान PID एक अडकलेला अनुप्रयोग आहे."
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -312,41 +312,41 @@ msgstr ""
 "%s प्रलंबित विषयाऐवजी दिलेले .apport किंवा .crash फाइल पासून क्रॅश अहवाल द्या. (फाइल "
 "एकमेव वितर्क म्हणून दिले गेले असेल तर.)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Apport आवृत्ती क्रमांक छापा."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "gdb सेशन चालवा"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "डिबग चिन्हे डाउनलोड न करता gdb सेशन चालवा"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "पूर्णपणे प्रतिकात्मक स्टॅक ट्रेसने %s अद्ययावत करा"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -363,7 +363,7 @@ msgid ""
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr ""
 
@@ -391,49 +391,49 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "संकुल उगम किंवा संकुल नाव निश्चित करू शकत नाही."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "वेब ब्राउजर सुरु करू शकत नाही"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "%s उघडण्याकरिता वेब ब्राउजर सुरु करू शकत नाही."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "संजाळ समस्या"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr "क्रॅश माहितीकोशाला जोडू शकत नाही, आपले इंटरनेट कनेक्शन तपासा."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "स्मृती अपुरी पडली"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "आपल्या प्रणालीमध्ये हा क्रॅश अहवाल प्रक्रिया करण्यासाठी पुरेशी स्मृती नाही."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -444,18 +444,18 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "समस्या अगोदरच माहित आहे"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 msgstr ""
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "ही समस्या आधीच विकसकांकडे आलेली आहे. धन्यवाद!"
 
@@ -767,19 +767,19 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr ""
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/ms.po
+++ b/po/ms.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2019-09-13 17:48+0000\n"
 "Last-Translator: abuyop <Unknown>\n"
 "Language-Team: Malay <ms@li.org>\n"
@@ -40,11 +40,11 @@ msgstr ""
 "Sila masukkan kata laluan anda untuk mencapai laporan masalah bagi program "
 "sistem"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "Pakej ini nampaknya tidak dipasang dengan betul"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -55,7 +55,7 @@ msgstr ""
 "pakej yang ada, sekiranya tidak berfungsi maka buang pakej-pakej pihak "
 "ketiga dan cuba sekali lagi."
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -68,21 +68,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "program tidak diketahui"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Maaf, program \"%s\" terpaksa ditutup tanpa dijangka"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Masalah pada %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -90,64 +90,64 @@ msgstr ""
 "Komputer anda tidak mempunyai ingatan bebas yang mencukupi untuk "
 "menganalisis masalah dan hantar laporan ke pembangun secara automatik."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Laporan masalah tidak sah"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "Anda tidak dibenarkan mencapai laporan masalah ini."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Ralat"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "Ruang cakera tidak mencukupi untuk memproses laporan ini."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr "Tiada PID dinyatakan"
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr "Anda perlu nyatakan satu PID. Sila rujuk --help untuk maklumat lanjut."
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "PID tidak sah"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr "ID proses yang dinyatakan tidak wujud."
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr "Bukan PID anda"
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr "ID proses yang dinyatakan bukan milik anda."
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "Tiada pakej dinyatakan"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Anda perlu menyatakan satu pakej atau satu PID. Sila rujuk --help untuk "
 "maklumat lanjut."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Kebenaran dinafikan"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -155,30 +155,30 @@ msgstr ""
 "Proses tersebut bukan milik anda. Sila jalankan program sebagai pemilik "
 "proses atau root."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "ID proses yang ditentukan tidak dimiliki oleh program tersebut."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Skrip simptom %s tidak menentukan pakej yang terjejas"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Pakej %s tidak wujud"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "Tidak dapat mencipta laporan"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "Mengemas kini laporan masalah"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -190,7 +190,7 @@ msgstr ""
 "\n"
 "Sila cipta laporan baru menggunakan \"apport-bug\"."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -211,24 +211,24 @@ msgstr ""
 "\n"
 "Adakah anda ingin meneruskannya?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "Tiada maklumat tambahan dikutip."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "Apakah jenis masalah yang anda ingin laporkan?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Simpton tidak diketahui"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Simptom \"%s\" tidak diketahui"
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -239,7 +239,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -247,31 +247,31 @@ msgstr ""
 "Selepas menutup mesej ini sila klik pada tetingkap aplikasi untuk melaporkan "
 "masalah tersebut."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop gagal memastikan ID proses tetingkap"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "Nyatakan nama pakej."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Tambah satu tag tambahan ke dalam laporan. Boleh dinyatakan beberapa kali."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -281,16 +281,16 @@ msgstr ""
 "hanya --pid. Jika tidak diberikan, papar satu senarai simptom yang "
 "diketahui. (Dilaksanakan jika satu argumen tunggal diberikan.)"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 "Klik satu tetingkap sebagai  satu sasaran untuk failkan satu laporan masalah"
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "Mula dalam mod kemas kini pepijat. Boleh ambil pilihan --package."
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -298,7 +298,7 @@ msgstr ""
 "Failkan satu laporan pepijat mengenai simptom. (Dilaksanakan jika nama "
 "simptom diberikan sebagai argumen sahaja.)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -306,7 +306,7 @@ msgstr ""
 "Nyatakan nama pakej dalam mod --file-bug. Ini merupakan pilihan jika --pid "
 "ditentukan. (Dilaksanakan jika nama pakej diberikan sebagai argumen sahaja.)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -315,11 +315,11 @@ msgstr ""
 "Nyatakan nama pakej dalam mod --file-bug. Ini merupakan pilihan jika --pid "
 "ditentukan. (Dilaksanakan jika nama pakej diberikan sebagai argumen sahaja.)"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "Pid yang disediakan adalah aplikasi kaku."
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -329,7 +329,7 @@ msgstr ""
 "yang ditangguh pada %s. (Dilaksanakan jika fail hanya diberikan sebagai "
 "argumen.)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -339,36 +339,36 @@ msgstr ""
 "selain dari melaporkannya. Fail ini kemudiannya boleh dilaporkan melalui "
 "komputer lain."
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Papar nombor versi Apport."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Tindakan ini akan melancarkan apport-retrace dalam tetingkap terminal untuk "
 "memeriksa kerosakan."
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "Jalankan sesi gdb"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Jalankan sesi gdb tanpa memuat turun simbol nyahpepijat"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Kemas kini %s dengan jejak surihan simbolik penuh"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr "Tidak mengingati tetapan status laporan dihantar"
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -390,7 +390,7 @@ msgstr ""
 "Masalah berpunca dari program %s yang mana telah berubah semejak kerosakan "
 "berlaku."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Laporan masalah ini sudah rosak dan tidak boleh diproses."
 
@@ -420,14 +420,14 @@ msgstr "snap %s"
 msgid "%s deb package"
 msgstr "pakej deb %s"
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s disediakan oleh snap yang diterbitkan oleh %s. Sila hubungi mereka "
 "melalui %s untuk mendapatkan bantuan."
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -437,41 +437,41 @@ msgstr ""
 "perhubungan telah disediakan; sila lawati forum di https://forum.snapcraft."
 "io/ untuk mendapatkan bantuan."
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "Tidak dapat mengenal pasti pakej atau nama sumber pakej."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "Tidak boleh memulakan pelayar sesawang"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Tidak boleh mulakan pelayar sesawang untuk membuka %s."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Masalah rangkaian"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Tidak dapat menyambung ke pangkalan data kerosakan, sila semak sambungan "
 "internet anda."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Kehabisan ingatan"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Sistem anda tidak mempunyai ingatan yang mencukupi untuk memproses laporan "
 "kerosakan ini."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -482,11 +482,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "Masalah sudah pun diketahui"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -496,7 +496,7 @@ msgstr ""
 "dalam pelayar sesawang. Sila semak jika anda boleh menambah maklumat "
 "lanjutan lagi yang dikira boleh dianggap berguna untuk para pembangun."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Masalah ini sudah dilaporkan kepada pembangun. Terima kasih!"
 
@@ -857,7 +857,7 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Ralar: %s bukanlah boleh laku. Menghentikan."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -865,7 +865,7 @@ msgstr ""
 "Ia berlaku ketika tangguh terdahulu, dan menghalang sistem menyambung semula "
 "dengan baik."
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -873,7 +873,7 @@ msgstr ""
 "Ia berlaku ketika hibernasi terdahulu, dan menghalang sistem menyambung "
 "semula dengan baik."
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/my.po
+++ b/po/my.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2012-09-04 12:14+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Burmese <my@li.org>\n"
@@ -36,11 +36,11 @@ msgstr "System ကိုပြဿနာအစီရင်ခံစာမျာ�
 msgid "Please enter your password to access problem reports of system programs"
 msgstr "မိမိကွန်ပျူတာ၏စနစ်ကိုပြဿနာအစီရင်ခံစာများဝင်ရောက်ကြည့်ရှုရန်သင့် password ကိုရိုက်ထည့်ပေးပါ"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "ဒီ package သည်ကောင်းမွန်စွာမသွင်းထားဘူးဟုထင်ရပါသည်"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -51,7 +51,7 @@ msgstr ""
 "အပ်ဒိတ်လုပ်ပြီးနောက် ထပ်စမ်းကြည့်ပါ၊ ၎င်းသည် အလုပ်မလုပ်ပါက သက်ဆိုင်ရာ third party "
 "ပက်ကေ့ဂျ်များကိုဖယ်ရှားပြီး ထပ်စမ်းကြည့်ပါ။"
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -64,21 +64,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "အမည်မသိပရိုဂရမ်"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "ဆောရီး၊ ပရိုဂရမ် \"%s\" သည်မမျှော်လင့်ပဲပိတ်သွားပါသည်"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "%s တွင်ပြသာနတက်နေပါသည်"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -86,63 +86,63 @@ msgstr ""
 "သင့်ကွန်ပျူတာတွင် ပြဿနာကိုအလိုအလျောက်ခွဲခြမ်းစိတ်ဖြာပြီး ဆော့ဖ်ဝဲရ်ရေးသားသူများထံ အစီရင်ခံစာပေးပို့ရန်အတွက် "
 "လုံလောက်သည့် free memory မရှိပါ။"
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "ပြဿနာသတင်းပို့ချက်မမှန်ကန်ပါ"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "ဤပြဿနာအစီရင်ခံစာသို့ ဝင်ရောက်ခွင့် သင့်တွင်မရှိပါ။"
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "ချို့ယွင်းချက်"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "ဤအစီရင်ခံစာလုပ်ဆောင်ရန်အတွက် ဒစ်ခ်နေရာမှာ မလုံလောက်ပါ။"
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr "PID မသတ်မှတ်ထားပါ။"
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr "PID သတ်မှတ်ရန် လိုအပ်ပါသည်။ နောက်ထပ်အချက်အလက်များအတွက် --help ကို ကြည့်ပါ။"
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "PID မမှန်ကန်ပါ"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr "သတ်မှတ်ထားသော လုပ်ငန်းစဉ် ID မရှိပါ။"
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr "သင်၏ PID မဟုတ်ပါ။"
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr "သတ်မှတ်ထားသော လုပ်ငန်းစဉ် ID မှာ သင်နှင့်မသက်ဆိုင်ပါ။"
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "ပက်ကေ့ဂျ် သတ်မှတ်ထားခြင်း မရှိပါ။"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "ပက်ကေ့ဂျ်တစ်ခု သို့မဟုတ် PID တစ်ခု သတ်မှတ်ရန် လိုအပ်ပါသည်။ နောက်ထပ်အချက်အလက်များအတွက် --help ကိုကြည့်ပါ။"
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "ခွင့်ပြုချက်ငြင်းပယ်ခြင်းခံရပါသည်"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -150,30 +150,30 @@ msgstr ""
 "သတ်မှတ်ထားသော လုပ်ငန်းစဉ်သည် သင်နှင့် မသက်ဆိုင်ပါ။ ကျေးဇူးပြု၍ ဤပရိုဂရမ်ကို လုပ်ငန်းစဉ်ပိုင်ရှင်အဖြစ် သို့မဟုတ် "
 "root အဖြစ် လုပ်ဆောင်ပါ။"
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "သတ်မှတ်ထားသော လုပ်ငန်းစဉ် ID သည် ပရိုဂရမ်တစ်ခုနှင့် မသက်ဆိုင်ပါ။"
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Symptom script %s သည် ထိခိုက်မှုရှိသောပက်ကေ့ဂျ်ကို မဆုံးဖြတ်နိုင်ပါ။"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Package %s သည်မတည်ရှိပါ"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "report မဖန်တီးနိုင်ပါ"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "ပြဿနာအစီရင်ခံစာကို အပ်ဒိတ်လုပ်နေခြင်း"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -184,7 +184,7 @@ msgstr ""
 "ပိတ်ထားပြီးဖြစ်သည်။\n"
 "ကျေးဇူးပြု၍ \"apport-bug\" ကို အသုံးပြုပြီး အစီရင်ခံစာအသစ်တစ်ခုဖန်တီးပါ။"
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -203,24 +203,24 @@ msgstr ""
 "\n"
 "သင် အမှန်တကယ် ရှေ့ဆက်လိုပါသလား။"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "နောက်ထပ် အချက်အလက် စုဆောင်းထားခြင်းမရှိပါ။"
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "ဘယ်လိုပြဿနာမျိုးကိုသတင်းပို့လိုပါသလား။"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Unknown symptom"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "symptom \"%s\" ကို မသိပါ။"
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -238,37 +238,37 @@ msgstr ""
 "တက်ဘ်တွင် မှန်ကန်သောအက်ပလီကေးရှင်းကို သင်ရှာတွေ့သည်အထိ ရွှေ့ပါ။ လုပ်ငန်းစဉ် ID မှာ ID ကော်လံတွင်ရှိသော "
 "စာရင်းပြုစုထားသည့်နံပါတ်ဖြစ်သည်။"
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 "ဤမက်ဆေ့ဂျ်ကိုပိတ်ပြီးနောက် ၎င်းနှင့်ပတ်သက်သည့် ပြဿနာတစ်ခုကို အစီရင်ခံရန်အတွက် Application Window ကို နှိပ်ပါ။"
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop သည် Window ၏ လုပ်ငန်းစဉ် ID ကို ဆုံးဖြတ်ရန် မအောင်မြင်ပါ။"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr "%(prog)s <သတင်းပို့မှုနံပါတ်>"
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "ပက်ကေ့ဂျ်အမည်ကို သတ်မှတ်ပါ။"
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "အစီရင်ခံစာတွင် အပိုတဂ်တစ်ခု ထည့်ပါ။ အကြိမ်ပေါင်းများစွာ သတ်မှတ်နိုင်ပါသည်။"
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -277,15 +277,15 @@ msgstr ""
 "bug filing မုဒ်တွင် စတင်ပါ။ --package နှင့် optional --pid သို့မဟုတ် --pid တစ်ခုသာ လိုအပ်သည်။ "
 "ပေးထားခြင်းမရှိပါက သိရှိထားသော symptoms စာရင်းကို ပြသပါ။ (အငြင်းအခုံတစ်ခုဖြစ်ပါက ညွှန်းဆိုပါ။)"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "ပြဿနာအစီရင်ခံစာတစ်ခု တင်ရန်အတွက် ပစ်မှတ်အဖြစ် ဝင်းဒိုးတစ်ခုကို နှိပ်ပါ။"
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "bug မွမ်းမံခြင်းမုဒ်တွင် စတင်ပါ။ ရွေးချယ်နိုင်သော --package တစ်ခုကို ယူနိုင်ပါသည်။"
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -293,7 +293,7 @@ msgstr ""
 "Symptom တစ်ခုအကြောင်း bug အစီရင်ခံစာတင်ပါ။ (Symptom အမည်ကို Argument တစ်ခုတည်းအဖြစ် "
 "ပေးထားပါက ညွှန်းဆိုရန်)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -301,7 +301,7 @@ msgstr ""
 "--file-bug မုဒ်တွင် ပက်ကေ့ဂျ်အမည်ကို သတ်မှတ်ပါ။ --pid ကို သတ်မှတ်ထားပါက စိတ်ကြိုက်ရွေးချယ်နိုင်ပါသည်။ "
 "(ပက်ကေ့ဂျ်အမည်ကို Argument တစ်ခုတည်းအဖြစ် ပေးထားပါက ညွှန်းဆိုရန်)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -310,11 +310,11 @@ msgstr ""
 "--file-bug မုဒ်တွင် လုပ်ဆောင်နေသောပရိုဂရမ်ကို သတ်မှတ်ပါ။ ၎င်းကို သတ်မှတ်ထားပါက bug အစီရင်ခံစာတွင် "
 "နောက်ထပ်အချက်အလက်များ ပါဝင်မည်ဖြစ်သည်။ (pid ကို Argument တစ်ခုတည်းအဖြစ်သာ ပေးထားပါက ညွှန်းဆိုရန်)"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "ပေးထားသော pid သည် hanging အက်ပလီကေးရှင်းတစ်ခုဖြစ်သည်။"
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -323,7 +323,7 @@ msgstr ""
 "%s ရှိ ဆိုင်းငံ့ထားသည့်အရာများအစား ပေးထားသည့် .apport သို့မဟုတ် .crash ဖိုင်မှ ပျက်စီးမှုကို အစီရင်ခံပါ။ "
 "( File ကို Argument တစ်ခုတည်းအဖြစ်သာ ပေးထားပါက ညွှန်းဆိုရန်)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -332,34 +332,34 @@ msgstr ""
 "bug တင်သည့်မုဒ်တွင် စုဆောင်းထားသောအချက်အလက်များကို အစီရင်ခံမည့်အစား ဖိုင်တစ်ခုတွင် သိမ်းဆည်းပါ။ ဤဖိုင်ကို "
 "အခြားစက်တစ်ခုမှ နောက်ပိုင်းတွင် အစီရင်ခံနိုင်ပါသည်။"
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Apport ဗားရှင်းနံပါတ်ကိုပရင့်ထုတ်မည်"
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr "ပျက်စီးမှုစစ်ဆေးရန်အတွက် Terminal Window တစ်ခုတွင် appport-retrace ကို ဖွင့်ပေးမည်ဖြစ်သည်။"
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "gdb session ကို ဖွင့်ပါ။"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "debug သင်္ကေတများကို ဒေါင်းလုဒ်မလုပ်ဘဲ gdb session ကို ဖွင့်ပါ။"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "အပြည့်အ၀ symbolic stack trace ဖြင့် %s ကို အပ်ဒိတ်လုပ်ပါ။"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr "ပေးပို့လာသည့် အစီရင်ခံစာအခြေအနေပြသတ်မှတ်ချက်များကို မမှတ်မိနိုင်ပါ။"
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -378,7 +378,7 @@ msgid ""
 "occurred."
 msgstr "ပျက်စီးမှုဖြစ်ပွားပြီးနောက် ပြောင်းလဲခဲ့သည့် ပရိုဂရမ် %s နှင့် ပြဿနာဖြစ်ခဲ့သည်။"
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "ဤပြဿနာအစီရင်ခံစာသည် ပျက်စီးနေပြီး လုပ်ဆောင်နိုင်ခြင်းမရှိပါ။"
 
@@ -407,12 +407,12 @@ msgstr "%s snap"
 msgid "%s deb package"
 msgstr "%s deb package"
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr "%s ကို %s မှ ထုတ်ဝေသော snap မှ ပံ့ပိုးပေးပါသည်။ အကူအညီအတွက် %s မှတစ်ဆင့် ၎င်းတို့ထံ ဆက်သွယ်ပါ။"
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -421,37 +421,37 @@ msgstr ""
 "%s ကို %s မှ ထုတ်ဝေသော snap မှ ပံ့ပိုးပေးပါသည်။ ဆက်သွယ်ရန်လိပ်စာ ပေးမထားပါ။ အကူအညီအတွက် ဖိုရမ် "
 "https://forum.snapcraft.io/ တွင် ဝင်ရောက်ကြည့်ရှုပါ။"
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "ပက်ကေ့ဂျ် သို့မဟုတ် အရင်းအမြစ်ပက်ကေ့ဂျ်အမည်ကို မဆုံးဖြတ်နိုင်ပါ။"
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "Web browser ကိုမဖွင့်နိုင်ပါ"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "%s ဖွင့်ရန် ဝဘ်ဘရောက်ဆာကို စတင်၍မရပါ။"
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "နတ်ဝေါ့ပြသာနာ"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr "ပျက်စီးနေသောဒေတာဘေ့စ်သို့ ချိတ်ဆက်၍မရပါ။ ကျေးဇူးပြု၍ အင်တာနက်ချိတ်ဆက်မှုကို စစ်ဆေးပါ။"
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Memory exhaustion"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "သင့်စနစ်တွင် ဤပျက်စီးမှုအစီရင်ခံစာလုပ်ဆောင်ရန်အတွက် လုံလောက်သော memory မရှိပါ။"
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -462,11 +462,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "ပြသာနာကိုသိရှိပြီးပါပြီ။"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -475,7 +475,7 @@ msgstr ""
 "ဤပြဿနာကို ဝဘ်ဘရောက်ဆာတွင် ပြသထားသည့် bug အစီရင်ခံစာတွင် အစီရင်ခံထားပြီးဖြစ်သည်။ ကျေးဇူးပြု၍ "
 "ဆော့ဖ်ဝဲရ်ရေးသားသူများအတွက် အထောက်အကူဖြစ်နိုင်သည့် နောက်ထပ်အချက်အလက်များထည့်သွင်းနိုင်ရန် စစ်ဆေးပါ။"
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "ဒီပြသာနာကို developer များသို့ပို့ပြီးပါပြီ။ ကျေးဇူးတင်ရှိပါသည်။"
 
@@ -815,14 +815,14 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "အမှားအယွင်း - %s သည် အကောင်ထည်ဖော်နိုင်သော အရာမဟုတ်ပါ။ ရပ်တန့်နေပါသည်။"
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 "၎င်းသည် ယခင် Suspend ကာလအတွင်း ဖြစ်ပွားခဲ့ပြီး စနစ်ကောင်းမွန်စွာ ပြန်လည်စတင်နိုင်စေရန် တားဆီးခဲ့သည်။"
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -830,7 +830,7 @@ msgstr ""
 "၎င်းသည် ယခင် Hibernation ကာလအတွင်း ဖြစ်ပွားခဲ့ပြီး စနစ်ကောင်းမွန်စွာ ပြန်လည်စတင်နိုင်စေရန် "
 "တားဆီးခဲ့သည်။"
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/nb.po
+++ b/po/nb.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2015-04-27 21:47+0000\n"
 "Last-Translator: Martin Pitt <martin@piware.de>\n"
 "Language-Team: Norwegian Bokmål <nb@li.org>\n"
@@ -38,11 +38,11 @@ msgstr "Feilrapporter for system"
 msgid "Please enter your password to access problem reports of system programs"
 msgstr "Skriv inn passordet ditt for å få tilgang til systemets feilrapporter"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "Denne pakken ser ikke ut til å være korrekt installert"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -50,7 +50,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -63,21 +63,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "ukjent program"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Beklager, programmet \"%s\" ble uventet avsluttet"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Problem i %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -85,62 +85,62 @@ msgstr ""
 "Datamaskinen din har ikke nok tilgjengelig minne for å kunne analysere og "
 "rapportere problemet automatisk."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Ugyldig problemrapport"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "Du har ikke tilgang til denne feilrapporten."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Feil"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "Det er ikke nok ledig diskplass til å behandle denne rapporten."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "Ugyldig prosess-id (PID)"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "Ingen pakke er spesifisert"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr "Du må spesifisere en pakke eller PID: Se --hjelp for mer informasjon."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Adgang nektet"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -148,30 +148,30 @@ msgstr ""
 "Den valgte prosessen tilhører ikke deg. Kjør dette programmet som eieren av "
 "prosessen eller som root."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "Den valgte prosess-IDen tilhører ikke noe program."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Symptomskript %s fant ingen berørte pakker"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Pakken %s finnes ikke"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "Kan ikke lage rapport"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "Oppdaterer problemrapport"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -183,7 +183,7 @@ msgstr ""
 "\n"
 "Vennligst lag en ny rapport ved å bruke «apport-bug»."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -203,24 +203,24 @@ msgstr ""
 "\n"
 "Ønsker du å fortsette?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "Ingen tilleggsinformasjon har blitt samlet inn."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "Hva slags problem vil du rapportere?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Ukjent symptom"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Symptomet \"%s\" er ukjent."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -231,7 +231,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -239,30 +239,30 @@ msgstr ""
 "Vennligst klikk på et programvindu etter at du har lukket denne meldingen, "
 "slik at du kan sende en feilrapport om problemet."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "«xprop» fant ikke vinduets prosess-ID"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "Angi pakkenavn."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "Legg til et ekstra stikkord i rapporten. Kan nevnes flere ganger."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -272,15 +272,15 @@ msgstr ""
 "kun --pid. Hvis ingen av disse er gitt vises en liste over kjente symptomer. "
 "(Underforstått at ett argument blir gitt)"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "Klikk på det aktuelle vinduet for å sende en feilrapport om problemet."
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "Start i feiloppdateringmodus. Aksepterer en alternativ --pakke."
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -288,7 +288,7 @@ msgstr ""
 "Send en feilmelding om et problem. (Underforstått hvis problemnavn er gitt "
 "som eneste argument)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -296,7 +296,7 @@ msgstr ""
 "Oppgi pakkenavn i --file-bug-modus. Dette er valgfritt hvis --pid er gitt. "
 "(Underforstått hvis pakkenavn er gitt som eneste argument.)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -306,11 +306,11 @@ msgstr ""
 "spesifisert, vil feilrapporten inneholde mer informasjon. (Dette er allerede "
 "implisert hvis «pid» oppgis som eneste argument.)"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "Den oppgitte pid-en er en applikasjon som henger."
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -319,7 +319,7 @@ msgstr ""
 "Rapporter kræsj fra en gitt .apport- eller .crash-fil i stedet for de "
 "gjeldende i %s. (Underforstått hvis en fil er gitt som eneste argument)."
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -329,35 +329,35 @@ msgstr ""
 "i stedet for å rapportere den. Filen kan innrapporteres senere, for eksempel "
 "fra en annen maskin."
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Skriv ut Apport-versjonsnummeret."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Dette vil starte apport-retrace i et terminalvindu for å undersøke krasjen."
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "Kjør gdb-økt"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Kjør gdb-økt uten å laste ned feilrapporteringssymboler"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Oppdater %s med symbolsk stabelsporing"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -377,7 +377,7 @@ msgstr ""
 "Problemet skjedde med programmet %s, som har endret seg siden kræsjen "
 "oppstod."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Denne feilrapporten er skadet, og kan ikke behandles."
 
@@ -405,50 +405,50 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "Kunne ikke bestemme pakken eller kildepakkens navn."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "Kunne ikke starte nettleser"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Kunne ikke starte nettleseren for å åpne %s."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Nettverksfeil"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Kan ikke koble til krasjdatabasen, vennligst sjekk internettforbindelsen."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Minne fullt"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "Systemet ditt har ikke nok minne til å behandle denne krasjrapporten."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -459,11 +459,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "Problemet er allerede kjent"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -473,7 +473,7 @@ msgstr ""
 "nettleseren. Hvis du har mer informasjon som kan hjelpe utviklerne å løse "
 "problemet, bør du legge det til i rapporten."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Dette problemet er allerede rapportert til utviklerne. Takk!"
 
@@ -825,7 +825,7 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Feil: %s er ikke et kjørbart program. Stopper."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -833,7 +833,7 @@ msgstr ""
 "Dette oppstod mens maskinen stod i hvilemodus, og hindret systemet fra å "
 "våkne skikkelig."
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -841,7 +841,7 @@ msgstr ""
 "Dette oppstod mens maskinen stod i dvalemodus, og hindret systemet fra å "
 "våkne skikkelig."
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/nds.po
+++ b/po/nds.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2011-10-07 06:10+0000\n"
 "Last-Translator: mafix <launchpad@marfix.net>\n"
 "Language-Team: German, Low <nds@li.org>\n"
@@ -36,11 +36,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr ""
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -57,111 +57,111 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr ""
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr ""
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr ""
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
 msgstr ""
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Ungültiger Problem Rapport"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr ""
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr ""
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr ""
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr ""
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr ""
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 msgstr ""
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr ""
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr ""
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr ""
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr ""
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -169,7 +169,7 @@ msgid ""
 "Please create a new report using \"apport-bug\"."
 msgstr ""
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -181,24 +181,24 @@ msgid ""
 "Do you really want to proceed?"
 msgstr ""
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr ""
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr ""
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr ""
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr ""
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -209,115 +209,115 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr ""
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr ""
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr ""
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -334,7 +334,7 @@ msgid ""
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr ""
 
@@ -362,49 +362,49 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr ""
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr ""
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr ""
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr ""
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr ""
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -412,18 +412,18 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr ""
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 msgstr ""
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 
@@ -735,19 +735,19 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr ""
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/ne.po
+++ b/po/ne.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2015-12-27 16:39+0000\n"
 "Last-Translator: sarojdhakal <Unknown>\n"
 "Language-Team: Nepali <ne@li.org>\n"
@@ -36,11 +36,11 @@ msgstr "प्रणाली समस्या प्रतिवेदनह�
 msgid "Please enter your password to access problem reports of system programs"
 msgstr "कृपया प्रणाली कार्यक्रम को समस्या रिपोर्ट पहुँच गर्न आफ्नो पासवर्ड प्रविष्ट  गर्नुहोस"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr ""
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -57,111 +57,111 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "अज्ञात उपक्रम"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "माफ गर्नुहोस्, \"%s\" उपक्रम अप्रत्याशित बन्द भयो।"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "%s मा समस्या"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
 msgstr ""
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "अवैध समस्या प्रतिवेदन"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "तपाईंले यो समस्या रिपोर्ट पहुँच गर्न अनुमति छैन।"
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "त्रुटि"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "अवैध PID"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "निर्दिष्ट नगरिएको प्यकेज"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "इजाजत अस्वीकार गरियो"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 msgstr ""
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr ""
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "%s प्याकेज अस्तित्वमा छैन"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "प्रतिवेदन सिर्जना गर्न सकिएन"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "समस्या प्रतिवेदन अद्यावधिक गर्दै"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -169,7 +169,7 @@ msgid ""
 "Please create a new report using \"apport-bug\"."
 msgstr ""
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -181,24 +181,24 @@ msgid ""
 "Do you really want to proceed?"
 msgstr ""
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "कुनै अतिरिक्त जानकारी संकलन गरिएन ।"
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "तपाईले कस्तो समस्या प्रतिवेदन गर्न चाहनुहुन्छ?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "अज्ञात लक्षण"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "\"%s\" लक्षण विदित छैन।"
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -209,51 +209,51 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "प्याकेज नाम खुलाउनुहोस्"
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -261,65 +261,65 @@ msgstr ""
 "कुनै लक्षण सम्बन्धी त्रुटि प्रतिवेदन दर्ता गर्नुहोस्। (जब लक्षण नाम नै एकमात्र तर्क भएमा लागू "
 "हुने)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr ""
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "gdb सत्र चलाउनुहोस्"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -336,7 +336,7 @@ msgid ""
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "यो समस्या रिपोर्ट क्षतिग्रस्त छ र अघी बढ्न सकिदैन।"
 
@@ -364,49 +364,49 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr ""
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "वेब ब्राउजर सुरु गर्न सकिएन"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "%s खोल्न वेब ब्राउजर सुरु गर्न सकिएन।"
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "सञ्जाल समस्या"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "मेमोरी सकियो"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -417,18 +417,18 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "पूर्वविदित समस्या"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 msgstr ""
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 
@@ -743,21 +743,21 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "त्रुटी: %s सञ्चालन गर्न सकिएन। रोक्दै ।"
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 "यो अघिल्लो निलम्बित हुने समयमा भयो र​ सिस्टमलाई राम्रो सङं पुन: शुरू हुन बाट रोक्यो।"
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 "यो अघिल्लो हाइबर्नेसन् हुने समयमा भयो र​ सिस्टमलाई राम्रो सङं पुन: शुरू हुन बाट रोक्यो।"
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/nl.po
+++ b/po/nl.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2022-04-01 10:43+0000\n"
 "Last-Translator: Hannie Dumoleyn <Unknown>\n"
 "Language-Team: Nederlands <nl_NL@li.org>\n"
@@ -42,11 +42,11 @@ msgstr ""
 "Voer uw wachtwoord in om toegang te krijgen tot de probleemrapporten van "
 "systeemprogramma's"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "Dit pakket lijkt niet juist te zijn geïnstalleerd"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -57,7 +57,7 @@ msgstr ""
 "indexen van beschikbare pakketten heeft bijgewerkt. Als dat niet werkt, "
 "verwijder dan gerelateerde pakketten van derden en probeer het nogmaals."
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -71,21 +71,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "onbekend programma"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Excuses, het programma \"%s\" werd onverwachts afgesloten"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Probleem in %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -93,62 +93,62 @@ msgstr ""
 "Uw computer heeft onvoldoende vrij werkgeheugen om het probleem automatisch "
 "te analyseren en een rapport naar de ontwikkelaars te sturen."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Ongeldig probleemrapport"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "U bent niet bevoegd om dit probleemrapport te bekijken."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Fout"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "Er is onvoldoende schijfruimte om dit rapport te verwerken."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr "Geen PID gespecifieerd"
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr "U dient een PID te specifiëren. Gebruik --help voor meer informatie."
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "Ongeldig PID"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr "De opgegeven proces-ID bestaat niet."
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr "Niet uw ID"
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr "De opgegeven proces-ID is niet van u."
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "Geen pakket opgegeven"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr "U moet een pakket of PID opgeven. Zie --help voor meer informatie."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Toegang geweigerd"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -156,30 +156,30 @@ msgstr ""
 "U bent niet de eigenaar van het opgegeven proces. Voer dit programma uit als "
 "proceseigenaar of als root."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "Het opgegeven proces-PID behoort niet tot een programma."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Symptoom-script %s kon geen betrokken pakket bepalen"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Pakket %s bestaat niet"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "Kan rapport niet aanmaken"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "Probleemrapport aan het bijwerken"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -191,7 +191,7 @@ msgstr ""
 "\n"
 "Maak alstublieft een nieuw rapport aan met \"apport-bug\"."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -211,24 +211,24 @@ msgstr ""
 "\n"
 "Wilt u echt doorgaan?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "Geen extra informatie verzameld."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "Wat voor soort probleem wilt u rapporteren?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Onbekend symptoom"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Het symptoom \"%s\" is onbekend."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -246,7 +246,7 @@ msgstr ""
 "voeren. Blader op het tabblad Processen totdat u de juiste toepassing vindt. "
 "De proces-ID is het nummer dat wordt vermeld in de ID-kolom."
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -254,32 +254,32 @@ msgstr ""
 "Nadat u dit bericht heeft gesloten dient u op een venster te klikken om "
 "daarvoor een probleem te rapporteren."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop kon het proces-ID niet bepalen van het venster"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "Pakketnaam opgeven"
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Voeg een extra tag aan het rapport toe. Dit kan meerdere keren worden "
 "opgegeven."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -290,16 +290,16 @@ msgstr ""
 "met bekende symptomen getoond worden. (Impliciet als een enkel argument is "
 "opgegeven.)"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "Klik het venster aan waar u een rapport voor wilt indienen"
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "In modus voor het updaten van bugs starten. Mogelijk met optioneel --package."
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -307,7 +307,7 @@ msgstr ""
 "Een foutrapport over een symptoom indienen. (Impliciet als symptoomnaam het "
 "enige argument is.)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -315,7 +315,7 @@ msgstr ""
 "Pakketnaam in --file-bug-modus opgeven. Dit is optioneel als een --pid is "
 "opgegeven. (Impliciet als pakketnaam het enige argument is.)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -324,11 +324,11 @@ msgstr ""
 "Indien u een programma uitvoert in de --file-bug modus, zal het bugrapport "
 "meer informatie bevatten."
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "De gegeven PID is een vastgelopen toepassing."
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -338,7 +338,7 @@ msgstr ""
 "plaats van de wachtende rapporten in %s. (Impliciet als file het enige "
 "argument is.)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -348,36 +348,36 @@ msgstr ""
 "bestand in plaats van het aan te melden. U kunt dit bestand dan op een later "
 "tijdstip vanaf een andere computer aanmelden."
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Het versienummer van Apport weergeven."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Dit zal apport-retrace starten in een terminalvenster om de crash te "
 "onderzoeken."
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "gdb-sessie draaien"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "gdb-sessie draaien zonder debugsymbolen te downloaden"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Update %s met volledige symbolic stack trace"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr "Instellingen voor rapportstatus verzenden kunnen niet worden onthouden"
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -400,7 +400,7 @@ msgstr ""
 "Het probleem deed zich voor bij het programma %s dat gewijzigd werd sinds "
 "het voorvallen van de crash."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Dit probleemrapport is beschadigd en kan niet worden verwerkt."
 
@@ -431,14 +431,14 @@ msgstr "%s snap"
 msgid "%s deb package"
 msgstr "%s deb package"
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s wordt geleverd door een snap uitgebracht door %s. Neem contact met hen op "
 "via %s voor hulp."
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -447,39 +447,39 @@ msgstr ""
 "%s wordt geleverd door een snap uitgebracht door %s. Er is geen contactadres "
 "beschikbaar; bezoek het forum op https://forum.snapcraft.io/ voor hulp."
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "Kon de naam van het pakket of het bronpakket niet bepalen."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "Kon de webbrowser niet starten"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Kon de webbrowser niet starten om %s te openen."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Netwerkprobleem"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Verbinding met crash-database mislukt, controleer uw internetverbinding."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Geheugen vol"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Uw systeem heeft onvoldoende geheugen om dit foutenrapport te verwerken."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -490,11 +490,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "Probleem reeds bekend"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -504,7 +504,7 @@ msgstr ""
 "webbrowser wordt weergegeven. Controleer of u extra informatie kunt "
 "toevoegen die voor de ontwikkelaars nuttig kan zijn."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Dit probleem is al doorgegeven aan de ontwikkelaars. Dank u wel!"
 
@@ -866,7 +866,7 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Fout: %s is geen uitvoerbaar bestand. Wordt stopgezet."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -874,7 +874,7 @@ msgstr ""
 "Dit gebeurde tijdens een eerdere pauzestand, waardoor het systeem niet op de "
 "juiste wijze herstart werd."
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -882,7 +882,7 @@ msgstr ""
 "Dit gebeurde tijdens een eerdere slaapstand, waardoor het systeem niet op de "
 "juiste wijze herstart werd."
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/oc.po
+++ b/po/oc.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2021-05-23 19:19+0000\n"
 "Last-Translator: Quentin PAGÈS <Unknown>\n"
 "Language-Team: Occitan (post 1500) <oc@li.org>\n"
@@ -40,11 +40,11 @@ msgstr ""
 "Picatz vòstre senhal per accedir a de rapòrts de problèmas de programas "
 "sistèma"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "Sembla qu'aqueste paquet es pas installat corrèctament."
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -55,7 +55,7 @@ msgstr ""
 "a jorn los indexes dels paquets disponibles, se fonciona pas, suprimissètz "
 "los paquets tèrces ligats e tornatz ensajar."
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -66,21 +66,21 @@ msgstr ""
 "Las versions installadas d'unes paquets son obsoletas. Metètz a jorn los "
 "paquets seguents, puèi verificatz se lo problèma es encara present :%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "programa desconegut"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "O planhèm, lo programa « %s » a quitat d'un biais imprevist"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Problèma dins %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -88,63 +88,63 @@ msgstr ""
 "Vòstre ordenador possedís pas pro de memòria liura per analisar "
 "automaticament lo problèma e mandar un rapòrt als desvolopaires."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Rapòrt d'incident invalid"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "Sètz pas autorizat a accedir aqueste rapòrt d'incident."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Error"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "I a pas pro d'espaci de disc disponible per tractar aqueste rapòrt."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr "Cap de PID especificat"
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr "Devètz especificar un PID. Vejatz --help per mai d’informacions."
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "PID invalida"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr "L'ID de processus indicat existís pas."
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr "Pas vòstre PID"
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr "L’identificant de processus indicat vos aparten pas."
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "Cap de paquet pas especificat"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Vos cal precisar un paquet o un PID. Utilizatz --help per mai d'informacions."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Autorizacion refusada"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -152,30 +152,30 @@ msgstr ""
 "Lo processus especificat vos aparten pas. Executatz aqueste programa en tant "
 "que proprietari del processus o en tant qu'administrator (root)."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "L'ID de processus especificat aparten pas a cap de programa."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "L'escript  %s a pas pogut determinar un paquet afectat"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Lo paquet %s existís pas"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "Impossible de crear lo rapòrt"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "Mesa a jorn del rapòrt d'incident"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -186,7 +186,7 @@ msgstr ""
 "tampat o s'agís d'un doblon.\n"
 "Creatz un rapòrt novèl en utilizant « apport-bug »."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -204,24 +204,24 @@ msgstr ""
 "\"apport-bug\"  e de ne far un comentari dins lo bug inicial.  \n"
 "Sètz segur que volètz contunhar ?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "Cap d'informacion suplementària es pas estada collectada."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "Quin tipe de problèma volètz senhalar ?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Simptòma desconegut"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Lo simptòma « %s » es desconegut."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -232,7 +232,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -240,32 +240,32 @@ msgstr ""
 "Aprèp la tampadura d'aqueste messatge, clicatz sus la fenèstra de "
 "l'aplicacion per la quala volètz senhalar un problèma."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop a pas pogut determinar l'ID del processus de la fenèstra"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "Indicatz lo nom del paquet."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Apondre un marcador suplementari pel rapòrt. Pòt èsser especificat mantun "
 "còp."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -275,15 +275,15 @@ msgstr ""
 "opcion, o simplament --pid. Se n'i a pas cap de provesit, aficha una lista "
 "de simptòmas coneguts. (Implicit se un sol argument es provesit.)"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "Clicatz sus la fenèstra per la quala volètz senhalar un problèma."
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "Començar en mòde « mesa a jorn de bug ». Accèpta l'opcion --package"
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -291,7 +291,7 @@ msgstr ""
 "Efectua un senhalament de bug a prepaus d'un simptòma. (Implicit se lo nom "
 "del simptòma es donat coma argument unic.)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -300,7 +300,7 @@ msgstr ""
 "pid es especificat. (Implicit se lo nom del paquet es donat coma argument "
 "unic.)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -310,11 +310,11 @@ msgstr ""
 "especificat, lo rapòrt de bug contendrà mai d'informacions. (implicita se "
 "l’identificant del processus es passat coma argument unic)"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "Lo pid provesit es una aplicacion que respond pas."
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -324,7 +324,7 @@ msgstr ""
 "partir de los que son en espèra dins %s. (Implicit se lo fichièr es donat "
 "coma argument unic.)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -334,37 +334,37 @@ msgstr ""
 "un fichièr puslèu que de generar un rapòrt. Aqueste fichièr poirà èsser "
 "utilizat pus tard a partir d'una autra maquina per mandar un rapòrt."
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Aficha lo numèro de version d'Apport."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Aquò va aviar apport-retrace dins una fenèstra de terminal per examinar lo "
 "crash."
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "Aviar una session gdb"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Executar la session gdb sens telecargar los simbòls de desbugatge"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Mesa a jorn de %s amb una traça de la pila totalament simbolica"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 "Impossible de se remembrar dels paramètres d'estat del rapòrt de mandadís"
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -386,7 +386,7 @@ msgid ""
 msgstr ""
 "Lo problèma concernís lo programa %s qu'a cambiat dempuèi lo plantatge."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Aqueste rapòrt d'incident es damatjat e pòt pas èsser tractat."
 
@@ -418,14 +418,14 @@ msgstr "snap %s"
 msgid "%s deb package"
 msgstr "paquet deb %s"
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s es provesit per un snap publicat per %s. Contactatz-los via %s per "
 "obténer d’ajuda."
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -435,41 +435,41 @@ msgstr ""
 "fornida ; consultatz lo forum a l’adreça https://forum.snapcraft.io/ per "
 "obténer d’ajuda."
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "Impossible de determinar lo nom del paquet o del paquet font."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "Impossible d'aviar lo navigador web"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Impossible d'aviar lo navigador web per dobrir %s."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Problèma de ret"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Impossible de se connectar a la basa de donadas dels plantatges. Verificatz "
 "vòstra connexion a l'Internet."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Memòria saturada"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Vòstre sistèma dispausa pas de pro de memòria per tractar aqueste rapòrt "
 "d'incident."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -480,11 +480,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "Problèma ja conegut"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -494,7 +494,7 @@ msgstr ""
 "vòstre navigador. Verificatz se podètz apondre d'informacions "
 "complementàrias susceptiblas d'ajudar los desvolopaires."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Aqueste problèma es ja estat senhalat als desvolopaires. Mercé !"
 
@@ -862,7 +862,7 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Error : %s es pas un executable. Arrèst."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -870,7 +870,7 @@ msgstr ""
 "Aquò s'es produit precedentament al moment d'una mesa en velha e a empachat "
 "lo sistèma de se reaviar corrèctament."
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -878,7 +878,7 @@ msgstr ""
 "Aquò s'es produit precedentament al moment d'una mesa en velha perlongada e "
 "a empachat lo sistèma de se reaviar corrèctament."
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2014-02-02 00:14+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Punjabi <pa@li.org>\n"
@@ -36,11 +36,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr ""
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -57,111 +57,111 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr ""
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr ""
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr ""
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
 msgstr ""
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr ""
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr ""
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr ""
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr ""
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr ""
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr ""
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 msgstr ""
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr ""
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr ""
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr ""
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr ""
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -169,7 +169,7 @@ msgid ""
 "Please create a new report using \"apport-bug\"."
 msgstr ""
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -181,24 +181,24 @@ msgid ""
 "Do you really want to proceed?"
 msgstr ""
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr ""
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr ""
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr ""
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr ""
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -209,115 +209,115 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr ""
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr ""
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr ""
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -334,7 +334,7 @@ msgid ""
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr ""
 
@@ -362,49 +362,49 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr ""
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr ""
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr ""
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr ""
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr ""
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -412,18 +412,18 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr ""
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 msgstr ""
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 
@@ -735,19 +735,19 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "ਗਲਤੀ: %s ਚੱਲਣਯੋਗ ਨਹੀਂ ਹੈ। ਬੰਦ ਹੋ ਰਿਹਾ ਹੈ।"
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2021-01-07 22:33+0000\n"
 "Last-Translator: Marek Adamski <Unknown>\n"
 "Language-Team: Polish <pl@li.org>\n"
@@ -37,11 +37,11 @@ msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 "Aby uzyskać dostęp do raportów o błędach systemowych, należy wprowadzić hasło"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "Prawdopobnie pakiet został zainstalowany nieprawidłowo"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -52,7 +52,7 @@ msgstr ""
 "zaktualizowaniu indeksów dostępnych pakietów, jeśli to nie zadziała, usunąć "
 "powiązane pakiety dostawców zewnętrznych i spróbować ponownie."
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -65,21 +65,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "nieznany program"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Przepraszamy, program %s został niespodziewanie zakończony"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Wystąpił problem w %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -87,68 +87,68 @@ msgstr ""
 "Komputer nie posiada wystarczającej ilości wolnej pamięci, aby automatycznie "
 "przeanalizować problem i zgłosić błąd do twórców programu."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Nieprawidłowe zgłoszenie o błędzie"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "Brak dostępu do zgłoszenia o błędzie."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Błąd"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 "Brak wystarczającej ilości wolnego miejsca na dysku, aby przetworzyć to "
 "zgłoszenie."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr "Nie określono PID"
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 "Należy podać PID. Więcej informacji dostępnych po wpisaniu --help w "
 "terminalu."
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "Nieprawidłowy identyfikator procesu"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr "Podany ID procesu nie istnieje."
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr "Nie Twój PID"
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr "Podany ID procesu nie należy do Ciebie."
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "Nie określono pakietu"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Należy określić pakiet lub identyfikator procesu. Proszę użyć opcji --help, "
 "aby uzyskać więcej informacji."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Brak dostępu"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -156,30 +156,30 @@ msgstr ""
 "Określony proces nie jest własnością bieżącego użytkownika. Proszę uruchomić "
 "ten program jako właściciel procesu lub jako administrator."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "Określony identyfikator procesu nie powiązany jest z żadnym programem."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Skrypt symptomu %s nie określił pakietu"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Pakiet %s nie istnieje"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "Nie można utworzyć raportu"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "Uaktualnianie zgłoszenia o błędzie"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -191,7 +191,7 @@ msgstr ""
 "\n"
 "Proszę zgłosić błąd używając narzędzia \"apport-bug\"."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -212,24 +212,24 @@ msgstr ""
 "\n"
 "Kontynuować?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "Nie zebrano dodatkowych informacji."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "Jaki rodzaj zgłoszenia ma zostać wysłany?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Nieznany symptom"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Symptom \"%s\" jest nieznany"
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -248,7 +248,7 @@ msgstr ""
 "Na karcie Procesy przewiń, aż znajdziesz odpowiedni program. Identyfikator "
 "procesu to numer podany w kolumnie Identyfikator."
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -256,32 +256,32 @@ msgstr ""
 "Po zamknięciu tej wiadomości, proszę kliknąć okno programu, aby zgłosić jego "
 "błąd."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 "Nie udało się określić identyfikatora okna procesu przy użyciu programu xprop"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr "%(prog)s <numer raportu>"
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "Określa nazwę pakietu"
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "Dodaje dodatkową etykietę do zgłoszenia. Można użyć kilkukrotnie."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 "%(prog)s [opcje] [symptom|pid|pakiet|ścieżka programu|plik .apport/.crash]"
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -291,17 +291,17 @@ msgstr ""
 "opcjonalnie --pid, lub tylko opcji --pid. Jeśli żadna opcja nie zostanie "
 "użyta, wyświetlona zostanie lista symptomów."
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "Zgłasza błąd programu wskazanego kliknięciem w okno docelowe"
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "Uruchomia w trybie aktualizacji zgłoszenia błędu. Można użyć z opcją --"
 "package."
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -309,7 +309,7 @@ msgstr ""
 "Zgłasza błąd dotyczący symptomu (wymuszone jeśli podano nazwę symptomu jako "
 "parametr)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -317,7 +317,7 @@ msgstr ""
 "Określa nazwę pakietu w trybie zgłaszania błędu. Opcjonalne, jeśli użyto "
 "opcję --pid (wymuszone, jeśli podano nazwę pakietu jako parametr)."
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -326,11 +326,11 @@ msgstr ""
 "Określa program w trybie zgłaszania błędu. Dodaje do zgłoszenia większą "
 "ilość informacji (pid jest podany jako jedyny parametr)."
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "Podany pid to numer zawieszonej aplikacji."
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -340,7 +340,7 @@ msgstr ""
 "crash zamiast oczekujących w %s (wymuszone, jeśli określono plik jako "
 "parametr)."
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -349,34 +349,34 @@ msgstr ""
 "Zapisuje informacje o błędzie do pliku, zamiast zgłaszać go. Raport zawarty "
 "w pliku, może być zgłoszony później z innego komputera."
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Wypisuje informacje o wersji"
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr "Analiza awarii w terminalu za pomocą apport-retrace"
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "Rozpoczyna sesję gdb"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Rozpoczęcie sesji gdb bez pobierania symboli debugowania"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Aktualizacja %s z pomocą fully symbolic stack trace"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr "Nie można zapamiętać ustawień statusu wysyłania zgłoszeń"
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -395,7 +395,7 @@ msgid ""
 "occurred."
 msgstr "Problem dotyczy programu %s, który został zmieniony od czasu awarii."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr ""
 "To zgłoszenie o błędzie jest uszkodzone i nie może zostać przetworzone."
@@ -426,14 +426,14 @@ msgstr "Snap %s"
 msgid "%s deb package"
 msgstr "Pakiet deb %s"
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s dostarczono przez snap opublikowany przez %s. Należy skontakować się za "
 "pomocą %s, aby uzyskać pomoc."
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -443,41 +443,41 @@ msgstr ""
 "kontaktowego; należy odwiedzić forum pod adresem https://forum.snapcraft."
 "io/, aby uzyskać pomoc."
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "Nie można ustalić pakietu lub nazwy pakietu źródłowego."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "Nie można uruchomić przeglądarki internetowej"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Nie można uruchomić przeglądarki internetowej, aby otworzyć %s."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Problem z siecią"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Nie można połączyć się z bazą danych awarii, proszę sprawdzić połączenie "
 "internetowe."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Pamięć wyczerpana"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "System nie dysponuje wystarczającą ilością pamięci, aby przetworzyć raport "
 "błędu."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -488,11 +488,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "Błąd został już zgłoszony"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -502,7 +502,7 @@ msgstr ""
 "internetowej. Proszę sprawdzić, czy można dodać jakiekolwiek dalsze "
 "informacje, które mogą być pomocne twórcom programu."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Programiści zostali już poinformowani o tym problemie. Dziękujemy!"
 
@@ -863,7 +863,7 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Błąd: nie można wykonać %s. Zatrzymywanie."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -871,7 +871,7 @@ msgstr ""
 "Wydarzyło się to podczas poprzedniego stanu wstrzymania i uniemożliwiło "
 "systemowi poprawne przejście do normalnego stanu pracy."
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -879,7 +879,7 @@ msgstr ""
 "Wydarzyło się to podczas poprzedniego stanu uśpienia i uniemożliwiło "
 "systemowi poprawne przejście do normalnego stanu pracy."
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2022-07-13 12:35+0000\n"
 "Last-Translator: Hugo Carvalho <hugokarvalho@hotmail.com>\n"
 "Language-Team: Portuguese <pt@li.org>\n"
@@ -40,11 +40,11 @@ msgstr ""
 "Por favor introduza a sua password para aceder a relatórios de problemas "
 "relativos a programas de sistema"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "Este pacote não parece estar instalado corretamente"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -55,7 +55,7 @@ msgstr ""
 "os índices dos pacotes disponíveis; se isso não funcionar, remova os pacotes "
 "de terceiros relacionados e tente novamente."
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -68,21 +68,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "programa desconhecido"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Desculpe, o programa %s fechou inesperadamente"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Problema em %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -90,64 +90,64 @@ msgstr ""
 "O seu computador não tem memória livre suficiente para analisar "
 "automáticamente o problema e enviar um relatório para os programadores."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Relatório do problema inválido"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "Você não tem autorização para aceder ao relatório deste problema."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Erro"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 "Não tem espaço livre suficiente no disco para processar este relatório."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr "PID não foi especificado"
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr "Precisa especificar um PID. Veja --help para obter mais informação."
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "PID inválido"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr "O ID do processo especificado não existe."
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr "Não é o seu PID"
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr "O ID do processo especificado não lhe pertence."
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "Nenhum pacote especificado"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Deve especificar um pacote ou um PID. Veja --help para mais informações."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Permissão negada"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -155,30 +155,30 @@ msgstr ""
 "O processo especificado não lhe pertence. Por favor execute este programa "
 "como dono do processo ou como \"root\"."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "O ID de processo especificado não pertence a um programa."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "O script de sintoma %s não determinou um pacote afetado."
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "O pacote %s não existe"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "Não foi possível criar relatório"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "Actualizando relatório de problemas"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -190,7 +190,7 @@ msgstr ""
 "\n"
 "Por favor, crie um novo relatório usando \"apport-bug\"."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -210,24 +210,24 @@ msgstr ""
 "\n"
 "Deseja realmente continuar?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "Nenhuma informação adicional colectada."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "Que tipo de problema quer reportar?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Sintoma desconhecido"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "O sintoma \"%s\" não é conhecido"
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -246,7 +246,7 @@ msgstr ""
 "Sistema. No separador Processos, deslocar com o rato até encontrar a "
 "aplicação correcta. O ID de processo é o número listado no ID da coluna."
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -254,32 +254,32 @@ msgstr ""
 "Após fechar esta mensagem, clique por favor na janela da aplicação para "
 "relatar um problema sobre ela."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop falhou ao determinar a ID do processo da janela"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr "%(prog)s <report number>"
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "Especifique o nome do pacote"
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Adicione uma marca extra ao relatório. Pode ser especificada várias vezes."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -289,16 +289,16 @@ msgstr ""
 "só um --pid. Se não for indicado nenhum, exibir uma lista de sintomas "
 "conhecidos. (Implícito se dor indicado um único argumento.)"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "Clique uma janela como alvo para preencher um relatório de problemas."
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "Iniciar em modo de actualização de erros. Pode levar um --package opcional."
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -306,7 +306,7 @@ msgstr ""
 "Submeter um relatório de bugs sobre um sintoma. (Implícito se for indicado "
 "um nome do sintoma como um único argumento.)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -315,7 +315,7 @@ msgstr ""
 "especificado. (Automático se um nome de pacote é fornecido como único "
 "argumento.)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -325,11 +325,11 @@ msgstr ""
 "especificado, o relatório de erros irá conter mais informações. (Implícito "
 "se pid for apenas argumento.)"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "O pid fornecido é uma aplicação pendente."
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -339,7 +339,7 @@ msgstr ""
 "arquivos pendentes em %s. (Automático se o arquivo é fornecido como único "
 "argumento)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -349,34 +349,34 @@ msgstr ""
 "vez de a relatar. Este ficheiro pode ser relatado mais tarde a partir de uma "
 "máquina diferente."
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Imprime o número da versão do Apport"
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr "Vai ser lançado apport-retrace no terminal para examinar o erro."
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "Executar sessão gdb"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Executar sessão gdb sem transferir símbolos de depuração"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Atualização %s com o conjunto simbolico do stack trace."
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr "Não me lembro de enviar o relatório estado de configurações"
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -399,7 +399,7 @@ msgstr ""
 "O problema aconteceu com o programa %s  que alterou desde que o crash "
 "ocorreu."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Este relatório de problema está danificado e não pode ser processado."
 
@@ -430,14 +430,14 @@ msgstr "snap %s"
 msgid "%s deb package"
 msgstr "pacote deb %s"
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s é fornecido por um snap publicado por %s. Contacte-os através de %s para "
 "obter ajuda."
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -447,41 +447,41 @@ msgstr ""
 "endereço de contacto; visite o fórum em https://forum.snapcraft.io/ para "
 "obter ajuda."
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "Não foi possível determinar o nome do pacote ou pacote fonte."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "Não é possível iniciar o navegador web"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Não é possível iniciar o navegador web para abrir %s"
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Problema na rede"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Não é possível estabelecer a ligação à base de dados de falhas, por favor "
 "verifique a sua ligação à Internet."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Exaustão da memória"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "O seu sistema não tem memória suficiente para processar o relatório desta "
 "paragem."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -492,11 +492,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "Problema já conhecido"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -506,7 +506,7 @@ msgstr ""
 "web. Por favor, verifique se poderá adicionar mais alguma informação que "
 "possa ser útil aos programadores."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Este problema já foi relatados aos programadores. Obrigado!"
 
@@ -867,7 +867,7 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Erro: %s não é um executável. A parar."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -875,7 +875,7 @@ msgstr ""
 "Isto ocorreu durante uma suspensão anterior, e não permitiu ao sistema "
 "acordar corretamente."
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -883,7 +883,7 @@ msgstr ""
 "Isto ocorreu durante uma hibernação anterior, e não permitiu ao sistema "
 "acordar corretamente."
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2014-12-30 18:25+0000\n"
 "Last-Translator: Salomão Carneiro de Brito <salomaocar@gmail.com>\n"
 "Language-Team: Portuguese (Brazil) <pt_BR@li.org>\n"
@@ -40,11 +40,11 @@ msgstr ""
 "Por favor, informe sua senha para acessar os relatórios de problemas dos "
 "programas do sistema"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "Este pacote não parece estar instalado corretamente"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -52,7 +52,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -65,21 +65,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "programa desconhecido"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Desculpe, o programa \"%s\" fechou inesperadamente"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Problema em %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -87,64 +87,64 @@ msgstr ""
 "Seu computador não possui memória suficiente para analisar automaticamente o "
 "problema e enviar um relatório aos desenvolvedores."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Relatório do problema inválido"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "Você não tem permissão para acessar esse relatório de problema."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Erro"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "Não há espaço suficiente em disco para processar este relatório."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "PID inválido"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "Nenhum pacote especificado"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Você precisa especificar o pacote ou o PID. Veja --help para mais "
 "informações."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Permissão negada"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -152,30 +152,30 @@ msgstr ""
 "O processo especificado não pertence a você. Por favor, execute este "
 "programa como dono do processo ou como usuário root."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "O ID do processo especificado não pertence a um programa."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "O script de sintoma %s não determinou um pacote afetado."
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "O pacote %s não existe."
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "Não foi possível criar o relatório"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "Atualizando o relatório de problema"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -186,7 +186,7 @@ msgstr ""
 "está duplicado ou já foi fechado.\n"
 "Por favor, crie um novo relatório utilizando o \"apport-bug\""
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -206,24 +206,24 @@ msgstr ""
 "\n"
 "Você realmente deseja continuar?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "Nenhuma informação adicional foi coletada."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "Que tipo de problema você deseja informar?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Sintoma desconhecido"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "O sintoma \"%s\" não é conhecido."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -234,7 +234,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -242,31 +242,31 @@ msgstr ""
 "Depois de fechar esta mensagem, por favor, clique na janela do aplicativo "
 "para relatar um problema sobre ele."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop falhou ao determinar a ID do processo da janela"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "Especificar o nome do pacote."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Adicione um rótulo a mais ao relatório. Pode ser especificado várias vezes."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -276,15 +276,15 @@ msgstr ""
 "pid, ou somente um --pid. Se nenhum é fornecido, mostra uma lista de "
 "sintomas conhecidos. (Automático se um único argumento é fornecido)"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "Clique na janela como alvo para preencher um relatório de problema."
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "Iniciar em modo de atualização de erro. Aceita o parâmetro --package."
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -292,7 +292,7 @@ msgstr ""
 "Submete um relatório de bug sobre um sintoma. (Automático se um nome de "
 "sintoma é fornecido como único argumento)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -301,7 +301,7 @@ msgstr ""
 "especificado. (Automático se um nome de pacote é fornecido como único "
 "argumento)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -311,11 +311,11 @@ msgstr ""
 "relatório de erro conterá mais informações. (Implícito se pid for dado como "
 "único argumento.)"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "O pid fornecido é de uma aplicação pendente."
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -325,7 +325,7 @@ msgstr ""
 "arquivos pendentes em %s. (Automático se o arquivo é fornecido como único "
 "argumento)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -335,36 +335,36 @@ msgstr ""
 "arquivo em vez de relatá-las. Esse arquivo pode ser reportado mais tarde ou "
 "de outra máquina."
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Imprimir o número da versão do Apport."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Isto irá executar o apport-retrace em uma janela de Terminal para examinar a "
 "falha."
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "Executar sessão gdb"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Executar sessão gdb sem baixar símbolos de depuração"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Atualizar %s com rastreamento de pilha totalmente simbólico"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -384,7 +384,7 @@ msgstr ""
 "O problema aconteceu com o programa %s que mudou desde que o problema "
 "ocorreu."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Este relatório de erros está danificado e não pode ser processado."
 
@@ -412,53 +412,53 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "Não foi possível determinar o pacote ou nome do pacote fonte."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "Não é possível iniciar navegador web"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Não é possível iniciar navegador web para abrir %s."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Problema na rede"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Não é possível conectar em uma base de dados quebrada, por favor verifique "
 "sua conexão com a internet."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Memória exaurida"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Seu sistema não tem memória o suficiente para processar este relatório de "
 "erro."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -469,11 +469,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "Problema já informado"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -483,7 +483,7 @@ msgstr ""
 "Por favor, verifique se você pode adicionar alguma informação adicional que "
 "possa ser útil aos desenvolvedores."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "O problema já foi reportado aos desenvolvedores. Obrigado!"
 
@@ -841,19 +841,19 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Erro: %s não é um executável. Interrompendo."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/ro.po
+++ b/po/ro.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2014-02-25 13:57+0000\n"
 "Last-Translator: Marian Vasile <marianvasile1972@gmail.com>\n"
 "Language-Team: Romanian Gnome Team <gnomero-list@lists.sourceforge.net>\n"
@@ -41,11 +41,11 @@ msgstr ""
 "Pentru a accesa rapoartele despre problemele cu programele sistemului "
 "trebuie să vă introduceți parola"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "Se pare că acest pachet nu este instalat corect"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -53,7 +53,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -66,21 +66,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "program necunoscut"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Programul „%s” s-a întrerupt într-un mod neașteptat"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Problemă în %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -88,65 +88,65 @@ msgstr ""
 "Calculatorul dumneavoastră nu dispune de suficientă memorie pentru a analiza "
 "automat problema și a trimite un raport despre eroare programatorilor."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Raport de probleme nevalid"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "Accesul la raport nu vă este permis."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Eroare"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 "Nu există suficient spațiu disponibil pe disc pentru a procesa acest raport."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "PID nevalid"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "Nu a fost specificat niciun pachet"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Trebuie să specificați un pachet sau un PID. Pentru mai multe informații "
 "consultați --help."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Permisiune refuzată"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -154,30 +154,30 @@ msgstr ""
 "Procesul selectat nu aparține acestui utilizator. Executați acest program în "
 "calitate de proprietar al procesului sau de utilizator „root”."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "Identificatorul de proces specificat nu aparține unui program."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Scriptul pentru simptome %s, nu a detectat niciun pachet afectat"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Pachetul %s nu există"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "Raportul nu poate fi creat"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "Se actualizează raportul de probleme"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -189,7 +189,7 @@ msgstr ""
 "\n"
 "Creați un nou raport, utilizând „apport-bug”."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -210,24 +210,24 @@ msgstr ""
 "\n"
 "Sigur doriți să continuați?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "Nu au fost colectate informații suplimentare."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "Ce fel de problemă doriți să raportați?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Simptom necunoscut"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Simptomul „%s” nu este cunoscut."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -238,7 +238,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -246,32 +246,32 @@ msgstr ""
 "După închiderea acestui mesaj faceți clic pe fereastra unei aplicații pentru "
 "a raporta o problemă despre ea."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop nu a reușit să determine ID-ul de proces al ferestrei"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "Specificați numele pachetului."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Adăugă o etichetă suplimentară raportului. Pot fi specificate mai multe "
 "etichete."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -282,17 +282,17 @@ msgstr ""
 "este prezent, atunci afișează o listă de simptome cunoscute. (Implicit, dacă "
 "se transmite un singur argument)."
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "Clic pe o fereastră pentru a raporta o problemă despre aceasta."
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "Pornește în modul de actualizare a defecțiunii. Poți lua un --package "
 "opțional."
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -300,7 +300,7 @@ msgstr ""
 "Trimite un raport de defecțiune despre un simptom. (Implicit, dacă numele "
 "simptomului este dat ca singurul argument.)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -309,7 +309,7 @@ msgstr ""
 "este specificat. (Implicit dacă numele pachetului este dat ca singurul "
 "argument)."
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -319,11 +319,11 @@ msgstr ""
 "acest lucru este specificat, raportul de eroare va conține mai multe "
 "informații. (Opțiune implicită dacă PID este unicul argument.)"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "PID-ul furnizat identifică o aplicație care nu mai răspunde."
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -332,7 +332,7 @@ msgstr ""
 "Raportează avaria din fișierul .apport sau .crash și nu a celor în așteptare "
 "din %s. (Implicit, dacă fișierul este dat ca singurul argument.)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -342,36 +342,36 @@ msgstr ""
 "fișier, în loc de a le raporta. Acest fișier poate fi apoi raportat mai "
 "târziu de pe o altă mașină."
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Tipărește numărul de versiune al Apport."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Această comandă va lansa apport-retrace într-o fereastră terminal pentru a "
 "examina eroarea."
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "Rulare sesiune gdb"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Rulați o sesiune gdb fără descărcarea simbolurilor pentru depanare"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Actualizați %s cu urmărirea întregii stive"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -390,7 +390,7 @@ msgstr ""
 "Problema a apărut la programul %s, care a fost modificat față de momentul "
 "apariției erorii."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Acest raport de probleme este deteriorat și nu poate fi procesat."
 
@@ -419,53 +419,53 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "Numele pachetului sau al pachetului sursă nu a putut fi determinat."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "Nu s-a putut porni navigatorul web"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Nu s-a putut porni navigatorul web pentru a deschide %s."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Problemă de rețea"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Nu s-a reușit conexiunea la baza de date despre avarii, verificați "
 "conexiunea la internet."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Epuizarea memoriei"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Sistemul nu dispune de suficientă memorie pentru a procesa acest raport de "
 "avarie."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -476,11 +476,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "Problemă deja cunoscută"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -490,7 +490,7 @@ msgstr ""
 "navigatorul web. Verificați dacă puteți adăuga informații suplimentare care "
 "ar putea fi utile programatorilor."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Această problemă a fost raportată deja dezvoltatorilor. Vă mulțumim!"
 
@@ -851,19 +851,19 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Eroare: %s nu este un fișier executabil. Se oprește."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2019-11-01 10:51+0000\n"
 "Last-Translator: Sandro <Unknown>\n"
 "Language-Team: Russian <ru@li.org>\n"
@@ -39,11 +39,11 @@ msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 "Введите свой пароль для доступа к отчётам об ошибках в системных программах"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "Возможно, этот пакет установлен неправильно"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -54,7 +54,7 @@ msgstr ""
 "индексов доступных пакетов. Если это не помогает, тогда удалите "
 "соответствующие сторонние пакеты и попробуйте ещё раз."
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -67,21 +67,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "неизвестная программа"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Извините, программа %s аварийно завершила свою работу"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Неполадка в %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -89,66 +89,66 @@ msgstr ""
 "В вашем компьютере недостаточно свободной памяти, чтобы автоматически "
 "проанализировать неполадку и отправить отчет разработчикам."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Неверный отчёт об ошибке"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "У вас нет доступа к отчёту о неполадке."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Ошибка"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "Недостаточно места на диске для обработки этого отчёта."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr "Не указан идентификатор процесса (PID)"
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 "Необходимо указать идентификатор процесса (PID). Смотрите --help для "
 "получения дополнительной информации."
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "Неверный PID"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr "Указанный ID процесса не существует."
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr "Не ваш PID"
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr "Указанный ID процесса не принадлежит вам."
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "Не указан пакет"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Необходимо указать пакет или PID. Запустите программу с ключом --help для "
 "получения дополнительной информации."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "В доступе отказано"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -156,30 +156,30 @@ msgstr ""
 "Указанный процесс запущен другим пользователем. Запустите эту программу с "
 "правами владельца процесса или администратора системы."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "Указанный PID принадлежит другому процессу."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Симптоматический скрипт %s не может определить затронутый пакет"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Пакет %s не существует"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "Невозможно создать отчет"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "Обновление отчета о проблеме"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -189,7 +189,7 @@ msgstr ""
 "Вы не являетесь отправителем или получателем отчета об этой проблеме, "
 "возможно отчет уже существует или уже был закрыт."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -210,24 +210,24 @@ msgstr ""
 "\n"
 "Вы действительно хотите продолжить?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "Дополнительная информация не была собрана."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "О какой проблеме вы бы хотели сообщить?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Неизвестный симптом"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Симптом «%s» не известен"
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -246,7 +246,7 @@ msgstr ""
 "Запустите его и найдите интересующее приложение на вкладке Процессы. "
 "Идентификатор процесса — номер, указанный в столбце ID."
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -254,31 +254,31 @@ msgstr ""
 "После закрытия этого сообщения, пожалуйста, щелкните по окну приложения, "
 "чтобы сообщить о проблеме."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop не удалось определить ID процесса этого окна"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr "%(prog)s <номер отчёта>"
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "Задайте имя пакета."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "Добавить дополнительный тег в отчет. Может быть указан несколько раз."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 "%(prog)s [параметры] [симптом|pid|пакет|путь к программе|.apport/.crash файл]"
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -289,17 +289,17 @@ msgstr ""
 "отображает список известных симптомов. (Применяется, когда передан "
 "единственный аргумент.)"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "Щелкните по целевому окну для заполнения отчёта о проблеме."
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "Запустить в режиме обновления ошибки. Может принимать дополнительный ключ --"
 "package."
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -307,7 +307,7 @@ msgstr ""
 "Отправить отчёт об ошибке с симптомом. (Применяется, когда название симптома "
 "передано в качестве единственного параметра.)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -315,7 +315,7 @@ msgstr ""
 "Указать имя пакета в режиме --file-bug. Необязательно, если указан --pid. "
 "(Применяется, когда имя пакета передано в качестве единственного параметра.)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -325,11 +325,11 @@ msgstr ""
 "отчет будет содержать больше информации. (Подразумевается, что pid — "
 "единственный указанный аргумент.)"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "Указанный идентификатор принадлежит процессу, который не отвечает."
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -339,7 +339,7 @@ msgstr ""
 "ожидаемых в %s. (Применяется, когда файл передан в качестве единственного "
 "параметра.)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -348,36 +348,36 @@ msgstr ""
 "При работе в режиме отправки отчета, сохраняет информацию в файле вместо ее "
 "отправки. Этот файл можно будет отправить позднее или с другого компьютера."
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Напечатать номер версии Apport."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Будет произведён запуск «apport-retrace» в окне терминала для выполнения "
 "проверки аварийного завершения работы."
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "Запустить сеанс gdb"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Запустить сеанс gdb, не выполняя загрузку отладочных символов"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Обновить %s с полным отслеживанием символического стека"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr "Не удаётся запомнить настройки статуса отправки отчёта"
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 "Неполадка произошла с программой %s, в которую были внесены изменения с "
 "момента её аварийного завершения работы."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Этот отчёт о неполадке повреждён и не может быть обработан."
 
@@ -428,14 +428,14 @@ msgstr "%s snap-пакет"
 msgid "%s deb package"
 msgstr "%s deb-пакет"
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s предоставлен в виде snap-пакета и опубликован %s. Для получения помощи "
 "свяжитесь с ними по %s."
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -444,39 +444,39 @@ msgstr ""
 "%s предоставлен в виде snap-пакета и опубликован %s. Контактный адрес не "
 "указан. Для получения помощи посетите форум https://forum.snapcraft.io/."
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "Не удалось определить имя пакета или имя пакета с исходным кодом."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "Не удалось запустить веб-браузер"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Не удалось запустить веб-браузер, чтобы открыть %s."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Неполадка с сетью"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Не удается подключиться к базе данных по сбоям, пожалуйста, проверьте "
 "подключение к Интернету."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Недостаток памяти"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "В системе недостаточно памяти для обработки этого отчёта об ошибке."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -487,11 +487,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "О неполадке уже известно"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -501,7 +501,7 @@ msgstr ""
 "браузере. Пожалуйста, проверьте, можете ли вы добавить в него иную полезную "
 "информацию, которая могла бы помочь разработчикам."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Сообщение о неисправности отправлено разработчикам. Спасибо за помощь!"
 
@@ -859,7 +859,7 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Ошибка: %s — не исполняемый файл. Остановка."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -867,7 +867,7 @@ msgstr ""
 "Это произошло во время предыдущего ждущего режима, что не даёт системе "
 "правильно выйти из него."
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -875,7 +875,7 @@ msgstr ""
 "Это произошло во время предыдущего спящего режима, что не даёт системе "
 "правильно выйти из него."
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/sc.po
+++ b/po/sc.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2010-08-01 10:24+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Sardinian <sc@li.org>\n"
@@ -36,11 +36,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr ""
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -61,21 +61,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "Programa disconnotu"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Nos dispiaghet; su programa \"%s\" s'est serradu de botu."
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Problema in %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -83,64 +83,64 @@ msgstr ""
 "Sa computadora tua no tenet bastante memòria lìbera pro analizare su "
 "problema automaticamente e pro imbiare un avisu a sos tècnicos."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Avisu de problema no vàlidu"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "No as permissu pro atzèdere a custu avisu de problema."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Errore"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "No b'at bastante ispàtziu in su discu pro protzessare cust'avisu."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "PID no vàlidu."
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "Perunu pachete seletzionadu"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Deves ispecificare unu pachete o unu PID. Consulta --help pro àere pius "
 "informatziones."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Permissu negadu."
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -148,30 +148,30 @@ msgstr ""
 "Su protzessu ispecificadu no t'apartenit. Eseguire custu programa comente "
 "proprietàriu de su protzessu o comente superutente."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "Su ID de protzessu ispecificadu no apartenit a perunu programa."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr ""
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr ""
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr ""
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -179,7 +179,7 @@ msgid ""
 "Please create a new report using \"apport-bug\"."
 msgstr ""
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -191,24 +191,24 @@ msgid ""
 "Do you really want to proceed?"
 msgstr ""
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr ""
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr ""
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr ""
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr ""
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -219,115 +219,115 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr ""
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr ""
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr ""
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -344,7 +344,7 @@ msgid ""
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "S'avisu de su problema s'est guastadu e no podet èssere protzessadu."
 
@@ -372,49 +372,49 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr ""
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr ""
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr ""
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr ""
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr ""
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -425,18 +425,18 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr ""
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 msgstr ""
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 
@@ -748,19 +748,19 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr ""
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/sd.po
+++ b/po/sd.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2018-11-11 06:23+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Sindhi <sd@li.org>\n"
@@ -36,11 +36,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr ""
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -57,111 +57,111 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr ""
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr ""
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "مسعلي ۾ %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
 msgstr ""
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr ""
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr ""
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr ""
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr ""
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr ""
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr ""
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 msgstr ""
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr ""
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr ""
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr ""
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr ""
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -169,7 +169,7 @@ msgid ""
 "Please create a new report using \"apport-bug\"."
 msgstr ""
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -181,24 +181,24 @@ msgid ""
 "Do you really want to proceed?"
 msgstr ""
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr ""
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr ""
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr ""
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr ""
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -209,115 +209,115 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr ""
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr ""
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr ""
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -334,7 +334,7 @@ msgid ""
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr ""
 
@@ -362,49 +362,49 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr ""
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr ""
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr ""
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr ""
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr ""
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -412,18 +412,18 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr ""
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 msgstr ""
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 
@@ -735,19 +735,19 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr ""
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/se.po
+++ b/po/se.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2012-08-17 12:37+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Northern Sami <se@li.org>\n"
@@ -36,11 +36,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr ""
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -57,111 +57,111 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr ""
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr ""
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr ""
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
 msgstr ""
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr ""
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr ""
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Meattáhus"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr ""
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr ""
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Ii beasa deikke"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 msgstr ""
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr ""
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr ""
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr ""
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr ""
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -169,7 +169,7 @@ msgid ""
 "Please create a new report using \"apport-bug\"."
 msgstr ""
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -181,24 +181,24 @@ msgid ""
 "Do you really want to proceed?"
 msgstr ""
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr ""
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr ""
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr ""
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr ""
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -209,115 +209,115 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr ""
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr ""
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr ""
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -334,7 +334,7 @@ msgid ""
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr ""
 
@@ -362,49 +362,49 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr ""
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr ""
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr ""
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr ""
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr ""
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -412,18 +412,18 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr ""
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 msgstr ""
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 
@@ -735,19 +735,19 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr ""
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2011-10-07 06:10+0000\n"
 "Last-Translator: Janith Sampath Bandara <sbslive@gmail.com>\n"
 "Language-Team: Sinhalese <si@li.org>\n"
@@ -36,11 +36,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr ""
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -57,111 +57,111 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "නොදන්නා වැඩසටහන"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "සමාවෙන්න, \"%s\" වැඩසටහන අනපේක්ෂිතව අවසන්විය"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "%s හි ගැටලුවක්"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
 msgstr ""
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "අවලංගු ගැටලුවක් වාර්තාවිනි"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr ""
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "දෝෂය"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr ""
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr ""
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "අවසර දීමට නොහැක"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 msgstr ""
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr ""
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr ""
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr ""
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr ""
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -169,7 +169,7 @@ msgid ""
 "Please create a new report using \"apport-bug\"."
 msgstr ""
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -181,24 +181,24 @@ msgid ""
 "Do you really want to proceed?"
 msgstr ""
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr ""
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr ""
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr ""
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr ""
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -209,115 +209,115 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr ""
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr ""
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr ""
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -334,7 +334,7 @@ msgid ""
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr ""
 
@@ -362,49 +362,49 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr ""
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr ""
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr ""
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr ""
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr ""
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -412,18 +412,18 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr ""
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 msgstr ""
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 
@@ -735,19 +735,19 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr ""
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/sk.po
+++ b/po/sk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2019-11-10 11:57+0000\n"
 "Last-Translator: Ľuboš Mudrák <lubosmudrak@azet.sk>\n"
 "Language-Team: Slovak <sk@li.org>\n"
@@ -40,11 +40,11 @@ msgstr ""
 "Zadajte prosím svoje heslo, aby mohol byť problém systémového programu "
 "nahlásený."
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "Vyzerá to tak, že tento balík nie je nainštalovaný korektne"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -52,7 +52,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -65,21 +65,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "neznámy program"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Prepáčte, program \"%s\" neočakávane skončil"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Problém v %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -87,63 +87,63 @@ msgstr ""
 "Váš počítač nemá dosť voľnej pamäte na automatickú analýzu problému a "
 "poslanie hlásenia vývojárom."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Neplatné hlásenie problému"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "Nemáte povolený prístup k tomuto hláseniu o probléme."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Chyba"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "Nie je dostatok voľného miesta na disku na spracovanie tohto hlásenia."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "Neplatné PID"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr "Proces s zadaným identifikátorom neexistuje."
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr "Proces s zadaným identifikátorom vám nepatrí."
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "Nebol špecifikovaný žiadny balík"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Je potrebné špecifikovať balík alebo PID. Pozrite --help pre viac informácií."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Prístup odmietnutý"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -151,30 +151,30 @@ msgstr ""
 "Nemáte dosah na označený proces. Prosím, spustite program ako jeho vlastník, "
 "alebo ako root."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "Zadaný identifikátor procesu nepatrí k programu."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Skript %s nebol schopný určiť postihnutý balík"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Balík %s neexistuje"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "Nie je možné vytvoriť hlásenie"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "Aktualizuje sa hlásenie o probléme"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -186,7 +186,7 @@ msgstr ""
 "\n"
 "Prosím vytvorte nové hlásenie pomocou \"apport-bug\"."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -206,24 +206,24 @@ msgstr ""
 "\n"
 "Naozaj chcete pokračovať?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "Neboli zozbierané žiadne dodatočné informácie."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "Aký druh problému chcete nahlásiť?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Neznámy príznak"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Príznak \"%s\"  nie je známy."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -234,7 +234,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -242,30 +242,30 @@ msgstr ""
 "Pre nahlásenie problému s aplikáciou kliknite, prosím, po zavretí tejto "
 "správy na okno aplikácie."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop nedokázal zistiť identifikátor procesu okna"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "Zadajte názov balíka."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "Pridať k hláseniu značku navyše. Môže byť zadaná viackrát."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -275,17 +275,17 @@ msgstr ""
 "alebo len --pid. Ak nie je zadaný ani jeden z nich, zobrazí sa zoznam "
 "známych príznakov. (Predpokladané ak je zadaný len jeden argument.)"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "Kliknite na okno ktoré bude cieľom pre vyplnenia hlásenia o chybe."
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "Začnite v režime aktualizácie chyby. Môžete použiť voliteľný argument --"
 "package."
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -293,7 +293,7 @@ msgstr ""
 "Vytvorte chybové hlásenie o príznaku. (Predpokladané ak je zadané ako jediný "
 "argument názov príznaku.)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -301,7 +301,7 @@ msgstr ""
 "Zadajte názov balíka v režime --file-bug. Je to voliteľné ak je zadaný --"
 "pid. (Predpokladané ak je zadané ako jediný argument názov.)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -311,11 +311,11 @@ msgstr ""
 "hlásenie obsahovať viac informácií. (Ak je číslo procesu uvedené ako jediný "
 "argument.)"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "Poskytnutý pid je zamrznutá aplikácia."
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -324,7 +324,7 @@ msgstr ""
 "Nahláste pád z daného .apport alebo .crash súboru namiesto zostávajúcich v "
 "%s. (Predpokladané ak je zadaný ako jediný argument súbor.)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -333,34 +333,34 @@ msgstr ""
 "Uložiť hlásenie do súboru namiesto priameho odosielania. Tento súbor môže "
 "byť nahlásený neskôr aj z iného zariadenia."
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Zobraziť čislo verzie programu Apport."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr "Týmto spustíte apport-retrace v terminálovom okne na preskúmanie pádu."
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "Spustiť gdb reláciu"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Spustiť gdb reláciu bez sťahovania ladiacich symbolov"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Aktualizovať %s pomocou úplného symbolického trasovania zásobníku"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -378,7 +378,7 @@ msgid ""
 "occurred."
 msgstr "Problém bol zaznamenaný v programe %s, ktorý bol po páde zmenený."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Toto hlásenie problému je poškodené a nie je možné ho spracovať."
 
@@ -406,51 +406,51 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "Nedá sa zistiť balík alebo zdrojový názov balíka."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "Nepodarilo sa spustiť internetový prehliadač"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Nepodarilo sa spustiť internetový prehliadač pre otvorenie %s."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Problém siete"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Nie je možné sa pripojiť do databázy pádov, prosím, skontrolujte vaše "
 "internetové pripojenie."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Vyčerpanie pamäte"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "Váš systém nemá dostatok pamäti na spracovanie chybového hlásenia."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -461,11 +461,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "Problém je už známy"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -475,7 +475,7 @@ msgstr ""
 "prehliadači. Skontrolujte, prosím, či môžete doplniť ďalšie informácie, "
 "ktoré môžu byť nápomocné pre vývojárov."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Tento problém bol už nahlásený vývojárom. Ďakujeme!"
 
@@ -818,7 +818,7 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Chyba: %s nie je spustiteľný. Zastavujem."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -826,7 +826,7 @@ msgstr ""
 "Toto sa stalo v priebehu minulého uspania do pamäti a zabránilo systému v "
 "prebudení."
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -834,7 +834,7 @@ msgstr ""
 "Toto sa stalo v priebehu minulého uspania na disk a zabránilo systému v "
 "prebudení."
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2015-04-27 21:46+0000\n"
 "Last-Translator: Andrej Znidarsic <andrej.znidarsic@gmail.com>\n"
 "Language-Team: Slovenian <sl@li.org>\n"
@@ -38,11 +38,11 @@ msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 "Vnesite svoje geslo za dostop do poročil o težavah s sistemskimi programi"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "Videti je, da ta paket ni nameščen pravilno"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -50,7 +50,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -63,21 +63,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "neznam program"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Program \"%s\" se je nepričakovano zaprl"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Težava v %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -85,62 +85,62 @@ msgstr ""
 "Vaš računalnik nima dovolj prostega pomnilnika za samodejno preučevanje "
 "težave in pošiljanje poročila razvijalcem."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Neveljavno poročilo o napaki"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "Dostop do poročila o napaki je bil zavrnjen."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Napaka"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "Na disku ni dovolj prostora za obdelavo tega poročila."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "Neveljaven PID"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "Naveden ni noben paket"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr "Navesti morate paket ali PID. Oglejte si --help za več podrobnosti."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Dovoljenje je zavrnjeno"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -148,30 +148,30 @@ msgstr ""
 "Navedeno opravilo ne pripada vam. Zaženite ta program kot lastnik opravila "
 "ali kot skrbnik."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "Naveden ID opravila ne pripada programu."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Skript simptoma %s ni zaznal prizadetega paketa"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Paket %s ne obstaja"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "Ni mogoče ustvariti poročila"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "Posodabljanje poročila o težavi"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -183,7 +183,7 @@ msgstr ""
 "\n"
 "Ustvarite novo poročilo z uporabo \"apport-bug\"."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -203,24 +203,24 @@ msgstr ""
 "\n"
 "Ali želite resnično nadaljevati?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "Dodatni podatki niso bili pridobljeni."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "O kakšni vrsti težave bi radi poročali?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Neznan simptom"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Simptom \"%s\" ni znan."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -231,7 +231,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -239,30 +239,30 @@ msgstr ""
 "Po zaprtju tega sporočila kliknite na okno programa za poročanje težav o "
 "njem."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop ni uspelo določevanje ID-ja opravila okna"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "Navedite ime paketa."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "Doda dodatno oznako poročilu. Določite jo lahko večkrat."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -272,17 +272,17 @@ msgstr ""
 "pdi, ali pa samo --pid. Če ne podate nobenega izmed naštetih, bo prikazan "
 "seznam znanih simptomov. (Privzeto, ko je podan samo en argument)."
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "Kliknite na okno kot cilj za izpolnjevanje poročila o težavi."
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "Zaženi v načinu posodabljanja hroščev. Lahko dodate izbiren parameter --"
 "package."
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -290,7 +290,7 @@ msgstr ""
 "Vloži prijavo hrošča o simptomu. (predpostavljeno, če je ime simptoma dano "
 "kot edini argument.)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -298,7 +298,7 @@ msgstr ""
 "V načinu --file-bug navedite ime paketa. Če je --pid podan, to ni obvezno. "
 "(Privzeto, ko je kot edini argument podano ime paketa)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -308,11 +308,11 @@ msgstr ""
 "poročilo o hrošču vsebovalo več podrobnosti (predpostavljeno, če je pid dan "
 "kot edini argument.)."
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "Program s posredovanom pid-jem se je obesil."
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -321,7 +321,7 @@ msgstr ""
 "Poroča o sesutju iz dane datoteke .apport ali .crah namesto iz čakajočih v "
 "%s. (Predpostavljeno, če je datoteka dana kot edini argument)."
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -330,34 +330,34 @@ msgstr ""
 "V načinu poročanja hrošča zbrane podatke shrani v datoteko namesto "
 "poročanja. To datoteko lahko uporabite za poročanje kasneje z druge naprave."
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Izpiši številko različice Apporta."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr "To bo v terminalu zagnalo apport-retrace za preučevanje sesutja."
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "Poženi sejo gdb"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Poženi sejo gdb brez prejemanja razhroščevalnih simbolov"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Posodobi %s s polno simbolično sledjo sklicev"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -374,7 +374,7 @@ msgid ""
 "occurred."
 msgstr "Težava se je zgodila s programom %s, ki se je od sesutja spremenil."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Poročilo o težavi je poškodovano, zato njegova obdelava ni mogoča."
 
@@ -402,51 +402,51 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "Ni bilo mogoče določiti imena paketa ali izvornega paketa."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "Spletnega brskalnika ni mogoče zagnati"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Spletni brskalnik ne more odpreti %s."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Težava z omrežjem"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Ni se mogoče povezati z zbirko podatkov o napakah. Preverite svojo "
 "internetno povezavo."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Pomnilnik je zapolnjen"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "Vašemu sistemu je zmanjkalo pomnilnika za obdelavo poročila o sesutju."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -457,11 +457,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "Težava je že znana"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -471,7 +471,7 @@ msgstr ""
 "prikazano v spletnem brskalniku. Preverite, če lahko dodate še kakšen "
 "podatek, ki bi lahko pomagal razvijalcem."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Ta težava je bila že poročana razvijalcem. Hvala vam!"
 
@@ -820,7 +820,7 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Napaka: %s ni izvedljiva datoteka. Ustavljanje."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -828,7 +828,7 @@ msgstr ""
 "To se je zgodilo med prejšnjim stanjem v pripravljenost in je preprečilo, da "
 "bi se sistem normalno zagnal."
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -836,7 +836,7 @@ msgstr ""
 "To se je zgodilo med prejšnjim stanjem mirovanja in je preprečilo, da bi se "
 "sistem normalno zagnal."
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/sq.po
+++ b/po/sq.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2015-04-27 21:46+0000\n"
 "Last-Translator: Vilson Gjeci <vilsongjeci@gmail.com>\n"
 "Language-Team: Albanian <sq@li.org>\n"
@@ -40,11 +40,11 @@ msgstr ""
 "Ju lutem vendosni fjalëkalimin tuaj që të keni akses në raportet e "
 "problemeve të programeve së sistemit."
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "Kjo paketë duket se nuk është instaluar në mënyrë korrekte"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -52,7 +52,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -66,21 +66,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "program i panjohur"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Na vjen keq, programi \"%s\" u mbyll papritur"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Problem në %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -88,65 +88,65 @@ msgstr ""
 "Kompjuteri juaj nuk ka kujtesë të lirë sa duhet për të analizuar "
 "automatikisht problemin dhe për t'i dërguar një raport zhvilluesve."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Raportim i pavlefshëm i problemit"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "Juve nuk ju lejohet të hyni në këtë raportim të problemit."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Gabim"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 "Nuk ka hapësirë të disponueshme disku sa duhet për të përpunuar këtë raport."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "PID i Pavlefshëm"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "Nuk është përcaktuar asnjë paketë"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Juve ju nevojitet të specifikoni një paketë apo një PID. Shikoni --help për "
 "më tepër informacion."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Leja ju mohohet"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -154,30 +154,30 @@ msgstr ""
 "Proçesi i përcaktuar nuk ju përket juve. Ju lutemi niseni këtë program si "
 "posedues i tij ose si rrënjë."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "ID-ja e specifikuar e proçesit nuk i përket një programi."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Skripti i simptomës %s nuk përcaktoi një paketë të ndikuar"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Paketa %s nuk ekziston"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "Nuk mund të krijoj raport"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "Duke përditësuar raportin e problemit"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -189,7 +189,7 @@ msgstr ""
 "\n"
 "Ju lutemi të krijoni një raport të ri duke përdorur \"apport-bug\"."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -209,24 +209,24 @@ msgstr ""
 "\n"
 "Dëshironi me të vërtetë të vazhdoni?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "Nuk u mblodh informacion shtesë."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "Çfarë lloj problemi dëshironi të raportoni?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Simptomë e panjohur"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Simptoma \"%s\" nuk njihet."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -237,7 +237,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -245,31 +245,31 @@ msgstr ""
 "Pasi ta mbyllni këtë mesazh ju lutemi të klikoni në dritaren e programit për "
 "të raportuar një problem të lidhur me të."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop dështoi në përcaktimin e ID të proçesit të dritares"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "Specifiko emrin e paketës."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Shtojini një etiketë më shumë raportit. Mund të specifikohet shumë herë."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -279,18 +279,18 @@ msgstr ""
 "pid, ose vetëm një --pid. Nëse asnjë nuk jepet, shfaq një listë të "
 "simptomave të njohura. (Vendoset nëse jepet vetëm një argument.)"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 "Kliko një ditare si shënjestër për të krijuar një raport rreth problemit."
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "Nise në mënyrë të përditësimit të gabimit. Mund të marrë një --paketë "
 "opsionale."
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -298,7 +298,7 @@ msgstr ""
 "Krijoni një raport defekti për një simptomë. (Vendoset nëse emri i simptomës "
 "jepet vetëm si një argument.)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -307,7 +307,7 @@ msgstr ""
 "specifikohet një --pid. (Emri i paketës së vendosur jepet vetëm si një "
 "argument.)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -317,11 +317,11 @@ msgstr ""
 "informacioni i gabimit do të përmbajë më tepër informacion. (Implikohet nëse "
 "pid është dhënë vetëm si argument)."
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "Pid i dhënë është një program në pritje."
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -330,7 +330,7 @@ msgstr ""
 "Raporto gabimin nga skedari i dhënë .apport ose .crash në vend të atyre që "
 "presin në %s. (Vendoset nëse skedari është dhënë vetëm si argument.)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -340,36 +340,36 @@ msgstr ""
 "një skedar në vend që ta raportoni atë. Ky skedar mund të raportohet më vonë "
 "nga një makinë tjetër."
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Printo numrin e versionit të Apport."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Kjo do të nise apport-retrace në një dritare terminali për të shqyrtuar "
 "gabimin."
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "Nis seksionin gdb"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Nis seksionin gdb pa shkarkuar simbolet e gabimeve"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Përditëso %s pa gjurmë të plota simbolike"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -386,7 +386,7 @@ msgid ""
 "occurred."
 msgstr "Problemi ndodhi me programin %s i cili ndryshoi që kur ndodhi gabimi."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Ky raportim i problemit është i dëmtuar dhe nuk mund të shqyrtohet."
 
@@ -415,52 +415,52 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "Nuk mund të përcaktojmë emrin e paketës apo të burimit të saj."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "Nuk jemi në gjendje të nisim shfletuesin e Internetit"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Nuk jemi në gjendje të nisim shfletuesin e Internetit për të hapur %s."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Problem i rrjetit"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Nuk mund të lidhemi me databazën e dëmtimeve, ju lutemi të kontrolloni "
 "lidhjen tuaj me Internetin."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Kujtesa u lodh"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Sistemi juaj nuk ka kujtesë sa duhet për të proçeduar këtë raport dëmtimi."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -471,11 +471,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "Problemi i njohur tashmë"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -485,7 +485,7 @@ msgstr ""
 "shfletuesin e Internetit. Ju lutemi kontrolloni nëse mund të shtoni "
 "infromacion të mëtejshëm i cili mund të ndihmojë krijuesit."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Ky problem ju është raportuar tashmë zhvilluesve. Faleminderit!"
 
@@ -844,7 +844,7 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Gabim: %s nuk është i ekzekutueshëm. Po ndalohet."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -852,7 +852,7 @@ msgstr ""
 "Kjo ndodhi gjatë një pezullimi të mëparshëm dhe e pengoi sistemin që të "
 "rinisë siç duhet."
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -860,7 +860,7 @@ msgstr ""
 "Kjo ndodhi gjatë një hibernimi të mëparshëm dhe e pengoi sistemin që të nisë "
 "siç duhet."
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2020-11-22 09:43+0000\n"
 "Last-Translator: Мирослав Николић <miroslavnikolic@rocketmail.com>\n"
 "Language-Team: српски <gnome-sr@googlegroups.org>\n"
@@ -39,11 +39,11 @@ msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 "Унесите вашу лозинку да приступите извештавању проблема системских програма"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "Изгледа да овај пакет није исправно инсталиран"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -54,7 +54,7 @@ msgstr ""
 "индекса доступних пакета, ако то не ради тада уклоните одговарајући пакет "
 "треће стране и покушајте поново."
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -67,21 +67,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "непознат програм"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Извините, програм „%s“ је неочекивано затворен"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Проблем у „%s“"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -89,63 +89,63 @@ msgstr ""
 "Ваш рачунар нема довољно слободне меморије да самостално анализира проблем и "
 "пошаље извештај ауторима."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Неисправан извештај о проблему"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "Вама није допуштено да приступите извештају овог проблема."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Грешка"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "Нема довољно простора на диску за обрађивање овог извештаја."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr "Нема наведеног ПИБ-а"
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr "Треба да наведете ПИБ. Видите „--help“ за више података."
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "Неисправан ПИБ"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr "Наведени ИБ процеса не постоји."
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr "Није ваш ПИД"
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr "Наведени ИБ процеса не припада вама."
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "Ниједан пакет није наведен"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Треба да одредите пакет или ПИБ. Погледајте „--help“ за више информација."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Приступ је одбијен"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -153,30 +153,30 @@ msgstr ""
 "Наведени процес не припада вама. Покрените овај програм као власник процеса "
 "или као администратор."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "Наведени ПИБ не припада програму."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Скрипта симптома „%s“ није одредила ниједан подутицајни пакет"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Пакет „%s“ не постоји"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "Не могу да направим извештај"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "Освежавам извештај о проблему"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -188,7 +188,7 @@ msgstr ""
 "\n"
 "Направите нови извештај користећи „apport-bug“."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -207,24 +207,24 @@ msgstr ""
 "\n"
 "Да ли заиста желите да наставите?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "Нису прикупљене додатне информације."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "О каквом проблему желите да известите?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Непознати симптом"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Симптом „%s“ није познат."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -235,7 +235,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -243,30 +243,30 @@ msgstr ""
 "Након затварања ове поруке кликните на прозор неког програма да известите о "
 "његовом проблему."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "икспроп није успео да одреди ИБ процеса прозора"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "Наводи назив пакета."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "Додаје додатну ознаку извештају. Може бити одређено више пута."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -277,17 +277,17 @@ msgstr ""
 "приказаће списак познатих симптома. (Подразумева се ако је дат само један "
 "аргумент.)"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "Притисните на прозор као циљ да попуните извештај о проблему."
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "Биће покренут у режиму слања грешке. Може да садржи опционални пакет (--"
 "package)."
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -295,7 +295,7 @@ msgstr ""
 "Попуниће извештај грешке о симптому. (Подразумева се ако је назив симптома "
 "дат као једини аргумент.)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -304,7 +304,7 @@ msgstr ""
 "изборно ако је одређен пиб (--pid). (Подразумева се ако је назив пакета дат "
 "као једини аргумент.)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -314,11 +314,11 @@ msgstr ""
 "извештај о грешци ће садржати више информација. (Подразумева се ако је пиб "
 "дат као једини аргумент.)"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "Обезбеђени пиб је проблематичан програм."
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -327,7 +327,7 @@ msgstr ""
 "Пријављује о урушавању из дате „.apport“ или „.crash“ датотеке уместо једне "
 "приправне у „%s“. (Подразумева се ако је датотека дата као једини аргумент.)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -337,34 +337,34 @@ msgstr ""
 "да шаље извештај. Датотека може бити послата касније и са неког другог "
 "рачунара."
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Приказује број издања Апорта."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr "Ово ће покренути „apport-retrace“ у прозору терминала да испита пад."
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "Покреће гдб сесију"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Покреће гдб сесију без преузимања симбола уклањања грешака"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Освежи „%s“ потпуном симболичком трасом спремника"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr "Не могу да запамтим подешавања стања извештаја слања"
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -386,7 +386,7 @@ msgstr ""
 "Проблем се догодио са програмом „%s“ који се изменио од када је дошло до "
 "урушавања."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Овај извештај о грешци је оштећен и не може бити обрађен."
 
@@ -417,14 +417,14 @@ msgstr "%s прилепак"
 msgid "%s deb package"
 msgstr "%s деб пакет"
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "„%s“ је обезбеђено прилепком објављеним од „%s“. Обратите им се путем „%s“ "
 "за помоћ."
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -433,40 +433,40 @@ msgstr ""
 "„%s“ је обезбеђено прилепком објављеним од „%s“. Нема адресе за контакт; "
 "посетите форум на „https://forum.snapcraft.io/ “ за помоћ."
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "Не могу да утврдим пакет или изворни назив пакета."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "Не могу да покренем прегледника интернета"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Не могу да покренем прегледника интернета да бих отворио „%s“."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Проблем са мрежом"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Не могу да успоставим везу са базом података о урушавањима, проверите везу "
 "са интернетом."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Недостатак меморије"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Ваш систем нема довољно меморије да обради овај извештај о паду система."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -477,11 +477,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "Проблем је већ познат"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -491,7 +491,7 @@ msgstr ""
 "интернета. Проверите да ли можете да додате било какву додатну информацију "
 "која би могла да буде од помоћи ауторима."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Овај проблем је већ пријављен програмерима. Хвала вам!"
 
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Грешка: „%s“ није извршни. Стајем."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -861,7 +861,7 @@ msgstr ""
 "Ово се догодило за време претходне обуставе, и спречило је систем да настави "
 "исправно."
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -869,7 +869,7 @@ msgstr ""
 "Ово се догодило за време претходног замрзавања, и спречило је систем да "
 "настави исправно."
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2022-10-16 12:22+0000\n"
 "Last-Translator: Arve Eriksson <Unknown>\n"
 "Language-Team: Swedish <sv@li.org>\n"
@@ -38,11 +38,11 @@ msgstr "Systemfelrapporter"
 msgid "Please enter your password to access problem reports of system programs"
 msgstr "Ange ditt lösenord för att komma åt systemprogrammens felrapporter"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "Detta paket verkar inte ha installerats korrekt"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -53,7 +53,7 @@ msgstr ""
 "uppdatering av indexet över tillgängliga paket; om det inte fungerar kan du "
 "ta bort berörda tredjepartspaket och försöka igen."
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -66,21 +66,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "okänt program"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Tyvärr, programmet \"%s\" avslutades oväntat"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Problem i %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -88,64 +88,64 @@ msgstr ""
 "Din dator har inte tillräckligt med ledigt minne för att automatiskt "
 "analysera problemet och skicka en rapport till utvecklarna."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Ogiltig felrapport"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "Du tillåts inte komma åt denna problemrapport."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Fel"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 "Det finns inte tillräckligt mycket diskutrymme för att behandla denna "
 "rapport."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr "Ingen PID angavs"
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr "Du måste ange en PID. Se --help för mer information."
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "Ogiltig PID"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr "Den angivna process-ID:n finns inte."
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr "Inte din PID"
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr "Den angivna process-ID:n tillhör inte dig."
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "Inget paket angivit"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr "DU måste ange ett paket eller en PID. Se --help för mer information."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Åtkomst nekad"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -153,30 +153,30 @@ msgstr ""
 "Den angivna processen tillhör inte dig. Kör det här programmet som "
 "processägaren eller som root."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "Det angivna process-id:t tillhör inte något program."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Symtomskriptet %s fastställde inte ett påverkat paket"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Paketet %s finns inte"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "Kan inte skapa rapporten"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "Uppdaterar problemrapporten"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -188,7 +188,7 @@ msgstr ""
 "\n"
 "Skapa en ny rapport med \"apport-bug\"."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -208,24 +208,24 @@ msgstr ""
 "\n"
 "Vill du verkligen fortsätta?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "Ingen ytterligare information har samlats in."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "Vilken typ av problem vill du rapportera?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Okänd symptom"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Symptomen \"%s\" är inte känd."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -243,7 +243,7 @@ msgstr ""
 "Processer, rulla tills du hittar programmet ifråga. Process-ID är numret som "
 "anges i ID-kolumnen."
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -251,30 +251,30 @@ msgstr ""
 "Efter att du stängt detta meddelande kan du klicka på ett programfönster för "
 "att rapportera ett problem med det."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop misslyckades med att fastställa process-ID för fönstret"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr "%(prog)s <rapportnummer>"
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "Ange paketnamn."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "Lägg till en extra tagg till rapporten. Kan anges flera gånger."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr "%(prog)s [alternativ] [symtom|pid|paket|sökväg|.apport-/.crash-fil]"
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -284,15 +284,15 @@ msgstr ""
 "bara en --pid. Om ingen anges så visas en lista över kända symptom. "
 "(Standard om ett enda argument anges.)"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "Klicka på ett fönster för att rapportera ett problem med det."
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "Starta i feluppdateringsläge. Kan ta emot en valfri --package."
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -300,7 +300,7 @@ msgstr ""
 "Skicka in en felrapport om ett symptom. (Standard om symptomnamnet anges som "
 "enda argument.)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -308,7 +308,7 @@ msgstr ""
 "Ange paketnamn i läget --file-bug. Detta är valfritt om en --pid anges. "
 "(Standard om paketnamnet anges som enda argument.)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -318,11 +318,11 @@ msgstr ""
 "felrapporten att innehålla mer information (underförstått om pid anges som "
 "enda argument.)"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "Det givna pid:t är ett program som har låst sig."
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -331,7 +331,7 @@ msgstr ""
 "Rapportera kraschen från angiven fil med ändelsen .apport eller .crash "
 "istället för de väntande i %s. (Standard om filen anges som enda argument.)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -341,36 +341,36 @@ msgstr ""
 "istället för att rapportera. Denna fil kan sedan rapporteras in från en "
 "annan dator."
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Skriv ut versionsnummer för Apport."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Detta kommer starta apport-retrace i ett terminalfönster för att undersöka "
 "kraschen."
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "Kör GDB-session"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Kör GDB-session utan att ladda ner felsökningssymboler"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Uppdatera %s med fullständigt symbolisk stackspårning"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr "Kan inte komma ihåg inställningar för att skicka rapportstatus"
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -393,7 +393,7 @@ msgstr ""
 "Problemet inträffade med programmet %s, vilket har ändrats sedan kraschen "
 "hände."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Den här problemrapporten är skadad och kan inte behandlas."
 
@@ -423,14 +423,14 @@ msgstr "%s snap"
 msgid "%s deb package"
 msgstr "%s deb-paket"
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s tillhandahålls som en snap, utgiven av %s. Kontakta dem via %s om du "
 "behöver hjälp."
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -439,40 +439,40 @@ msgstr ""
 "%s tillhandahålls som en snap, utgiven av %s. Ingen kontaktinformation "
 "finns; besök forumet på https://forum.snapcraft.io/ om du behöver hjälp."
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "Kunde inte bestämma paketet eller källpaketets namn."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "Kunde inte starta webbläsaren"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Kunde inte starta webbläsaren för att öppna %s."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Nätverksproblem"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Kan inte ansluta till kraschdatabasen. Kontrollera din internetanslutning."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Slut på minne"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Ditt system har inte tillräckligt mycket minne att behandla den här "
 "kraschrapporten."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -483,11 +483,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "Problemet är redan känt"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -497,7 +497,7 @@ msgstr ""
 "webbläsaren. Kontrollera om du kan lägga till ytterligare information som "
 "kan vara av användning för utvecklarna."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Problemet har redan rapporterats till utvecklarna. Tack!"
 
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Error: %s är inte körbar. Stoppar."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -866,7 +866,7 @@ msgstr ""
 "Detta inträffade under ett föregående vänteläge, och hindrade systemet från "
 "att fortsätta korrekt."
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -874,7 +874,7 @@ msgstr ""
 "Detta inträffade under ett föregående viloläge, och hindrade systemet från "
 "att fortsätta korrekt."
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/szl.po
+++ b/po/szl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2019-06-04 16:41+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Silesian <szl@li.org>\n"
@@ -36,11 +36,11 @@ msgstr "Reporty problymōw systymowych"
 msgid "Please enter your password to access problem reports of system programs"
 msgstr "Wkludź hasło, żeby dostać dostymp do reportōw ô błyndach systymowych"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "Tyn paket niy wyglōndo na zainstalowany noleżnie"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -61,21 +61,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "niyznōmy program"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Program %s niyspodzianie sie zawar"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Problym we %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -83,64 +83,64 @@ msgstr ""
 "We kōmputrze niy styko wolnyj pamiyńci, coby autōmatycznie przeanalizować "
 "problym i zgłosić feler do twōrcōw programu."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Niynoleżne zgłoszynie ô błyndzie"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "Niy mosz dostympu do tego zgłoszynio ô błyndzie."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Feler"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "Na dysku niy styko wolnego placu, coby przetworzić to zgłoszynie."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "Niynoleżny idyntyfikatōr procesu"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr "Ôkryślōny idyntyfikatōr procesu niy istnieje."
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr "Niy twōj PID"
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr "Ôkryślōny idyntyfikatōr procesu niy noleży do ciebie."
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "Niy ôkryślōno paketu"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Trzeba ôkryślić paket abo idyntyfikatōr procesu. Użyj ôpcyje --help, coby "
 "dostać wiyncyj informacyji."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Brak dostympu"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -148,30 +148,30 @@ msgstr ""
 "Ôkryślōny proces niy noleży do ciebie. Ôtwōrz tyn program jako posiedziciel "
 "procesu abo root."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "Ôkryślōny idyntyfikatōr procesu niy noleży do programu."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Skrypt symptōmu %s niy ôkryślōł tykniyntego paketu"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Paket %s niy istnieje"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "Niy idzie stworzić reportu"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "Uaktualnianie zgłoszynio ô błyńdzie"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -183,7 +183,7 @@ msgstr ""
 "\n"
 "Zgłoś feler bez noczynie „apport-bug”."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -203,24 +203,24 @@ msgstr ""
 "\n"
 "Na isto chcesz kōntynuować?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "Żodne ekstra informacyje niy były zebrane."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "Jaki problym chcesz zgłosić?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Niyznōmy symptōm"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Symptōm „%s” je niyznōmy."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -231,37 +231,37 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 "Po zawrzyniu tyj wiadōmości kliknij ôkno programu, coby zgłosić jego problym."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop niy poradziōł znojś idyntyfikatora procesu tego ôkna"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "Ôkryśl miano paketu."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "Przidowo ekstra etyketa do zgłoszynio. Idzie użyć pora razy."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -271,17 +271,17 @@ msgstr ""
 "ôpcjōnalnie --pid, abo ino ôpcyje --pid. Jeźli żodno ôpcyjo niy ôstanie "
 "użyto, pokoż wykoz symptōmōw."
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "Kliknij w ôkno jako cyj do wysłanio zgłoszynio problymu."
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "Zacznij w trybie aktualizacyje zgłoszynio błyndu. Idzie użyć z ôpcyjōm --"
 "package."
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -289,7 +289,7 @@ msgstr ""
 "Zgłoś błōnd ô symptōmie (wymuszōne, jeźli było podano miano symptōmu za "
 "parameter)."
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -297,7 +297,7 @@ msgstr ""
 "Ôkryśl miano paketu w trybie --file-bug. Ôpcjōnalne, jeźli użyto była ôpcyjo "
 "--pid (wymuszōne, jeźli było podano miano paketu za jedyny parameter)."
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -307,11 +307,11 @@ msgstr ""
 "bydzie wiyncyj informacyji  (wymuszōne, jak pid je podany za jedyny "
 "parameter)."
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "Podany pid to numer zawieszōnyj aplikacyje."
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -321,7 +321,7 @@ msgstr ""
 "zamiast tych, co czekajōm w %s (wymuszōne, jeźli zbiōr bōł dany za jedyny "
 "parameter)."
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -330,34 +330,34 @@ msgstr ""
 "Zapisuje informacyje ô błyndzie do zbioru zamiast zgłoszać go. Report "
 "zawarty we zbiorze, może być zgłoszōny niyskorzij z inkszego kōmputra."
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Pokoż informacyje ô wersyji Apport."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr "Analiza awaryje w terminalu ze pōmocōm apport-retrace."
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "Ôtwōrz sesyjo gdb"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Ôtwōrz sesyjo gdb bez pobiyranio symbolōw debugowanio"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Aktualizacyjo %s ze pōmocōm fully symbolic stack trace"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr "Niy pamiyntōm sztelōnkōw sztandu wysyłanio reportōw"
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -376,7 +376,7 @@ msgid ""
 "occurred."
 msgstr "Problym tyko programu %s, co bōł zmiyniōny ôd czasu awaryje."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Te zgłoszynie ô problymie je poprzniōne i niy może być przetworzōne."
 
@@ -404,51 +404,51 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "Niy idzie znojś paketu abo miana paketu zdrzōdłowego."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "Niy idzie ôtworzić przeglōndarki internetowyj"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Niy idzie ôtworzić przeglōndarki internetowyj, żeby ôtworzić %s."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Problym z necym"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Niy idzie połōnczyć sie z bazōm danych awaryji, wejzdrzij na swoje "
 "połōnczynie internetowe."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Pamiyńć spotrzebowano"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "Systymowi niy styko pamiyńci, coby przetworzić tyn report błyndu."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -459,11 +459,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "Problym je już znōmy"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -473,7 +473,7 @@ msgstr ""
 "internetowyj. Wejzdrzij, eli idzie przidać jake dalsze informacyje, co mogōm "
 "być pōmōc twōrcōm programu."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Programisty sōm już poinformowani ô tym problymie. Dziynkujymy!"
 
@@ -832,7 +832,7 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Błōnd: niy idzie wykōnać %s. Zastawianie."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -840,7 +840,7 @@ msgstr ""
 "Trefiyło sie to w czasie poprzednigo uspanio i niy przizwolyło systymowi na "
 "noleżne ôbudzynie."
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -848,7 +848,7 @@ msgstr ""
 "Trefiyło sie to w czasie poprzednij hibernacyje i niy przizwolyło systymowi "
 "na noleżne ôbudzynie."
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/ta.po
+++ b/po/ta.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ta(3)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2012-03-10 22:25+0000\n"
 "Last-Translator: Sarrvesh <sarrfriend@gmail.com>\n"
 "Language-Team: tamil <Ubuntu-l10n-tam@lists.ubuntu.com>\n"
@@ -38,11 +38,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr ""
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -50,7 +50,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -59,21 +59,21 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr ""
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr ""
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "%s இல் இடர்பாடு"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -81,91 +81,91 @@ msgstr ""
 "தங்கள் கணிப்பொறியில் தேவையான இடம் இல்லாததால் மென்பொருட்களை ஆராய்ந்து பிரச்சனைகளை "
 "தெரிவிக்க இயலவில்லை"
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr ""
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "இந்தப்  பிழை அறிக்கையை அணுக தங்களுக்கு அனுமதி கிடையாது"
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "பிழை"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "இப் பிழை அறிக்கையைக் கையாள போதிய இடம் தங்கள் கணிப்பொறியில் இல்லை."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr ""
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr ""
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "அனுமதி மறுக்கப்பட்டது"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 msgstr ""
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr ""
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr ""
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "அறிக்கையை உருவாக்க இயலவில்லை"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr ""
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -173,7 +173,7 @@ msgid ""
 "Please create a new report using \"apport-bug\"."
 msgstr ""
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -185,24 +185,24 @@ msgid ""
 "Do you really want to proceed?"
 msgstr ""
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr ""
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "எத்தகையப் பிழையை அறிவிக்க விரும்புகிறீர்கள்?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr ""
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr ""
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -213,115 +213,115 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr ""
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr ""
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr ""
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -338,7 +338,7 @@ msgid ""
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr ""
 
@@ -366,49 +366,49 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "பொதிகளின் அல்லது மூல தொகுப்புகளின் பெயரை நிர்ணயிக்க முடியவில்லை."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr ""
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr ""
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr ""
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr ""
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -416,18 +416,18 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr ""
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 msgstr ""
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 
@@ -739,19 +739,19 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr ""
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2012-04-20 15:01+0000\n"
 "Last-Translator: RajaSekharReddy Genupula <Unknown>\n"
 "Language-Team: Telugu <te@li.org>\n"
@@ -36,11 +36,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "ఈ ప్యాకేజీ సరిగ్గా ఇన్స్టాల్ కాదు అనిపిస్తుంది"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -57,21 +57,21 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "తెలియని కార్యక్రమం"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "క్షమించాలి, కార్యక్రమం \"% s\" అనుకోకుండా మూసివేయబడింది"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr ""
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -79,92 +79,92 @@ msgstr ""
 "మీ కంప్యూటర్ ఆటోమేటిక్గా సమస్య విశ్లేషించేందుకు మరియు డెవలపర్లకు ఒక నివేదిక పంపేందుకు తగినంత ఉచిత "
 "మెమరీ లేదు."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "చెల్లని సమస్య నివేదిక"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "సమస్య నివేదిక ప్రవేశ సౌలబ్య మునకు  మీకు  అనుమతి లేదు"
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "దోషము"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "ఈ నివేదిక ప్రాసెస్ చేయడానికి తగినంత డిస్క్ స్థలం అందుబాటులో  లేదు."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "చెల్లని PID"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "ప్యాకేజీ పేర్కొనలేదు"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr "మీరు ఒక ప్యాకేజీ లేదా ఒక PID పేర్కొనాలి. చూడండి  --help మరింత సమాచారం కొరకు ."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "అనుమతి నిరాకరించబడింది"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 msgstr ""
 "పేర్కొన్న ప్రక్రియ మీకు సంబంధించినది కాదు. ప్రక్రియ యజమాని లేదా, root  లాగ ఈ ప్రోగ్రామ్ రన్ చెయ్యండి."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "పేర్కొన్న ప్రక్రియ ID ఒక కార్యక్రమానికి సంబంధించినది కాదు."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "లక్షణం లిపి% s ఒక బాధిత ప్యాకేజీ గుర్తించేందుకు లేదు"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "ప్యాకేజీ% s లేదు"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "నివేదిక సృష్టించడం సాధ్యం కాదు"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "సమస్య నివేదిక నవీకరిస్తోంది"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -174,7 +174,7 @@ msgstr ""
 "మీరు ఈ సమస్య నివేదిక యొక్క రిపోర్టర్ లేదా చందాదారుల కాదు, లేదా నివేదిక నకిలీ లేదా ఇప్పటికే మూసివేయబడింది.\n"
 "\"apport-bug\" ఉపయోగించి ఒక నివేదిక రూపొందించండి."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -186,24 +186,24 @@ msgid ""
 "Do you really want to proceed?"
 msgstr ""
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "అదనపు సమాచారం సేకరించ లేదు"
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr ""
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr ""
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr ""
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -214,115 +214,115 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr ""
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr ""
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr ""
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -339,7 +339,7 @@ msgid ""
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "ఈ సమస్య నివేదిక పాడైనది మరియు ప్రక్రియ సాద్యం  కాదు"
 
@@ -367,49 +367,49 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr ""
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr ""
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr ""
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr ""
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr ""
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -417,18 +417,18 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr ""
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 msgstr ""
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 
@@ -740,19 +740,19 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr ""
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/tg.po
+++ b/po/tg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2015-04-27 21:47+0000\n"
 "Last-Translator: Martin Pitt <martin@piware.de>\n"
 "Language-Team: Tajik <tg@li.org>\n"
@@ -40,11 +40,11 @@ msgstr ""
 "Лутфан, пароли худро ворид кунед, то ин ки ба гузоришҳои мушкилиҳои "
 "барномаҳои системавӣ дастрасӣ пайдо кунед"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "Чунин менамояд, ки ин баста ба таври дуруст насб нашудааст"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -52,7 +52,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -65,21 +65,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "барномаи номаълум"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Мутаассифона, барномаи \"%s\" ногаҳонан пӯшида шуд"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Мушкилӣ дар %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -87,64 +87,64 @@ msgstr ""
 "Компютери шумо барои ба таври худкор ташхис кардани мушкилӣ ва фиристодани "
 "гузориш ба таҳиягарон ҳофизаи озоди кофӣ надорад."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Гузориши мушкилӣ беэътибор аст"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "Шумо наметавонед ба ин гузориши мушкилӣ дастрасӣ пайдо кунед."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Хатогӣ"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "Барои коркарди ин гузориш фазои диск кофӣ нест."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "PID беэътибор"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "Ягон баста муайян нашудааст"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Шумо бояд баста ё PID-ро муайян кунед. Барои маълумоти бештар \"--help\"-ро "
 "истифода баред."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Дастарсӣ манъ аст"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -152,30 +152,30 @@ msgstr ""
 "Раванди муайяншуда ба шумо тааллуқ надорад. Лутфан, ин барномаро ҳамчун "
 "раванди root иҷро кунед."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "ID-и раванди муайяншуда ба барнома тааллуқ надорад."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Скрипти нишонаи %s бастаи таъсиргирифтаро муайян накард"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Бастаи %s вуҷуд надорад"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "Гузориш эҷод намешавад"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "Навсозии гузориши мушкилӣ"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -187,7 +187,7 @@ msgstr ""
 "\n"
 "Лутфан, гузориши навро тавассути \"apport-bug\" эҷод кунед."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -208,24 +208,24 @@ msgstr ""
 "\n"
 "Шумо воқеан мехоҳед идома диҳед?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "Ягон маълумоти иловагӣ ҷамъ карда намешавад."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "Шумо мехоҳед кадом намуди мушкилиро гузориш диҳед?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Мушкилии номаълум"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Мушкилии \"%s\" номаълум аст."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -236,7 +236,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -244,32 +244,32 @@ msgstr ""
 "Баъд аз пӯшидани ин паём, лутфан, ба равзанаи барнома зер кунед, то ин ки "
 "мушкилии онро гузориш диҳед."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop ID-и раванди равзанаро муайян карда натавонист"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "Муайян кардани номи баста."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Иловакунии барчаспи иловагӣ ба гузориш. Метавонад якчанд маротиба муайян "
 "карда шавад."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -280,17 +280,17 @@ msgstr ""
 "нашуда бошад, рӯйхати нишонаҳои маълум намоиш дода мешавад. (Агар аргументи "
 "ягона дода шавад, ба кор меояд.)"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "Ба равзанае зер кунед ва мушкилиро гузориш диҳед."
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "Оғоз кардан дар ҳолати навсозии хатогиҳо. Метавонад \"--package\"-и "
 "ихтиёриро гирад."
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -298,7 +298,7 @@ msgstr ""
 "Фиристодани гузориши хатогӣ оид ба нишона. (Танҳо агар номи нишона танҳо "
 "ҳамчун аргумент дода шудааст, тааллуқ дорад.)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -307,7 +307,7 @@ msgstr ""
 "бошад, ин ихтиёрӣ мебошад. (Агар ба номи баста танҳо як аргумент дода шавад, "
 "ба кор меояд.)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -317,11 +317,11 @@ msgstr ""
 "карда шавад, гузориши хатогӣ маълумоти бештарро дар бар мегирад.  (Агар ба "
 "pid танҳо як аргумент дода шавад, ба кор меояд.)"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "Pid-и пешниҳодшуда барномаи боздошта мебошад."
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -331,7 +331,7 @@ msgstr ""
 "мунтазир дар %s. (Агар файл ҳамчун аргументи ягона дода шавад, истифода "
 "мешавад.)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -341,36 +341,36 @@ msgstr ""
 "он ба файл захира кунед. Ин файл метавонад баъдан дар компютери дигар "
 "гузориш дода шавад."
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Чоп кардани рақами версияи Apport."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Ин apport-retrace-ро дар равзанаи терминал аз нав оғоз мекунад, то ин ки "
 "нокомӣ ташхис карда шавад."
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "Иҷро кардани ҷаласаи gdb"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Иҷро кардани ҷаласаи gdb бе боргирии аломатҳои ислоҳи хатоҳо"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Навсозӣ кардани %s бо пайгирии аломатии анбора"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -389,7 +389,7 @@ msgstr ""
 "Мушкилӣ бо барномаи %s ба вуҷуд омад, ки аз лаҳзаи ба вуҷуд омадани нокомӣ "
 "тағйир ёфт."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Гузориши мушкилӣ вайроншуда мебошад ва наметавонад коркард шавад."
 
@@ -417,51 +417,51 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "Баста ё номи бастаи аслӣ муайян карда нашуд."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "Браузер оғоз намешавад"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Барои кушодани %s браузер оғоз намешавад."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Мушкилии шабака"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Ба пойгоҳи иттилоотии нокомӣ пайваст шудан нашуд, лутфан, пайвасти Интернети "
 "худро санҷед."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Ҳофиза кофӣ нест"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "Системаи шумо барои коркарди ин гузориши нокомӣ ҳофизаи кофӣ надорад."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -472,11 +472,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "Мушкилӣ аллакай дониста мебошад"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -486,7 +486,7 @@ msgstr ""
 "гузориш дода шуда буд. Лутфан, санҷед, ки оё шумо метавонед ягон маълумоти "
 "бештарро илова кунед, ки метавонад барои таҳиягарон фоидаовар бошад."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Ин мушкилӣ аллакай ба таҳиягарон гузориш дода шуд. Ташаккур ба шумо!"
 
@@ -843,19 +843,19 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Хатогӣ: %s иҷро намешавад. Амал қатъ карда шуд."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2017-10-15 15:48+0000\n"
 "Last-Translator: Rockworld <sumoisrock@gmail.com>\n"
 "Language-Team: Thai <th@li.org>\n"
@@ -36,11 +36,11 @@ msgstr "การรายงานปัญหาระบบ"
 msgid "Please enter your password to access problem reports of system programs"
 msgstr "โปรดป้อนรหัสผ่านเพื่อเข้าถึงรายงานปัญหาของโปรแกรมระบบ"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "ดูเหมือนว่าแพคเกจนี้จะไม่ได้ถูกติดตั้งอย่างถูกต้อง"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -60,21 +60,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "โปรแกรมนี้ไม่รู้จัก"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "ขออภัย โปรแกรม \"%s\" ปิดลงโดยไม่คาดหมาย"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "ปัญหาใน %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -82,62 +82,62 @@ msgstr ""
 "ระบบของคุณไม่มีหน่วยความจำเหลือเพีัยงพอที่จะทำการตรวจสอบ, วิเคราะปัญหา "
 "และส่งรายงานกลับไปที่นักพัฒนาได้"
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "รายงานปัญหาไม่ถูกต้อง"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "คุณไม่ได้รับอนุญาตให้ดูรายงานปัญหานี้"
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "ผิดพลาด"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "พื้นที่ว่างบนดิืสไม่พอสำหรับดำเนินการกับรายงานนี้ได้"
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "PID ไม่ถูกต้อง"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "ไม่ได้ระบุแพกเกจ"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr "คุณต้องระบุแพกเกจสักตัวหรือเลข PID ดู --help สำหรับข้อมูลเพิ่มเติม"
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "ไม่ได้รับสิทธิ์"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -145,30 +145,30 @@ msgstr ""
 "กระบวนการที่ระบุไม่ใช่ของคุณ "
 "โปรดเรียกใช้โปรแกรมนี้ในฐานะเจ้าของกระบวนการหรือในฐานะผู้ดูแลระบบขั้นสูง"
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "ID ของกระบวนการที่ระบุไม่ใช่ของโปรแกรมใด"
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "สคริปต์อาการ %s ไม่ได้กำหนดแพกเกจที่ได้รับผลกระทบ"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "ไม่มีแพกเกจ %s อยู่"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "ไม่สามารถสร้างรายงานได้"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "กำลังปรับข้อมูลรายงานปัญหา"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -179,7 +179,7 @@ msgstr ""
 "\n"
 "โปรดสร้างรายงานใหม่โดยใช้ \"apport-bug\""
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -198,24 +198,24 @@ msgstr ""
 "\n"
 "คุณต้องการดำเนินการต่อไปหรือไม่?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "ไม่มีการรวบรวมข้อมูลเพิ่มเติมใด ๆ"
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "ปัญหาแบบใดที่คุณต้องการที่จะรายงาน?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "อาการที่ไม่รู้จัก"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "ไม่รู้จักอาการ \"%s\""
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -226,36 +226,36 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr "หลังจากที่ปิดข้อความนี้แล้ว โปรดคลิกบนหน้าต่างโปรแกรมเพื่อรายงานปัญหานี้"
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop ไม่สามารถกำหนด ID โปรเซสของหน้าต่างได้"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "ระบุชื่อแพกเกจ"
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "เพิ่มแท็กพิเศษไปในรายงาน สามารถระบุได้หลาย ๆ ครั้ง"
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -265,21 +265,21 @@ msgstr ""
 "ถ้าไม่ใส่อาร์กิวเมนต์ดังกล่าว ให้แสดงรายการอาการที่รู้ว่าเกิดขึ้น "
 "(ไม่ทำงานถ้าใส่เพียงอาร์กิวเมนต์เดียว)"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "คลิกหน้าต่างเพื่อเป็นเป้าหมายสำหรับรายงานปัญหา"
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "เริ่มทำงานในโหมดอัปเดตปัญหา สามารถใช้อาร์กิวเมนต์ --package พร้อมตัวเลือกได้"
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr "รายงานปัญหาเกี่ยวกับอาการ (ไม่ทำงานถ้าชื่ออาการถูกใส่เพียงอาร์กิวเมนต์)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -287,7 +287,7 @@ msgstr ""
 "ระบุชื่อแพกเกจในโหมด --file-bug ถ้าระบุ --pid นี่จะเป็นตัวเลือก "
 "(ไม่ทำงานถ้าชื่อแพกเกจถูกใส่เพียงอาร์กิวเมนต์)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -296,11 +296,11 @@ msgstr ""
 "ระบุโปรแกรมที่กำลังทำงานในโหมด --file-bug ถ้ามีการระบุ "
 "รายงานปัญหาจะประกอบด้วยข้อมูลเพิ่มเติม  (ไม่ทำงานถ้า pid ถูกใส่เพียงอาร์กิวเมนต์)"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "pid ที่ระบุเป็นโปรแกรมที่ทำงานค้างอยู่"
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -309,7 +309,7 @@ msgstr ""
 "รายงานความล้มเหลวจากแฟ้ม .apport หรือ .crash ที่ให้มาแทนที่กำลังรออยู่ใน %s "
 "(ไม่ทำงานถ้าแฟ้มถูกใส่เพียงอาร์กิวเมนต์)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -318,35 +318,35 @@ msgstr ""
 "ในโหมดรายงานปัญหา บันทึกข้อมูลที่รวบรวมเป็นแฟ้มแทนที่จะรายงาน "
 "แฟ้มนี้สามารถเก็บไว้รายงานได้ทีหลังโดยใช้เครื่องอื่นได้"
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "พิมพ์หมายเลขรุ่น Apport"
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "การดำเนินการนี้จะเป็นการเรียกใช้ apport-retrace ในหน้าต่างเทอร์มินัลเพื่อตรวจสอบความล้มเหลว"
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "เรียกใช้วาระ gdb"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "เรียกใช้วาระ gdb session โดยไม่ต้องดาวน์โหลดสัญลักษณ์การดีบั๊ก"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "อัปเดต %s พร้อมข้อมูลการติดตามสแตกเชิงสัญลักษณ์"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -363,7 +363,7 @@ msgid ""
 "occurred."
 msgstr "มีปัญหาเกิดขึ้นกับโปรแกรม %s ซึ่งมีการเปลี่ยนแปลงตั้งแต่เกิดความล้มเหลวขึ้น"
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "รายงานปัญหาเสียหายทำให้ไม่สามารถดำเนินการต่้อได้"
 
@@ -391,50 +391,50 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "ไม่สามารถกำหนดแพกเกจหรือชื่อแพกเกจต้นฉบับได้"
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "ไม่สามารถเริ่มเว็บเบราว์เซอร์ได้"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "ไม่สามารถเริ่มเว็บเบราว์เซอร์เพื่อเปิด %s"
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "ปัญหาเครือข่าย"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "ไม่สามารถเชื่อมต่อไปที่ฐานข้อมูลความล้มเหลวได้ โปรดตรวจสอบการเชื่อมต่ออินเทอร์เน็ตของคุณ"
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "หน่วยความจำหมด"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "ระบบของคุณมีหน่วยความจำไม่เพียงพอสำหรับประมวลผลการรายงานปัญหานี้"
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -445,11 +445,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "ปัญหาที่ทราบแล้ว"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -458,7 +458,7 @@ msgstr ""
 "ปัญหานี้ถูกรายงานอยู่แล้วในรายงานปัญหาที่แสดงในเว็บเบราว์เซอร์ "
 "โปรดตรวจสอบว่าคุณสามารถเพิ่มข้อมูลเพิ่มเติมที่อาจเป็นประโยชน์ต่อนักพัฒนาได้หรือไม่"
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "ปัญหานี้ถูกรายงานให้ทางผู้พัฒนาไปแล้ว ขอขอบคุณ!"
 
@@ -793,19 +793,19 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "ผิดพลาด: %s ไม่ใช่แฟ้มปฏิบัติการ กำลังหยุดทำงาน"
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr "นี่เกิดขึ้นระหว่างการพักเครื่องครั้งที่ผ่านมา และป้องกันไม่ให้ระบบทำงานต่อได้อย่างถูกต้อง"
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr "นี่เกิดขึ้นระหว่างการไฮเบอร์เนตครั้งที่ผ่านมา และป้องกันไม่ให้ระบบทำงานต่อได้อย่างถูกต้อง"
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 13:02+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2023-02-08 11:17+0000\n"
 "Last-Translator: Sabri Ünal <Unknown>\n"
 "Language-Team: Turkish <tr@li.org>\n"
@@ -38,11 +38,11 @@ msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 "Lütfen sistem programlarının problem raporlarına ulaşmak için şifrenizi girin"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "Bu paket doğru yüklenmiş gibi görünmüyor."
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -53,7 +53,7 @@ msgstr ""
 "güncelleştirdikten sonra yeniden deneyin, eğer bu işinizi görmezse ilişkili "
 "üçüncü parti paketleri kaldırıp yeniden deneyin."
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -66,21 +66,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "bilinmeyen program"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Üzgünüm, \"%s\" programı beklenmedik şekilde kapandı"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "%s'de problem"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -88,65 +88,65 @@ msgstr ""
 "Bilgisayarınız otomatik olarak sorunu analiz etmek ve geliştiricilere rapor "
 "göndermek için yeterli boş belleğe sahip değil."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Geçersiz sorun raporu"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "Bu hata raporuna erişmeye izniniz yok."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Hata"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "Bu raporu işlemek için yeterli disk alanı yok."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr "PID belirtilmemiş"
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 "PID belirtmeniz gerekiyor. Daha fazla bilgi için --help sayfasını inceleyin."
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "Geçersiz PID"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr "Belirtilen işlem kimliği mevcut değil."
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr "Sizin İşlem Kimliğiniz değil"
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr "Belirtilen işlem kimliği size ait değil."
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "Hiçbir paket belirtilmemiş"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Bir paket veya PID belirtmelisiniz. Daha fazla bilgi için --help çıktısına "
 "bakın."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "İzin verilmedi"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -154,30 +154,30 @@ msgstr ""
 "Belirtilen süreç size ait değil. Lütfen bu programı süreç sahibi veya root "
 "olarak çalıştırın."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "Belirlenen işlem ID'si bir programa ait değil."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Symptom betiği %s etkin bir paket tanımlamadı"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "%s pakedi bulunamadı"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "Rapor oluşturulamıyor"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "Sorun raporu güncelleniyor"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -189,7 +189,7 @@ msgstr ""
 "\n"
 "Lütfen ''apport-bug'' kullanarak yeni bir rapor oluşturun."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -210,24 +210,24 @@ msgstr ""
 "\n"
 "Gerçekten devam etmek istiyor musunuz?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "Hiçbir ek bilgi toplanmadı."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "Ne tür bir sorun bildirmek istiyorsunuz?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Bilinmeyen belirti"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "\"%s\" belirtisi bilinmiyor."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -246,7 +246,7 @@ msgstr ""
 "İşlemler sekmesinde doğru uygulamayı bulana kadar kaydırın.  İşlem kimliği, "
 "kimlik sütununda listelenen numaradır."
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -254,31 +254,31 @@ msgstr ""
 "Bu iletiyi kapattıktan sonra lütfen bununla ilgili sorunu bildirmek için bir "
 "uygulama penceresine tıklayın."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop, pencrenin işlem kimliğini saptamada başarısız oldu"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr "%(prog)s <report number>"
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "Paket adı belirtin."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "Rapora fazladan bir etiket ekleyin. Birçok kez belirtilmiş olabilir."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -288,15 +288,15 @@ msgstr ""
 "--pid gerektirir. Eğer hiçbiri belirtilmezse, bilinen belirtilerin listesini "
 "göster. (Kastedilen; eğer tek bir argüman verilirse.)"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "Bir sorunu bildirmek için hedef olarak bir pencereye tıklayın."
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "Hata güncelleme kipinde başlat. Seçime bağlı --package alınabilir."
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -304,7 +304,7 @@ msgstr ""
 "Bir belirti için hata raporu dosyala. (Kastedilen; eğer belirti adı sadece "
 "argüman olarak verilirse.)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -312,7 +312,7 @@ msgstr ""
 "--dosya-hata modunda paket adını belirtin. Bir -pid belirtilmişse, bu "
 "seçenek opsiyoneldir. (Paket adı tek argüman olarak verilmişse uygulanır.)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -322,11 +322,11 @@ msgstr ""
 "belirtilmişse, hata raporu daha fazla ayrıntı içerecektir.(PID 'in tek "
 "parametre olarak verilmesi durumu kastedilmiştir)"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "Belirtilen pid (program id) askıdaki bir uygulama"
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -335,7 +335,7 @@ msgstr ""
 "Hata raporunu %s'te beklemekte olanlar yerine .apport veya .crash "
 "dosyalarından bildirin. (Eğer dosya adı verilen tek argüman ise)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -344,36 +344,36 @@ msgstr ""
 "Hata belirtme kipinde, toplanan bilgileri raporlamak yerine onları bir "
 "dosyaya kaydedin. Bu dosya daha sonra farklı bir makineden raporlanabilir."
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Apport sürüm numarasını yazdır."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Bu, çökmeyi incelemek için bir uçbirim penceresinde \"apport-retrace\" "
 "komutunu çalıştıracak."
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "gdb oturumunu çalıştır"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "gdb oturumunu böcek temizleme simgelerini indirmeden çalıştır"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "%s dosyasını tümüyle sembolik küme iziyle güncelle"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr "Rapor gönderme durum ayarları hatırlanamıyor"
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -393,7 +393,7 @@ msgid ""
 msgstr ""
 "Çökme olduktan sonra değişime uğrayan %s yazılımıyla ilgili sorun oluştu."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Bu sorun raporu hasarlı, bu nedenle işlenemiyor."
 
@@ -422,14 +422,14 @@ msgstr "%s snap paketi"
 msgid "%s deb package"
 msgstr "%s deb paketi"
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s, %s tarafından yayınlanan bir snap aracılığıyla sağlanmaktadır. Yardım "
 "için %s aracılığıyla iletişime geçin."
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -439,38 +439,38 @@ msgstr ""
 "adresi bulunmamaktadır; yardım için https://forum.snapcraft.io/ adresindeki "
 "forumu ziyaret edin."
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "Paket ya da kaynak kod paketi adı belirlenemedi."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "Ağ tarayıcı başlatılamıyor"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "%s açmak için ağ tarayıcı başlatılamıyor."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Ağ sorunu"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Çöküş veritabanına bağlanılamıyor, lütfen internet bağlantınızı kontrol edin."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Yetersiz bellek"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "Sisteminiz bu çökme raporunu işlemek için yeterli belleğe sahip değil."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -481,11 +481,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "Sorun önceden bildirilmiş"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -495,7 +495,7 @@ msgstr ""
 "bildirilmiş. Lütfen geliştiricilere yardımcı olabilecek ek bir bilgi ekleyip "
 "ekleyemeyeceğinize bakın."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Bu sorun daha önce geliştiricilere bildirildi. Teşekkür ederiz!"
 
@@ -846,7 +846,7 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Hata: %s yürütülebilir değil. Durduruluyor."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -854,7 +854,7 @@ msgstr ""
 "Bu durum bir önceki beklemeye almadan kaynaklamıştır ve sistemin düzenli "
 "devam etmesini engellemiştir."
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -862,7 +862,7 @@ msgstr ""
 "Bu durum bir önceki uykuya almadan kaynaklamıştır ve sistemin düzenli devam "
 "etmesini engellemiştir."
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2017-10-13 22:15+0000\n"
 "Last-Translator: Gheyret T.Kenji <Unknown>\n"
 "Language-Team: Uyghur Computer Science Association <UKIJ@yahoogroups.com>\n"
@@ -38,11 +38,11 @@ msgstr "سىستېما مەسىلە دوكلاتى"
 msgid "Please enter your password to access problem reports of system programs"
 msgstr "ئىمنى كىرگۈزۈپ سىستېما مەسىلە دوكلاتىنى كۆرۈڭ."
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "مەزكۇر بوغچا توغرا ئورنىتىلمىغاندەك قىلىدۇ"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -50,7 +50,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -63,21 +63,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "نامەلۇم پروگرامما"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "كەچۈرۈڭ، پروگرامما  «%s» ئويلىمىغان يەردىن تاقىلىپ قالدى"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "مەسىلە %s نىڭدا"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -85,62 +85,62 @@ msgstr ""
 "مەسىلىنى ئاپتوماتىك ئانالىز قىلىش ۋە ئىجادىيەتچىگە مەلۇمات يوللاشقا كېرەكلىك "
 "ئەسلەك يېتەرلىك ئەمەس ئىكەن."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "مەلۇمات ئىناۋەتسىز"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "بۇ مەسىلىنى مەلۇم قىلىش ھوقۇقىڭىز يوق."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "خاتالىق"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "مەزكۇر مەلۇماتنى بىر تەرەپ قىلىشقا كېرەكلىك دىسكا بوشلۇقى يوق."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "ئىناۋەتسىز PID"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr "كۆرسىتىلگەن جەريان ID مەۋجۇت ئەمەس."
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr "سىزنىڭ PID ئەمەس"
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr "كۆرسىتىلگەن جەريان ID سىزگە تەۋە ئەمەس."
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "بوغچا كۆرسىتىلمىگەن."
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr "بوغچا ياكى بىر PID نى كۆرسىتىڭ. تەپسىلاتلار ئۈچۈن --help نى ئىشلىتىڭ."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "ھوقۇقىڭىز يەتمىدى"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -148,30 +148,30 @@ msgstr ""
 "بۇ سىزنىڭ پروگراممىڭىز ئەمەس. مەزكۇر پروگراممىنى ئۆزىڭىزنىڭ ياكى root نىڭ "
 "ھوقۇقىدا ئىجرا قىلدۇرۇڭ."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "كۆرسىتىلگەن PID مەزكۇر پروگراممىنىڭ PID ئەمەس."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "ئەھۋال قوليازما %s تەسىر كۆرسىتىدىغان بوغچىنى بەلگىلىمىگەن"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "بوغچا %s مەۋجۇت ئەمەس"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "مەلۇمات قۇرالمىدى"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "مەلۇماتىنى يېڭىلاۋاتىدۇ"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -183,7 +183,7 @@ msgstr ""
 "\n"
 "«apport-bug» نى ئىشلىتىپ يېڭىدىن مەلۇمات تەييارلاڭ."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -202,24 +202,24 @@ msgstr ""
 "\n"
 "راستلا داۋاملاشتۇرامسىز؟"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "قوشۇمچە ئۇچۇرلار توپلانمىدى."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "قانداق مەسىلىنى مەلۇم قىلماقچى؟"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "نامەلۇم ھادىسە"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "ھادىسە «%s» نامەلۇم."
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -230,37 +230,37 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 "ئۇچۇرنى ياپقاندىن كېيىن پروگرامما كۆزنىكىنى چېكىپ، بۇ مەسىلىنى مەلۇم قىلىڭ."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop كۆزنەكنىڭ ئىجرا ID سىنى تېپىشتا مەغلۇپ بولدى"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "بوغچا ئاتىنى كۆرسىتىپ بېرىڭ."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "دوكلاتقا يېڭىدىن خەتكۈش قوشۇڭ، كۆپ قېتىم بەلگىلەشكە بولىدۇ."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -271,17 +271,17 @@ msgstr ""
 "كۆرۈلگەن ئالامەتلەرنىڭ تىزىمىنى كۆرسىتىدۇ. (پەقەت يالغۇز ئارگۇمېنت "
 "بېرىلگەندىلا.)"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "خاتالىق دوكلاتىنى تولدۇرۇش ئۈچۈن كۆزنەكنى نىشان قىلىپ چېكىڭ"
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "كەمتۈك يېڭىلاش ھالىتىدە قوزغىتىش. --package دېگەن تاللانمىنى ئىشلىتىشكە "
 "بولىدۇ."
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -289,7 +289,7 @@ msgstr ""
 "ھادىسە ھەققىدە مەلۇمات تەييارلاڭ. (Implied if symptom name is given as only "
 "argument)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -297,7 +297,7 @@ msgstr ""
 "--file-bug ھالىتىدە بوغچا ئاتىنى كۆرسىتىڭ. ئەگەر --pid كۆرسىتىلگەن بولسا، "
 "بۇنى كۆرسەتمىسىمۇ بولىدۇ.(Implied if package name is given as only argument.)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -307,12 +307,12 @@ msgstr ""
 "كۆرسىتىلسە، كەمتۈك مەلۇماتىغا تېخىمۇ كۆپ ئۇچۇرلار قوشۇلىدۇ. (Implied if pid "
 "is given as only argument.)"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr ""
 "تەمىنلەنگەن pid بولسا بىر ئېسىلىپ قالغان(توختاپ قالغان) پروگرامما ئىكەن."
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -322,7 +322,7 @@ msgstr ""
 "apport ياكى .crash ھۆججىتىنى ئىشلىتىپ يوللاش(پەقەت ھۆججەت ئاتى ئارگۇمېنت "
 "شەكىلدە بېرىلگەندىلا.)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -331,35 +331,35 @@ msgstr ""
 "كەمتۈك يېزىش ھالىتىدە، توپلانغان ئۇچۇرلارنى مەلۇم قىلماي ھۆججەتكە ساقلاپ "
 "قويۇشقا، بۇ ھۆججەتنى كېيىن باشقا كومپيۇتېر ئارقىلىق يوللاشقىمۇ بولىدۇ."
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Apport نىڭ نەشر نومۇرىنى بېسىپ چىقىرىدۇ."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "crash نى تەكشۈرۈش ئۈچۈن apport-retrace تېرمىنال كۆزنىكىدە ئىجرا بولىدۇ."
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "gdb ئەڭگىمەسىنى ئىجرا قىلىش"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "سازلاش بەلگىلىرىنى چۈشۈرمەيلا gdb ئەڭگىمەسىنى ئىجرا قىلىش"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "%s نى تولۇق بەلگىلەر بىلەن يېڭىلاش"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr "دوكلات ھالىتى تەڭشىكىنى ئەۋەتىش ئۇنتۇلغان"
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -378,7 +378,7 @@ msgid ""
 "occurred."
 msgstr "توقۇنۇشتا ئۆزگەرگەن پروگرامما %s تە خاتالىق كۆرۈلدى."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "بوغچا بۇزۇلغان بولغاچقا بىر تەرەپ قىلغىلى بولمىدى."
 
@@ -407,50 +407,50 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "بوغچا ياكى مەنبە كود بوغچىسىنىڭ نامىنى بېكىتكىلى بولمىدى."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "توركۆرگۈنى قوزغاتقىلى بولمىدى"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "%s نى كۆرىدىغان توركۆرگۈنى قوزغاتقىلى بولمىدى."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "توردىكى مەسىلە"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr "crash ساندىنىغا باغلىنالمىدى، ئىنتېرنېت باغلىنىشىنى تەكشۈرۈپ كۆرۈڭ."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "ئەسلەك يېتىشمىدى"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "سىستېمىڭىزدا مەزكۇر crash مەلۇماتىنى بىر تەرەپ قىلىشقا يېتەرلىك ئەسلەك يوق."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -461,11 +461,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "مەسىلە ئاللىقاچان ئايدىڭلاشقان"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -475,7 +475,7 @@ msgstr ""
 "كۆرۈڭ، ئەگەر سىزنىڭ مەلۇماتىڭىزدا تېخىمۇ كۆپرەك ئۇچۇرلار بار بولسا "
 "ئىجادىيەتچىلەر ئۈچۈن تېخىمۇ پايدىلىق بولاتتى."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "مەسىلە ئىجادىيەتچىلەرگە مەلۇم قىلىندى. سىزگە تەشەككۈر!"
 
@@ -837,7 +837,7 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "خاتالىق: %s نى ئىجرا قىلغىلى بولمايدۇ. توختىتىۋاتىدۇ."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -845,7 +845,7 @@ msgstr ""
 "بۇ ئالدىنقى قېتىملىق توڭدا(suspend) دە يۈز بەرگەن بولۇپ، سىستېمىنى نورمال "
 "داۋام قىلغىلى بولمىدى."
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -853,7 +853,7 @@ msgstr ""
 "بۇ ئالدىنقى قېتىملىق ئۈچەكتە(hibernation) دە يۈز بەرگەن بولۇپ، سىستېمىنى "
 "نورمال داۋام قىلغىلى بولمىدى."
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2020-10-01 04:32+0000\n"
 "Last-Translator: Mykola Tkach <chistomov@gmail.com>\n"
 "Language-Team: Ukrainian <uk@li.org>\n"
@@ -40,11 +40,11 @@ msgstr ""
 "Будь ласка введіть свій пароль для отримання длступу до звіті системних "
 "програм"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "Здається, що цей пакунок встановлено невірно"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -55,7 +55,7 @@ msgstr ""
 "індексів доступних пакунків, якщо це не допоможе, вилучіть пов’язані "
 "сторонні пакунки та повторіть спробу."
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -68,21 +68,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "невідома програма"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "На жаль, програма \"%s\" несподівано закрилася"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Помилка у %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -90,65 +90,65 @@ msgstr ""
 "На вашому комп'ютері недостатньо вільної пам'яті для автоматичного аналізу "
 "проблеми та надсилання розробникам звіту."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Неправильний звіт про помилку"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "Ви не маєте доступу до цього звіту."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Помилка"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "Недостатньо місця на диску для обробки цього звіту."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr "PID не вказано"
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 "Вам потрібно зазначити PID. Перегляньте --help для більш детальної інформації"
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "Неправильний PID"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr "Зазначеного ідентифікатора процесу не існує."
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr "Не ваш PID"
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr "Вказаний ідентифікатор процесу вам не належить."
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "Не вказано пакунок"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Необхідно вказати пакунок або PID. Наберіть --help для отримання додаткової "
 "інформації."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "У доступі відмовлено"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -156,30 +156,30 @@ msgstr ""
 "Зазначений процес Вам не належить. Будь ласка, запустіть програму як власник "
 "процесу або як root."
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "Зазначений процес ID не належить до програми."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Симптоматичний скрипт %s не може визначити постраждалих пакунків"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Пакунку %s не існує"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "Неможливо створити звіт"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "Оновлення звіту про проблеми"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -191,7 +191,7 @@ msgstr ""
 "\n"
 "Будь-ласка, створіть новий звіт за допомогою \"apport-bug\"."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -210,24 +210,24 @@ msgstr ""
 "\n"
 "Ви справді бажаєте продовжити?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "Не зібрано додаткової інформації."
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "Про яку проблему ви бажаєте повідомити?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Невідомий симптом"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Симптом «%s» не відомий"
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -246,7 +246,7 @@ msgstr ""
 "вкладці \"Процеси\" шукаєте потрібну Вам програму. ID процесу – це номер, "
 "вказаний у колонці ID."
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -254,30 +254,30 @@ msgstr ""
 "Після того, як сховаєте дане повідомлення, будь-ласка, клацніть на вікно "
 "програми для того, щоб відіслати звіт про помилку."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "Помилка xprop: не вдалося визначити ID процесу вікна"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "Вкажіть назву пакунку."
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "Додати додаткову мітку до звіту. Може бути задано декілька разів."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -287,16 +287,16 @@ msgstr ""
 "pid, або просто --pid. Якщо ні одного не вказано, показати список відомих "
 "симптомів. (Мається на увазі якщо задано один аргумент.)"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "Натисніть на цільове вікно для заповнення звіту про помилку."
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "Запустити у режимі оновлення помилки. Може виконуватися з ключем --package."
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -304,7 +304,7 @@ msgstr ""
 "Відправити звіт про помилку з симптомом. (Мається на увазі, якщо ім'я "
 "симптому дано як єдиний аргумент.)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -312,7 +312,7 @@ msgstr ""
 "Вкажіть назву пакунку у режимі --file-bug. Необов’язково якщо вказано --pid. "
 "(Припустимо що назва пакунку вказана у якості єдиного аргументу)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -322,11 +322,11 @@ msgstr ""
 "про помилку міститиме більше інформації. (Мається на увазі, що вказано "
 "єдиний аргумент- pid.)"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "Вказаний ідентифікатор належить процесу, який не відповідає."
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -335,7 +335,7 @@ msgstr ""
 "Повідомити про аварію із наданого файлу .apport або .crash замість файлів у "
 "черзі в %s. (За умови, що файл надано у якості єдиного параметру.)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -344,36 +344,36 @@ msgstr ""
 "У режимі збору помилок замість надсилати зібрану інформацію, збережіть її у "
 "файл. Цей файл можна буде відправити пізніше з іншого комп'ютера."
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "Надрукувати номер версії Apport ."
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Буде здійснено запуск «apport-retrace» у вікні терміналу для перевірки "
 "аварійного завершення роботи."
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "Запустити сеанс gdb"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Запустити сеанс gdb, оминувши завантаження символів відлагодження"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Оновити %s з повним відстеженням символьного стеку"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr "Неможливо запам'ятати параметри стану для надсилання звіту"
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -395,7 +395,7 @@ msgstr ""
 "Проблема у програмі %s, до якої були внесені зміни з моменту аварійного "
 "завершення її роботи."
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Цей звіт про помилку пошкоджено та не може бути оброблено."
 
@@ -425,14 +425,14 @@ msgstr "%s snap"
 msgid "%s deb package"
 msgstr "%s пакунок deb"
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s постачається в snap, оприлюднено від %s. Зв'яжіться через %s для "
 "отримання допомоги."
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -441,39 +441,39 @@ msgstr ""
 "%s постачається в snap, оприлюднено від %s. Контактної адреси не вказано; "
 "відвідайте форум https://forum.snapcraft.io/ для отримання допомоги."
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "Не вдалося визначити ім'я пакунку або ім'я пакунку з вихідним кодом."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "Неможливо запустити веб-переглядач"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Не вдається запустити веб-переглядач, щоб відкрити %s."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Проблема з мережею"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Не вдається під'єднатися до пошкодженої бази даних, будь ласка, перевірте "
 "з'єднання з мережею Інтернет."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Пам'ять вичерпано"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "У системі недостатньо пам'яті для обробки цього звіту про аварію."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -484,11 +484,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "Про помилку вже відомо"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -498,7 +498,7 @@ msgstr ""
 "ласка, перевірте, чи можете ви додати до нього іншу корисну інформацію, яка "
 "могла б допомогти розробникам."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Про цю проблему розробникам вже відомо. Дякуємо!"
 
@@ -859,7 +859,7 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Помилка: %s — невиконуваний файл. Зупинка."
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -867,7 +867,7 @@ msgstr ""
 "Це сталося під час попереднього сеансу призупинення роботи і призвело до "
 "неможливості належного відновлення роботи системи."
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -875,7 +875,7 @@ msgstr ""
 "Це сталося під час попереднього сеансу присипляння і призвело до "
 "неможливості належного відновлення роботи системи."
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/uk.po
+++ b/po/uk.po
@@ -8,15 +8,15 @@ msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2023-02-23 23:16+0100\n"
-"PO-Revision-Date: 2020-10-01 04:32+0000\n"
-"Last-Translator: Mykola Tkach <chistomov@gmail.com>\n"
+"PO-Revision-Date: 2023-02-21 12:31+0000\n"
+"Last-Translator: Volodymyr Shypovych <Unknown>\n"
 "Language-Team: Ukrainian <uk@li.org>\n"
 "Language: uk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2022-12-07 14:36+0000\n"
-"X-Generator: Launchpad (build 41e7553f8097ce3a683f90e835708cbe7bf0006c)\n"
+"X-Launchpad-Export-Date: 2023-02-23 22:20+0000\n"
+"X-Generator: Launchpad (build b826c8bc42f0c41016fa141bf50faee47f7ecd80)\n"
 
 #: ../apport/com.ubuntu.apport.policy.in.h:1
 msgid "Collect system information"
@@ -177,7 +177,7 @@ msgstr "Неможливо створити звіт"
 
 #: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
-msgstr "Оновлення звіту про проблеми"
+msgstr "Оновлення звіту про проблему"
 
 #: ../apport/ui.py:688
 msgid ""
@@ -186,9 +186,8 @@ msgid ""
 "\n"
 "Please create a new report using \"apport-bug\"."
 msgstr ""
-"Ви не є відправником чи отримувачем звіту про дану проблему, можливо звіт "
-"вже існує або вже був закритий.\n"
-"\n"
+"Ви не є автором або підписником цього звіту про проблему, або звіт вже "
+"існує, або вже закритий.\n"
 "Будь-ласка, створіть новий звіт за допомогою \"apport-bug\"."
 
 #: ../apport/ui.py:700
@@ -332,8 +331,9 @@ msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
-"Повідомити про аварію із наданого файлу .apport або .crash замість файлів у "
-"черзі в %s. (За умови, що файл надано у якості єдиного параметру.)"
+"Повідомити про аварійне завершення із наданого файлу .apport або .crash "
+"замість файлів у черзі в %s. (За умови, що файл надано у якості єдиного "
+"параметру.)"
 
 #: ../apport/ui.py:1072
 msgid ""
@@ -795,15 +795,15 @@ msgstr "Відіслати їх як вкладення? [так/ні]"
 #: ../bin/apport-unpack.py:29
 #, python-format
 msgid "%(prog)s <report> <target directory>"
-msgstr ""
+msgstr "%(prog)s <звіт> <цільова тека>"
 
 #: ../bin/apport-unpack.py:31
 msgid "Report file to unpack"
-msgstr ""
+msgstr "Файл звіту для розпакування"
 
 #: ../bin/apport-unpack.py:33
 msgid "directory to unpack report to"
-msgstr ""
+msgstr "цільова тека для розпаковки звіту"
 
 #: ../bin/apport-unpack.py:59
 msgid "Destination directory exists and is not empty."

--- a/po/uz.po
+++ b/po/uz.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2012-12-20 18:03+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Uzbek <uz@li.org>\n"
@@ -36,11 +36,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr ""
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -57,111 +57,111 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr ""
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr ""
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr ""
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
 msgstr ""
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr ""
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr ""
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr ""
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr ""
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr ""
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr ""
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 msgstr ""
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr ""
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr ""
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr ""
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr ""
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -169,7 +169,7 @@ msgid ""
 "Please create a new report using \"apport-bug\"."
 msgstr ""
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -181,24 +181,24 @@ msgid ""
 "Do you really want to proceed?"
 msgstr ""
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr ""
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr ""
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr ""
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr ""
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -209,115 +209,115 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr ""
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr ""
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr ""
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -334,7 +334,7 @@ msgid ""
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr ""
 
@@ -362,49 +362,49 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr ""
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr ""
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr ""
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr ""
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr ""
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -412,18 +412,18 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr ""
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 msgstr ""
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 
@@ -735,19 +735,19 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr ""
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2011-03-27 11:11+0000\n"
 "Last-Translator: Nguyễn Anh <Unknown>\n"
 "Language-Team: Vietnamese <vi@li.org>\n"
@@ -36,11 +36,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr ""
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -61,21 +61,21 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "chương trình không xác định"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Xin lỗi, chương trình \"%s\" đã kết thúc bất ngờ"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "Vấn đề trong %s"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -83,63 +83,63 @@ msgstr ""
 "Máy tính của bạn không đủ bộ nhớ trống để tự động phân tích vấn đề và gửi "
 "báo cáo tới các nhà phát triển."
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "Báo cáo vấn đề không hợp lệ"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "Bạn không được phép truy cập báo cáo vấn đề này."
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "Lỗi"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "Không đủ dung lượng đĩa để thực hiện báo cáo này."
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "PID không hợp lệ"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "Chưa gói nào được xác định"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Bạn cần xác định một gói hoặc một PID. Xem --help để biết thêm thông tin."
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "Không đủ quyền truy cập"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -147,31 +147,31 @@ msgstr ""
 "Tiến trình không phải của bạn. Vui lòng chạy chương trình với tài khoản của "
 "chủ tiến trình hoặc với tài khoản quản trị root"
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "ID của tiến trình không phải của một chương trình."
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 "Trình tìm triệu chứng %s không xác định được gói phần mềm đã bị ảnh hưởng"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Gói %s không tồn tại"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "Không tạo được bản báo cáo"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "Cập nhật lại vấn đề đang báo cáo"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -182,7 +182,7 @@ msgstr ""
 "này đã bị báo trùng hoặc đã bị đóng.\n"
 "Hãy tạo một tạo một báo lỗi mới sử dụng \"apport-bug\"."
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -200,24 +200,24 @@ msgstr ""
 "lỗi\" và tạo một chú giải về vấn đề mà bạn báo.\n"
 "Bạn có thật sự muốn thực hiện?"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "Không có thêm thông tin đã được thu tập"
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "Bạn muốn báo cáo vấn đề loại nào?"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "Dấu hiệu không xác định"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Không biết dấu hiệu \"%s\""
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -228,7 +228,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -236,30 +236,30 @@ msgstr ""
 "Sau khi đóng thông điệp này vui lòng nhấp vào một cửa sổ ứng dụng để báo cáo "
 "một vấn đề về nó."
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop không thể định số ID tiến trình của cửa sổ"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr ""
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "Thêm một thẻ cho báo cáo. Có thể thực hiện nhiều lần."
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -269,15 +269,15 @@ msgstr ""
 "chỉ là --pid. Nếu không cách nào trong hai cách trên được sử dụng, hiển thị "
 "danh sách những dấu hiệu đã biết. (Mặc định nếu một tham số được đưa ra.)"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "Bắt đầu ở chế độ cập nhật lỗi. Có thể dùng tuỳ chọn --package."
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -285,7 +285,7 @@ msgstr ""
 "Đệ trình báo cáo lỗi về một triệu chứng. (Mặc định nếu tên triệu chứng là "
 "tham số duy nhất.)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -293,18 +293,18 @@ msgstr ""
 "Xác định tên gói trong chế độ --file-bug. Tùy chọn này nếu một --pid được "
 "xác định. (Mặc định nếu tên gói được đưa ra như là tham số duy nhất.)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -313,41 +313,41 @@ msgstr ""
 "Báo cáo lỗi sử dụng các tệp .apport hoặc .crash thay vì sử dụng các tệp tạm "
 "trong %s. (Mặc định nếu tệp tin là tham số duy nhất.)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "In ra số phiên bản Trình báo lỗi"
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr ""
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -364,7 +364,7 @@ msgid ""
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Báo cáo vấn đề này bị hỏng và không thể được thực hiện"
 
@@ -392,50 +392,50 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "Không thể xác định tên của gói hoặc gói nguồn."
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "Không thể bật trình duyệt web"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Không thể bật trình duyệt web để mở %s."
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "Lỗi mạng"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Không thể kết nối tới cơ sở lỗi, vui lòng kiểm tra kết nối Internet của bạn."
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "Hết bộ nhớ"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "Hệ thống của bạn không đủ bộ nhớ để thực hiện báo cáo lỗi này."
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -446,11 +446,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "Vấn đề đã biết"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -460,7 +460,7 @@ msgstr ""
 "lòng kiểm tra nếu bạn có thể thêm bất cứ thông tin gì có ích cho những người "
 "phát triển."
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 
@@ -790,19 +790,19 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr ""
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2022-10-10 02:46+0000\n"
 "Last-Translator: Luke Luo <Unknown>\n"
 "Language-Team: Chinese (China) <zh_CN@li.org>\n"
@@ -36,11 +36,11 @@ msgstr "系统问题报告"
 msgid "Please enter your password to access problem reports of system programs"
 msgstr "请输入您的密码以查看系统程序问题报告。"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "该软件包似乎没有被正确安装"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -50,7 +50,7 @@ msgstr ""
 "%s 软件包似乎不是官方版本。请在更新可用包索引后重试，如果仍然不能工作，请移除"
 "这些第三方软件包后再试。"
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -62,111 +62,111 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "未知程序"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "对不起，%s 程序异常退出"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "%s 中的问题"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
 msgstr "您的计算机剩余空间不足，程序无法自动诊断问题并向开发者发送问题报告。"
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "无效的问题报告"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "您没有访问这个问题报告的权限。"
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "错误"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "没有足够的磁盘空间来处理报告。"
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr "没有指定 PID"
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr "你需要指定一个 PID。获取更多信息请使用 --help 参数。"
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "无效的 PID"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr "指定的进程ID不存在。"
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr "不是您的 PID"
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr "这个指定的进程 ID 不属于您。"
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "没有指定软件包"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr "您需要指定一个软件包或者 PID。使用 --help 选项来获取更多信息。"
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "拒绝访问"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 msgstr "指定的进程只能以进程的所有者或 root 身份运行。"
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "指定的进程 ID 不属于一个程序。"
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "症状脚本 %s 没有划定受影响的包"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "软件包 %s 不存在"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "无法创建报告"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "更新问题报告"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -176,7 +176,7 @@ msgstr ""
 "您不是该问题报告的报告者或订阅者，或者该报告被视为重复或已经关闭。\n"
 "请使用 apport-bug 新建一份报告。"
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -193,24 +193,24 @@ msgstr ""
 "的报告进行评论。\n"
 "您确定要继续么？"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "未收集更多信息。"
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "您想报告什么类型的问题？"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "未知症状"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "症状 %s 未知。"
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -227,36 +227,36 @@ msgstr ""
 "可以通过运行System Monitor应用程序找到进程ID。在Processes选项卡中，滚动直到找"
 "到正确的应用程序。进程ID是ID列中列出的编号。"
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr "在关闭这个消息只后，请点击要报告问题的程序窗口。"
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop 无法确定窗口的进程 ID"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "请指定包的名称。"
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "向报告中添加额外的标记，可多次指定。"
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -265,21 +265,21 @@ msgstr ""
 "以填写 bug 模式启动。需要 --package 和可选的 --pid 参数，或单独使用 --pid 参"
 "数。如果二者均未给出，将显示一系列症状供选择。"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "点击一个窗口作为提交问题报告的目标。"
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "启动错误更新模式。可以使用选项 --package 来指定软件包。"
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr "针对某个症状报告 bug。"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -287,7 +287,7 @@ msgstr ""
 "--file-bug 模式中指定软件包名。如果指定了 --pid，则是可选的。(如果只给定软件"
 "包名这一个参数则为必需。)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -296,11 +296,11 @@ msgstr ""
 "在 --file-bug 模式中指定运行的程序。如果指定，该问题报告将包含更多的信息。(默"
 "认指定 pid 作为唯一参数。)"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "此进程号的程序是挂起的。"
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -309,7 +309,7 @@ msgstr ""
 "从给定的 .apport 或者  .crash 文件，而不是从正在处理的 %s 中汇报崩溃。(如果文"
 "件只给定了参数时实现。)"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -318,34 +318,34 @@ msgstr ""
 "在提交报告过程中，将收集到的信息保存到要报告的文件中。该文件可用于稍后在另一"
 "台机器上提交。"
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "输出 Apport 版本号"
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr "这将在终端窗口中启动 apport-retrace，以检查此崩溃。"
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "运行 gdb 会话"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "不下载调试符号的情况下运行 gdb 会话"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "利用全符号的堆栈跟踪更新 %s"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr "无法记取发送报告的状态设置"
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr "保存崩溃报告状态失败， 无法设置自动或永不报告模式。"
@@ -362,7 +362,7 @@ msgid ""
 "occurred."
 msgstr "自崩溃发生起已更改的程序 %s 出现问题。"
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "该问题报告已损坏，无法处理。"
 
@@ -390,12 +390,12 @@ msgstr "%s snap"
 msgid "%s deb package"
 msgstr "%s deb 软件包"
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr "%s是由snap提供%s发布的软件。通过%s联系他们以获得帮助。"
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -404,37 +404,37 @@ msgstr ""
 "%s 是 %s 提供的一个 Snap，但没有提供联系地址。请访问 https://forum.snapcraft."
 "io 以寻求帮助。"
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "无法检测包或者源码包的名称。"
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "无法打开浏览器"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "无法使用浏览器打开网页 %s"
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "网络问题"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr "无法连接到崩溃数据库，请检查您的 Internet 连接。"
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "内存耗尽"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "您的系统没有足够的内存来处理此崩溃报告。"
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -445,18 +445,18 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "该问题为已知问题"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 msgstr "关于这个问题，之前已经有如网页所示的报告。您是否有所补充？"
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "已将此问题报告给开发人员。谢谢！"
 
@@ -782,19 +782,19 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "错误：%s 不是可执行文件，停止。"
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr "发生于之前的挂起时，并且使系统午饭正常恢复。"
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr "发生于之前的休眠时，并且使系统午饭正常恢复。"
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/zh_HK.po
+++ b/po/zh_HK.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2012-10-09 16:49+0000\n"
 "Last-Translator: Roy Chan <roy.chan@linux.org.hk>\n"
 "Language-Team: Chinese (Hong Kong) <zh_HK@li.org>\n"
@@ -36,11 +36,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "這個套件似乎尚未正確安裝"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -60,111 +60,111 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "不明的程式"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "對不起，該程式 \"%s\" 不正常起關閉了"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "於 %s 中的問題"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
 msgstr "你的電腦沒有足夠的記憶體以自動分析問題並把問題回報至開發者。"
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "不存在的問題報告"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "你沒有權限去存取這個報告。"
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "錯誤"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "你沒有足夠的硬碟空間去處理這個報告。"
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "無效的進程ID"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "沒有指定軟件包"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr "你必須指定一個軟件包或進程ID。請輸入 --help 獲得更多資訊。"
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "動作不被許可"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 msgstr "被指定的程序並不屬於你的。請以其擁有者身份或管理員身份運行。"
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "指定的進程ID並不屬於一個程式。"
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "問題判斷指令 %s 無法辨認受影響的套件"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "軟件包 %s 不存在"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "不能創建報告"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "正在更新問題報告"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -175,7 +175,7 @@ msgstr ""
 "\n"
 "請使用「apport-bug」來建立一份新的問題回報。"
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -194,24 +194,24 @@ msgstr ""
 "\n"
 "您真的想要繼續嗎？"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "沒有收集到額外的資訊。"
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "您想回報哪種問題？"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "未知的症狀"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "症狀 %s 未知。"
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -222,36 +222,36 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr "在關閉本訊息後，請點擊應用程式視窗來回報有關它的訊息。"
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop 無法得知該視窗的程序 ID"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "指定套件名稱"
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "加入額外標籤至回報中。可以多次分別指定。"
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -260,21 +260,21 @@ msgstr ""
 "啟動為錯誤歸檔模式。需要 --packages 和一個可選擇的 --pid，或是只需 --pid。若"
 "兩者都未給予，顯示一份已知症狀的列表。（暗示若只有給予單一參數。）"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "請點擊要作為問題報告目標發送的視窗。"
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "加上 --package 指令以啟動軟體錯誤更新模式。"
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr "建立一份關於症狀的錯誤報告。（暗示若症狀名稱是唯一給予的參數。）"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -282,7 +282,7 @@ msgstr ""
 "在 --file-bug 模式中指定套件名稱。若指定 --pid 則是可選擇的。（暗示若套件名稱"
 "是唯一給予的參數。）"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -291,11 +291,11 @@ msgstr ""
 "在 --file-bug 模式中指定一個正在執行中的程式。如果有指定，該臭蟲回報將包含更"
 "多資訊。(表示是否只要提供 pid 為引數。)"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "提供的 pid 是懸凍的應用程式。"
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -304,7 +304,7 @@ msgstr ""
 "從特定的 .apport 或 .crash 檔案來回報當機，代替等待中的 %s。（暗示若特定檔案"
 "是唯一給予的參數。）"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -313,34 +313,34 @@ msgstr ""
 "在臭蟲歸檔模式中，收集的資訊將儲存在檔案中而不是將它回報。這個檔案可以稍後從"
 "不同機器回報。"
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "列印 Apport 版本號。"
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr "這會在終端機視窗中啟動 apport-retrace 以檢查程式當掉原因。"
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "執行 gdb 作業階段"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "執行 gdb 作業階段而不下載除錯符號"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "以完整的符號堆疊追蹤來更新 %s"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr ""
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
@@ -357,7 +357,7 @@ msgid ""
 "occurred."
 msgstr "發生問題的程式 %s 自上次遭遇當掉之後已有變動。"
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "這個問題報告已損壞並不能繼續處理。"
 
@@ -385,49 +385,49 @@ msgstr ""
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "無法確定套件或原始碼套件名稱。"
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "無法啟動網頁瀏覽器"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "無法以網頁瀏覽器開啟 %s。"
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "網絡問題"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr "無法連線至系統崩潰資料庫，請檢查您的網絡連線。"
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "記憶體耗盡"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "您的系統沒有足夠的記憶體來處理此份當機報告。"
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -438,11 +438,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "問題已發現"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -451,7 +451,7 @@ msgstr ""
 "此問題在網頁瀏覽器上顯示的錯誤報告中已經回報，請檢查您是否能提供更多可能對開"
 "發者有用的進一步資訊。"
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "此問題已經回報給開發者。感謝您！"
 
@@ -775,19 +775,19 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr ""
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-10 12:34+0100\n"
+"POT-Creation-Date: 2023-02-23 23:16+0100\n"
 "PO-Revision-Date: 2019-08-13 14:40+0000\n"
 "Last-Translator: Cheng-Chia Tseng <pswo10680@gmail.com>\n"
 "Language-Team: Chinese (Taiwan) <zh_TW@li.org>\n"
@@ -36,11 +36,11 @@ msgstr "系統問題報告"
 msgid "Please enter your password to access problem reports of system programs"
 msgstr "請輸入密碼以存取系統程式的問題報告"
 
-#: ../apport/ui.py:166
+#: ../apport/ui.py:167
 msgid "This package does not seem to be installed correctly"
 msgstr "這個軟體包似乎尚未正確安裝"
 
-#: ../apport/ui.py:176
+#: ../apport/ui.py:177
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:206
+#: ../apport/ui.py:207
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -60,111 +60,111 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:369
+#: ../apport/ui.py:370
 msgid "unknown program"
 msgstr "未知程式"
 
-#: ../apport/ui.py:372
+#: ../apport/ui.py:373
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "對不起，\"%s\" 程式已不正常關閉"
 
-#: ../apport/ui.py:375 ../apport/ui.py:1907
+#: ../apport/ui.py:376 ../apport/ui.py:1924
 #, python-format
 msgid "Problem in %s"
 msgstr "在 %s 中的問題"
 
-#: ../apport/ui.py:380
+#: ../apport/ui.py:381
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
 msgstr "閣下電腦無足夠可用記憶體供自動分析問題並向開發者傳送報告。"
 
-#: ../apport/ui.py:440 ../apport/ui.py:458 ../apport/ui.py:631
-#: ../apport/ui.py:640 ../apport/ui.py:877 ../apport/ui.py:1685
-#: ../apport/ui.py:1868 ../apport/ui.py:1873
+#: ../apport/ui.py:441 ../apport/ui.py:459 ../apport/ui.py:632
+#: ../apport/ui.py:641 ../apport/ui.py:878 ../apport/ui.py:1688
+#: ../apport/ui.py:1885 ../apport/ui.py:1890
 msgid "Invalid problem report"
 msgstr "無效的問題回報"
 
-#: ../apport/ui.py:441
+#: ../apport/ui.py:442
 msgid "You are not allowed to access this problem report."
 msgstr "您無權存取此問題報告。"
 
-#: ../apport/ui.py:449
+#: ../apport/ui.py:450
 msgid "Error"
 msgstr "錯誤"
 
-#: ../apport/ui.py:451
+#: ../apport/ui.py:452
 msgid "There is not enough disk space available to process this report."
 msgstr "無足夠磁碟空間處理此報告。"
 
-#: ../apport/ui.py:489
+#: ../apport/ui.py:490
 msgid "No PID specified"
 msgstr "沒有指定 PID"
 
-#: ../apport/ui.py:491
+#: ../apport/ui.py:492
 msgid "You need to specify a PID. See --help for more information."
 msgstr "您需要指定一個 PID。更多說明請見 --help。"
 
-#: ../apport/ui.py:502 ../apport/ui.py:607
+#: ../apport/ui.py:503 ../apport/ui.py:608
 msgid "Invalid PID"
 msgstr "PID 無效"
 
-#: ../apport/ui.py:503
+#: ../apport/ui.py:504
 msgid "The specified process ID does not exist."
 msgstr "指定的程序 ID 不存在。"
 
-#: ../apport/ui.py:508
+#: ../apport/ui.py:509
 msgid "Not your PID"
 msgstr "不是您的 PID"
 
-#: ../apport/ui.py:509
+#: ../apport/ui.py:510
 msgid "The specified process ID does not belong to you."
 msgstr "指定的程序 ID 不屬於您。"
 
-#: ../apport/ui.py:564
+#: ../apport/ui.py:565
 msgid "No package specified"
 msgstr "未指定軟體包"
 
-#: ../apport/ui.py:566
+#: ../apport/ui.py:567
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr "您要指定軟體包或 PID。更多資訊請見 --help。"
 
-#: ../apport/ui.py:594
+#: ../apport/ui.py:595
 msgid "Permission denied"
 msgstr "權限不足"
 
-#: ../apport/ui.py:596
+#: ../apport/ui.py:597
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 msgstr "指定的程序並不屬於您。請以程序擁有者或是 root 身份執行此程式。"
 
-#: ../apport/ui.py:609
+#: ../apport/ui.py:610
 msgid "The specified process ID does not belong to a program."
 msgstr "指定的程序 ID 並不屬於程式。"
 
-#: ../apport/ui.py:633
+#: ../apport/ui.py:634
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "徵狀判斷指令稿 %s 無法判斷出受影響的軟體包"
 
-#: ../apport/ui.py:641
+#: ../apport/ui.py:642
 #, python-format
 msgid "Package %s does not exist"
 msgstr "%s 軟體包不存在"
 
-#: ../apport/ui.py:670 ../apport/ui.py:882 ../apport/ui.py:915
-#: ../apport/ui.py:925
+#: ../apport/ui.py:671 ../apport/ui.py:883 ../apport/ui.py:916
+#: ../apport/ui.py:926
 msgid "Cannot create report"
 msgstr "無法建立報告"
 
-#: ../apport/ui.py:685 ../apport/ui.py:744 ../apport/ui.py:762
+#: ../apport/ui.py:686 ../apport/ui.py:745 ../apport/ui.py:763
 msgid "Updating problem report"
 msgstr "正在更新問題報告"
 
-#: ../apport/ui.py:687
+#: ../apport/ui.py:688
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -175,7 +175,7 @@ msgstr ""
 "\n"
 "請使用「apport-bug」來建立一份新的問題回報。"
 
-#: ../apport/ui.py:699
+#: ../apport/ui.py:700
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -194,24 +194,24 @@ msgstr ""
 "\n"
 "您真的想要繼續嗎？"
 
-#: ../apport/ui.py:745 ../apport/ui.py:763
+#: ../apport/ui.py:746 ../apport/ui.py:764
 msgid "No additional information collected."
 msgstr "沒有收集到額外的資訊。"
 
-#: ../apport/ui.py:826
+#: ../apport/ui.py:827
 msgid "What kind of problem do you want to report?"
 msgstr "您想要回報何種問題？"
 
-#: ../apport/ui.py:847
+#: ../apport/ui.py:848
 msgid "Unknown symptom"
 msgstr "不知名徵狀"
 
-#: ../apport/ui.py:848
+#: ../apport/ui.py:849
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "「%s」徵狀不為人所知。"
 
-#: ../apport/ui.py:884
+#: ../apport/ui.py:885
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -222,36 +222,36 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:900
+#: ../apport/ui.py:901
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr "在關閉本訊息後，請點擊應用程式視窗來回報有關它的訊息。"
 
-#: ../apport/ui.py:917 ../apport/ui.py:926
+#: ../apport/ui.py:918 ../apport/ui.py:927
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop 無法得知該視窗的程序 ID"
 
-#: ../apport/ui.py:941
+#: ../apport/ui.py:942
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:942
+#: ../apport/ui.py:943
 msgid "Specify package name."
 msgstr "指定軟體包名稱。"
 
-#: ../apport/ui.py:949 ../apport/ui.py:1082
+#: ../apport/ui.py:950 ../apport/ui.py:1083
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "加入額外標籤至回報中。可以多次分別指定。"
 
-#: ../apport/ui.py:987
+#: ../apport/ui.py:988
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:998
+#: ../apport/ui.py:999
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -260,21 +260,21 @@ msgstr ""
 "啟動為臭蟲歸檔模式。需要 --package 或再加上 --pid，或是只需 --pid。若兩者都未"
 "給予，顯示已知徵狀列表。(暗示若只有給予單一參數。)"
 
-#: ../apport/ui.py:1007
+#: ../apport/ui.py:1008
 msgid "Click a window as a target for filing a problem report."
 msgstr "請點擊要作為問題報告目標發送的視窗。"
 
-#: ../apport/ui.py:1016
+#: ../apport/ui.py:1017
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "以臭蟲更新模式啟動。可以加上選用的參數 --package。"
 
-#: ../apport/ui.py:1025
+#: ../apport/ui.py:1026
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr "建立關於症狀的錯誤報告。(暗示是否只要提供症狀名稱作為引數。)"
 
-#: ../apport/ui.py:1034
+#: ../apport/ui.py:1035
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -282,7 +282,7 @@ msgstr ""
 "在 --file-bug 模式中指定軟體包名稱。若指定 --pid 則前者不加亦可。(表示是否只"
 "要提供 pid 為引數。)"
 
-#: ../apport/ui.py:1045
+#: ../apport/ui.py:1046
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -291,11 +291,11 @@ msgstr ""
 "在 --file-bug 模式中指定一個正在執行中的程式。如果有指定，該臭蟲回報將包含更"
 "多資訊。(表示是否只要提供 pid 為引數。)"
 
-#: ../apport/ui.py:1053
+#: ../apport/ui.py:1054
 msgid "The provided pid is a hanging application."
 msgstr "提供的 pid 是懸凍的應用程式。"
 
-#: ../apport/ui.py:1061
+#: ../apport/ui.py:1062
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -304,7 +304,7 @@ msgstr ""
 "從特定的 .apport 或 .crash 檔案來回報當掉情形，代替等待中的 %s。（暗示若特定"
 "檔案是唯一給予的參數。）"
 
-#: ../apport/ui.py:1071
+#: ../apport/ui.py:1072
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -313,34 +313,34 @@ msgstr ""
 "在臭蟲歸檔模式中，收集的資訊將儲存在檔案中而不是將它回報。這個檔案可以稍後從"
 "不同機器回報。"
 
-#: ../apport/ui.py:1090
+#: ../apport/ui.py:1091
 msgid "Print the Apport version number."
 msgstr "列印 Apport 版本號碼。"
 
-#: ../apport/ui.py:1252
+#: ../apport/ui.py:1253
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr "這會在終端機視窗中啟動 apport-retrace 以檢查程式當掉原因。"
 
-#: ../apport/ui.py:1256
+#: ../apport/ui.py:1257
 msgid "Run gdb session"
 msgstr "執行 gdb 作業階段"
 
-#: ../apport/ui.py:1257
+#: ../apport/ui.py:1258
 msgid "Run gdb session without downloading debug symbols"
 msgstr "執行 gdb 作業階段而不下載除錯符號"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1259
+#: ../apport/ui.py:1260
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "以完整的符號堆疊追蹤來更新 %s"
 
-#: ../apport/ui.py:1321
+#: ../apport/ui.py:1322
 msgid "Can't remember send report status settings"
 msgstr "無法儲存「傳送回報狀態」設定"
 
-#: ../apport/ui.py:1325
+#: ../apport/ui.py:1326
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr "儲存回報當機狀態時發生錯誤，無法設定自動或永不回報模式。"
@@ -357,7 +357,7 @@ msgid ""
 "occurred."
 msgstr "發生問題的程式 %s 自上次遭遇當掉之後已有變動。"
 
-#: ../apport/ui.py:1506 ../apport/ui.py:1626 ../apport/ui.py:1877
+#: ../apport/ui.py:1506 ../apport/ui.py:1629 ../apport/ui.py:1894
 msgid "This problem report is damaged and cannot be processed."
 msgstr "此問題報告已損壞故無法處理。"
 
@@ -385,12 +385,12 @@ msgstr "%s snap"
 msgid "%s deb package"
 msgstr "%s deb 套件包"
 
-#: ../apport/ui.py:1583
+#: ../apport/ui.py:1586
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1588
+#: ../apport/ui.py:1591
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -399,37 +399,37 @@ msgstr ""
 "%s 是由 %s 所發布的 snap 。開發者沒有提供聯絡地址；請前往論壇 https://forum."
 "snapcraft.io/ 尋求協助。"
 
-#: ../apport/ui.py:1687
+#: ../apport/ui.py:1690
 msgid "Could not determine the package or source package name."
 msgstr "無法決定軟體包或原始碼軟體包名稱。"
 
-#: ../apport/ui.py:1712
+#: ../apport/ui.py:1715
 msgid "Unable to start web browser"
 msgstr "無法啟動網頁瀏覽器"
 
-#: ../apport/ui.py:1713
+#: ../apport/ui.py:1716
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "無法啟動網頁瀏覽器以開啟 %s。"
 
-#: ../apport/ui.py:1823
+#: ../apport/ui.py:1840
 msgid "Network problem"
 msgstr "網路問題"
 
-#: ../apport/ui.py:1827
+#: ../apport/ui.py:1844
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr "無法連接到當機資料庫，請檢查您的網路連線。"
 
-#: ../apport/ui.py:1859
+#: ../apport/ui.py:1876
 msgid "Memory exhaustion"
 msgstr "記憶體耗盡"
 
-#: ../apport/ui.py:1861
+#: ../apport/ui.py:1878
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "您的系統沒有足夠的記憶體來處理此份當機報告。"
 
-#: ../apport/ui.py:1912
+#: ../apport/ui.py:1929
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -440,11 +440,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:1968 ../apport/ui.py:1980
+#: ../apport/ui.py:1985 ../apport/ui.py:1997
 msgid "Problem already known"
 msgstr "已知問題"
 
-#: ../apport/ui.py:1970
+#: ../apport/ui.py:1987
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -453,7 +453,7 @@ msgstr ""
 "此問題在網路瀏覽器顯示之臭蟲報告中已回報。請檢查您是否能新增任何可能對開發者"
 "有幫助的進一步資訊。"
 
-#: ../apport/ui.py:1982
+#: ../apport/ui.py:1999
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "此問題已經回報給開發者。感謝您！"
 
@@ -782,19 +782,19 @@ msgstr ""
 msgid "Error: %s is not an executable. Stopping."
 msgstr "錯誤：%s 並非可執行檔。結束處理。"
 
-#: ../data/apportcheckresume.py:68
+#: ../data/apportcheckresume.py:67
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr "在上次暫停時遭遇這個問題，並使系統無法正常恢復。"
 
-#: ../data/apportcheckresume.py:73
+#: ../data/apportcheckresume.py:72
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr "在上次休眠時遭遇這個問題，並使系統無法正常恢復。"
 
-#: ../data/apportcheckresume.py:81
+#: ../data/apportcheckresume.py:80
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."


### PR DESCRIPTION
Import translation updates from https://translations.launchpad.net/ubuntu/lunar/+source/apport for languages that have updates. Do not update translations that have no changes except for updated metadata (POT-Creation-Date, X-Launchpad-Export-Date, and X-Generator).