### PR TITLE
fix: Use URL for debug bug pattern URL

### DIFF
--- a/etc/apport/crashdb.conf
+++ b/etc/apport/crashdb.conf
@@ -41,7 +41,7 @@ databases = {
     'debug': {
         # for debugging
         'impl': 'memory',
-        'bug_pattern_url': '/tmp/bugpatterns.xml',
+        'bug_pattern_url': 'file:///tmp/bugpatterns.xml',
         'distro': 'debug'
     },
 }


### PR DESCRIPTION
`bug_pattern_url` must be a URL and not only a file. Otherwise apport will fail:

```
Traceback (most recent call last):
  File "/usr/share/apport/apport-gtk", line 698, in <module>
    app.run_argv()
  File "/usr/lib/python3/dist-packages/apport/ui.py", line 868, in run_argv
    return self.run_report_bug()
  File "/usr/lib/python3/dist-packages/apport/ui.py", line 627, in run_report_bug
    self.collect_info(symptom_script)
  File "/usr/lib/python3/dist-packages/apport/ui.py", line 1624, in collect_info
    bpthread.exc_raise()
  File "/usr/lib/python3/dist-packages/apport/REThread.py", line 62, in exc_raise
    raise self._exception[1].with_traceback(self._exception[2])
  File "/usr/lib/python3/dist-packages/apport/REThread.py", line 37, in run
    self._retval = self.__target(*self.__args, **self.__kwargs)
  File "/usr/lib/python3/dist-packages/apport/report.py", line 1232, in search_bug_patterns
    with urllib.request.urlopen(url) as request:
  File "/usr/lib/python3.10/urllib/request.py", line 216, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/lib/python3.10/urllib/request.py", line 503, in open
    req = Request(fullurl, data)
  File "/usr/lib/python3.10/urllib/request.py", line 322, in __init__
    self.full_url = url
  File "/usr/lib/python3.10/urllib/request.py", line 348, in full_url
    self._parse()
  File "/usr/lib/python3.10/urllib/request.py", line 377, in _parse
    raise ValueError("unknown url type: %r" % self.full_url)
ValueError: unknown url type: '/tmp/bugpatterns.xml'
```