### PR TITLE
fix: Only open browser as user (via sudo) if running as root

### DIFF
--- a/apport/ui.py
+++ b/apport/ui.py
@@ -45,6 +45,7 @@ import apport.fileutils
 import apport.logging
 import apport.REThread
 from apport.packaging_impl import impl as packaging
+from apport.user_group import get_process_user_and_group
 
 __version__ = "2.26.0"
 
@@ -124,7 +125,7 @@ def run_as_real_user(args: list[str]) -> None:
     run the command with it to get the user's web browser settings.
     """
     uid = _get_env_int("SUDO_UID", _get_env_int("PKEXEC_UID"))
-    if uid is None:
+    if uid is None or not get_process_user_and_group().is_root():
         subprocess.run(args, check=False)
         return
 

--- a/apport/user_group.py
+++ b/apport/user_group.py
@@ -1,0 +1,25 @@
+# Copyright (C) 2023 Canonical Ltd.
+# Author: Benjamin Drung <benjamin.drung@canonical.com>
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+"""Functions around users and groups."""
+
+import dataclasses
+import os
+
+
+@dataclasses.dataclass()
+class UserGroupID:
+    """Pair of user and group ID."""
+
+    uid: int
+    gid: int
+
+    def is_root(self) -> bool:
+        """Check if the user or group ID is root."""
+        return self.uid == 0 or self.gid == 0
+
+
+def get_process_user_and_group() -> UserGroupID:
+    """Return the current process’s real user and group."""
+    return UserGroupID(os.getuid(), os.getgid())

--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -2753,3 +2753,16 @@ class T(unittest.TestCase):
             run_as_real_user(["/bin/true"])
 
         run_mock.assert_called_once_with(["/bin/true"], check=False)
+
+    @unittest.mock.patch("os.getgid", unittest.mock.MagicMock(return_value=37))
+    @unittest.mock.patch("os.getuid", unittest.mock.MagicMock(return_value=37))
+    @unittest.mock.patch.dict("os.environ", {"SUDO_UID": "0"})
+    def test_run_as_real_user_non_root(self) -> None:
+        # pylint: disable=no-self-use
+        """Test run_as_real_user() as non-root and SUDO_UID set."""
+        with unittest.mock.patch(
+            "subprocess.run", side_effect=mock_sudo_calls
+        ) as run_mock:
+            run_as_real_user(["/bin/true"])
+
+        run_mock.assert_called_once_with(["/bin/true"], check=False)

--- a/tests/unit/test_user_group.py
+++ b/tests/unit/test_user_group.py
@@ -1,0 +1,25 @@
+# Copyright (C) 2023 Canonical Ltd.
+# Author: Benjamin Drung <benjamin.drung@canonical.com>
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+"""Unit tests for apport.user_group."""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from apport.user_group import get_process_user_and_group
+
+
+class TestUserGroup(unittest.TestCase):
+    # pylint: disable=missing-function-docstring
+    """Unit tests for apport.user_group."""
+
+    @patch("os.getgid", MagicMock(return_value=0))
+    @patch("os.getuid", MagicMock(return_value=0))
+    def test_get_process_user_and_group_is_root(self) -> None:
+        self.assertTrue(get_process_user_and_group().is_root())
+
+    @patch("os.getgid", MagicMock(return_value=2000))
+    @patch("os.getuid", MagicMock(return_value=3000))
+    def test_get_process_user_and_group_is_not_root(self) -> None:
+        self.assertFalse(get_process_user_and_group().is_root())


### PR DESCRIPTION
By setting the environment variable `SUDO_UID` or `PKEXEC_UID` Apport can be tricked into calling `xdg-open` via sudo for the specified user ID.

Prevent that unexpected behavior if Apport was not called as root.