### PR TITLE
chore: Add todos for functions/methods that should be split

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -28,14 +28,9 @@ disable=bad-option-value,fixme,
   invalid-name,
   missing-docstring,
   too-many-arguments,
-  too-many-branches,
   too-many-instance-attributes,
   too-many-lines,
-  too-many-locals,
-  too-many-nested-blocks,
   too-many-public-methods,
-  too-many-return-statements,
-  too-many-statements,
 
 
 [REPORTS]

--- a/apport/crashdb.py
+++ b/apport/crashdb.py
@@ -137,6 +137,8 @@ class CrashDatabase:
             self._duplicate_db_upgrade(result[0])
 
     def check_duplicate(self, crash_id, report=None):
+        # TODO: Split into smaller functions/methods
+        # pylint: disable=too-many-branches,too-many-statements
         """Check whether a crash is already known.
 
         If the crash is new, it will be added to the duplicate database and the
@@ -255,6 +257,8 @@ class CrashDatabase:
         return None
 
     def known(self, report):
+        # TODO: Split into smaller functions/methods
+        # pylint: disable=too-many-branches
         """Check if the crash db already knows about the crash signature.
 
         Check if the report has a DuplicateSignature, crash_signature(), or

--- a/apport/crashdb_impl/launchpad.py
+++ b/apport/crashdb_impl/launchpad.py
@@ -304,6 +304,8 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
         return "https://bugs.launchpad.net/bugs/" + str(crash_id)
 
     def download(self, crash_id):
+        # TODO: Split into smaller functions/methods
+        # pylint: disable=too-many-branches,too-many-statements
         """Download the problem report from given ID and return a Report."""
         report = apport.report.Report()
         b = self.launchpad.bugs[crash_id]
@@ -658,6 +660,8 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
         return sources[0].source_package_version
 
     def get_fixed_version(self, crash_id):
+        # TODO: Split into smaller functions/methods
+        # pylint: disable=too-many-branches,too-many-return-statements
         """Return the package version that fixes a given crash.
 
         Return None if the crash is not yet fixed, or an empty string if the
@@ -772,6 +776,8 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
         return None
 
     def close_duplicate(self, report, crash_id, master_id):
+        # TODO: Split into smaller functions/methods
+        # pylint: disable=too-many-branches,too-many-statements
         """Mark a crash id as duplicate of given master ID.
 
         If master is None, id gets un-duplicated.
@@ -1522,6 +1528,8 @@ and more
             )
 
         def test_2_update_traces(self):
+            # TODO: Split into separate test cases
+            # pylint: disable=too-many-statements
             """update_traces()"""
             r = self.crashdb.download(self.get_segv_report())
             self.assertIn("CoreDump", r)

--- a/apport/hookutils.py
+++ b/apport/hookutils.py
@@ -68,6 +68,8 @@ def attach_file_if_exists(
 
 
 def read_file(path, force_unicode=False):
+    # TODO: Split into smaller functions/methods
+    # pylint: disable=too-many-return-statements
     """Return the contents of the specified path.
 
     If the contents is valid UTF-8, or force_unicode is True, then the value
@@ -499,7 +501,6 @@ def _spawn_pkttyagent():
                 if event_type & select.EPOLLHUP:
                     os.close(r)
                     return
-    return
 
 
 def kill_pkttyagent():

--- a/apport/packaging_impl/apt_dpkg.py
+++ b/apport/packaging_impl/apt_dpkg.py
@@ -626,6 +626,8 @@ class __AptDpkgPackageInfo(PackageInfo):
     def get_source_tree(
         self, srcpackage, output_dir, version=None, sandbox=None
     ):
+        # TODO: Split into smaller functions/methods
+        # pylint: disable=too-many-branches,too-many-locals
         """Download source package and unpack it into output_dir.
 
         This also has to care about applying patches etc., so that output_dir
@@ -744,6 +746,9 @@ class __AptDpkgPackageInfo(PackageInfo):
         install_dbg=True,
         install_deps=False,
     ):
+        # TODO: Split into smaller functions/methods
+        # pylint: disable=too-many-branches,too-many-locals
+        # pylint: disable=too-many-nested-blocks,too-many-statements
         """Install packages into a sandbox (for apport-retrace).
 
         In order to work without any special permissions and without touching
@@ -1440,6 +1445,8 @@ class __AptDpkgPackageInfo(PackageInfo):
         )
 
     def _search_contents(self, file, map_cachedir, release, arch):
+        # TODO: Split into smaller functions/methods
+        # pylint: disable=too-many-branches,too-many-locals,too-many-statements
         """Search file in Contents.gz."""
         if not map_cachedir:
             if not self._contents_dir:
@@ -1679,6 +1686,9 @@ class __AptDpkgPackageInfo(PackageInfo):
     def _build_apt_sandbox(
         self, apt_root, apt_sources, distro_name, release_codename, origins
     ):
+        # TODO: Split into smaller functions/methods
+        # pylint: disable=too-many-branches,too-many-locals,too-many-statements
+
         # pre-create directories, to avoid apt.Cache() printing "creating..."
         # messages on stdout
         if not os.path.exists(os.path.join(apt_root, "var", "lib", "apt")):

--- a/apport/report.py
+++ b/apport/report.py
@@ -562,6 +562,8 @@ class Report(problem_report.ProblemReport):
             self["UserGroups"] = "N/A"
 
     def _check_interpreted(self):
+        # TODO: Split into smaller functions/methods
+        # pylint: disable=too-many-branches
         """Check if process is a script.
 
         Use ExecutablePath, ProcStatus and ProcCmdline to determine if
@@ -688,6 +690,8 @@ class Report(problem_report.ProblemReport):
         return spec.origin
 
     def add_proc_info(self, pid=None, proc_pid_fd=None, extraenv=None):
+        # TODO: Split into smaller functions/methods
+        # pylint: disable=too-many-branches,too-many-statements
         """Add /proc/pid information.
 
         If neither pid nor self.pid are given, it defaults to the process'
@@ -892,6 +896,8 @@ class Report(problem_report.ProblemReport):
         return ret
 
     def add_gdb_info(self, rootdir=None, gdb_sandbox=None):
+        # TODO: Split into smaller functions/methods
+        # pylint: disable=too-many-branches,too-many-locals,too-many-statements
         """Add information from gdb.
 
         This requires that the report has a CoreDump and an
@@ -1134,6 +1140,9 @@ class Report(problem_report.ProblemReport):
         package: typing.Optional[str],
         srcpackage: typing.Optional[str],
     ):
+        # TODO: Split into smaller functions/methods
+        # pylint: disable=too-many-branches
+
         # determine package names, unless already given as arguments
         # avoid path traversal
         if not package:
@@ -1425,6 +1434,9 @@ class Report(problem_report.ProblemReport):
         return None
 
     def standard_title(self):
+        # TODO: Split into smaller functions/methods
+        # pylint: disable=too-many-branches,too-many-locals
+        # pylint: disable=too-many-return-statements,too-many-statements
         """Create an appropriate title for a crash database entry.
 
         This contains the topmost function name from the stack trace and the
@@ -1585,6 +1597,9 @@ class Report(problem_report.ProblemReport):
         return obsolete
 
     def crash_signature(self):
+        # TODO: Split into smaller functions/methods
+        # pylint: disable=too-many-branches,too-many-return-statements
+        # pylint: disable=too-many-statements
         """Get a signature string for a crash.
 
         This is suitable for identifying duplicates.
@@ -1871,6 +1886,8 @@ class Report(problem_report.ProblemReport):
                         self[k] = pattern.sub(repl, self[k])
 
     def gdb_command(self, sandbox, gdb_sandbox=None):
+        # TODO: Split into smaller functions/methods
+        # pylint: disable=too-many-branches,too-many-locals
         """Build gdb command for this report.
 
         This builds a gdb command for processing the given report, by setting

--- a/apport/sandboxutils.py
+++ b/apport/sandboxutils.py
@@ -139,6 +139,8 @@ def make_sandbox(
     log_timestamps=False,
     dynamic_origins=False,
 ):
+    # TODO: Split into smaller functions/methods
+    # pylint: disable=too-many-branches,too-many-locals,too-many-statements
     """Build a sandbox with the packages that belong to a particular report.
 
     This downloads and unpacks all packages from the report's Package and

--- a/apport/ui.py
+++ b/apport/ui.py
@@ -176,6 +176,8 @@ def thread_collect_info(
     symptom_script=None,
     ignore_uninstalled=False,
 ):
+    # TODO: Split into smaller functions/methods
+    # pylint: disable=too-many-branches,too-many-statements
     """Collect information about report.
 
     Encapsulate calls to add_*_info() and update given report, so that this
@@ -432,6 +434,9 @@ class UserInterface:
         return result
 
     def run_crash(self, report_file):
+        # TODO: Split into smaller functions/methods
+        # pylint: disable=too-many-branches,too-many-return-statements
+        # pylint: disable=too-many-statements
         """Present and report a particular crash.
 
         If confirm is True, ask the user what to do about it, and offer to file
@@ -644,6 +649,9 @@ class UserInterface:
         os.kill(int(pid), signal.SIGSEGV)
 
     def run_report_bug(self, symptom_script=None):
+        # TODO: Split into smaller functions/methods
+        # pylint: disable=too-many-branches,too-many-return-statements
+        # pylint: disable=too-many-statements
         """Report a bug.
 
         If a pid is given on the command line, the report will contain runtime
@@ -949,6 +957,8 @@ class UserInterface:
         self.run_report_bug(script)
 
     def run_argv(self):
+        # TODO: Split into smaller functions/methods
+        # pylint: disable=too-many-return-statements
         """Call appopriate run_* method according to command line arguments.
 
         Return True if at least one report has been processed, and False
@@ -1058,6 +1068,8 @@ class UserInterface:
         return args
 
     def parse_argv(self, argv: list[str]) -> argparse.Namespace:
+        # TODO: Split into smaller functions/methods
+        # pylint: disable=too-many-branches,too-many-statements
         """Parse command line options.
 
         If a single argument is given without any options, this tries to "do
@@ -1471,6 +1483,8 @@ class UserInterface:
     def collect_info(
         self, symptom_script=None, ignore_uninstalled=False, on_finished=None
     ):
+        # TODO: Split into smaller functions/methods
+        # pylint: disable=too-many-branches,too-many-locals,too-many-statements
         """Collect additional information.
 
         Call all the add_*_info() methods and display a progress dialog during

--- a/apport_python_hook.py
+++ b/apport_python_hook.py
@@ -32,6 +32,9 @@ def enabled():
 
 
 def apport_excepthook(binary, exc_type, exc_obj, exc_tb):
+    # TODO: Split into smaller functions/methods
+    # pylint: disable=too-many-branches,too-many-locals
+    # pylint: disable=too-many-return-statements,too-many-statements
     """Catch an uncaught exception and make a traceback."""
     # create and save a problem report. Note that exceptions in this code
     # are bad, and we probably need a per-thread reentrancy guard to
@@ -146,6 +149,8 @@ def apport_excepthook(binary, exc_type, exc_obj, exc_tb):
 
 
 def dbus_service_unknown_analysis(exc_obj, report):
+    # TODO: Split into smaller functions/methods
+    # pylint: disable=too-many-locals
     # pylint: disable=import-outside-toplevel; for Python starup time
     import re
     import subprocess

--- a/bin/apport-retrace
+++ b/bin/apport-retrace
@@ -343,6 +343,9 @@ def print_traces(report):
 
 
 def main():
+    # TODO: Split into smaller functions/methods
+    # pylint: disable=too-many-branches,too-many-locals,too-many-nested-blocks
+    # pylint: disable=too-many-statements
     apport.memdbg("start")
 
     gettext.textdomain("apport")

--- a/data/apport
+++ b/data/apport
@@ -902,6 +902,9 @@ def consistency_checks(
 
 
 def process_crash(options: argparse.Namespace) -> int:
+    # TODO: Split into smaller functions/methods
+    # pylint: disable=too-many-branches,too-many-locals
+    # pylint: disable=too-many-return-statements,too-many-statements
     """Process crash and return exit code."""
     logger = logging.getLogger()
 

--- a/data/general-hooks/generic.py
+++ b/data/general-hooks/generic.py
@@ -19,6 +19,8 @@ import apport.hookutils
 
 
 def add_info(report, ui):
+    # TODO: Split into smaller functions/methods
+    # pylint: disable=too-many-branches,too-many-locals
     nm = apport.hookutils.nonfree_kernel_modules()
     if nm:
         report["NonfreeKernelModules"] = " ".join(nm)

--- a/data/general-hooks/parse_segv.py
+++ b/data/general-hooks/parse_segv.py
@@ -78,6 +78,8 @@ class ParseSegv:
         return regs
 
     def parse_disassembly(self, disassembly):
+        # TODO: Split into smaller functions/methods
+        # pylint: disable=too-many-branches
         if not self.regs:
             raise ValueError("Registers not loaded yet!?")
         lines = disassembly.splitlines()
@@ -238,6 +240,9 @@ class ParseSegv:
         raise ValueError("Could not resolve register '%s'" % (reg_orig))
 
     def calculate_arg(self, arg):
+        # TODO: Split into smaller functions/methods
+        # pylint: disable=too-many-branches
+
         # Check for and pre-remove segment offset
         segment = 0
         if arg.startswith("%") and ":" in arg:
@@ -301,6 +306,8 @@ class ParseSegv:
         return value % 0x10000000000000000
 
     def report(self):
+        # TODO: Split into smaller functions/methods
+        # pylint: disable=too-many-branches,too-many-statements
         understood = False
         reason = []
         details = ["Segfault happened at: %s" % (self.line)]

--- a/data/whoopsie-upload-all
+++ b/data/whoopsie-upload-all
@@ -30,6 +30,9 @@ from problem_report import MalformedProblemReport
 
 
 def process_report(report):
+    # TODO: Split into smaller functions/methods
+    # pylint: disable=too-many-branches,too-many-return-statements
+    # pylint: disable=too-many-statements
     """Collect information for a report and mark for whoopsie upload
 
     errors.ubuntu.com does not collect any hook data anyway, so we do not need

--- a/gtk/apport-gtk
+++ b/gtk/apport-gtk
@@ -110,6 +110,9 @@ class GTKUserInterface(apport.ui.UserInterface):
         return spinner
 
     def ui_update_view(self, shown_keys=None):
+        # TODO: Split into smaller functions/methods
+        # pylint: disable=too-many-branches
+
         # do nothing if the dialog is already destroyed when the data
         # collection finishes
         if not self.w("details_treeview").get_property("visible"):
@@ -228,6 +231,8 @@ class GTKUserInterface(apport.ui.UserInterface):
     def ui_present_report_details(
         self, allowed_to_report=True, modal_for=None
     ) -> apport.ui.Action:
+        # TODO: Split into smaller functions/methods
+        # pylint: disable=too-many-branches,too-many-locals,too-many-statements
         icon = None
         self.collect_called = False
         report_type = self.report.get("ProblemType")

--- a/kde/apport-kde
+++ b/kde/apport-kde
@@ -138,6 +138,8 @@ class ReportDialog(Dialog):
     """Report dialog wrapper"""
 
     def __init__(self, report, allowed_to_report, ui, desktop_info):
+        # TODO: Split into smaller functions/methods
+        # pylint: disable=too-many-branches,too-many-statements
         if "DistroRelease" not in report:
             report.add_os_info()
         distro = report["DistroRelease"]

--- a/problem_report.py
+++ b/problem_report.py
@@ -123,6 +123,9 @@ class ProblemReport(collections.UserDict):
         self["Tags"] = " ".join(sorted(new_tags))
 
     def load(self, file, binary=True, key_filter=None):
+        # TODO: Split into smaller functions/methods
+        # pylint: disable=too-many-branches,too-many-nested-blocks
+        # pylint: disable=too-many-statements
         """Initialize problem report from a file-like object.
 
         If binary is False, binary data is not loaded; the dictionary key is
@@ -211,6 +214,8 @@ class ProblemReport(collections.UserDict):
         self.old_keys = set(self.data.keys())
 
     def extract_keys(self, file, bin_keys, directory):
+        # TODO: Split into smaller functions/methods
+        # pylint: disable=too-many-branches
         """Extract only one binary element from the problem report.
 
         Binary elements like kernel crash dumps can be very big. This method
@@ -361,6 +366,8 @@ class ProblemReport(collections.UserDict):
         return value
 
     def write(self, file, only_new=False):
+        # TODO: Split into smaller functions/methods
+        # pylint: disable=too-many-branches,too-many-locals,too-many-statements
         """Write information into the given file-like object.
 
         If only_new is True, only keys which have been added since the last
@@ -565,6 +572,8 @@ class ProblemReport(collections.UserDict):
         skip_keys=None,
         priority_fields=None,
     ):
+        # TODO: Split into smaller functions/methods
+        # pylint: disable=too-many-branches,too-many-locals,too-many-statements
         """Write MIME/Multipart RFC 2822 formatted data into file.
 
         file must be a file-like object, not a path.  It needs to be opened in

--- a/tests/integration/test_fileutils.py
+++ b/tests/integration/test_fileutils.py
@@ -53,6 +53,8 @@ class T(unittest.TestCase):
         return [r1, r2]
 
     def test_find_package_desktopfile(self):
+        # TODO: Split into smaller functions/methods
+        # pylint: disable=too-many-branches
         """find_package_desktopfile()"""
         # package without any .desktop file
         nodesktop = "bash"

--- a/tests/integration/test_hookutils.py
+++ b/tests/integration/test_hookutils.py
@@ -223,6 +223,8 @@ class T(unittest.TestCase):
         unittest.mock.MagicMock(return_value=[]),
     )
     def test_attach_mac_events(self):
+        # TODO: Split into separate test cases
+        # pylint: disable=too-many-statements
         """attach_mac_events()"""
         denied_log = (
             "[  351.624338] type=1400 audit(1343775571.688:27):"

--- a/tests/integration/test_problem_report.py
+++ b/tests/integration/test_problem_report.py
@@ -341,7 +341,7 @@ class T(unittest.TestCase):
         self.assertEqual(pr["Before"], "xtestx")
         self.assertEqual(pr["ZAfter"], "ytesty")
 
-    def test_add_to_existing(self):
+    def test_add_to_existing(self):  # pylint: disable=too-many-statements
         """Add information to an existing report."""
         # original report
         pr = problem_report.ProblemReport()

--- a/tests/integration/test_report.py
+++ b/tests/integration/test_report.py
@@ -115,6 +115,8 @@ class T(unittest.TestCase):
         self.assertNotIn(grp.getgrgid(os.getgid()).gr_name, pr["UserGroups"])
 
     def test_add_proc_info(self):
+        # TODO: Split into separate test cases
+        # pylint: disable=too-many-statements
         """add_proc_info()."""
         # check without additional safe environment variables
         pr = apport.report.Report()
@@ -343,6 +345,8 @@ class T(unittest.TestCase):
         self.assertIn("PATH=(custom, user)", r["ProcEnviron"])
 
     def test_check_interpreted(self):
+        # TODO: Split into separate test cases
+        # pylint: disable=too-many-statements
         """_check_interpreted()."""
         restore_root = False
         if os.getuid() == 0:
@@ -1087,6 +1091,8 @@ int main() { return f(42); }
         )
 
     def test_search_bug_patterns(self):
+        # TODO: Split into separate test cases
+        # pylint: disable=too-many-statements
         """search_bug_patterns()."""
         # create some test patterns
         patterns = textwrap.dedent(
@@ -1275,6 +1281,8 @@ int main() { return f(42); }
         )
 
     def test_add_hooks_info(self):
+        # TODO: Split into separate test cases
+        # pylint: disable=too-many-statements
         """add_hooks_info()."""
         orig_general_hook_dir = apport.report.GENERAL_HOOK_DIR
         apport.report.GENERAL_HOOK_DIR = tempfile.mkdtemp()

--- a/tests/integration/test_signal_crashes.py
+++ b/tests/integration/test_signal_crashes.py
@@ -969,6 +969,8 @@ class T(unittest.TestCase):
         expect_report: bool = True,
         via_socket: bool = False,
     ):
+        # TODO: Split into smaller functions/methods
+        # pylint: disable=too-many-branches,too-many-locals,too-many-statements
         """Generate a test crash.
 
         This runs command (by default TEST_EXECUTABLE) in cwd, lets it crash,

--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -2020,6 +2020,8 @@ class T(unittest.TestCase):
     )
     @unittest.mock.patch("sys.stderr", new_callable=io.StringIO)
     def test_run_symptom(self, stderr_mock):
+        # TODO: Split into separate test cases
+        # pylint: disable=too-many-statements
         """run_symptom()"""
         # unknown symptom
         self.ui = UserInterfaceMock(["ui-test", "-s", "foobar"])

--- a/tests/system/test_packaging_apt_dpkg.py
+++ b/tests/system/test_packaging_apt_dpkg.py
@@ -37,6 +37,8 @@ class T(unittest.TestCase):
 
     @unittest.skipUnless(has_internet(), "online test")
     def test_install_packages_versioned(self):
+        # TODO: Split into smaller functions/methods
+        # pylint: disable=too-many-locals,too-many-statements
         """install_packages() with versions and with cache"""
         release = self._setup_foonux_config(updates=True)
         wanted = {

--- a/tests/unit/test_crashdb.py
+++ b/tests/unit/test_crashdb.py
@@ -608,6 +608,8 @@ class T(unittest.TestCase):
         )
 
     def test_known_address_sig(self):
+        # TODO: Split into separate test cases
+        # pylint: disable=too-many-statements
         """known() for address signatures"""
         self.crashes.init_duplicate_db(":memory:")
 

--- a/tests/unit/test_parse_segv.py
+++ b/tests/unit/test_parse_segv.py
@@ -152,6 +152,8 @@ class T(unittest.TestCase):
         self.assertRaises(ValueError, segv.parse_disassembly, "")
 
     def test_invalid_01_disassembly(self):
+        # TODO: Split into separate test cases
+        # pylint: disable=too-many-statements
         """Require valid disassembly."""
         regs = "a 0x10"
 

--- a/tests/unit/test_report.py
+++ b/tests/unit/test_report.py
@@ -56,6 +56,8 @@ class T(unittest.TestCase):
         self.assertFalse(r.has_useful_stacktrace())
 
     def test_standard_title(self):
+        # TODO: Split into separate test cases
+        # pylint: disable=too-many-statements
         """standard_title()."""
         report = apport.report.Report()
         self.assertEqual(report.standard_title(), None)


### PR DESCRIPTION
To prevent introducing big functions, add `TODO`s for functions/methods that should be split and remove the override from the global pylint configuration.