### PR TITLE
fix: Fix raising OSError if _command_output() runs into a timeout

### DIFF
--- a/apport/report.py
+++ b/apport/report.py
@@ -154,7 +154,9 @@ def _read_maps(proc_pid_fd):
 
 
 def _command_output(
-    command: list[str], env: typing.Optional[dict[str, str]] = None
+    command: list[str],
+    env: typing.Optional[dict[str, str]] = None,
+    timeout: float = 1800,
 ) -> str:
     """Run command and capture its output.
 
@@ -172,12 +174,16 @@ def _command_output(
             errors="replace",
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
-            timeout=1800,
+            timeout=timeout,
         )
     except subprocess.TimeoutExpired as error:
+        if error.stdout:
+            output = f": {error.stdout.decode().rstrip()}"
+        else:
+            output = " with no stdout"
         raise OSError(
             f"Error: command {str(error.cmd)} timed out"
-            f" after {error.timeout} seconds: {error.stdout.rstrip()}"
+            f" after {error.timeout} seconds{output}"
         ) from error
     if sp.returncode == 0:
         return sp.stdout.rstrip()

--- a/tests/integration/test_report.py
+++ b/tests/integration/test_report.py
@@ -1925,6 +1925,20 @@ int main() { return f(42); }
         out = apport.report._command_output(["env"], env=fake_env)
         self.assertIn("GCONV_PATH", out)
 
+    def test_command_output_timeout(self):
+        with self.assertRaisesRegex(
+            OSError, "timed out after 0.1 seconds: fail$"
+        ):
+            apport.report._command_output(
+                ["sh", "-c", "echo fail; sleep 3600"], timeout=0.1
+            )
+
+    def test_command_output_timeout_no_output(self):
+        with self.assertRaisesRegex(
+            OSError, "timed out after 0.1 seconds with no stdout"
+        ):
+            apport.report._command_output(["sleep", "3600"], timeout=0.1)
+
     def test_command_output_raises_error(self):
         with self.assertRaisesRegex(OSError, "failed with exit code 1"):
             apport.report._command_output(["false"])


### PR DESCRIPTION
mypy complains:

```
apport/report.py:179: error: On Python 3 formatting "b'abc'" with "{}" produces "b'abc'", not "abc"; use "{!r}" if this is desired behavior  [str-bytes-safe]
apport/report.py:180: error: Item "None" of "Optional[bytes]" has no attribute "rstrip"  [union-attr]
```

The mypy complains can be converted into a test case that fail:

```
ERROR: test_command_output_timeout_no_output (tests.integration.test_report.T.test_command_output_timeout_no_output)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/bdrung/projects/apport/apport/apport/report.py", line 169, in _command_output
    sp = subprocess.run(
         ^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/subprocess.py", line 550, in run
    stdout, stderr = process.communicate(input, timeout=timeout)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/subprocess.py", line 1207, in communicate
    stdout, stderr = self._communicate(input, endtime, timeout)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/subprocess.py", line 2060, in _communicate
    self._check_timeout(endtime, orig_timeout, stdout, stderr)
  File "/usr/lib/python3.11/subprocess.py", line 1251, in _check_timeout
    raise TimeoutExpired(
subprocess.TimeoutExpired: Command '['sleep', '3600']' timed out after 0.1 seconds

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/bdrung/projects/apport/apport/tests/integration/test_report.py", line 1938, in test_command_output_timeout_no_output
    apport.report._command_output(["sleep", "3600"], timeout=0.1)
  File "/home/bdrung/projects/apport/apport/apport/report.py", line 182, in _command_output
    f" after {error.timeout} seconds: {error.stdout.rstrip()}"
                                       ^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'rstrip'
```