### PR TITLE
fix: Fix parsing options with spaces in sources.list

### DIFF
--- a/tests/integration/test_packaging_apt_dpkg.py
+++ b/tests/integration/test_packaging_apt_dpkg.py
@@ -1,5 +1,6 @@
 import gzip
 import os
+import pathlib
 import shutil
 import subprocess
 import tempfile
@@ -529,6 +530,14 @@ deb http://secondary.mirror tuxy extra
         self.assertRaises(
             SystemError, impl._get_primary_mirror_from_apt_sources, s
         )
+
+    def test_mirror_from_apt_sources_with_options(self) -> None:
+        """Test _get_primary_mirror_from_apt_sources() with options"""
+        sources = pathlib.Path(self.workdir) / "sources.list"
+        expected = "https://example.com/"
+        sources.write_text(f"deb [ arch=riscv64 ] {expected} suite component")
+        actual = impl._get_primary_mirror_from_apt_sources(str(sources))
+        self.assertEqual(actual, expected)
 
     def test_get_modified_conffiles(self):
         """get_modified_conffiles()"""


### PR DESCRIPTION
In `sources.list` the enclosing brackets of the options can be separated by spaces from option values, e.g.

```
deb [ arch=riscv64 ] http://ports.ubuntu.com/ubuntu-ports/ lunar main
```

Bug: https://launchpad.net/bugs/1822712
Fixes: f7ab55f ("* apt/dpkg: Recognize options in apt sources.list. (LP: #1238620)")
Thanks: Heinrich Schuchardt <heinrich.schuchardt@canonical.com>