### PR TITLE
fix(tests): Fix false positives for test_run_crash_anonymity

### DIFF
--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -9,6 +9,7 @@ import io
 import locale
 import os
 import pwd
+import re
 import shutil
 import signal
 import stat
@@ -1537,6 +1538,12 @@ class T(unittest.TestCase):
         report = dump.getvalue().decode("UTF-8")
 
         for s in self._get_sensitive_strings():
+            self.assertIsNone(
+                re.search(rf"\b{re.escape(s)}\b", report),
+                "dump contains sensitive word '%s':\n%s" % (s, report),
+            )
+            if s == "ubuntu" or len(s) < 5 and "/" not in s:
+                continue
             self.assertNotIn(
                 s,
                 report,


### PR DESCRIPTION
The test `test_run_crash_anonymity` can fail if the user or host name is short:

```
======================================================================
FAIL: test_run_crash_anonymity (tests.integration.test_ui.T)
run_crash() anonymization
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3.10/unittest/mock.py", line 1369, in patched
    return func(*newargs, **newkeywargs)
  File "/<<PKGBUILDDIR>>/tests/integration/test_ui.py", line 1650, in test_run_crash_anonymity
    self.assertNotIn(
AssertionError: 'kin' unexpectedly found in 'ProblemType: Crash\nArchitecture: amd64\n[...]'
```

The string `kin` can be found in the report (for example in the tag `kinetic`). So only search for full words in the report if the string is short (less than five characters and not the string `ubuntu`).