### PR TITLE
apport-retrace: Do not drop environment variables when calling GDB

### DIFF
--- a/apport/report.py
+++ b/apport/report.py
@@ -927,6 +927,7 @@ class Report(problem_report.ProblemReport):
             "NihAssertionMessage": "print (char*) __nih_abort_msg",
         }
         gdb_cmd, environ = self.gdb_command(rootdir, gdb_sandbox)
+        environ["HOME"] = "/nonexistent"
         if not gdb_cmd:
             raise FileNotFoundError(
                 errno.ENOENT,
@@ -1899,7 +1900,7 @@ class Report(problem_report.ProblemReport):
         if not gdb_path:
             return "", ""
         command = [gdb_path]
-        environ = {"HOME": "/nonexistent"}
+        environ = {}
 
         if not same_arch:
             # check if we have gdb-multiarch

--- a/bin/apport-retrace
+++ b/bin/apport-retrace
@@ -592,7 +592,7 @@ Thank you for your understanding, and sorry for the inconvenience!
                     cmd += w
             apport.log("Calling gdb command: " + cmd, options.timestamps)
         apport.memdbg("before calling gdb")
-        subprocess.call(gdb_cmd, env=environ)
+        subprocess.call(gdb_cmd, env=os.environ | environ)
     else:
         # regenerate gdb info
         apport.memdbg("before collecting gdb info")


### PR DESCRIPTION
Running `lay src` in the GDB session opened by `apport-retrace` fails with:

```
(gdb) lay src
Cannot enable the TUI: error opening terminal [TERM=<unset>]
```

This is caused by calling `gdb` with a minimal environment that does not include `TERM`.

Keep the minimal environment for `Report.add_gdb_info` (for not translating the gdb output), but use the full environment when an interactive GDB session is started via `apport-retrace`.

Bug: https://launchpad.net/bugs/2012374