### PR TITLE
fix(tests): Clear environment for test_run_as_real_user_no_sudo

### DIFF
--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -2767,7 +2767,7 @@ class T(unittest.TestCase):
         )
         self.assertEqual(run_mock.call_count, 2)
 
-    @unittest.mock.patch.dict("os.environ", {})
+    @unittest.mock.patch.dict("os.environ", {}, clear=True)
     def test_run_as_real_user_no_sudo(self) -> None:
         # pylint: disable=no-self-use
         """Test run_as_real_user() without sudo env variables."""


### PR DESCRIPTION
The test `test_run_as_real_user_no_sudo` can fail if the environment has `SUDO_UID` set and is run as root:

```
======================================================================
FAIL: test_run_as_real_user_no_sudo (tests.integration.test_ui.T.test_run_as_real_user_no_sudo)
Test run_as_real_user() without sudo env variables.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3.11/unittest/mock.py", line 1369, in patched
    return func(*newargs, **newkeywargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/unittest/mock.py", line 1822, in _inner
    return f(*args, **kw)
           ^^^^^^^^^^^^^^
  File "/tmp/autopkgtest.Z6SSWK/autopkgtest_tmp/tests/integration/test_ui.py", line 2779, in test_run_as_real_user_no_sudo
    run_mock.assert_called_once_with(["/bin/true"], check=False)
  File "/usr/lib/python3.11/unittest/mock.py", line 945, in assert_called_once_with
    return self.assert_called_with(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/unittest/mock.py", line 933, in assert_called_with
    raise AssertionError(_error_message()) from cause
AssertionError: expected call not found.
Expected: run(['/bin/true'], check=False)
Actual: run(['/bin/true'], check=False, env={'SHELL': '/bin/bash', 'no_proxy': '127.0.0.1,127.0.1.1,localhost,localdomain,novalocal,internal,archive.ubuntu.com,ports.ubuntu.com,security.ubuntu.com,ddebs.ubuntu.com,changelogs.ubuntu.com,launchpad.net,10.24.0.0/24', 'AUTOPKGTEST_NORMAL_USER': 'ubuntu', 'AUTOPKGTEST_TMP': '/tmp/autopkgtest.Z6SSWK/autopkgtest_tmp', 'PWD': '/tmp/autopkgtest.Z6SSWK/autopkgtest_tmp', 'ADT_TEST_TRIGGERS': 'apport/2.26.1-0ubuntu1', 'LOGNAME': 'root', 'HOME': '/home/ubuntu', 'ADTTMP': '/tmp/autopkgtest.Z6SSWK/autopkgtest_tmp', 'https_proxy': 'http://squid.internal:3128', 'AUTOPKGTEST_ARTIFACTS': '/tmp/autopkgtest.Z6SSWK/unit-and-integration-tests-artifacts', 'TERM': 'linux', 'USER': 'root', 'DEB_BUILD_OPTIONS': 'parallel=1', 'SHLVL': '2', 'ADT_NORMAL_USER': 'ubuntu', 'http_proxy': 'http://squid.internal:3128', 'DEBUGINFOD_URLS': 'https://debuginfod.ubuntu.com ', 'ADT_ARTIFACTS': '/tmp/autopkgtest.Z6SSWK/unit-and-integration-tests-artifacts', 'PATH': '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin', 'MAIL': '/var/mail/root', 'DEBIAN_FRONTEND': 'noninteractive', 'OLDPWD': '/tmp/autopkgtest.Z6SSWK/build.jCs/src', '_': '/usr/bin/python3', 'APPORT_CRASHDB_CONF': '/tmp/tmpri_h0dcw', 'APPORT_IGNORE_OBSOLETE_PACKAGES': '1', 'APPORT_DISABLE_DISTRO_CHECK': '1'}, user=1000, group=1000, extra_groups=[1000, 4, 20, 24, 25, 27, 29, 30, 44, 46, 118, 119])
```

Clear the mocked environment to be empty to ensure `SUDO_UID` is not set.