### PR TITLE
refactor: Increase pylint's maximum public methods to 25

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -27,7 +27,6 @@ disable=bad-option-value,fixme,
   duplicate-code,
   invalid-name,
   missing-docstring,
-  too-many-public-methods,
 
 
 [REPORTS]
@@ -52,3 +51,6 @@ max-args=6
 
 # Maximum number of attributes for a class (see R0902).
 max-attributes=9
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=25

--- a/apport/crashdb.py
+++ b/apport/crashdb.py
@@ -28,6 +28,8 @@ def _u(string):
 
 
 class CrashDatabase:
+    # TODO: Check if some methods can be made private
+    # pylint: disable=too-many-public-methods
     def __init__(self, auth_file, options):
         """Initialize crash database connection.
 

--- a/apport/crashdb_impl/launchpad.py
+++ b/apport/crashdb_impl/launchpad.py
@@ -1324,7 +1324,7 @@ if __name__ == "__main__":
         return try_to_get_from_cache
 
     class _T(unittest.TestCase):
-        # pylint: disable=protected-access
+        # pylint: disable=protected-access,too-many-public-methods
 
         # this assumes that a source package 'coreutils' exists and builds a
         # binary package 'coreutils'

--- a/apport/packaging_impl/apt_dpkg.py
+++ b/apport/packaging_impl/apt_dpkg.py
@@ -42,7 +42,7 @@ from apport.packaging import PackageInfo, freedesktop_os_release
 
 
 class __AptDpkgPackageInfo(PackageInfo):
-    # pylint: disable=too-many-instance-attributes
+    # pylint: disable=too-many-instance-attributes,too-many-public-methods
     """Concrete apport.packaging.PackageInfo class implementation for
     python-apt and dpkg, as found on Debian and derivatives such as Ubuntu."""
 

--- a/apport/ui.py
+++ b/apport/ui.py
@@ -335,6 +335,8 @@ class Action:
 
 
 class UserInterface:
+    # TODO: Check if some methods can be made private
+    # pylint: disable=too-many-public-methods
     """Apport user interface API.
 
     This provides an abstract base class for encapsulating the workflow and

--- a/tests/integration/test_report.py
+++ b/tests/integration/test_report.py
@@ -21,7 +21,7 @@ from tests.paths import patch_data_dir, restore_data_dir
 
 
 class T(unittest.TestCase):
-    # pylint: disable=protected-access
+    # pylint: disable=protected-access,too-many-public-methods
 
     @classmethod
     def setUpClass(cls):

--- a/tests/integration/test_signal_crashes.py
+++ b/tests/integration/test_signal_crashes.py
@@ -55,7 +55,7 @@ required_fields = [
 
 
 class T(unittest.TestCase):
-    # pylint: disable=protected-access
+    # pylint: disable=protected-access,too-many-public-methods
     TEST_EXECUTABLE = os.path.realpath("/bin/sleep")
     TEST_ARGS = ["86400"]
 

--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -184,7 +184,8 @@ class UserInterfaceMock(apport.ui.UserInterface):
     "apport.hookutils._root_command_prefix",
     unittest.mock.MagicMock(return_value=[]),
 )
-class T(unittest.TestCase):  # pylint: disable=too-many-instance-attributes
+class T(unittest.TestCase):
+    # pylint: disable=too-many-instance-attributes,too-many-public-methods
     TEST_EXECUTABLE = os.path.realpath("/bin/sleep")
     TEST_ARGS = ["86400"]
 

--- a/tests/system/test_ui_gtk.py
+++ b/tests/system/test_ui_gtk.py
@@ -51,7 +51,7 @@ else:
 @unittest.skipIf(
     GI_IMPORT_ERROR, f"gi Python module not available: {GI_IMPORT_ERROR}"
 )
-class T(unittest.TestCase):
+class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
     POLLING_INTERVAL_MS = 10
 
     @classmethod

--- a/tests/unit/test_crashdb.py
+++ b/tests/unit/test_crashdb.py
@@ -9,7 +9,7 @@ import apport.report
 from apport.crashdb_impl.memory import CrashDatabase
 
 
-class T(unittest.TestCase):
+class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
     def setUp(self):
         self.workdir = tempfile.mkdtemp()
         self.dupdb_dir = os.path.join(self.workdir, "dupdb")

--- a/tests/unit/test_problem_report.py
+++ b/tests/unit/test_problem_report.py
@@ -10,7 +10,7 @@ import problem_report
 bin_data = b"ABABABABAB\0\0\0Z\x01\x02"
 
 
-class T(unittest.TestCase):
+class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
     def test_add_tags(self):
         """Test ProblemReport.add_tags()."""
         report = problem_report.ProblemReport()


### PR DESCRIPTION
Increase the allowed maximum public methods to 25 and move the overrides to the individual classes. It is okay for test case classes to have more than 25 tests inside.