### PR TITLE
refactor(gtk/kde): Add assertions to make mypy happy

### DIFF
--- a/gtk/apport-gtk
+++ b/gtk/apport-gtk
@@ -233,6 +233,7 @@ class GTKUserInterface(apport.ui.UserInterface):
     ) -> apport.ui.Action:
         # TODO: Split into smaller functions/methods
         # pylint: disable=too-many-branches,too-many-locals,too-many-statements
+        assert self.report
         icon = None
         self.collect_called = False
         report_type = self.report.get("ProblemType")

--- a/kde/apport-kde
+++ b/kde/apport-kde
@@ -126,6 +126,7 @@ class ProgressDialog(Dialog):
 
     def set(self, value: typing.Optional[float] = None) -> None:
         progress = self.findChild(QProgressBar, "progress")
+        assert isinstance(progress, QProgressBar)
         if not value:
             progress.setRange(0, 0)
             progress.setValue(0)
@@ -369,8 +370,8 @@ class MainUserInterface(apport.ui.UserInterface):
         apport.ui.UserInterface.__init__(self, argv)
         self.ui_data_path = os.path.dirname(argv[0])
         # Help unit tests get at the dialog.
-        self.dialog = None
-        self.progress = None
+        self.dialog: typing.Optional[ReportDialog] = None
+        self.progress: typing.Optional[ProgressDialog] = None
 
     #
     # ui_* implementation of abstract UserInterface classes
@@ -512,6 +513,7 @@ class MainUserInterface(apport.ui.UserInterface):
         self.progress.show()
 
     def ui_set_upload_progress(self, progress: typing.Optional[float]) -> None:
+        assert self.progress
         if progress:
             self.progress.set(progress)
         else:


### PR DESCRIPTION
mypy complains:

```
gtk/apport-gtk:238: error: "None" has no attribute "get"  [attr-defined]
gtk/apport-gtk:280: error: Value of type "None" is not indexable  [index]
gtk/apport-gtk:413: error: Unsupported right operand type for in ("None")  [operator]
gtk/apport-gtk:414: error: Value of type "None" is not indexable  [index]
kde/apport-kde:130: error: "QObject" has no attribute "setRange"  [attr-defined]
kde/apport-kde:131: error: "QObject" has no attribute "setValue"  [attr-defined]
kde/apport-kde:133: error: "QObject" has no attribute "setRange"  [attr-defined]
kde/apport-kde:134: error: "QObject" has no attribute "setValue"  [attr-defined]
kde/apport-kde:413: error: Incompatible types in assignment (expression has type "ReportDialog", variable has type "None")  [assignment]
kde/apport-kde:417: error: "None" has no attribute "exec_"  [attr-defined]
kde/apport-kde:426: error: "None" has no attribute "continue_button"  [attr-defined]
kde/apport-kde:429: error: "None" has no attribute "send_error_report"  [attr-defined]
kde/apport-kde:431: error: "None" has no attribute "ignore_future_problems"  [attr-defined]
kde/apport-kde:516: error: "None" has no attribute "set"  [attr-defined]
kde/apport-kde:518: error: "None" has no attribute "set"  [attr-defined]
```

Add assertions to ensure that the variables are not `None`.