### PR TITLE
feat: Already add package info during Python crashes

### DIFF
--- a/apport_python_hook.py
+++ b/apport_python_hook.py
@@ -54,6 +54,7 @@ def apport_excepthook(binary, exc_type, exc_obj, exc_tb):
             return
 
         try:
+            import contextlib
             import io
             import os
             import re
@@ -114,6 +115,10 @@ def apport_excepthook(binary, exc_type, exc_obj, exc_tb):
             pass
         if pr.check_ignored():
             return
+
+        with contextlib.suppress(SystemError, ValueError):
+            pr.add_package_info()
+        pr["_HooksRun"] = "no"
 
         report_dir = os.environ.get("APPORT_REPORT_DIR", "/var/crash")
         try:


### PR DESCRIPTION
Commit ea64857890ac6cb8ad056af255cf7b706850bea7 ("feat: Already add package info during crash") added the package info to the crash report during crash to prevent package list discrepancies between crash and reporting. This commit only changed reports for crashes of compiled programs.

Apply the same logic to Python crashes. Apport uses `apport_python_hook` for Python to intercept stack traces.