### PR TITLE
fix: Catch HTTPError in UserInterface.file_report

### DIFF
--- a/apport/ui.py
+++ b/apport/ui.py
@@ -1822,34 +1822,36 @@ class UserInterface:
             args=(self.report, progress_callback, message_callback),
         )
         upthread.start()
-        while upthread.is_alive():
-            self.ui_set_upload_progress(self.upload_progress)
-            try:
-                title, text, msg_displayed = message_queue.get(
-                    block=True, timeout=0.1
-                )
-                self.ui_info_message(title, text)
-                msg_displayed.set()
-                upthread.exc_raise()
-            except queue.Empty:
-                pass
-            except KeyboardInterrupt:
-                sys.exit(1)
-            except (smtplib.SMTPConnectError, urllib.error.URLError) as error:
-                self.ui_error_message(
-                    _("Network problem"),
-                    "%s\n\n%s"
-                    % (
-                        _(
-                            "Cannot connect to crash database,"
-                            " please check your Internet connection."
-                        ),
-                        str(error),
-                    ),
-                )
-                return
+        try:
+            while upthread.is_alive():
+                self.ui_set_upload_progress(self.upload_progress)
+                try:
+                    title, text, msg_displayed = message_queue.get(
+                        block=True, timeout=0.1
+                    )
+                    self.ui_info_message(title, text)
+                    msg_displayed.set()
+                    upthread.exc_raise()
+                except queue.Empty:
+                    pass
 
-        upthread.exc_raise()
+            upthread.exc_raise()
+        except KeyboardInterrupt:
+            sys.exit(1)
+        except (smtplib.SMTPConnectError, urllib.error.URLError) as error:
+            self.ui_error_message(
+                _("Network problem"),
+                "%s\n\n%s"
+                % (
+                    _(
+                        "Cannot connect to crash database,"
+                        " please check your Internet connection."
+                    ),
+                    str(error),
+                ),
+            )
+            return
+
         ticket = upthread.return_value()
         self.ui_stop_upload_progress()
 


### PR DESCRIPTION
Uploading the crash report can fail with a `HTTPError`:

```
Traceback (most recent call last):
  File "/usr/share/apport/apport-gtk", line 698, in <module>
    app.run_argv()
  File "/usr/lib/python3/dist-packages/apport/ui.py", line 933, in run_argv
    return self.run_crashes()
           ^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/apport/ui.py", line 333, in run_crashes
    self.run_crash(f)
  File "/usr/lib/python3/dist-packages/apport/ui.py", line 438, in run_crash
    self.file_report()
  File "/usr/lib/python3/dist-packages/apport/ui.py", line 1852, in file_report
    upthread.exc_raise()
  File "/usr/lib/python3/dist-packages/apport/REThread.py", line 62, in exc_raise
    raise self._exception[1].with_traceback(self._exception[2])
  File "/usr/lib/python3/dist-packages/apport/REThread.py", line 37, in run
    self._retval = self.__target(*self.__args, **self.__kwargs)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/apport/crashdb_impl/launchpad.py", line 231, in upload
    ticket = upload_blob(
             ^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/apport/crashdb_impl/launchpad.py", line 1285, in upload_blob
    result = opener.open(req)
             ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/urllib/request.py", line 525, in open
    response = meth(req, response)
               ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/urllib/request.py", line 634, in http_response
    response = self.parent.error(
               ^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/urllib/request.py", line 563, in error
    return self._call_chain(*args)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/urllib/request.py", line 496, in _call_chain
    result = func(*args)
             ^^^^^^^^^^^
  File "/usr/lib/python3.11/urllib/request.py", line 643, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 502: Bad Gateway
```

Catch this exception even when the uploading thread fails quickly and the while loop is not entered.

Bug: https://launchpad.net/bugs/2008638