### PR TITLE
fix(tests): Fix type hint for _write_crashdb_config_hook

### DIFF
--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -520,7 +520,9 @@ class T(unittest.TestCase):  # pylint: disable=too-many-instance-attributes
         self.ui.collect_info()
         self.assertTrue(os.stat(self.report_file.name).st_mode & stat.S_IRGRP)
 
-    def _write_crashdb_config_hook(self, crashdb: str, bash_hook: str = None):
+    def _write_crashdb_config_hook(
+        self, crashdb: str, bash_hook: typing.Optional[str] = None
+    ) -> None:
         """Write source_bash.py hook that sets CrashDB"""
         with open(
             os.path.join(self.hookdir, "source_bash.py"), "w", encoding="utf-8"


### PR DESCRIPTION
```
tests/integration/test_ui.py:523: error: Incompatible default for argument "bash_hook" (default has type "None", argument has type "str")  [assignment]
tests/integration/test_ui.py:523: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
tests/integration/test_ui.py:523: note: Use https://github.com/hauntsaninja/no_implicit_optional to automatically upgrade your codebase
```