### PR TITLE
fix(apport-unpack): Catch MalformedProblemReport on extraction

### DIFF
--- a/bin/apport-unpack
+++ b/bin/apport-unpack
@@ -83,7 +83,7 @@ def main():
         else:
             with open(args.report, "rb") as f:
                 pr.extract_keys(f, bin_keys, args.target_directory)
-    except OSError as error:
+    except (OSError, problem_report.MalformedProblemReport) as error:
         fatal("%s", str(error))
 
 

--- a/tests/integration/test_apport_unpack.py
+++ b/tests/integration/test_apport_unpack.py
@@ -106,6 +106,26 @@ class T(unittest.TestCase):
         )
         self.assertEqual(process.stdout, "")
 
+    def test_broken_core_dump(self):
+        """Test unpacking a report file that has a malformed CoreDump entry."""
+        with tempfile.NamedTemporaryFile("wb") as report_file:
+            report_file.write(
+                b"CoreDump: base64\n H4sICAAAAAAC/0NvcmVEdW1wAA==\n"
+                b" 7Z0LYFPV/cdP0rQ\n"
+            )
+            report_file.flush()
+            process = self._call_apport_unpack(
+                [report_file.name, self.unpack_dir]
+            )
+
+        self.assertEqual(process.returncode, 1)
+        self.assertEqual(
+            process.stderr,
+            "ERROR: Malformed problem report: Incorrect padding. "
+            "Is this a proper .crash text file?\n",
+        )
+        self.assertEqual(process.stdout, "")
+
     def _call_apport_unpack(self, argv: list) -> subprocess.CompletedProcess:
         return subprocess.run(
             ["apport-unpack"] + argv,


### PR DESCRIPTION
Commit b06d44fb61e51dd637cab89452b7c6b632c7e243 catches `binascii.Error` and raise a `MalformedProblemReport` exception instead, but `apport-unpack` does not catch `MalformedProblemReport` on extracting the keys:

```
$ printf "CoreDump: base64\n H4sICAAAAAAC/0NvcmVEdW1wAA==\n 7Z0LYFPV/cdP0rQ\n" > malformed.crash
$ apport-unpack malformed.crash unpack
Traceback (most recent call last):
  File "/usr/bin/apport-unpack", line 91, in <module>
    main()
  File "/usr/bin/apport-unpack", line 85, in main
    pr.extract_keys(f, bin_keys, args.target_directory)
  File "/usr/lib/python3/dist-packages/problem_report.py", line 254, in extract_keys
    bd, line_value = self._decompress_line(
                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/problem_report.py", line 316, in _decompress_line
    raise MalformedProblemReport(str(error)) from None
problem_report.MalformedProblemReport: Malformed problem report: Incorrect padding. Is this a proper .crash text file?
```

Bug: https://launchpad.net/bugs/1997912