### PR TITLE
refactor(apport-cli): Move saving the report into a separate function

### DIFF
--- a/apport/ui.py
+++ b/apport/ui.py
@@ -348,8 +348,8 @@ class UserInterface:
     def __init__(self, argv: list[str]):
         """Initialize program state and parse command line options."""
         self.gettext_domain = "apport"
-        self.report = None
-        self.report_file = None
+        self.report: typing.Optional[apport.report.Report] = None
+        self.report_file: typing.Optional[str] = None
         self.cur_package = None
         self.offer_restart = False
         self.specified_a_pkg = False

--- a/bin/apport-cli
+++ b/bin/apport-cli
@@ -202,6 +202,16 @@ class CLIUserInterface(apport.ui.UserInterface):
     # ui_* implementation of abstract UserInterface classes
     #
 
+    def _save_report_in_temp_directory(self) -> str:
+        assert self.report
+        prefix = "apport."
+        if "Package" in self.report:
+            prefix += self.report["Package"].split()[0] + "."
+        (fd, report_file) = tempfile.mkstemp(prefix=prefix, suffix=".apport")
+        with os.fdopen(fd, "wb") as f:
+            self.report.write(f)
+        return report_file
+
     def ui_present_report_details(
         self, allowed_to_report=True, modal_for=None
     ) -> apport.ui.Action:
@@ -255,15 +265,7 @@ class CLIUserInterface(apport.ui.UserInterface):
             if response == save:
                 # we do not already have a report file if we report a bug
                 if not self.report_file:
-                    prefix = "apport."
-                    if "Package" in self.report:
-                        prefix += self.report["Package"].split()[0] + "."
-                    (fd, self.report_file) = tempfile.mkstemp(
-                        prefix=prefix, suffix=".apport"
-                    )
-                    with os.fdopen(fd, "wb") as f:
-                        self.report.write(f)
-
+                    self.report_file = self._save_report_in_temp_directory()
                 print(_("Problem report file:") + " " + self.report_file)
 
             return return_value

--- a/tests/integration/test_ui_cli.py
+++ b/tests/integration/test_ui_cli.py
@@ -9,9 +9,11 @@
 
 """Command line Apport user interface tests."""
 
+import io
 import os
 import pathlib
 import unittest
+from gettext import gettext as _
 
 import apport.report
 from tests.helper import import_module_from_file, skip_if_command_is_missing
@@ -61,3 +63,15 @@ class TestApportCli(unittest.TestCase):
             "11\n\n",
             report,
         )
+
+    @unittest.mock.patch("sys.stdout", new_callable=io.StringIO)
+    def test_save_report_in_temp_directory(
+        self, stdout_mock: io.StringIO
+    ) -> None:
+        self.app.report["Package"] = "bash"
+        with unittest.mock.patch.object(
+            apport_cli.CLIDialog, "run"
+        ) as run_mock:
+            run_mock.return_value = 4
+            self.app.ui_present_report_details()
+        self.assertIn(_("Problem report file:"), stdout_mock.getvalue())


### PR DESCRIPTION
Move saving the problem report in a temporary directory into a separate function. Assert that `self.report` is not `None` to make mypy happy.