### PR TITLE
fix: Correct range of system users/groups from 499 to dynamic 999

### DIFF
--- a/apport/report.py
+++ b/apport/report.py
@@ -548,10 +548,11 @@ class Report(problem_report.ProblemReport):
         """
         # Use effective uid in case privileges were dropped
         user = pwd.getpwuid(os.geteuid())[0]
+        sys_gid_max = apport.fileutils.get_sys_gid_max()
         groups = [
             name
             for name, p, gid, memb in grp.getgrall()
-            if user in memb and gid < 1000
+            if user in memb and gid <= sys_gid_max
         ]
         groups.sort()
         if groups:

--- a/doc/data-format.tex
+++ b/doc/data-format.tex
@@ -177,8 +177,9 @@ environment.
     processor/system architecture (e. g. \verb!i386!)
 
     \item [UserGroups:] (optional) System groups of the user reporting the
-    problem; for privacy reasons this should only include IDs smaller than 500,
-    no groups which belong to other real users.
+    problem; for privacy reasons this should only include IDs smaller than
+    `SYS_GID_MAX` (specified in `/etc/login.defs` which defaults to 999 on
+    Debian based systems), no groups which belong to other real users.
 
     \item [Tags:] (optional) A space-delimited list of tage that may be passed
     to the crash database, depending on which one is used.

--- a/tests/integration/test_signal_crashes.py
+++ b/tests/integration/test_signal_crashes.py
@@ -205,10 +205,11 @@ class T(unittest.TestCase):
             self.assertIn(k, allowed_vars)
 
         # UserGroups only has system groups
+        sys_gid_max = apport.fileutils.get_sys_gid_max()
         for g in pr["UserGroups"].split():
             if g == "N/A":
                 continue
-            self.assertLess(grp.getgrnam(g).gr_gid, 500)
+            self.assertLessEqual(grp.getgrnam(g).gr_gid, sys_gid_max)
 
         self.assertNotIn("root", pr["UserGroups"])
 


### PR DESCRIPTION
The test case `test_crash_apport` will fail if the test executing user is member of a system group with an ID between 500 and 999:

```
======================================================================
FAIL: test_crash_apport (tests.integration.test_signal_crashes.T.test_crash_apport)
Report generation with apport.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/<<PKGBUILDDIR>>/tests/integration/test_signal_crashes.py", line 211, in test_crash_apport
    self.assertLess(grp.getgrnam(g).gr_gid, 500)
AssertionError: 992 not less than 500

======================================================================
```

The default maximum system user/group ID on Debian based systems in 999 (defined in `/etc/login.defs`), but the Linux Standard Base (LSB) only specifies 499 as maximum (in "User ID Ranges").

Read the maximum system user group ID from `/etc/login.defs` and default to 999 if it is not set.