### PR TITLE
refactor: Increase pylint's max attributes to 9

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -27,7 +27,6 @@ disable=bad-option-value,fixme,
   duplicate-code,
   invalid-name,
   missing-docstring,
-  too-many-instance-attributes,
   too-many-lines,
   too-many-public-methods,
 
@@ -51,3 +50,6 @@ max-line-length=79
 
 # Maximum number of arguments for function / method.
 max-args=6
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=9

--- a/apport/packaging_impl/apt_dpkg.py
+++ b/apport/packaging_impl/apt_dpkg.py
@@ -40,6 +40,7 @@ from apport.packaging import PackageInfo, freedesktop_os_release
 
 
 class __AptDpkgPackageInfo(PackageInfo):
+    # pylint: disable=too-many-instance-attributes
     """Concrete apport.packaging.PackageInfo class implementation for
     python-apt and dpkg, as found on Debian and derivatives such as Ubuntu."""
 

--- a/bin/crash-digger
+++ b/bin/crash-digger
@@ -21,7 +21,7 @@ import apport
 from apport.crashdb import get_crashdb
 
 
-class CrashDigger:
+class CrashDigger:  # pylint: disable=too-many-instance-attributes
     def __init__(
         self,
         config_dir,

--- a/kde/apport-kde
+++ b/kde/apport-kde
@@ -134,7 +134,7 @@ class ProgressDialog(Dialog):
             progress.setValue(int(value * 1000))
 
 
-class ReportDialog(Dialog):
+class ReportDialog(Dialog):  # pylint: disable=too-many-instance-attributes
     """Report dialog wrapper"""
 
     def __init__(self, report, allowed_to_report, ui, desktop_info):

--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -44,6 +44,7 @@ def mock_run_calls_except_pgrep(
 
 
 class UserInterfaceMock(apport.ui.UserInterface):
+    # pylint: disable=too-many-instance-attributes
     """Concrete apport.ui.UserInterface suitable for automatic testing"""
 
     def __init__(self, argv: typing.Optional[list[str]] = None):
@@ -181,7 +182,7 @@ class UserInterfaceMock(apport.ui.UserInterface):
     "apport.hookutils._root_command_prefix",
     unittest.mock.MagicMock(return_value=[]),
 )
-class T(unittest.TestCase):
+class T(unittest.TestCase):  # pylint: disable=too-many-instance-attributes
     TEST_EXECUTABLE = os.path.realpath("/bin/sleep")
     TEST_ARGS = ["86400"]
 


### PR DESCRIPTION
Increase the allowed maximum attributes to nine and move the overrides to the individual classes.