### PR TITLE
chore: Fix pylint 2.16.2 complains

### DIFF
--- a/apport/crashdb_impl/launchpad.py
+++ b/apport/crashdb_impl/launchpad.py
@@ -394,7 +394,7 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
                     attachment.seek(0)
                     report[key] = attachment.read()
             else:
-                raise Exception(
+                raise NotImplementedError(
                     "Unknown attachment type: " + attachment.filename
                 )
         return report

--- a/apport/packaging_impl/rpm.py
+++ b/apport/packaging_impl/rpm.py
@@ -181,7 +181,9 @@ class RPMPackageInfo:
         a third-party source."""
         # This is a list of official keys, set by the concrete subclass
         if not self.official_keylist:
-            raise Exception("Subclass the RPM implementation for your distro!")
+            raise NotImplementedError(
+                "Subclass the RPM implementation for your distro!"
+            )
         hdr = self._get_header(package)
         if not hdr:
             return False

--- a/apport/ui.py
+++ b/apport/ui.py
@@ -1564,7 +1564,6 @@ class UserInterface:
                 else:
                     self.ui_stop_info_collection_progress()
                     sys.exit(0)
-                    return
 
             # append snap tags, if this report is about the snap
             if "Snap" in self.report and "SnapTags" in self.report:

--- a/gtk/apport-gtk
+++ b/gtk/apport-gtk
@@ -675,7 +675,6 @@ class GTKUserInterface(apport.ui.UserInterface):
         self.w("window_information_collection").hide()
         self.w("window_report_upload").hide()
         sys.exit(0)
-        return True
 
 
 def text_to_markup(text: str) -> str:


### PR DESCRIPTION
pylint 2.16.2 complains:

```
************* Module apport.ui
apport/ui.py:1567:20: W0101: Unreachable code (unreachable)
************* Module apport.packaging_impl.rpm
apport/packaging_impl/rpm.py:184:12: W0719: Raising too general exception: Exception (broad-exception-raised)
************* Module apport.crashdb_impl.launchpad
apport/crashdb_impl/launchpad.py:397:16: W0719: Raising too general exception: Exception (broad-exception-raised)
************* Module gtk.apport-gtk
gtk/apport-gtk:678:8: W0101: Unreachable code (unreachable)
```

Remove the unreachable code and replace both exceptions with `NotImplementedError` which is more precise.