### PR TITLE
refactor: Increase pylint's max args to 6

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -27,7 +27,6 @@ disable=bad-option-value,fixme,
   duplicate-code,
   invalid-name,
   missing-docstring,
-  too-many-arguments,
   too-many-instance-attributes,
   too-many-lines,
   too-many-public-methods,
@@ -46,3 +45,9 @@ score=no
 
 # Maximum number of characters on a single line.
 max-line-length=79
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method.
+max-args=6

--- a/apport/crashdb.py
+++ b/apport/crashdb.py
@@ -735,7 +735,7 @@ class CrashDatabase:
         change_description=False,
         attachment_comment=None,
         key_filter=None,
-    ):
+    ):  # pylint: disable=too-many-arguments
         """Update the given report ID with all data from report.
 
         This creates a text comment with the "short" data (see

--- a/apport/crashdb_impl/github.py
+++ b/apport/crashdb_impl/github.py
@@ -312,7 +312,7 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
         change_description=False,
         attachment_comment=None,
         key_filter=None,
-    ):
+    ):  # pylint: disable=too-many-arguments
         raise NotImplementedError(
             "This method is not relevant for Github database implementation."
         )

--- a/apport/crashdb_impl/launchpad.py
+++ b/apport/crashdb_impl/launchpad.py
@@ -409,7 +409,7 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
         change_description=False,
         attachment_comment=None,
         key_filter=None,
-    ):
+    ):  # pylint: disable=too-many-arguments
         """Update the given report ID with all data from report.
 
         This creates a text comment with the "short" data (see

--- a/apport/crashdb_impl/memory.py
+++ b/apport/crashdb_impl/memory.py
@@ -129,7 +129,7 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
         change_description=False,
         attachment_comment=None,
         key_filter=None,
-    ):
+    ):  # pylint: disable=too-many-arguments
         """Update the given report ID with all data from report.
 
         This creates a text comment with the "short" data (see

--- a/apport/packaging.py
+++ b/apport/packaging.py
@@ -290,7 +290,7 @@ class PackageInfo:
         origins=None,
         install_dbg=True,
         install_deps=False,
-    ):
+    ):  # pylint: disable=too-many-arguments
         """Install packages into a sandbox (for apport-retrace).
 
         In order to work without any special permissions and without touching

--- a/apport/packaging_impl/apt_dpkg.py
+++ b/apport/packaging_impl/apt_dpkg.py
@@ -137,7 +137,7 @@ class __AptDpkgPackageInfo(PackageInfo):
         release_codename,
         origins,
         arch,
-    ):
+    ):  # pylint: disable=too-many-arguments
         """Build apt sandbox and return apt.Cache(rootdir=) (initialized
         lazily).
 
@@ -745,7 +745,7 @@ class __AptDpkgPackageInfo(PackageInfo):
         origins=None,
         install_dbg=True,
         install_deps=False,
-    ):
+    ):  # pylint: disable=too-many-arguments
         # TODO: Split into smaller functions/methods
         # pylint: disable=too-many-branches,too-many-locals
         # pylint: disable=too-many-nested-blocks,too-many-statements

--- a/apport/sandboxutils.py
+++ b/apport/sandboxutils.py
@@ -138,7 +138,7 @@ def make_sandbox(
     verbose=False,
     log_timestamps=False,
     dynamic_origins=False,
-):
+):  # pylint: disable=too-many-arguments
     # TODO: Split into smaller functions/methods
     # pylint: disable=too-many-branches,too-many-locals,too-many-statements
     """Build a sandbox with the packages that belong to a particular report.

--- a/bin/crash-digger
+++ b/bin/crash-digger
@@ -34,7 +34,7 @@ class CrashDigger:
         dupcheck_mode=False,
         publish_dir=None,
         crash_db=None,
-    ):
+    ):  # pylint: disable=too-many-arguments
         """Initialize pools."""
 
         self.retrace_pool = set()

--- a/tests/integration/test_signal_crashes.py
+++ b/tests/integration/test_signal_crashes.py
@@ -968,7 +968,7 @@ class T(unittest.TestCase):
         hook_before_apport=None,
         expect_report: bool = True,
         via_socket: bool = False,
-    ):
+    ):  # pylint: disable=too-many-arguments
         # TODO: Split into smaller functions/methods
         # pylint: disable=too-many-branches,too-many-locals,too-many-statements
         """Generate a test crash.


### PR DESCRIPTION
Increase the allowed maximum arguments to six and move the overrides to the individual functions/methods.