### PR TITLE
fix: Support running signal crash via socket tests in containers

### DIFF
--- a/tests/integration/test_signal_crashes.py
+++ b/tests/integration/test_signal_crashes.py
@@ -848,7 +848,12 @@ class T(unittest.TestCase):
         args = apport_binary.parse_arguments(
             self._apport_args(process, sig, dump_mode)
         )
-        self._forward_crash_to_container(socket_path, args, stdin.fileno())
+        with unittest.mock.patch(
+            "apport.fileutils.search_map"
+        ) as search_map_mock:
+            search_map_mock.return_value = True
+            self._forward_crash_to_container(socket_path, args, stdin.fileno())
+            search_map_mock.assert_called()
 
         # call apport like systemd does via socket activation
         def child_setup():


### PR DESCRIPTION
Running `test_core_dump_packaged_sigquit_via_socket` in a container runs into a timeout:

```
test_core_dump_packaged_sigquit_via_socket (tests.integration.test_signal_crashes.T.test_core_dump_packaged_sigquit_via_socket)
Executable create core files via socket, no report for SIGQUIT. ... 46	../sysdeps/unix/sysv/linux/arm/libc-do-syscall.S: No such file or directory.
warning: target file /proc/4067/cmdline contained unexpected null characters
ERROR:root:user is trying to trick apport into accessing a socket that doesn't belong to the container
autopkgtest [05:27:10]: kill with SIGTERM did not work sending SIGKILL
```

Mock the `apport.fileutils.search_map` calls to prevent not forwarding the test crash to the container.