### PR TITLE
fix: Use ProblemReport for running generic hook manually

### DIFF
--- a/data/general-hooks/generic.py
+++ b/data/general-hooks/generic.py
@@ -16,9 +16,11 @@ import re
 
 import apport.fileutils
 import apport.hookutils
+import apport.ui
+from problem_report import ProblemReport
 
 
-def add_info(report, ui):
+def add_info(report: ProblemReport, ui: apport.ui.HookUI) -> None:
     # TODO: Split into smaller functions/methods
     # pylint: disable=too-many-branches,too-many-locals
     nm = apport.hookutils.nonfree_kernel_modules()
@@ -125,7 +127,7 @@ Do you want to continue the report process anyway?
 
 
 if __name__ == "__main__":
-    r = {}
-    add_info(r, None)
+    r = ProblemReport()
+    add_info(r, apport.ui.NoninteractiveHookUI())
     for key, value in r.items():
         print(f"{key}: {value}")

--- a/tests/integration/test_hooks.py
+++ b/tests/integration/test_hooks.py
@@ -11,8 +11,10 @@
 
 import datetime
 import os
+import pathlib
 import shutil
 import subprocess
+import sys
 import tempfile
 import unittest
 
@@ -22,6 +24,9 @@ from tests.paths import get_data_directory, local_test_environment
 
 
 class T(unittest.TestCase):
+    data_dir: pathlib.Path
+    env: dict[str, str]
+
     @classmethod
     def setUpClass(cls):
         cls.data_dir = get_data_directory()
@@ -39,6 +44,17 @@ class T(unittest.TestCase):
         apport.fileutils.report_dir = self.orig_report_dir
 
         shutil.rmtree(self.workdir)
+
+    def test_general_hook_generic(self) -> None:
+        """Test running general-hooks/generic.py."""
+        process = subprocess.run(
+            [sys.executable, self.data_dir / "general-hooks" / "generic.py"],
+            check=True,
+            env=self.env,
+            encoding="utf-8",
+            stdout=subprocess.PIPE,
+        )
+        self.assertIn("ProblemType: Crash", process.stdout)
 
     def test_package_hook_nologs(self):
         """package_hook without any log files."""


### PR DESCRIPTION
Running the generic general hook manually fails:

```
$ python3 data/general-hooks/generic.py
Traceback (most recent call last):
  File "/home/bdrung/projects/apport/apport/data/general-hooks/generic.py", line 129, in <module>
    add_info(r, None)
  File "/home/bdrung/projects/apport/apport/data/general-hooks/generic.py", line 123, in add_info
    if report["ProblemType"] == "Crash":
       ~~~~~~^^^^^^^^^^^^^^^
KeyError: 'ProblemType'
```

Use an instance of `ProblemReport` like Apport would use.