### PR TITLE
fix(tests): Fix check for full name in test_run_crash_anonymity

### DIFF
--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -1492,6 +1492,18 @@ class T(unittest.TestCase):  # pylint: disable=too-many-instance-attributes
         self.assertIn("KernelDebug", self.ui.report)
         self.assertEqual(self.ui.report["ProblemType"], "KernelCrash")
 
+    @staticmethod
+    def _get_sensitive_strings() -> list[str]:
+        p = pwd.getpwuid(os.getuid())
+        sensitive_strings = [
+            os.uname().nodename,
+            p.pw_name,
+            p.pw_gecos,
+            p.pw_dir,
+            os.getcwd(),
+        ]
+        return sensitive_strings
+
     def test_run_crash_anonymity(self):
         """run_crash() anonymization"""
         r = self._gen_test_crash()
@@ -1517,16 +1529,7 @@ class T(unittest.TestCase):  # pylint: disable=too-many-instance-attributes
         self.ui.report.write(dump)
         report = dump.getvalue().decode("UTF-8")
 
-        p = pwd.getpwuid(os.getuid())
-        bad_strings = [
-            os.uname().nodename,
-            p.pw_name,
-            p.pw_gecos,
-            p.pw_dir,
-            os.getcwd(),
-        ]
-
-        for s in bad_strings:
+        for s in self._get_sensitive_strings():
             self.assertNotIn(
                 s,
                 report,

--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -1518,7 +1518,13 @@ class T(unittest.TestCase):  # pylint: disable=too-many-instance-attributes
         report = dump.getvalue().decode("UTF-8")
 
         p = pwd.getpwuid(os.getuid())
-        bad_strings = [os.uname()[1], p[0], p[4], p[5], os.getcwd()]
+        bad_strings = [
+            os.uname().nodename,
+            p.pw_name,
+            p.pw_gecos,
+            p.pw_dir,
+            os.getcwd(),
+        ]
 
         for s in bad_strings:
             self.assertNotIn(

--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -1498,11 +1498,11 @@ class T(unittest.TestCase):  # pylint: disable=too-many-instance-attributes
         sensitive_strings = [
             os.uname().nodename,
             p.pw_name,
-            p.pw_gecos,
+            p.pw_gecos.split(",")[0],
             p.pw_dir,
             os.getcwd(),
         ]
-        return sensitive_strings
+        return [s for s in sensitive_strings if s]
 
     def test_run_crash_anonymity(self):
         """run_crash() anonymization"""


### PR DESCRIPTION
The value `pw_gecos` contains a comma separated list where the first element might be the full user name. Split the first element from `pw_gecos` (if it is not empty) to check that the full name is not in the crash report.