### PR TITLE
fix(apport-kde): Fix showing progress in the progress bar

### DIFF
--- a/apport/ui.py
+++ b/apport/ui.py
@@ -2075,7 +2075,7 @@ class UserInterface:
             "this function must be overridden by subclasses"
         )
 
-    def ui_set_upload_progress(self, progress):
+    def ui_set_upload_progress(self, progress: typing.Optional[float]) -> None:
         """Update data upload progress bar.
 
         Set the progress bar in the debug data upload progress window to the

--- a/bin/apport-cli
+++ b/bin/apport-cli
@@ -22,6 +22,7 @@ import subprocess
 import sys
 import tempfile
 import termios
+import typing
 from gettext import gettext as _
 
 import apport.ui
@@ -307,7 +308,7 @@ class CLIUserInterface(apport.ui.UserInterface):
         )
         self.progress.show()
 
-    def ui_set_upload_progress(self, progress):
+    def ui_set_upload_progress(self, progress: typing.Optional[float]) -> None:
         assert self.progress is not None
         self.progress.set(progress)
 

--- a/gtk/apport-gtk
+++ b/gtk/apport-gtk
@@ -15,6 +15,7 @@ import os
 import re
 import subprocess
 import sys
+import typing
 from gettext import gettext as _
 
 import apport
@@ -490,7 +491,7 @@ class GTKUserInterface(apport.ui.UserInterface):
         while Gtk.events_pending():
             Gtk.main_iteration_do(False)
 
-    def ui_set_upload_progress(self, progress):
+    def ui_set_upload_progress(self, progress: typing.Optional[float]) -> None:
         """Set the progress bar in the debug data upload progress
         window to the given ratio (between 0 and 1, or None for indefinite
         progress).

--- a/kde/apport-kde
+++ b/kde/apport-kde
@@ -130,9 +130,8 @@ class ProgressDialog(Dialog):
             progress.setRange(0, 0)
             progress.setValue(0)
         else:
-            value = int(value)
             progress.setRange(0, 1000)
-            progress.setValue(value * 1000)
+            progress.setValue(int(value * 1000))
 
 
 class ReportDialog(Dialog):

--- a/kde/apport-kde
+++ b/kde/apport-kde
@@ -16,6 +16,7 @@ import os
 import shutil
 import subprocess
 import sys
+import typing
 from gettext import gettext as _
 
 import apport.logging
@@ -123,7 +124,7 @@ class ProgressDialog(Dialog):
         if self.sender().buttonRole(button) == QDialogButtonBox.RejectRole:
             sys.exit(0)
 
-    def set(self, value=None):
+    def set(self, value: typing.Optional[float] = None) -> None:
         progress = self.findChild(QProgressBar, "progress")
         if not value:
             progress.setRange(0, 0)
@@ -509,7 +510,7 @@ class MainUserInterface(apport.ui.UserInterface):
         )
         self.progress.show()
 
-    def ui_set_upload_progress(self, progress):
+    def ui_set_upload_progress(self, progress: typing.Optional[float]) -> None:
         if progress:
             self.progress.set(progress)
         else:

--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -136,7 +136,7 @@ class UserInterfaceMock(apport.ui.UserInterface):
         self.upload_progress_pulses = 0
         self.upload_progress_active = True
 
-    def ui_set_upload_progress(self, progress):
+    def ui_set_upload_progress(self, progress: typing.Optional[float]) -> None:
         assert self.upload_progress_active
         self.upload_progress_pulses += 1
 

--- a/tests/system/test_ui_kde.py
+++ b/tests/system/test_ui_kde.py
@@ -20,7 +20,7 @@ from gettext import gettext as _
 try:
     from PyQt5.QtCore import QCoreApplication, QTimer
     from PyQt5.QtGui import QIcon
-    from PyQt5.QtWidgets import QApplication, QTreeWidget
+    from PyQt5.QtWidgets import QApplication, QProgressBar, QTreeWidget
 
     PYQT5_IMPORT_ERROR = None
 except ImportError as error:
@@ -771,3 +771,12 @@ class T(unittest.TestCase):
         self.app.ui_present_report_details(False)
         self.assertFalse(self.app.dialog.send_error_report.isVisible())
         self.assertFalse(self.app.dialog.send_error_report.isChecked())
+
+    def test_ui_set_upload_progress(self):
+        self.app.ui_start_upload_progress()
+        try:
+            self.app.ui_set_upload_progress(0.5)
+            progress = self.app.progress.findChild(QProgressBar, "progress")
+            self.assertEqual(progress.value(), 500)
+        finally:
+            self.app.ui_stop_upload_progress()


### PR DESCRIPTION
Commit 57c674a6d906a6e66a5c795aa45710cd2844d24d tries to fix following crash:

```
$ ubuntu-bug dolphin
Traceback (most recent call last):
  File "/usr/share/apport/apport-kde", line 532, in <module>
    sys.exit(UserInterface.run_argv())
  File "/usr/lib/python3/dist-packages/apport/ui.py", line 717, in run_argv
    return self.run_report_bug()
  File "/usr/lib/python3/dist-packages/apport/ui.py", line 558, in run_report_bug
    self.file_report()
  File "/usr/lib/python3/dist-packages/apport/ui.py", line 1391, in file_report
    self.ui_set_upload_progress(__upload_progress)
  File "/usr/share/apport/apport-kde", line 442, in ui_set_upload_progress
    self.progress.set(progress)
  File "/usr/share/apport/apport-kde", line 129, in set
    progress.setValue(value * 1000)
TypeError: setValue(self, int): argument 1 has unexpected type 'float'
```

The value is a float between 0 and 1. Converting the value to integer before multiplying by 1000 result only two values for the progress bar: 0% and 100%.