### PR TITLE
refactor: Move pylint's invalid-name overrides to affected files

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -10,6 +10,12 @@ extension-pkg-whitelist=apt_pkg  # wokeignore:rule=whitelist
 persistent=no
 
 
+[BASIC]
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,j,k,lp,ui,_
+
+
 [MESSAGES CONTROL]
 
 # Disable the message, report, category or checker with the given id(s). You
@@ -25,7 +31,6 @@ disable=bad-option-value,fixme,
   # TODO: Fix all following disabled checks!
   consider-using-f-string,
   duplicate-code,
-  invalid-name,
   missing-docstring,
 
 

--- a/apport/REThread.py
+++ b/apport/REThread.py
@@ -9,6 +9,9 @@
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
 
+# pylint: disable=invalid-name
+# pylint: enable=invalid-name
+
 import sys
 import threading
 

--- a/apport/crashdb.py
+++ b/apport/crashdb.py
@@ -9,6 +9,9 @@
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
 
+# TODO: Address following pylint complaints
+# pylint: disable=invalid-name
+
 import functools
 import os
 import shutil

--- a/apport/crashdb_impl/debian.py
+++ b/apport/crashdb_impl/debian.py
@@ -75,16 +75,16 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
 
         # Frame the report in the format the BTS understands
         try:
-            (buggyPackage, buggyVersion) = report["Package"].split(" ")
+            (buggy_package, buggy_version) = report["Package"].split(" ")
         except (KeyError, ValueError):
             return False
 
         with tempfile.NamedTemporaryFile() as temp:
             temp.file.write(
-                ("Package: " + buggyPackage + "\n").encode("UTF-8")
+                ("Package: " + buggy_package + "\n").encode("UTF-8")
             )
             temp.file.write(
-                ("Version: " + buggyVersion + "\n\n\n").encode("UTF-8")
+                ("Version: " + buggy_version + "\n\n\n").encode("UTF-8")
             )
             temp.file.write(
                 ("=============================\n\n").encode("UTF-8")
@@ -116,13 +116,13 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
         msg.add_header("X-Debbugs-CC", self.options["sender"])
         msg.add_header("Usertag", "apport-%s" % report["ProblemType"].lower())
 
-        s = smtplib.SMTP(self.options["smtphost"])
-        s.sendmail(
+        smtp = smtplib.SMTP(self.options["smtphost"])
+        smtp.sendmail(
             self.options["sender"],
             self.options["recipient"],
             msg.as_string().encode("UTF-8"),
         )
-        s.quit()
+        smtp.quit()
         return True
 
     def get_comment_url(self, report, handle):

--- a/apport/crashdb_impl/github.py
+++ b/apport/crashdb_impl/github.py
@@ -117,9 +117,9 @@ class Github:
                 "Authentication not started. Use a with statement to do so"
             )
 
-        t = time.time()
-        waittime = self.__cooldown - (t - self.__last_request)
-        if t + waittime > self.__expiry:
+        current_time = time.time()
+        waittime = self.__cooldown - (current_time - self.__last_request)
+        if current_time + waittime > self.__expiry:
             self.message_callback(
                 "Failed login",
                 "Github authentication expired. Please try again.",

--- a/apport/crashdb_impl/launchpad.py
+++ b/apport/crashdb_impl/launchpad.py
@@ -11,6 +11,8 @@
 # the full text of the license.
 
 # pylint: disable=too-many-lines
+# TODO: Address following pylint complaints
+# pylint: disable=invalid-name
 
 import atexit
 import email

--- a/apport/crashdb_impl/memory.py
+++ b/apport/crashdb_impl/memory.py
@@ -9,6 +9,9 @@
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
 
+# TODO: Address following pylint complaints
+# pylint: disable=invalid-name
+
 import time
 
 import apport.crashdb

--- a/apport/fileutils.py
+++ b/apport/fileutils.py
@@ -9,6 +9,9 @@
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
 
+# TODO: Address following pylint complaints
+# pylint: disable=invalid-name
+
 import configparser
 import contextlib
 import functools

--- a/apport/hookutils.py
+++ b/apport/hookutils.py
@@ -13,6 +13,8 @@
 # the full text of the license.
 
 # pylint: disable=too-many-lines
+# TODO: Address following pylint complaints
+# pylint: disable=invalid-name
 
 import base64
 import datetime

--- a/apport/logging.py
+++ b/apport/logging.py
@@ -41,8 +41,8 @@ def memdbg(checkpoint):
         return
 
     memstat = {}
-    with open("/proc/self/status", encoding="utf-8") as f:
-        for line in f:
+    with open("/proc/self/status", encoding="utf-8") as status_file:
+        for line in status_file:
             if line.startswith("Vm"):
                 (field, size, _) = line.split()
                 memstat[field[:-1]] = int(size) / 1024.0

--- a/apport/packaging.py
+++ b/apport/packaging.py
@@ -260,8 +260,8 @@ class PackageInfo:
         Apport (such as /etc/default/apport in Debian/Ubuntu).
         """
         try:
-            with open(self.configuration, encoding="utf-8") as f:
-                conf = f.read()
+            with open(self.configuration, encoding="utf-8") as config_file:
+                conf = config_file.read()
         except OSError:
             # if the file does not exist, assume it's enabled
             return True
@@ -360,14 +360,14 @@ class PackageInfo:
         work, but might be slow for your backend, so you might want to
         reimplement this.
         """
-        for p in self.package_name_glob("*"):
-            if not self.is_distro_package(p):
+        for package in self.package_name_glob("*"):
+            if not self.is_distro_package(package):
                 continue
             try:
-                self.get_version(p)
+                self.get_version(package)
                 continue
             except ValueError:
-                return p
+                return package
         return None
 
     _os_version = None

--- a/apport/packaging_impl/apt_dpkg.py
+++ b/apport/packaging_impl/apt_dpkg.py
@@ -13,6 +13,8 @@ This is used on Debian and derivatives such as Ubuntu.
 # the full text of the license.
 
 # pylint: disable=too-many-lines
+# TODO: Address following pylint complaints
+# pylint: disable=invalid-name
 
 import contextlib
 import datetime

--- a/apport/packaging_impl/rpm.py
+++ b/apport/packaging_impl/rpm.py
@@ -22,6 +22,9 @@ distributions.
 # is_distro_package() as well, if you don't sign all your official packages
 # (cough cough Fedora rawhide cough)
 
+# TODO: Address following pylint complaints
+# pylint: disable=invalid-name
+
 import hashlib
 import os
 import stat

--- a/apport/report.py
+++ b/apport/report.py
@@ -10,6 +10,8 @@
 # the full text of the license.
 
 # pylint: disable=too-many-lines
+# TODO: Address following pylint complaints
+# pylint: disable=invalid-name
 
 import atexit
 import errno

--- a/apport/sandboxutils.py
+++ b/apport/sandboxutils.py
@@ -227,8 +227,8 @@ def make_sandbox(
         pkg_list = (
             report.get("Package", "") + "\n" + report.get("Dependencies", "")
         )
-        m = re.compile(r"\[origin: ([a-zA-Z0-9][a-zA-Z0-9\+\.\-]+)\]")
-        origins = set(m.findall(pkg_list))
+        match = re.compile(r"\[origin: ([a-zA-Z0-9][a-zA-Z0-9\+\.\-]+)\]")
+        origins = set(match.findall(pkg_list))
         if origins:
             apport.logging.log("Origins: %s" % origins)
 

--- a/apport/ui.py
+++ b/apport/ui.py
@@ -14,6 +14,8 @@ implementation (like GTK, Qt, or CLI).
 # the full text of the license.
 
 # pylint: disable=too-many-lines
+# TODO: Address following pylint complaints
+# pylint: disable=invalid-name
 
 import argparse
 import ast

--- a/bin/apport-cli
+++ b/bin/apport-cli
@@ -15,6 +15,9 @@
 #    w3m, lynx: do not work
 #    elinks: works
 
+# TODO: Address following pylint complaints
+# pylint: disable=invalid-name
+
 import errno
 import os
 import re

--- a/bin/apport-retrace
+++ b/bin/apport-retrace
@@ -12,6 +12,9 @@
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
 
+# TODO: Address following pylint complaints
+# pylint: disable=invalid-name
+
 import argparse
 import gettext
 import os

--- a/bin/apport-unpack
+++ b/bin/apport-unpack
@@ -12,6 +12,9 @@
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
 
+# pylint: disable=invalid-name
+# pylint: enable=invalid-name
+
 import argparse
 import gettext
 import gzip
@@ -35,17 +38,17 @@ def parse_args():
     return parser.parse_args()
 
 
-def load_report(report: str) -> problem_report.ProblemReport:
-    pr = problem_report.ProblemReport()
-    if report == "-":
-        pr.load(sys.stdin, binary=False)
-    elif report.endswith(".gz"):
-        with gzip.open(report, "rb") as f:
-            pr.load(f, binary=False)
+def load_report(report_filename: str) -> problem_report.ProblemReport:
+    report = problem_report.ProblemReport()
+    if report_filename == "-":
+        report.load(sys.stdin, binary=False)
+    elif report_filename.endswith(".gz"):
+        with gzip.open(report_filename, "rb") as report_file:
+            report.load(report_file, binary=False)
     else:
-        with open(report, "rb") as f:
-            pr.load(f, binary=False)
-    return pr
+        with open(report_filename, "rb") as report_file:
+            report.load(report_file, binary=False)
+    return report
 
 
 def main():
@@ -64,25 +67,25 @@ def main():
 
     bin_keys = []
     try:
-        pr = load_report(args.report)
+        report = load_report(args.report)
     except (OSError, problem_report.MalformedProblemReport) as error:
         fatal("%s", str(error))
-    for key, value in pr.items():
+    for key, value in report.items():
         if value is None:
             bin_keys.append(key)
             continue
-        with open(os.path.join(args.target_directory, key), "wb") as f:
+        with open(os.path.join(args.target_directory, key), "wb") as key_file:
             if isinstance(value, str):
-                f.write(value.encode("UTF-8"))
+                key_file.write(value.encode("UTF-8"))
             else:
-                f.write(value)
+                key_file.write(value)
     try:
         if args.report.endswith(".gz"):
-            with gzip.open(args.report, "rb") as f:
-                pr.extract_keys(f, bin_keys, args.target_directory)
+            with gzip.open(args.report, "rb") as key_file:
+                report.extract_keys(key_file, bin_keys, args.target_directory)
         else:
-            with open(args.report, "rb") as f:
-                pr.extract_keys(f, bin_keys, args.target_directory)
+            with open(args.report, "rb") as key_file:
+                report.extract_keys(key_file, bin_keys, args.target_directory)
     except (OSError, problem_report.MalformedProblemReport) as error:
         fatal("%s", str(error))
 

--- a/bin/apport-valgrind
+++ b/bin/apport-valgrind
@@ -14,6 +14,9 @@
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
 
+# TODO: Address following pylint complaints
+# pylint: disable=invalid-name
+
 import argparse
 import gettext
 import os

--- a/bin/crash-digger
+++ b/bin/crash-digger
@@ -9,6 +9,9 @@
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
 
+# pylint: disable=invalid-name
+# pylint: enable=invalid-name
+
 import argparse
 import errno
 import os
@@ -313,11 +316,11 @@ def main():
 
     if opts.lockfile:
         try:
-            f = os.open(
+            lock_file = os.open(
                 opts.lockfile, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o666
             )
-            os.write(f, ("%u\n" % os.getpid()).encode())
-            os.close(f)
+            os.write(lock_file, ("%u\n" % os.getpid()).encode())
+            os.close(lock_file)
         except OSError as error:
             if error.errno == errno.EEXIST:
                 sys.exit(0)

--- a/bin/dupdb-admin
+++ b/bin/dupdb-admin
@@ -11,6 +11,9 @@
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
 
+# pylint: disable=invalid-name
+# pylint: enable=invalid-name
+
 import argparse
 import os.path
 import sys

--- a/data/apport
+++ b/data/apport
@@ -18,6 +18,8 @@
 # pylint fails to import the apport module, because it has the same name.
 # See bug https://github.com/PyCQA/pylint/issues/7093
 # pylint: disable=c-extension-no-member,no-name-in-module,not-callable
+# TODO: Address following pylint complaints
+# pylint: disable=invalid-name
 
 import argparse
 import array

--- a/data/apport-checkreports
+++ b/data/apport-checkreports
@@ -12,6 +12,9 @@
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
 
+# pylint: disable=invalid-name
+# pylint: enable=invalid-name
+
 import argparse
 import sys
 
@@ -38,8 +41,8 @@ else:
     reports = get_new_reports()
 
 if len(reports) > 0:
-    for r in reports:
-        print(r.split(".")[0].split("_")[-1])
+    for report in reports:
+        print(report.split(".")[0].split("_")[-1])
     if apport.packaging.enabled():
         sys.exit(0)
     else:

--- a/data/apportcheckresume
+++ b/data/apportcheckresume
@@ -27,48 +27,48 @@ def main(argv=None):
         if not packaging.enabled():
             return -1
 
-        pr = apport.report.Report(problem_type="KernelOops")
+        report = apport.report.Report(problem_type="KernelOops")
 
         libdir = "/var/lib/pm-utils"
         flagfile = libdir + "/status"
         stresslog = libdir + "/stress.log"
         hanglog = libdir + "/resume-hang.log"
 
-        pr.add_os_info()
-        pr.add_proc_info()
-        pr.add_user_info()
-        pr.add_package(apport.packaging.get_kernel_package())
+        report.add_os_info()
+        report.add_proc_info()
+        report.add_user_info()
+        report.add_package(apport.packaging.get_kernel_package())
 
         # grab the contents of the suspend/resume flag file
-        attach_file_if_exists(pr, flagfile, "Failure")
+        attach_file_if_exists(report, flagfile, "Failure")
 
         # grab the contents of the suspend/hibernate log file
-        attach_file_if_exists(pr, "/var/log/pm-suspend.log", "SleepLog")
+        attach_file_if_exists(report, "/var/log/pm-suspend.log", "SleepLog")
 
         # grab the contents of the suspend/resume stress test log if present.
-        attach_file_if_exists(pr, stresslog, "StressLog")
+        attach_file_if_exists(report, stresslog, "StressLog")
 
         # Ensure we are appropriately tagged.
-        if "Failure" in pr:
-            pr.add_tags(["resume ", pr["Failure"]])
+        if "Failure" in report:
+            report.add_tags(["resume ", report["Failure"]])
 
             # Record the failure mode.
-            pr["Failure"] += "/resume"
+            report["Failure"] += "/resume"
 
         # If we had a late hang pull in the resume-hang logfile.  Also
         # add an additional tag so we can pick these out.
         if os.path.exists(hanglog):
-            attach_file_if_exists(pr, hanglog, "ResumeHangLog")
-            pr.add_tags(["resume-late-hang"])
+            attach_file_if_exists(report, hanglog, "ResumeHangLog")
+            report.add_tags(["resume-late-hang"])
 
         # Generate a sensible report message.
-        if pr.get("Failure") == "suspend/resume":
-            pr["Annotation"] = _(
+        if report.get("Failure") == "suspend/resume":
+            report["Annotation"] = _(
                 "This occurred during a previous suspend,"
                 " and prevented the system from resuming properly."
             )
         else:
-            pr["Annotation"] = _(
+            report["Annotation"] = _(
                 "This occurred during a previous hibernation,"
                 " and prevented the system from resuming properly."
             )
@@ -76,13 +76,13 @@ def main(argv=None):
         # If we had a late hang make sure the dialog is clear that they may
         # not have noticed.  Also update the bug title so we notice.
         if os.path.exists(hanglog):
-            pr["Annotation"] += "  " + _(
+            report["Annotation"] += "  " + _(
                 "The resume processing hung very near the end"
                 " and will have appeared to have completed normally."
             )
-            pr["Failure"] = "late resume"
+            report["Failure"] = "late resume"
 
-        if pr.check_ignored():
+        if report.check_ignored():
             return 0
 
         nowtime = datetime.datetime.now()
@@ -93,7 +93,7 @@ def main(argv=None):
             os.open(pr_filename, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o640),
             "wb",
         ) as report_file:
-            pr.write(report_file)
+            report.write(report_file)
         return 0
     except Exception:
         print("apportcheckresume failed")

--- a/data/dump_acpi_tables.py
+++ b/data/dump_acpi_tables.py
@@ -1,5 +1,8 @@
 #!/usr/bin/python3
 
+# TODO: Address following pylint complaints
+# pylint: disable=invalid-name
+
 import os
 import stat
 import sys

--- a/data/general-hooks/generic.py
+++ b/data/general-hooks/generic.py
@@ -21,9 +21,9 @@ import apport.hookutils
 def add_info(report, ui):
     # TODO: Split into smaller functions/methods
     # pylint: disable=too-many-branches,too-many-locals
-    nm = apport.hookutils.nonfree_kernel_modules()
-    if nm:
-        report["NonfreeKernelModules"] = " ".join(nm)
+    nonfree_modules = apport.hookutils.nonfree_kernel_modules()
+    if nonfree_modules:
+        report["NonfreeKernelModules"] = " ".join(nonfree_modules)
 
     # check for low space
     mounts = {"/": "system", "/var": "/var", "/tmp": "/tmp"}
@@ -35,10 +35,10 @@ def add_info(report, ui):
 
     for mount, mount_name in mounts.items():
         try:
-            st = os.statvfs(mount)
+            stat = os.statvfs(mount)
         except FileNotFoundError:
             continue
-        free_mb = st.f_bavail * st.f_frsize / 1000000
+        free_mb = stat.f_bavail * stat.f_frsize / 1000000
 
         if free_mb < treshold:
             report["UnreportableReason"] = (

--- a/data/general-hooks/parse_segv.py
+++ b/data/general-hooks/parse_segv.py
@@ -12,6 +12,9 @@
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
 
+# TODO: Address following pylint complaints
+# pylint: disable=invalid-name
+
 import logging
 import re
 import sys

--- a/data/java_uncaught_exception
+++ b/data/java_uncaught_exception
@@ -36,13 +36,13 @@ def main():
     # read from the JVM process a sequence of key, value delimited by null
     # bytes
     items = sys.stdin.read().split("\0")
-    d = {}
+    data = {}
     while items:
         key = items.pop(0)
         if not items:
             break
         value = items.pop(0)
-        d[key] = value
+        data[key] = value
 
     # create report
     report = apport.report.Report(problem_type="Crash")
@@ -57,7 +57,7 @@ def main():
     report.add_user_info()
 
     # add in data which was fed to us from the JVM process
-    for key, value in d.items():
+    for key, value in data.items():
         report[key] = value
 
     # Add an ExecutablePath pointing to the file where the main class resides
@@ -81,8 +81,8 @@ def main():
     report["Title"] = make_title(report)
 
     try:
-        with apport.fileutils.make_report_file(report) as f:
-            report.write(f)
+        with apport.fileutils.make_report_file(report) as report_file:
+            report.write(report_file)
     except OSError as error:
         apport.fatal("Cannot create report: %s", str(error))
     return 0

--- a/data/kernel_oops
+++ b/data/kernel_oops
@@ -11,6 +11,9 @@
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
 
+# TODO: Address following pylint complaints
+# pylint: disable=invalid-name
+
 import os
 import sys
 from gettext import gettext as _

--- a/data/package_hook
+++ b/data/package_hook
@@ -65,27 +65,27 @@ def main():
     options = parse_args()
 
     # create report
-    pr = apport.Report("Package")
-    pr.add_package(options.package)
-    pr["SourcePackage"] = apport.packaging.get_source(options.package)
-    pr["ErrorMessage"] = (sys.stdin, False)
+    report = apport.Report("Package")
+    report.add_package(options.package)
+    report["SourcePackage"] = apport.packaging.get_source(options.package)
+    report["ErrorMessage"] = (sys.stdin, False)
 
     if options.tags:
-        pr.add_tags(options.tags)
+        report.add_tags(options.tags)
 
     for line in options.logs or []:
         if os.path.isfile(line):
-            pr[mkattrname(line)] = (line,)
+            report[mkattrname(line)] = (line,)
         elif os.path.isdir(line):
-            for f in os.listdir(line):
-                path = os.path.join(line, f)
+            for log_file in os.listdir(line):
+                path = os.path.join(line, log_file)
                 if os.path.isfile(path):
-                    pr[mkattrname(path)] = (path,)
+                    report[mkattrname(path)] = (path,)
 
     # write report
     try:
-        with apport.fileutils.make_report_file(pr) as f:
-            pr.write(f)
+        with apport.fileutils.make_report_file(report) as report_file:
+            report.write(report_file)
     except OSError as error:
         apport.fatal("Cannot create report: %s", str(error))
 

--- a/data/recoverable_problem
+++ b/data/recoverable_problem
@@ -67,15 +67,15 @@ def main():
     report.add_os_info()
     report.add_user_info()
 
-    ds = report.get("DuplicateSignature", "")
+    duplicate_signature = report.get("DuplicateSignature", "")
     exec_path = report.get("ExecutablePath", "")
-    if exec_path and ds:
-        report["DuplicateSignature"] = "%s:%s" % (exec_path, ds)
+    if exec_path and duplicate_signature:
+        report["DuplicateSignature"] = f"{exec_path}:{duplicate_signature}"
 
     # Write the final report
     try:
-        with apport.fileutils.make_report_file(report) as f:
-            report.write(f)
+        with apport.fileutils.make_report_file(report) as report_file:
+            report.write(report_file)
     except OSError as error:
         apport.fatal("Cannot create report: %s", str(error))
 

--- a/data/unkillable_shutdown
+++ b/data/unkillable_shutdown
@@ -47,13 +47,13 @@ def orphaned_processes(omit_pids):
     """
     my_pid = os.getpid()
     my_sid = os.getsid(0)
-    for d in os.listdir("/proc"):
+    for process in os.listdir("/proc"):
         try:
-            pid = int(d)
+            pid = int(process)
         except ValueError:
             continue
-        if pid == 1 or pid == my_pid or d in omit_pids:
-            apport.warning("ignoring: %s", d)
+        if pid == 1 or pid == my_pid or process in omit_pids:
+            apport.warning("ignoring: %s", process)
             continue
 
         try:
@@ -64,45 +64,51 @@ def orphaned_processes(omit_pids):
             continue
 
         if sid == my_sid:
-            apport.warning("ignoring same sid: %s", d)
+            apport.warning("ignoring same sid: %s", process)
             continue
 
         try:
-            os.readlink(os.path.join("/proc", d, "exe"))
+            os.readlink(os.path.join("/proc", process, "exe"))
         except OSError as error:
             if error.errno == errno.ENOENT:
                 # kernel thread or similar, silently ignore
                 continue
             apport.warning(
-                "Could not read information about pid %s: %s", d, str(error)
+                "Could not read information about pid %s: %s",
+                process,
+                str(error),
             )
             continue
 
-        yield d
+        yield process
 
 
 def do_report(pid, omit_pids):
     """Create a report for a particular PID."""
 
-    r = apport.Report("Bug")
+    report = apport.Report("Bug")
     try:
-        r.add_proc_info(pid)
+        report.add_proc_info(pid)
     except (ValueError, AssertionError):
         # happens if ExecutablePath doesn't exist (any more?), ignore
         return
 
-    r["Tags"] = "shutdown-hang"
-    r["Title"] = "does not terminate at computer shutdown"
-    if "ExecutablePath" in r:
-        r["Title"] = os.path.basename(r["ExecutablePath"]) + " " + r["Title"]
-    r["Processes"] = apport.hookutils.command_output(["ps", "aux"])
-    r["InitctlList"] = apport.hookutils.command_output(["initctl", "list"])
+    report["Tags"] = "shutdown-hang"
+    report["Title"] = "does not terminate at computer shutdown"
+    if "ExecutablePath" in report:
+        report["Title"] = (
+            os.path.basename(report["ExecutablePath"]) + " " + report["Title"]
+        )
+    report["Processes"] = apport.hookutils.command_output(["ps", "aux"])
+    report["InitctlList"] = apport.hookutils.command_output(
+        ["initctl", "list"]
+    )
     if omit_pids:
-        r["OmitPids"] = " ".join(omit_pids)
+        report["OmitPids"] = " ".join(omit_pids)
 
     try:
-        with apport.fileutils.make_report_file(r) as f:
-            r.write(f)
+        with apport.fileutils.make_report_file(report) as report_file:
+            report.write(report_file)
     except FileExistsError as error:
         apport.warning(
             "Cannot create report: %s already exists", error.filename

--- a/data/whoopsie-upload-all
+++ b/data/whoopsie-upload-all
@@ -13,6 +13,9 @@
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
 
+# TODO: Address following pylint complaints
+# pylint: disable=invalid-name
+
 import argparse
 import errno
 import fcntl

--- a/gtk/apport-gtk
+++ b/gtk/apport-gtk
@@ -11,6 +11,9 @@
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
 
+# TODO: Address following pylint complaints
+# pylint: disable=invalid-name
+
 import os
 import re
 import subprocess

--- a/kde/apport-kde
+++ b/kde/apport-kde
@@ -12,6 +12,9 @@
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
 
+# TODO: Address following pylint complaints
+# pylint: disable=invalid-name
+
 import os
 import shutil
 import subprocess

--- a/problem_report.py
+++ b/problem_report.py
@@ -9,6 +9,9 @@
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
 
+# TODO: Address following pylint complaints
+# pylint: disable=invalid-name
+
 import base64
 import binascii
 import collections

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,8 @@
 #!/usr/bin/python3
 
+# TODO: Address following pylint complaints
+# pylint: disable=invalid-name
+
 # distutils-extra needs porting, pylint: disable=deprecated-module
 import distutils.command.build
 import distutils.command.clean

--- a/tests/integration/test_apport_unpack.py
+++ b/tests/integration/test_apport_unpack.py
@@ -19,7 +19,7 @@ import problem_report
 from tests.paths import local_test_environment
 
 
-class T(unittest.TestCase):
+class TestApportUnpack(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.env = (
@@ -28,18 +28,18 @@ class T(unittest.TestCase):
         cls.workdir = tempfile.mkdtemp()
 
         # create problem report file with all possible data types
-        r = problem_report.ProblemReport()
+        report = problem_report.ProblemReport()
         cls.utf8_str = b"a\xe2\x99\xa5b"
         cls.bindata = b"\x00\x01\xFF\x40"
-        r["utf8"] = cls.utf8_str
-        r["unicode"] = cls.utf8_str.decode("UTF-8")
-        r["binary"] = cls.bindata
-        r["compressed"] = problem_report.CompressedValue(b"FooFoo!")
-        r["separator"] = ""
+        report["utf8"] = cls.utf8_str
+        report["unicode"] = cls.utf8_str.decode("UTF-8")
+        report["binary"] = cls.bindata
+        report["compressed"] = problem_report.CompressedValue(b"FooFoo!")
+        report["separator"] = ""
 
         cls.report_file = os.path.join(cls.workdir, "test.apport")
-        with open(cls.report_file, "wb") as f:
-            r.write(f)
+        with open(cls.report_file, "wb") as report_file:
+            report.write(report_file)
 
         cls.unpack_dir = os.path.join(cls.workdir, "un pack")
 
@@ -137,5 +137,5 @@ class T(unittest.TestCase):
         )
 
     def _get_unpack(self, fname):
-        with open(os.path.join(self.unpack_dir, fname), "rb") as f:
-            return f.read()
+        with open(os.path.join(self.unpack_dir, fname), "rb") as file_:
+            return file_.read()

--- a/tests/integration/test_apport_valgrind.py
+++ b/tests/integration/test_apport_valgrind.py
@@ -18,7 +18,7 @@ from tests.paths import local_test_environment
 
 
 @skip_if_command_is_missing("valgrind")
-class T(unittest.TestCase):
+class TestApportValgrind(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.env = os.environ | local_test_environment()
@@ -102,8 +102,8 @@ void makeleak(void){
     /*free(leak);*/
 }"""
 
-        with open("memleak.c", "w", encoding="utf-8") as fd:
-            fd.write(code)
+        with open("memleak.c", "w", encoding="utf-8") as soure_file:
+            soure_file.write(code)
         cmd = ["gcc", "-Wall", "-Werror", "-g", "memleak.c", "-o", "memleak"]
         self.assertEqual(
             subprocess.call(cmd), 0, "compiling memleak.c failed."
@@ -148,6 +148,6 @@ void makeleak(void){
             "A log file %s should exist but does not" % logpath,
         )
 
-        with open(logpath, encoding="utf-8") as f:
-            log = f.read()
+        with open(logpath, encoding="utf-8") as log_file:
+            log = log_file.read()
             self.assertIn(exepath, log)

--- a/tests/integration/test_crash_digger.py
+++ b/tests/integration/test_crash_digger.py
@@ -9,6 +9,9 @@
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
 
+# TODO: Address following pylint complaints
+# pylint: disable=invalid-name
+
 import os
 import shutil
 import subprocess

--- a/tests/integration/test_fileutils.py
+++ b/tests/integration/test_fileutils.py
@@ -1,3 +1,6 @@
+# TODO: Address following pylint complaints
+# pylint: disable=invalid-name
+
 import os
 import pwd
 import shutil

--- a/tests/integration/test_github.py
+++ b/tests/integration/test_github.py
@@ -19,7 +19,7 @@ except ImportError as error:
 
 
 @unittest.skipIf(IMPORT_ERROR, f"module not available: {IMPORT_ERROR}")
-class T(unittest.TestCase):
+class TestGitHub(unittest.TestCase):
     # pylint: disable=protected-access
 
     def setUp(self):
@@ -58,9 +58,9 @@ class T(unittest.TestCase):
         nodata = {}
         snapdata = {"SnapGitOwner": "gimli", "SnapGitName": "axe"}
 
-        with self.github as g:
-            self.crashdb.github = g
-            self.crashdb_barren.github = g
+        with self.github as github:
+            self.crashdb.github = github
+            self.crashdb_barren.github = github
 
             # Snap fields are not set and the database specifies no
             # norepository_{owner,name}
@@ -111,21 +111,21 @@ class T(unittest.TestCase):
         # No __enter__, no authentication data
         self.assertRaises(RuntimeError, self.github.authentication_complete)
         self.message_cb.assert_not_called()
-        with self.github as g:
+        with self.github as github:
             # Error message missing
-            self.assertRaises(RuntimeError, g.authentication_complete)
+            self.assertRaises(RuntimeError, github.authentication_complete)
             self.message_cb.assert_called_with("Login required", ANY)
             # Error message awry
-            self.assertRaises(RuntimeError, g.authentication_complete)
+            self.assertRaises(RuntimeError, github.authentication_complete)
             # Still not authorized
-            self.assertFalse(g.authentication_complete())
+            self.assertFalse(github.authentication_complete())
             # Slow down!
-            self.assertFalse(g.authentication_complete())
+            self.assertFalse(github.authentication_complete())
             # Access token OK
-            self.assertTrue(g.authentication_complete())
-        with self.github as g:
+            self.assertTrue(github.authentication_complete())
+        with self.github as github:
             # Expired (requires __enter__ again to update __expiry).
-            self.assertRaises(RuntimeError, g.authentication_complete)
+            self.assertRaises(RuntimeError, github.authentication_complete)
             self.message_cb.assert_called_with(
                 "Failed login",
                 "Github authentication expired. Please try again.",

--- a/tests/integration/test_helper.py
+++ b/tests/integration/test_helper.py
@@ -7,7 +7,7 @@ import unittest
 from tests.helper import pidof, read_shebang
 
 
-class T(unittest.TestCase):
+class TestHelper(unittest.TestCase):
     def test_pidof_non_existing_program(self):
         self.assertEqual(pidof("non-existing"), set())
 

--- a/tests/integration/test_hooks.py
+++ b/tests/integration/test_hooks.py
@@ -9,6 +9,9 @@
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
 
+# TODO: Address following pylint complaints
+# pylint: disable=invalid-name
+
 import datetime
 import os
 import shutil

--- a/tests/integration/test_hookutils.py
+++ b/tests/integration/test_hookutils.py
@@ -1,3 +1,6 @@
+# TODO: Address following pylint complaints
+# pylint: disable=invalid-name
+
 import locale
 import os
 import re

--- a/tests/integration/test_java_crashes.py
+++ b/tests/integration/test_java_crashes.py
@@ -20,7 +20,7 @@ from tests.paths import get_data_directory, local_test_environment
 
 
 @skip_if_command_is_missing("java")
-class T(unittest.TestCase):
+class TestJavaCrashes(unittest.TestCase):
     def setUp(self):
         self.env = os.environ | local_test_environment()
         datadir = get_data_directory()
@@ -91,19 +91,21 @@ class T(unittest.TestCase):
         """Check that we have one crash report, and verify its contents."""
         reports = apport.fileutils.get_new_reports()
         self.assertEqual(len(reports), 1, "did not create a crash report")
-        r = apport.report.Report()
-        with open(reports[0], "rb") as f:
-            r.load(f)
-        self.assertEqual(r["ProblemType"], "Crash")
-        self.assertTrue(r["ProcCmdline"].startswith("java -classpath"), r)
+        report = apport.report.Report()
+        with open(reports[0], "rb") as report_file:
+            report.load(report_file)
+        self.assertEqual(report["ProblemType"], "Crash")
         self.assertTrue(
-            r["StackTrace"].startswith(
+            report["ProcCmdline"].startswith("java -classpath"), report
+        )
+        self.assertTrue(
+            report["StackTrace"].startswith(
                 "java.lang.RuntimeException: Can't catch this"
             )
         )
         if ".jar!" in main_file:
-            self.assertEqual(r["MainClassUrl"], "jar:file:" + main_file)
+            self.assertEqual(report["MainClassUrl"], "jar:file:" + main_file)
         else:
-            self.assertEqual(r["MainClassUrl"], "file:" + main_file)
-        self.assertIn("DistroRelease", r)
-        self.assertIn("ProcCwd", r)
+            self.assertEqual(report["MainClassUrl"], "file:" + main_file)
+        self.assertIn("DistroRelease", report)
+        self.assertIn("ProcCwd", report)

--- a/tests/integration/test_packaging.py
+++ b/tests/integration/test_packaging.py
@@ -1,3 +1,6 @@
+# TODO: Address following pylint complaints
+# pylint: disable=invalid-name
+
 import unittest
 
 import apport.packaging

--- a/tests/integration/test_packaging_apt_dpkg.py
+++ b/tests/integration/test_packaging_apt_dpkg.py
@@ -1,3 +1,6 @@
+# TODO: Address following pylint complaints
+# pylint: disable=invalid-name
+
 import gzip
 import os
 import pathlib

--- a/tests/integration/test_packaging_rpm.py
+++ b/tests/integration/test_packaging_rpm.py
@@ -12,7 +12,7 @@ except ImportError:
 
 @unittest.skipUnless(HAS_RPM, "rpm module not available")
 @skip_if_command_is_missing("rpm")
-class T(unittest.TestCase):
+class TestPackagingRpm(unittest.TestCase):
     def test_get_dependencies(self):
         """get_dependencies()."""
         deps = impl.get_dependencies("bash")
@@ -27,9 +27,9 @@ class T(unittest.TestCase):
     def test_get_headers_by_tag(self):
         """_get_headers_by_tag()."""
         # pylint: disable=protected-access
-        headersByTag = impl._get_headers_by_tag("basenames", "/bin/bash")
-        self.assertEqual(len(headersByTag), 1)
-        self.assertTrue(headersByTag[0]["n"].startswith("bash"))
+        headers_by_tag = impl._get_headers_by_tag("basenames", "/bin/bash")
+        self.assertEqual(len(headers_by_tag), 1)
+        self.assertTrue(headers_by_tag[0]["n"].startswith("bash"))
 
     def test_get_system_architecture(self):
         """get_system_architecture()."""

--- a/tests/integration/test_problem_report.py
+++ b/tests/integration/test_problem_report.py
@@ -1,3 +1,6 @@
+# TODO: Address following pylint complaints
+# pylint: disable=invalid-name
+
 import email
 import gzip
 import io

--- a/tests/integration/test_python_crashes.py
+++ b/tests/integration/test_python_crashes.py
@@ -10,6 +10,9 @@
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
 
+# TODO: Address following pylint complaints
+# pylint: disable=invalid-name
+
 import atexit
 import os
 import re

--- a/tests/integration/test_recoverable_problem.py
+++ b/tests/integration/test_recoverable_problem.py
@@ -21,7 +21,7 @@ import apport.report
 from tests.paths import get_data_directory, local_test_environment
 
 
-class T(unittest.TestCase):
+class TestRecoverableProblem(unittest.TestCase):
     def setUp(self):
         self.env = os.environ | local_test_environment()
         self.report_dir = tempfile.mkdtemp()

--- a/tests/integration/test_report.py
+++ b/tests/integration/test_report.py
@@ -1,4 +1,6 @@
 # pylint: disable=too-many-lines
+# TODO: Address following pylint complaints
+# pylint: disable=invalid-name
 
 import atexit
 import grp

--- a/tests/integration/test_signal_crashes.py
+++ b/tests/integration/test_signal_crashes.py
@@ -8,6 +8,8 @@
 # the full text of the license.
 
 # pylint: disable=too-many-lines
+# TODO: Address following pylint complaints
+# pylint: disable=invalid-name
 
 import argparse
 import collections

--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -1,4 +1,6 @@
 # pylint: disable=too-many-lines
+# TODO: Address following pylint complaints
+# pylint: disable=invalid-name
 
 import contextlib
 import errno

--- a/tests/integration/test_ui_cli.py
+++ b/tests/integration/test_ui_cli.py
@@ -18,10 +18,10 @@ from tests.helper import import_module_from_file, skip_if_command_is_missing
 from tests.paths import is_local_source_directory, local_test_environment
 
 if is_local_source_directory():
-    apport_cli_path = "bin/apport-cli"
+    APPORT_CLI_PATH = "bin/apport-cli"
 else:
-    apport_cli_path = "/usr/bin/apport-cli"
-apport_cli = import_module_from_file(pathlib.Path(apport_cli_path))
+    APPORT_CLI_PATH = "/usr/bin/apport-cli"
+apport_cli = import_module_from_file(pathlib.Path(APPORT_CLI_PATH))
 
 
 class TestApportCli(unittest.TestCase):
@@ -38,7 +38,7 @@ class TestApportCli(unittest.TestCase):
         os.environ.update(cls.orig_environ)
 
     def setUp(self):
-        self.app = apport_cli.CLIUserInterface([apport_cli_path])
+        self.app = apport_cli.CLIUserInterface([APPORT_CLI_PATH])
         self.app.report = apport.report.Report()
         self.app.report.add_os_info()
         self.app.report["ExecutablePath"] = "/bin/bash"

--- a/tests/system/test_apport_valgrind.py
+++ b/tests/system/test_apport_valgrind.py
@@ -24,7 +24,7 @@ with open("/proc/meminfo", encoding="utf-8") as f:
 
 
 @skip_if_command_is_missing("valgrind")
-class T(unittest.TestCase):
+class TestApportValgrind(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.env = os.environ | local_test_environment()

--- a/tests/system/test_github_query.py
+++ b/tests/system/test_github_query.py
@@ -9,11 +9,11 @@ except ImportError as error:
     IMPORT_ERROR = error
 
 
-some_id = "a654870577ad2a2ab5b1"
+SOME_ID = "a654870577ad2a2ab5b1"
 
 
 @unittest.skipIf(IMPORT_ERROR, f"module not available: {IMPORT_ERROR}")
-class T(unittest.TestCase):
+class TestGitHubQuery(unittest.TestCase):
     def setUp(self):
         self.crashdb = self._get_gh_database("Lorem", "Ipsum")
         self.message_cb = Mock()
@@ -23,10 +23,10 @@ class T(unittest.TestCase):
 
     def test_api_authentication(self):
         """Test if we can contact Github authentication service."""
-        with self.github as g:
-            data = {"client_id": some_id, "scope": "public_repo"}
+        with self.github as github:
+            data = {"client_id": SOME_ID, "scope": "public_repo"}
             url = "https://github.com/login/device/code"
-            response = g.api_authentication(url, data)
+            response = github.api_authentication(url, data)
             # Sample response:
             # {
             #     'device_code': '35fe1f072913d46c00ad3e4a83e57facfb758f67',
@@ -49,7 +49,7 @@ class T(unittest.TestCase):
                 "impl": "github",
                 "repository_owner": repository_owner,
                 "repository_name": repository_name,
-                "github_app_id": some_id,
+                "github_app_id": SOME_ID,
                 "labels": ["apport"],
             },
         )

--- a/tests/system/test_packaging_apt_dpkg.py
+++ b/tests/system/test_packaging_apt_dpkg.py
@@ -1,4 +1,6 @@
 # pylint: disable=too-many-lines
+# TODO: Address following pylint complaints
+# pylint: disable=invalid-name
 
 import glob
 import gzip

--- a/tests/system/test_python_crashes.py
+++ b/tests/system/test_python_crashes.py
@@ -10,6 +10,9 @@
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
 
+# TODO: Address following pylint complaints
+# pylint: disable=invalid-name
+
 import atexit
 import os
 import shutil

--- a/tests/system/test_signal_crashes.py
+++ b/tests/system/test_signal_crashes.py
@@ -1,3 +1,6 @@
+# TODO: Address following pylint complaints
+# pylint: disable=invalid-name
+
 import errno
 import os
 import resource

--- a/tests/system/test_ui_gtk.py
+++ b/tests/system/test_ui_gtk.py
@@ -10,6 +10,8 @@
 # the full text of the license.
 
 # pylint: disable=too-many-lines
+# TODO: Address following pylint complaints
+# pylint: disable=invalid-name
 
 import os
 import shutil

--- a/tests/system/test_ui_kde.py
+++ b/tests/system/test_ui_kde.py
@@ -9,6 +9,10 @@
 # Free Software Foundation; either version 2 of the License, or (at your
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
+
+# TODO: Address following pylint complaints
+# pylint: disable=invalid-name
+
 import os
 import shutil
 import tempfile

--- a/tests/unit/test_crashdb.py
+++ b/tests/unit/test_crashdb.py
@@ -1,3 +1,6 @@
+# TODO: Address following pylint complaints
+# pylint: disable=invalid-name
+
 import copy
 import os.path
 import shutil

--- a/tests/unit/test_fileutils.py
+++ b/tests/unit/test_fileutils.py
@@ -1,3 +1,6 @@
+# TODO: Address following pylint complaints
+# pylint: disable=invalid-name
+
 import io
 import time
 import unittest

--- a/tests/unit/test_helper.py
+++ b/tests/unit/test_helper.py
@@ -11,11 +11,11 @@ class Multiply:  # pylint: disable=too-few-public-methods
     def __init__(self, multiplier):
         self.multiplier = multiplier
 
-    def multiply(self, x: int) -> int:
-        return x * self.multiplier
+    def multiply(self, factor: int) -> int:
+        return factor * self.multiplier
 
 
-class T(unittest.TestCase):
+class TestTestHelper(unittest.TestCase):
     def test_get_init_systemd(self):
         open_mock = unittest.mock.mock_open(read_data="systemd\n")
         with unittest.mock.patch("builtins.open", open_mock):
@@ -24,6 +24,6 @@ class T(unittest.TestCase):
 
     def test_wrap_object_with_statement(self):
         with wrap_object(Multiply, "__init__") as mock:
-            m = Multiply(7)
-            self.assertEqual(m.multiply(6), 42)
+            multiply = Multiply(7)
+            self.assertEqual(multiply.multiply(6), 42)
         mock.assert_called_once_with(7)

--- a/tests/unit/test_hookutils.py
+++ b/tests/unit/test_hookutils.py
@@ -7,7 +7,7 @@ import unittest.mock
 import apport.hookutils
 
 
-class T(unittest.TestCase):
+class TestHookutils(unittest.TestCase):
     @unittest.mock.patch("apport.hookutils.root_command_output")
     def test_attach_dmesg(self, root_command_output_mock):
         """attach_dmesg()"""

--- a/tests/unit/test_packaging_impl.py
+++ b/tests/unit/test_packaging_impl.py
@@ -6,7 +6,7 @@ import unittest.mock
 from apport.packaging_impl import determine_packaging_implementation
 
 
-class T(unittest.TestCase):
+class TestPackagingImpl(unittest.TestCase):
     @unittest.mock.patch("apport.packaging_impl.freedesktop_os_release")
     def test_determine_ubuntu(self, os_release_mock):
         os_release_mock.return_value = {

--- a/tests/unit/test_parse_segv.py
+++ b/tests/unit/test_parse_segv.py
@@ -131,7 +131,7 @@ DISASM = """\
 """
 
 
-class T(unittest.TestCase):
+class TestHookParseSegv(unittest.TestCase):
     """Test Segfault Parser."""
 
     def test_invalid_00_registers(self):

--- a/tests/unit/test_problem_report.py
+++ b/tests/unit/test_problem_report.py
@@ -1,3 +1,6 @@
+# TODO: Address following pylint complaints
+# pylint: disable=invalid-name
+
 import email
 import io
 import locale

--- a/tests/unit/test_report.py
+++ b/tests/unit/test_report.py
@@ -1,4 +1,6 @@
 # pylint: disable=too-many-lines
+# TODO: Address following pylint complaints
+# pylint: disable=invalid-name
 
 import os
 import textwrap

--- a/tests/unit/test_rethread.py
+++ b/tests/unit/test_rethread.py
@@ -1,3 +1,6 @@
+# TODO: Address following pylint complaints
+# pylint: disable=invalid-name
+
 import sys
 import time
 import traceback


### PR DESCRIPTION
Move pylint's invalid-name overrides to affected files to allow getting this alert for new cases. Address the pylint complains for files that only have a few complains.