### PR TITLE
fix(tests): Correct type of local_path in get_data_directory to str

### DIFF
--- a/tests/paths.py
+++ b/tests/paths.py
@@ -9,7 +9,7 @@ _DATADIR = _SRCDIR / "data"
 
 
 def get_data_directory(
-    local_path: typing.Optional[os.PathLike] = None,
+    local_path: typing.Optional[str] = None,
 ) -> pathlib.Path:
     """Return absolute path for apport's data directory.
 


### PR DESCRIPTION
All calls to `get_data_directory` that specify `local_path` pass a string. So correct that type.