### PR TITLE
fix(apport): Print proper error message if /proc/<pid> is gone

### DIFF
--- a/data/apport
+++ b/data/apport
@@ -908,7 +908,16 @@ def process_crash(options: argparse.Namespace) -> int:
     core_ulimit = options.core_ulimit
     coredump_fd = sys.stdin.fileno()
 
-    get_pid_info(options.pid)
+    try:
+        get_pid_info(options.pid)
+    except FileNotFoundError as error:
+        logger.error(
+            "%s not found. "
+            "Cannot collect crash information for process %i any more.",
+            error.filename,
+            options.pid,
+        )
+        return 1
 
     process_start = get_process_starttime()
     if not consistency_checks(options, process_start):


### PR DESCRIPTION
Following unhandled exception of apport was found on a bug report:

```
ERROR: apport (pid 21210) Fri Feb 24 16:07:46 2023: Unhandled exception:
Traceback (most recent call last):
  File "/usr/share/apport/apport", line 848, in main
    get_pid_info(pid)
  File "/usr/share/apport/apport", line 98, in get_pid_info
    proc_pid_fd = os.open(
                  ^^^^^^^^
```

Print a proper error message and exit in this case.

Bug: https://launchpad.net/bugs/2008638