### PR TITLE
refactor: Move pylint's too-many-lines overrides to affected files

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -27,7 +27,6 @@ disable=bad-option-value,fixme,
   duplicate-code,
   invalid-name,
   missing-docstring,
-  too-many-lines,
   too-many-public-methods,
 
 

--- a/apport/crashdb_impl/launchpad.py
+++ b/apport/crashdb_impl/launchpad.py
@@ -10,6 +10,8 @@
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
 
+# pylint: disable=too-many-lines
+
 import atexit
 import email
 import gzip

--- a/apport/hookutils.py
+++ b/apport/hookutils.py
@@ -12,6 +12,8 @@
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
 
+# pylint: disable=too-many-lines
+
 import base64
 import datetime
 import glob

--- a/apport/packaging_impl/apt_dpkg.py
+++ b/apport/packaging_impl/apt_dpkg.py
@@ -12,6 +12,8 @@ This is used on Debian and derivatives such as Ubuntu.
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
 
+# pylint: disable=too-many-lines
+
 import contextlib
 import datetime
 import glob

--- a/apport/report.py
+++ b/apport/report.py
@@ -9,6 +9,8 @@
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
 
+# pylint: disable=too-many-lines
+
 import atexit
 import errno
 import fnmatch

--- a/apport/ui.py
+++ b/apport/ui.py
@@ -13,6 +13,8 @@ implementation (like GTK, Qt, or CLI).
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
 
+# pylint: disable=too-many-lines
+
 import argparse
 import ast
 import configparser

--- a/data/apport
+++ b/data/apport
@@ -13,6 +13,8 @@
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
 
+# pylint: disable=too-many-lines
+
 # pylint fails to import the apport module, because it has the same name.
 # See bug https://github.com/PyCQA/pylint/issues/7093
 # pylint: disable=c-extension-no-member,no-name-in-module,not-callable

--- a/tests/integration/test_report.py
+++ b/tests/integration/test_report.py
@@ -1,3 +1,5 @@
+# pylint: disable=too-many-lines
+
 import atexit
 import grp
 import io

--- a/tests/integration/test_signal_crashes.py
+++ b/tests/integration/test_signal_crashes.py
@@ -7,6 +7,8 @@
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
 
+# pylint: disable=too-many-lines
+
 import argparse
 import collections
 import grp

--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -1,3 +1,5 @@
+# pylint: disable=too-many-lines
+
 import contextlib
 import errno
 import glob

--- a/tests/system/test_packaging_apt_dpkg.py
+++ b/tests/system/test_packaging_apt_dpkg.py
@@ -1,3 +1,5 @@
+# pylint: disable=too-many-lines
+
 import glob
 import gzip
 import os

--- a/tests/system/test_ui_gtk.py
+++ b/tests/system/test_ui_gtk.py
@@ -9,6 +9,8 @@
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
 
+# pylint: disable=too-many-lines
+
 import os
 import shutil
 import subprocess

--- a/tests/unit/test_report.py
+++ b/tests/unit/test_report.py
@@ -1,3 +1,5 @@
+# pylint: disable=too-many-lines
+
 import os
 import textwrap
 import unittest


### PR DESCRIPTION
Move pylint's too-many-lines overrides to affected files to allow getting this alert for new cases.