### PR TITLE
refactor(apport): Drop using proc_pid_fd from is_same_ns

### DIFF
--- a/data/apport
+++ b/data/apport
@@ -474,7 +474,7 @@ def is_systemd_watchdog_restart(signum: int):
         return False
 
 
-def is_same_ns(pid, ns):
+def is_same_ns(pid: int, ns: str) -> bool:
     if not os.path.exists(f"/proc/self/ns/{ns}") or not os.path.exists(
         f"/proc/{pid}/ns/{ns}"
     ):
@@ -494,14 +494,7 @@ def is_same_ns(pid, ns):
 
     # check to see if the process is part of the system.slice (LP: #1870060)
     if os.path.exists(f"/proc/{pid}/cgroup"):
-        global proc_pid_fd  # pylint: disable=global-statement
-        proc_pid_fd = os.open(
-            f"/proc/{pid}", os.O_RDONLY | os.O_PATH | os.O_DIRECTORY
-        )
-
-        with open(
-            "cgroup", opener=proc_pid_opener, encoding="utf-8"
-        ) as cgroup:
+        with open(f"/proc/{pid}/cgroup", encoding="utf-8") as cgroup:
             for line in cgroup:
                 fields = line.split(":")
                 if fields[-1].startswith("/system.slice"):

--- a/tests/integration/test_signal_crashes.py
+++ b/tests/integration/test_signal_crashes.py
@@ -786,6 +786,31 @@ class T(unittest.TestCase):
             report["ExecutablePath"], os.path.realpath("/bin/ping")
         )
 
+    @unittest.mock.patch("os.readlink")
+    def test_is_not_same_ns(
+        self, readlink_mock: unittest.mock.MagicMock
+    ) -> None:
+        readlink_mock.side_effect = ["mnt:[1]", "mnt:[2]"]
+        open_mock = unittest.mock.mock_open(read_data="0::/user.slice\n")
+        command = [self.TEST_EXECUTABLE] + self.TEST_ARGS
+        with subprocess.Popen(command) as test_process, unittest.mock.patch(
+            "builtins.open", open_mock
+        ):
+            try:
+                same_ns = apport_binary.is_same_ns(test_process.pid, "mnt")
+                self.assertFalse(same_ns)
+            finally:
+                test_process.kill()
+        readlink_mock.assert_has_calls(
+            [
+                unittest.mock.call(f"/proc/{test_process.pid}/ns/mnt"),
+                unittest.mock.call("/proc/self/ns/mnt"),
+            ]
+        )
+        open_mock.assert_called_with(
+            f"/proc/{test_process.pid}/cgroup", encoding="utf-8"
+        )
+
     #
     # Helper methods
     #


### PR DESCRIPTION
Instead of using `proc_pid_fd` in `is_same_ns()` just specify the path to the cgroup file. The other code in the function does that already.