### PR TITLE
refactor: Use f-strings everywhere

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -29,7 +29,6 @@ good-names=i,j,k,lp,ui,_
 # --disable=W".
 disable=bad-option-value,fixme,
   # TODO: Fix all following disabled checks!
-  consider-using-f-string,
   duplicate-code,
   missing-docstring,
 

--- a/apport/crashdb_impl/debian.py
+++ b/apport/crashdb_impl/debian.py
@@ -80,12 +80,8 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
             return False
 
         with tempfile.NamedTemporaryFile() as temp:
-            temp.file.write(
-                ("Package: " + buggy_package + "\n").encode("UTF-8")
-            )
-            temp.file.write(
-                ("Version: " + buggy_version + "\n\n\n").encode("UTF-8")
-            )
+            temp.file.write(f"Package: {buggy_package}\n".encode("UTF-8"))
+            temp.file.write(f"Version: {buggy_version}\n\n\n".encode("UTF-8"))
             temp.file.write(
                 ("=============================\n\n").encode("UTF-8")
             )
@@ -114,7 +110,7 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
 
         # Subscribe the submitted to the bug report
         msg.add_header("X-Debbugs-CC", self.options["sender"])
-        msg.add_header("Usertag", "apport-%s" % report["ProblemType"].lower())
+        msg.add_header("Usertag", f"apport-{report['ProblemType'].lower()}")
 
         smtp = smtplib.SMTP(self.options["smtphost"])
         smtp.sendmail(

--- a/apport/crashdb_impl/memory.py
+++ b/apport/crashdb_impl/memory.py
@@ -86,11 +86,10 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
         SourcePackage.
         """
         if "SourcePackage" in report:
-            return "http://%s.bugs.example.com/%i" % (
-                report["SourcePackage"],
-                handle,
+            return (
+                f"http://{report['SourcePackage']}.bugs.example.com/{handle}"
             )
-        return "http://bugs.example.com/%i" % handle
+        return f"http://bugs.example.com/{handle}"
 
     def get_id_url(self, report, crash_id):
         """Return URL for a given report ID.
@@ -217,9 +216,9 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
         already marked as fixed (having ID 'master').
         """
         assert self.reports[master]["fixed_version"] is not None
-        self.reports[crash_id]["comment"] = (
-            "regression, already fixed in #%i" % master
-        )
+        self.reports[crash_id][
+            "comment"
+        ] = f"regression, already fixed in #{master}"
 
     def _mark_dup_checked(self, crash_id, report):
         """Mark crash id as checked for being a duplicate."""

--- a/apport/fileutils.py
+++ b/apport/fileutils.py
@@ -200,8 +200,8 @@ def seen_report(report):
 
 
 def mark_report_upload(report):
-    upload = "%s.upload" % report.rsplit(".", 1)[0]
-    uploaded = "%s.uploaded" % report.rsplit(".", 1)[0]
+    upload = f"{report.rsplit('.', 1)[0]}.upload"
+    uploaded = f"{report.rsplit('.', 1)[0]}.uploaded"
     # if uploaded exists and is older than the report remove it and upload
     if os.path.exists(uploaded) and os.path.exists(upload):
         report_st = os.stat(report)
@@ -219,7 +219,7 @@ def mark_hanging_process(report, pid):
         raise ValueError("report does not have the ExecutablePath attribute")
 
     uid = os.geteuid()
-    base = "%s.%s.%s.hanging" % (subject, str(uid), pid)
+    base = f"{subject}.{str(uid)}.{pid}.hanging"
     path = os.path.join(report_dir, base)
     with open(path, "a", encoding="utf-8"):
         pass
@@ -436,7 +436,7 @@ def make_report_file(report, uid=None):
     if not uid:
         uid = os.geteuid()
 
-    path = os.path.join(report_dir, "%s.%s.crash" % (subject, str(uid)))
+    path = os.path.join(report_dir, f"{subject}.{str(uid)}.crash")
     return open(path, "xb")
 
 
@@ -610,7 +610,7 @@ def get_core_path(
         timestamp = "unknown"
     else:
         if timestamp is None:
-            with open("/proc/%s/stat" % pid, encoding="utf-8") as stat_file:
+            with open(f"/proc/{pid}/stat", encoding="utf-8") as stat_file:
                 stat_contents = stat_file.read()
             timestamp = get_starttime(stat_contents)
 
@@ -623,13 +623,7 @@ def get_core_path(
 
     # This is similar to systemd-coredump, but with the exe name instead
     # of the command name
-    core_name = "core.%s.%s.%s.%s.%s" % (
-        exe,
-        uid,
-        get_boot_id(),
-        str(pid),
-        str(timestamp),
-    )
+    core_name = f"core.{exe}.{uid}.{get_boot_id()}.{str(pid)}.{str(timestamp)}"
 
     core_path = os.path.join(core_dir, core_name)
 
@@ -746,7 +740,7 @@ def links_with_shared_library(path, lib):
         return True
 
     for linked_lib in libs:
-        if linked_lib.startswith(lib + ".so."):
+        if linked_lib.startswith(f"{lib}.so."):
             return True
 
     return False

--- a/apport/logging.py
+++ b/apport/logging.py
@@ -6,7 +6,7 @@ import time
 def log(message, timestamp=False):
     """Log the given string to stdout. Prepend timestamp if requested."""
     if timestamp:
-        sys.stdout.write("%s: " % time.strftime("%x %X"))
+        sys.stdout.write(f"{time.strftime('%x %X')}: ")
     print(message)
 
 
@@ -48,6 +48,6 @@ def memdbg(checkpoint):
                 memstat[field[:-1]] = int(size) / 1024.0
 
     sys.stderr.write(
-        "Size: %.1f MB, RSS: %.1f MB, Stk: %.1f MB @ %s\n"
-        % (memstat["VmSize"], memstat["VmRSS"], memstat["VmStk"], checkpoint)
+        f"Size: {memstat['VmSize']:.1f} MB, RSS: {memstat['VmRSS']:.1f} MB,"
+        f" Stk: {memstat['VmStk']:.1f} MB @ {checkpoint}\n"
     )

--- a/apport/packaging.py
+++ b/apport/packaging.py
@@ -51,8 +51,7 @@ except ImportError:  # Python < 3.10
                 errno = error.errno
         else:
             raise OSError(
-                errno,
-                "Unable to read files {}".format(", ".join(os_release_files)),
+                errno, f"Unable to read files {', '.join(os_release_files)}"
             )
 
         return ret

--- a/apport/packaging_impl/rpm.py
+++ b/apport/packaging_impl/rpm.py
@@ -54,10 +54,10 @@ class RPMPackageInfo:
             raise ValueError
         # Note - "version" here seems to refer to the full EVR, so..
         if not hdr["e"]:
-            return hdr["v"] + "-" + hdr["r"]
+            return f"{hdr['v']}-{hdr['r']}"
         if not hdr["v"] or not hdr["r"]:
             return None
-        return hdr["e"] + ":" + hdr["v"] + "-" + hdr["r"]
+        return f"{hdr['e']}:{hdr['v']}-{hdr['r']}"
 
     def get_available_version(self, package):
         """Return the latest available version of a package."""
@@ -263,7 +263,7 @@ class RPMPackageInfo:
         argument."""
         matches = self.ts.dbMatch(tag, arg)
         if matches.count() == 0:
-            raise ValueError("Could not find package with %s: %s" % (tag, arg))
+            raise ValueError(f"Could not find package with {tag}: {arg}")
         return matches
 
     @staticmethod
@@ -287,15 +287,15 @@ class RPMPackageInfo:
             qlen = qlen - 1
 
         if qlen == 0:
-            raise ValueError("No headers found for this envra: %s" % envra)
+            raise ValueError(f"No headers found for this envra: {envra}")
         return h
 
     @staticmethod
     def _make_envra_from_header(h):
         """Generate an ENVRA string from an rpm header."""
-        nvra = "%s-%s-%s.%s" % (h["n"], h["v"], h["r"], h["arch"])
+        nvra = f"{h['n']}-{h['v']}-{h['r']}.{h['arch']}"
         if h["e"]:
-            envra = "%s:%s" % (h["e"], nvra)
+            envra = f"{h['e']}:{nvra}"
         else:
             envra = nvra
         return envra

--- a/apport/sandboxutils.py
+++ b/apport/sandboxutils.py
@@ -31,7 +31,7 @@ def needed_packages(report):
 
     # first, grab the versions that we captured at crash time
     for line in (
-        report.get("Package", "") + "\n" + report.get("Dependencies", "")
+        f"{report.get('Package', '')}\n{report.get('Dependencies', '')}"
     ).splitlines():
         if not line.strip():
             continue
@@ -52,7 +52,7 @@ def report_package_versions(report):
     """Return package -> version dictionary from report."""
     pkg_vers = {}
     for line in (
-        report.get("Package", "") + "\n" + report.get("Dependencies", "")
+        f"{report.get('Package', '')}\n{report.get('Dependencies', '')}"
     ).splitlines():
         if not line.strip():
             continue
@@ -117,8 +117,7 @@ def needed_runtime_packages(
         if pkg:
             if verbose:
                 apport.logging.log(
-                    "dynamically loaded %s needs package %s, queueing"
-                    % (line, pkg)
+                    f"dynamically loaded {line} needs package {pkg}, queueing"
                 )
             pkgs.add(pkg)
         else:
@@ -225,12 +224,12 @@ def make_sandbox(
     origins = None
     if dynamic_origins:
         pkg_list = (
-            report.get("Package", "") + "\n" + report.get("Dependencies", "")
+            f"{report.get('Package', '')}\n{report.get('Dependencies', '')}"
         )
         match = re.compile(r"\[origin: ([a-zA-Z0-9][a-zA-Z0-9\+\.\-]+)\]")
         origins = set(match.findall(pkg_list))
         if origins:
-            apport.logging.log("Origins: %s" % origins)
+            apport.logging.log(f"Origins: {origins}")
 
     # unpack packages, if any, using cache and sandbox
     try:
@@ -293,7 +292,7 @@ def make_sandbox(
                     pkg = "systemd"
             if pkg:
                 apport.logging.log(
-                    "Installing extra package %s to get %s" % (pkg, path),
+                    f"Installing extra package {pkg} to get {path}",
                     log_timestamps,
                 )
                 pkgs.append((pkg, pkg_versions.get(pkg)))

--- a/apport_python_hook.py
+++ b/apport_python_hook.py
@@ -113,7 +113,7 @@ def apport_excepthook(binary, exc_type, exc_obj, exc_tb):
         if "ExecutableTimestamp" in report:
             report["ExecutableTimestamp"] = str(int(os.stat(binary).st_mtime))
         try:
-            report["PythonArgs"] = "%r" % sys.argv
+            report["PythonArgs"] = f"{sys.argv!r}"
         except AttributeError:
             pass
         if report.check_ignored():
@@ -195,21 +195,19 @@ def dbus_service_unknown_analysis(exc_obj, report):
         except (NoSectionError, NoOptionError):
             if sys.stderr:
                 sys.stderr.write(
-                    "Invalid D-BUS .service file %s: %s"
-                    % (service_file, exc_obj.get_dbus_message())
+                    f"Invalid D-BUS .service file {service_file}:"
+                    f" {exc_obj.get_dbus_message()}"
                 )
             continue
 
     if not services:
-        report["DbusErrorAnalysis"] = "no service file providing " + dbus_name
+        report["DbusErrorAnalysis"] = f"no service file providing {dbus_name}"
     else:
         report["DbusErrorAnalysis"] = "provided by"
         for service, exe, running in services:
-            report["DbusErrorAnalysis"] += " %s (%s is %srunning)" % (
-                service,
-                exe,
-                ("" if running else "not "),
-            )
+            report[
+                "DbusErrorAnalysis"
+            ] += f" {service} ({exe} is {'' if running else 'not '}running)"
 
 
 def install():

--- a/bin/apport-cli
+++ b/bin/apport-cli
@@ -35,7 +35,7 @@ class CLIDialog:
     """Command line dialog wrapper."""
 
     def __init__(self, heading, text):
-        self.heading = "\n*** " + heading + "\n"
+        self.heading = f"\n*** {heading}\n"
         self.text = text
         self.keys = []
         self.buttons = []
@@ -94,7 +94,7 @@ class CLIDialog:
                 else:
                     print(_("What would you like to do? Your options are:"))
                 for index, button in enumerate(self.buttons):
-                    print("  %s: %s" % (self.keys[index], button))
+                    print(f"  {self.keys[index]}: {button}")
 
                 if len(self.keys) <= 10:
                     # A 10 option prompt would can still be a single character
@@ -139,7 +139,7 @@ class CLIProgressDialog(CLIDialog):
             return
 
         if progress is not None:
-            sys.stdout.write("\r%u%%" % (progress * 100))
+            sys.stdout.write(f"\r{progress * 100}%")
         else:
             sys.stdout.write(".")
         sys.stdout.flush()
@@ -162,7 +162,7 @@ class CLIUserInterface(apport.ui.UserInterface):
             # ignore internal keys
             if key.startswith("_"):
                 continue
-            details += "== %s =================================\n" % key
+            details += f"== {key} =================================\n"
             # string value
             keylen = len(self.report[key])
             if (
@@ -269,7 +269,7 @@ class CLIUserInterface(apport.ui.UserInterface):
                 # we do not already have a report file if we report a bug
                 if not self.report_file:
                     self.report_file = self._save_report_in_temp_directory()
-                print(_("Problem report file:") + " " + self.report_file)
+                print(f"{_('Problem report file:')} {self.report_file}")
 
             return return_value
 
@@ -398,7 +398,7 @@ class CLIUserInterface(apport.ui.UserInterface):
 
         Return path if the user selected a file, or None if cancelled.
         """
-        print("\n***  " + text)
+        print(f"\n***  {text}")
         while True:
             sys.stdout.write(_("Path to file (Enter to cancel):"))
             sys.stdout.write(" ")
@@ -413,14 +413,12 @@ class CLIUserInterface(apport.ui.UserInterface):
                 return f
 
     def open_url(self, url):
-        text = "%s\n\n  %s\n\n%s" % (
-            _("To continue, you must visit the following URL:"),
-            url,
-            _(
-                "You can launch a browser now,"
-                " or copy this URL into a browser on another computer."
-            ),
+        header = _("To continue, you must visit the following URL:")
+        footer = _(
+            "You can launch a browser now,"
+            " or copy this URL into a browser on another computer."
         )
+        text = f"{header}\n\n  {url}\n\n{footer}"
 
         answer = self.ui_question_choice(
             text, [_("Launch a browser now")], False

--- a/bin/apport-retrace
+++ b/bin/apport-retrace
@@ -271,19 +271,19 @@ def get_code(srcdir, filename, line, context=5):
 
     files = find_file_dir(filename, srcdir, 1)
     if not files:
-        return "  [Error: %s was not found in source tree]\n" % filename
+        return f"  [Error: {filename} was not found in source tree]\n"
 
     result = ""
     lineno = 0
     # make enough room for all line numbers
-    format_str = "  %%%ii: %%s" % len(str(line + context))
+    width = len(str(line + context))
 
     with open(files[0], "rb") as f:
         for ln in f:
             ln = ln.decode("UTF8", errors="replace")
             lineno += 1
             if line - context <= lineno <= line + context:
-                result += format_str % (lineno, ln)
+                result += f"  {lineno:{width}d}: {ln}"
 
     return result
 
@@ -315,17 +315,14 @@ def gen_source_stacktrace(report, sandbox):
         for frame in report["Stacktrace"].splitlines():
             m = src_frame.match(frame)
             if m:
-                result += (
-                    frame
-                    + "\n"
-                    + get_code(
-                        srcdir, os.path.basename(m.group(1)), int(m.group(2))
-                    )
+                code = get_code(
+                    srcdir, os.path.basename(m.group(1)), int(m.group(2))
                 )
+                result += f"{frame}\n{code}"
             else:
                 m = other_frame.search(frame)
                 if m:
-                    result += frame + "\n"
+                    result += f"{frame}\n"
 
         report["StacktraceSource"] = result
     finally:
@@ -402,19 +399,18 @@ def main():
                 )
                 crashdb.mark_retrace_failed(
                     options.report,
-                    """Thank you for your report!
+                    f"""Thank you for your report!
 
 However, processing it in order to get sufficient information for the
 developers failed, since the report is ill-formed. Perhaps the report data got
 modified?
 
-  %s
+  {str(error)}
 
 If you encounter the crash again, please file a new report.
 
 Thank you for your understanding, and sorry for the inconvenience!
-"""
-                    % str(error),
+""",
                 )
                 sys.exit(0)
             else:
@@ -480,10 +476,9 @@ Thank you for your understanding, and sorry for the inconvenience!
 
     if options.sandbox:
         if options.sandbox_dir:
-            sandbox_dir = "%s/%s/%s/report-sandbox/" % (
-                options.sandbox_dir,
-                report["DistroRelease"],
-                report["Architecture"],
+            sandbox_dir = (
+                f"{options.sandbox_dir}/{report['DistroRelease']}"
+                f"/{report['Architecture']}/report-sandbox/"
             )
         else:
             sandbox_dir = None
@@ -519,10 +514,9 @@ Thank you for your understanding, and sorry for the inconvenience!
             # ExecPath
             fake_report["ProcMaps"] = "\n\n"
             if options.sandbox_dir:
-                gdb_sandbox_dir = "%s/%s/%s/gdb-sandbox/" % (
-                    options.sandbox_dir,
-                    report["DistroRelease"],
-                    system_arch,
+                gdb_sandbox_dir = (
+                    f"{options.sandbox_dir}/{report['DistroRelease']}"
+                    f"/{system_arch}/gdb-sandbox/"
                 )
             else:
                 gdb_sandbox_dir = None
@@ -543,16 +537,16 @@ Thank you for your understanding, and sorry for the inconvenience!
         if report["DistroRelease"][-5:] in ("18.04", "20.04"):
             if gdb_sandbox and sandbox:
                 machine = report["Uname"].split()[-1]
-                target = "%s-linux-gnu" % machine
-                if not os.path.exists("/usr/lib/debug/.dwz/%s" % target):
+                target = f"{machine}-linux-gnu"
+                if not os.path.exists(f"/usr/lib/debug/.dwz/{target}"):
                     # don't create a broken symlink
                     if os.path.exists(
-                        "%s/usr/lib/debug/.dwz/%s" % (sandbox, target)
+                        f"{sandbox}/usr/lib/debug/.dwz/{target}"
                     ):
                         try:
                             os.symlink(
-                                "%s/usr/lib/debug/.dwz/%s" % (sandbox, target),
-                                "/usr/lib/debug/.dwz/%s" % target,
+                                f"{sandbox}/usr/lib/debug/.dwz/{target}",
+                                f"/usr/lib/debug/.dwz/{target}",
                             )
                         except PermissionError:
                             print(
@@ -564,15 +558,13 @@ Thank you for your understanding, and sorry for the inconvenience!
                             )
                             sys.exit(0)
                         except FileExistsError:
-                            if os.readlink(
-                                "/usr/lib/debug/.dwz/%s" % target
-                            ) == "%s/usr/lib/debug/.dwz/%s" % (
-                                sandbox,
-                                target,
+                            if (
+                                os.readlink(f"/usr/lib/debug/.dwz/{target}")
+                                == f"{sandbox}/usr/lib/debug/.dwz/{target}"
                             ):
                                 pass
                 else:
-                    if not os.path.islink("/usr/lib/debug/.dwz/%s" % target):
+                    if not os.path.islink(f"/usr/lib/debug/.dwz/{target}"):
                         print(
                             "apport is unlikely to produce a quality retrace"
                             " if it can not create a symlink in the host"
@@ -593,10 +585,10 @@ Thank you for your understanding, and sorry for the inconvenience!
                 if cmd:
                     cmd += " "
                 if " " in w:
-                    cmd += "'" + w + "'"
+                    cmd += f"'{w}'"
                 else:
                     cmd += w
-            apport.log("Calling gdb command: " + cmd, options.timestamps)
+            apport.log(f"Calling gdb command: {cmd}", options.timestamps)
         apport.memdbg("before calling gdb")
         subprocess.call(gdb_cmd, env=os.environ | environ)
     else:
@@ -631,10 +623,10 @@ Thank you for your understanding, and sorry for the inconvenience!
 
     # Cleanup the .dwz machine symlink for LP: #1818918
     if gdb_sandbox and sandbox and target:
-        if os.path.exists(
-            "/usr/lib/debug/.dwz/%s" % target
-        ) and os.path.islink("/usr/lib/debug/.dwz/%s" % target):
-            os.unlink("/usr/lib/debug/.dwz/%s" % target)
+        if os.path.exists(f"/usr/lib/debug/.dwz/{target}") and os.path.islink(
+            f"/usr/lib/debug/.dwz/{target}"
+        ):
+            os.unlink(f"/usr/lib/debug/.dwz/{target}")
 
     modified = False
 
@@ -665,23 +657,15 @@ Thank you for your understanding, and sorry for the inconvenience!
                     res = crashdb.check_duplicate(int(crashid), report)
                     if res:
                         if res[1] is None:
-                            apport.log(
-                                "Report is a duplicate of #%i (not fixed yet)"
-                                % res[0],
-                                options.timestamps,
-                            )
+                            version = "not fixed yet"
                         elif res[1] == "":
-                            apport.log(
-                                "Report is a duplicate of #%i"
-                                " (fixed in latest version)" % res[0],
-                                options.timestamps,
-                            )
+                            version = "fixed in latest version"
                         else:
-                            apport.log(
-                                "Report is a duplicate of #%i"
-                                " (fixed in version %s)" % res,
-                                options.timestamps,
-                            )
+                            version = f"fixed in version {res[1]}"
+                        apport.log(
+                            f"Report is a duplicate of #{res[0]} ({version})",
+                            options.timestamps,
+                        )
                         update_bug = False
                     else:
                         apport.log(
@@ -705,23 +689,20 @@ Thank you for your understanding, and sorry for the inconvenience!
 
                     if not report.has_useful_stacktrace():
                         if outdated_msg:
-                            invalid_msg = (
-                                """Thank you for your report!
+                            invalid_msg = f"""Thank you for your report!
 
 However, processing it in order to get sufficient information for the
 developers failed (it does not generate a useful symbolic stack trace). This
 might be caused by some outdated packages which were installed on your system
 at the time of the report:
 
-%s
+{outdated_msg}
 
 Please upgrade your system to the latest package versions. If you still
 encounter the crash, please file a new report.
 
 Thank you for your understanding, and sorry for the inconvenience!
 """
-                                % outdated_msg
-                            )
                             apport.log(
                                 "No crash signature and outdated packages,"
                                 " invalidating report",

--- a/bin/apport-valgrind
+++ b/bin/apport-valgrind
@@ -119,8 +119,8 @@ options = parse_options()
 
 try:
     apport.memdbg("start")
-    apport.memdbg("Executable: " + options.exe)
-    apport.memdbg("Command arguments: " + str(options))
+    apport.memdbg(f"Executable: {options.exe}")
+    apport.memdbg(f"Command arguments: {str(options)}")
 
     gettext.textdomain("apport")
 
@@ -195,10 +195,10 @@ try:
     # prep to run valgrind
     argv = ["valgrind"]
     argv += ["-v", "--tool=memcheck", "--leak-check=full", "--num-callers=40"]
-    argv += ["--log-file=%s" % options.log]
+    argv += [f"--log-file={options.log}"]
     argv += ["--track-origins=yes"]
     if not options.no_sandbox:
-        argv += ["--extra-debuginfo-path=%s/usr/lib/debug/" % debugrootdir]
+        argv += [f"--extra-debuginfo-path={debugrootdir}/usr/lib/debug/"]
     argv += [exepath]
 
     apport.memdbg("before calling valgrind")

--- a/bin/crash-digger
+++ b/bin/crash-digger
@@ -65,14 +65,14 @@ class CrashDigger:  # pylint: disable=too-many-instance-attributes
         if config_dir:
             self.releases = os.listdir(config_dir)
             self.releases.sort()
-            apport.log("Available releases: %s" % str(self.releases), True)
+            apport.log(f"Available releases: {str(self.releases)}", True)
         else:
             self.releases = None
 
         if self.dup_db:
             self.crashdb.init_duplicate_db(self.dup_db)
             # this verified DB integrity; make a backup now
-            shutil.copy2(self.dup_db, self.dup_db + ".backup")
+            shutil.copy2(self.dup_db, f"{self.dup_db}.backup")
 
     def fill_pool(self):
         """Query crash db for new IDs to process."""
@@ -80,14 +80,13 @@ class CrashDigger:  # pylint: disable=too-many-instance-attributes
         if self.dupcheck_mode:
             self.dupcheck_pool.update(self.crashdb.get_dup_unchecked())
             apport.log(
-                "fill_pool: dup check pool now: %s" % str(self.dupcheck_pool),
+                f"fill_pool: dup check pool now: {str(self.dupcheck_pool)}",
                 True,
             )
         else:
             self.retrace_pool.update(self.crashdb.get_unretraced())
             apport.log(
-                "fill_pool: retrace pool now: %s" % str(self.retrace_pool),
-                True,
+                f"fill_pool: retrace pool now: {str(self.retrace_pool)}", True
             )
 
     def retrace_next(self):
@@ -95,8 +94,8 @@ class CrashDigger:  # pylint: disable=too-many-instance-attributes
 
         crash_id = self.retrace_pool.pop()
         apport.log(
-            "retracing %s#%i (left in pool: %i)"
-            % ("LP: " if self.lp else "", crash_id, len(self.retrace_pool)),
+            f"retracing {'LP: ' if self.lp else ''}#{crash_id}"
+            f" (left in pool: {len(self.retrace_pool)})",
             True,
         )
 
@@ -110,8 +109,8 @@ class CrashDigger:  # pylint: disable=too-many-instance-attributes
             return
         if rel not in self.releases:
             apport.log(
-                "crash is release %s which does not have a config available,"
-                " skipping" % rel,
+                f"crash is release {rel} which does not have a config"
+                f" available, skipping",
                 True,
             )
             return
@@ -139,8 +138,8 @@ class CrashDigger:  # pylint: disable=too-many-instance-attributes
         )
         if result != 0:
             apport.log(
-                "retracing %s#%i failed with status: %i"
-                % ("LP: " if self.lp else "", crash_id, result),
+                f"retracing {'LP: ' if self.lp else ''}#{crash_id} failed"
+                f" with status: {result}",
                 True,
             )
             if result == 99:
@@ -155,8 +154,8 @@ class CrashDigger:  # pylint: disable=too-many-instance-attributes
 
         crash_id = self.dupcheck_pool.pop()
         apport.log(
-            "checking %s#%i for duplicate (left in pool: %i)"
-            % ("LP: " if self.lp else "", crash_id, len(self.dupcheck_pool)),
+            f"checking {'LP: ' if self.lp else ''}#{crash_id} for duplicate"
+            f" (left in pool: {len(self.dupcheck_pool)})",
             True,
         )
 
@@ -174,33 +173,24 @@ class CrashDigger:  # pylint: disable=too-many-instance-attributes
                 str(error)
                 == "bug description must contain standard apport format data"
             ):
-                apport.log("Cannot download report: " + str(error), True)
+                apport.log(f"Cannot download report: {str(error)}", True)
                 apport.error(
                     "Cannot download report %s: %s", crash_id, str(error)
                 )
                 return
-            apport.log("Cannot download report: " + str(error), True)
+            apport.log(f"Cannot download report: {str(error)}", True)
             apport.error("Cannot download report %i: %s", crash_id, str(error))
             return
 
         res = self.crashdb.check_duplicate(crash_id, report)
         if res:
             if res[1] is None:
-                apport.log(
-                    "Report is a duplicate of #%i (not fixed yet)" % res[0],
-                    True,
-                )
+                version = "not fixed yet"
             elif res[1] == "":
-                apport.log(
-                    "Report is a duplicate of #%i (fixed in latest version)"
-                    % res[0],
-                    True,
-                )
+                version = "fixed in latest version"
             else:
-                apport.log(
-                    "Report is a duplicate of #%i (fixed in version %s)" % res,
-                    True,
-                )
+                version = f"fixed in version {res[1]}"
+            apport.log(f"Report is a duplicate of #{res[0]} ({version})", True)
         else:
             apport.log("Duplicate check negative", True)
 
@@ -319,7 +309,7 @@ def main():
             lock_file = os.open(
                 opts.lockfile, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o666
             )
-            os.write(lock_file, ("%u\n" % os.getpid()).encode())
+            os.write(lock_file, (f"{os.getpid()}\n").encode())
             os.close(lock_file)
         except OSError as error:
             if error.errno == errno.EEXIST:

--- a/bin/dupdb-admin
+++ b/bin/dupdb-admin
@@ -28,14 +28,14 @@ def command_dump(crashdb, _):
     for sig, (crash_id, version, lastchange) in crashdb.duplicate_db_dump(
         True
     ).items():
-        sys.stdout.write("%7i: %s " % (crash_id, sig))
+        sys.stdout.write(f"{crash_id:7d}: {sig} ")
         if version == "":
             sys.stdout.write("[fixed] ")
         elif version:
-            sys.stdout.write("[fixed in: %s] " % version)
+            sys.stdout.write(f"[fixed in: {version}] ")
         else:
             sys.stdout.write("[open] ")
-        print("last change: %s" % str(lastchange))
+        print(f"last change: {str(lastchange)}")
 
 
 def command_changeid(crashdb, args):

--- a/data/apportcheckresume
+++ b/data/apportcheckresume
@@ -30,9 +30,9 @@ def main(argv=None):
         report = apport.report.Report(problem_type="KernelOops")
 
         libdir = "/var/lib/pm-utils"
-        flagfile = libdir + "/status"
-        stresslog = libdir + "/stress.log"
-        hanglog = libdir + "/resume-hang.log"
+        flagfile = f"{libdir}/status"
+        stresslog = f"{libdir}/stress.log"
+        hanglog = f"{libdir}/resume-hang.log"
 
         report.add_os_info()
         report.add_proc_info()
@@ -86,8 +86,8 @@ def main(argv=None):
             return 0
 
         nowtime = datetime.datetime.now()
-        pr_filename = "/var/crash/susres.%s.crash" % (
-            str(nowtime).replace(" ", "_")
+        pr_filename = (
+            f"/var/crash/susres.{str(nowtime).replace(' ', '_')}.crash"
         )
         with os.fdopen(
             os.open(pr_filename, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o640),

--- a/data/dump_acpi_tables.py
+++ b/data/dump_acpi_tables.py
@@ -13,7 +13,7 @@ def dump_acpi_table(filename, tablename, out):
     if not os.access(filename, os.R_OK):
         return
 
-    out.write("%s @ 0x0000000000000000\n" % tablename[0:4])
+    out.write(f"{tablename[0:4]} @ 0x0000000000000000\n")
     n = 0
     with open(filename, "rb") as f:
         hex_str = ""
@@ -23,25 +23,25 @@ def dump_acpi_table(filename, tablename, out):
                 val = ord(byte)
                 if (n & 15) == 0:
                     if n > 65535:
-                        hex_str = "   %4.4X: " % n
+                        hex_str = f"   {n:04X}: "
                     else:
-                        hex_str = "    %4.4X: " % n
+                        hex_str = f"    {n:04X}: "
                     ascii_str = ""
 
-                hex_str = hex_str + "%2.2X " % val
+                hex_str = f"{hex_str}{val:02X} "
 
                 if (val < 32) or (val > 126):
-                    ascii_str = ascii_str + "."
+                    ascii_str = f"{ascii_str}."
                 else:
                     ascii_str = ascii_str + chr(val)
                 n = n + 1
                 if (n & 15) == 0:
-                    out.write("%s %s\n" % (hex_str, ascii_str))
+                    out.write(f"{hex_str} {ascii_str}\n")
                 byte = f.read(1)
         finally:
             if (n % 16) != 0:
                 hex_str += "   " * (16 - n % 16)
-                out.write("%s %s\n" % (hex_str, ascii_str))
+                out.write(f"{hex_str} {ascii_str}\n")
 
     out.write("\n")
 

--- a/data/gcc_ice_hook
+++ b/data/gcc_ice_hook
@@ -18,7 +18,7 @@ import apport.fileutils
 
 # parse command line arguments
 if len(sys.argv) != 3:
-    print("Usage: %s <executable name> <gcc -E output file>" % sys.argv[0])
+    print(f"Usage: {sys.argv[0]} <executable name> <gcc -E output file>")
     print(
         'If "-" is specified as second argument,'
         " the preprocessed source is read from stdin."

--- a/data/iwlwifi_error_dump
+++ b/data/iwlwifi_error_dump
@@ -23,9 +23,7 @@ if len(sys.argv) != 2:
     sys.exit(1)
 
 phy = os.path.basename(sys.argv[1])
-sysfs_path = (
-    "/sys/kernel/debug/ieee80211/" + phy + "/iwlwifi/iwlmvm/fw_error_dump"
-)
+sysfs_path = f"/sys/kernel/debug/ieee80211/{phy}/iwlwifi/iwlmvm/fw_error_dump"
 if not os.path.exists(sysfs_path):
     sys.exit(1)
 
@@ -50,8 +48,8 @@ if m:
 
     pr["IwlFwVersion"] = fw_version
     pr["IwlErrorCode"] = error_code
-    pr["DuplicateSignature"] = "iwlwifi:" + fw_version + ":" + error_code
-    pr["Title"] += ": " + error_code
+    pr["DuplicateSignature"] = f"iwlwifi:{fw_version}:{error_code}"
+    pr["Title"] += f": {error_code}"
 
 # Get iwl firmware dump file from debugfs
 try:

--- a/data/java_uncaught_exception
+++ b/data/java_uncaught_exception
@@ -26,7 +26,7 @@ def make_title(report):
     lines = report["StackTrace"].split("\n")
     message = lines[0].strip()
     stackframe = lines[1].strip()
-    return "%s in %s" % (message, stackframe)
+    return f"{message} in {stackframe}"
 
 
 def main():

--- a/data/kernel_crashdump
+++ b/data/kernel_crashdump
@@ -27,11 +27,11 @@ pr.add_os_info()
 vmcore_path = os.path.join(apport.fileutils.report_dir, "vmcore")
 # only accept plain files here, not symlinks; otherwise we might recursively
 # include the report, or similar DoS attacks
-if os.path.exists(vmcore_path + ".log"):
+if os.path.exists(f"{vmcore_path}.log"):
     try:
-        log_fd = os.open(vmcore_path + ".log", os.O_RDONLY | os.O_NOFOLLOW)
+        log_fd = os.open(f"{vmcore_path}.log", os.O_RDONLY | os.O_NOFOLLOW)
         pr["VmCoreLog"] = (os.fdopen(log_fd, "rb"),)
-        os.unlink(vmcore_path + ".log")
+        os.unlink(f"{vmcore_path}.log")
     except OSError as error:
         apport.fatal("Cannot open vmcore log: %s", str(error))
 
@@ -61,7 +61,7 @@ else:
             # compare against euid here so that we can test this as non-root
             if os.lstat(timedir).st_uid != os.geteuid():
                 apport.fatal("%s has unsafe permissions, ignoring", timedir)
-            report_name = package + "-" + timestamp + ".crash"
+            report_name = f"{package}-{timestamp}.crash"
             try:
                 crash_report = os.path.join(
                     apport.fileutils.report_dir, report_name

--- a/data/kernel_oops
+++ b/data/kernel_oops
@@ -38,7 +38,7 @@ pr["SourcePackage"] = "linux"
 
 pr["OopsText"] = oops
 u = os.uname()
-pr["Uname"] = "%s %s %s" % (u[0], u[2], u[4])
+pr["Uname"] = f"{u[0]} {u[2]} {u[4]}"
 
 # write report
 try:

--- a/data/unkillable_shutdown
+++ b/data/unkillable_shutdown
@@ -96,9 +96,9 @@ def do_report(pid, omit_pids):
     report["Tags"] = "shutdown-hang"
     report["Title"] = "does not terminate at computer shutdown"
     if "ExecutablePath" in report:
-        report["Title"] = (
-            os.path.basename(report["ExecutablePath"]) + " " + report["Title"]
-        )
+        report[
+            "Title"
+        ] = f"{os.path.basename(report['ExecutablePath'])} {report['Title']}"
     report["Processes"] = apport.hookutils.command_output(["ps", "aux"])
     report["InitctlList"] = apport.hookutils.command_output(
         ["initctl", "list"]

--- a/data/whoopsie-upload-all
+++ b/data/whoopsie-upload-all
@@ -44,14 +44,14 @@ def process_report(report):
     Return path of upload stamp if report was successfully processed, or None
     otherwise.
     """
-    upload_stamp = "%s.upload" % report.rsplit(".", 1)[0]
+    upload_stamp = f"{report.rsplit('.', 1)[0]}.upload"
 
     # whoopsie-upload-all is only called if autoreporting of crashes is set,
     # so its unlikely that systems with that set are interested in having the
     # .crash file around. Additionally, having .crash files left over causes
     # systemd's PathExistsGlob to be constantly triggered. See systemd issue
     # #16669 and LP: #1891657 for some details.
-    uploaded_stamp = upload_stamp + "ed"
+    uploaded_stamp = f"{upload_stamp}ed"
     if os.path.exists(uploaded_stamp) and os.path.exists(report):
         report_st = os.stat(report)
         uploaded_st = os.stat(uploaded_stamp)
@@ -83,7 +83,7 @@ def process_report(report):
             r.load(f, binary="compressed")
             report_stat = os.stat(report)
     except (MalformedProblemReport, OSError, zlib.error) as error:
-        sys.stderr.write("ERROR: cannot load %s: %s\n" % (report, str(error)))
+        sys.stderr.write(f"ERROR: cannot load {report}: {str(error)}\n")
         return None
     if r.get("ProblemType", "") != "Crash" and "ExecutablePath" not in r:
         logging.info("  skipping, not a crash")
@@ -97,8 +97,7 @@ def process_report(report):
             r.add_package_info()
         except (SystemError, ValueError) as error:
             sys.stderr.write(
-                "ERROR: cannot add package info on %s: %s\n"
-                % (report, str(error))
+                f"ERROR: cannot add package info on {report}: {str(error)}\n"
             )
             return None
         # add information from package specific hooks
@@ -106,8 +105,7 @@ def process_report(report):
             r.add_hooks_info()
         except Exception as error:  # pylint: disable=broad-except
             sys.stderr.write(
-                "WARNING: hook failed for processing %s: %s\n"
-                % (report, str(error))
+                f"WARNING: hook failed for processing {report}: {str(error)}\n"
             )
 
         try:
@@ -119,9 +117,7 @@ def process_report(report):
             # is missing or gdb is not available, but apport-retrace could
             # still process it.
             if getattr(error, "errno", None) != errno.ENOENT:
-                sys.stderr.write(
-                    "ERROR: processing %s: %s\n" % (report, str(error))
-                )
+                sys.stderr.write(f"ERROR: processing {report}: {str(error)}\n")
                 if os.path.exists(report):
                     os.unlink(report)
                 return None
@@ -156,8 +152,8 @@ def collect_info():
     """
     if os.geteuid() != 0:
         sys.stderr.write(
-            "WARNING: Not running as root, cannot process reports"
-            " which are not owned by uid %i\n" % os.getuid()
+            f"WARNING: Not running as root, cannot process reports"
+            f" which are not owned by uid {os.getuid()}\n"
         )
 
     stamps = set()
@@ -185,9 +181,9 @@ def wait_uploaded(stamps, timeout):
         # determine missing stamps
         missing = ""
         for stamp in stamps:
-            uploaded = stamp + "ed"
+            uploaded = f"{stamp}ed"
             if os.path.exists(stamp) and not os.path.exists(uploaded):
-                missing += uploaded + " "
+                missing += f"{uploaded} "
         if not missing:
             return True
 

--- a/gtk/apport-gtk
+++ b/gtk/apport-gtk
@@ -34,7 +34,7 @@ try:
     from gi.repository import GdkX11, GLib, Gtk, Wnck
 except (AssertionError, ImportError, RuntimeError) as error:
     # probably distribution upgrade or session just closing down?
-    sys.stderr.write("Cannot start: %s\n" % str(error))
+    sys.stderr.write(f"Cannot start: {str(error)}\n")
     sys.exit(1)
 
 have_display = os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY")
@@ -211,8 +211,7 @@ class GTKUserInterface(apport.ui.UserInterface):
             self.collect_called = True
             self.ui_update_view()
         self.w("title_label").set_label(
-            "<big><b>%s</b></big>"
-            % _("Send problem report to the developers?")
+            f"<big><b>{_('Send problem report to the developers?')}</b></big>"
         )
         self.w("title_label").show()
         self.w("subtitle_label").hide()
@@ -248,7 +247,7 @@ class GTKUserInterface(apport.ui.UserInterface):
         if self.allowed_to_report:
             self.w("remember_send_report_choice").show()
             self.w("send_problem_notice_label").set_label(
-                "<b>%s</b>" % self.w("send_problem_notice_label").get_label()
+                f"<b>{self.w('send_problem_notice_label').get_label()}</b>"
             )
             self.w("send_problem_notice_label").show()
             self.w("dont_send_button").grab_focus()
@@ -283,7 +282,7 @@ class GTKUserInterface(apport.ui.UserInterface):
                 icon = "distributor-logo"
                 name = os.path.basename(self.report["ExecutablePath"])
                 title = _('The program "%s" has stopped responding.') % name
-            self.w("title_label").set_label("<big><b>%s</b></big>" % title)
+            self.w("title_label").set_label(f"<big><b>{title}</b></big>")
         elif not self.report_file or report_type == "Bug":
             self.w("remember_send_report_choice").hide()
             self.w("send_problem_notice_label").hide()
@@ -292,7 +291,7 @@ class GTKUserInterface(apport.ui.UserInterface):
             self.w("ignore_future_problems").set_active(False)
             self.w("ignore_future_problems").hide()
             self.w("title_label").set_label(
-                "<big><b>%s</b></big>" % self.get_system_application_title()
+                f"<big><b>{self.get_system_application_title()}</b></big>"
             )
             self.w("subtitle_label").hide()
             icon = "distributor-logo"
@@ -324,7 +323,7 @@ class GTKUserInterface(apport.ui.UserInterface):
                     )
                 else:
                     t = _("The application %s has closed unexpectedly.") % n
-                self.w("title_label").set_label("<big><b>%s</b></big>" % t)
+                self.w("title_label").set_label(f"<big><b>{t}</b></big>")
                 self.w("subtitle_label").hide()
 
                 pid = apport.ui.get_pid(self.report)
@@ -349,7 +348,7 @@ class GTKUserInterface(apport.ui.UserInterface):
                 else:
                     title_text = self.get_system_application_title()
                 self.w("title_label").set_label(
-                    "<big><b>%s</b></big>" % title_text
+                    f"<big><b>{title_text}</b></big>"
                 )
                 self.w("subtitle_label").show()
                 self.w("subtitle_label").set_label(

--- a/kde/apport-kde
+++ b/kde/apport-kde
@@ -89,7 +89,7 @@ class Dialog(QDialog):
 
         self.setWindowTitle(title)
         if self.findChild(QLabel, "heading"):
-            self.findChild(QLabel, "heading").setText("<h2>%s</h2>" % heading)
+            self.findChild(QLabel, "heading").setText(f"<h2>{heading}</h2>")
         self.findChild(QLabel, "text").setText(text)
 
     def on_buttons_clicked(self, button):
@@ -600,7 +600,7 @@ if __name__ == "__main__":
     app.setWindowIcon(QIcon.fromTheme("apport"))
     translator = QTranslator()
     translator.load(
-        "qtbase_" + QLocale.system().name(),
+        f"qtbase_{QLocale.system().name()}",
         QLibraryInfo.location(QLibraryInfo.TranslationsPath),
     )
     app.installTranslator(translator)

--- a/problem_report.py
+++ b/problem_report.py
@@ -271,18 +271,12 @@ class ProblemReport(collections.UserDict):
                 else:
                     break
         if missing_keys:
-            raise KeyError(
-                "Cannot find %s in report" % ", ".join(missing_keys)
-            )
+            raise KeyError(f"Cannot find {', '.join(missing_keys)} in report")
         if False in b64_block.values():
-            raise ValueError(
-                "%s has no binary content"
-                % [
-                    item
-                    for item, element in b64_block.items()
-                    if element is False
-                ]
-            )
+            items = [
+                item for item, element in b64_block.items() if element is False
+            ]
+            raise ValueError(f"{items} has no binary content")
 
     def get_tags(self) -> set[str]:
         """Return the set of tags."""
@@ -470,8 +464,8 @@ class ProblemReport(collections.UserDict):
                 if len(v) >= 4 and v[3]:
                     if size == 0:
                         raise OSError(
-                            "did not get any data for field %s from %s"
-                            % (k, str(v[0]))
+                            f"did not get any data"
+                            f" for field {k} from {str(v[0])}"
                         )
 
             # flush compressor and write the rest
@@ -735,8 +729,8 @@ class ProblemReport(collections.UserDict):
         assert hasattr(k, "isalnum")
         if not k.replace(".", "").replace("-", "").replace("_", "").isalnum():
             raise ValueError(
-                "key '%s' contains invalid characters"
-                " (only numbers, letters, '.', '_', and '-' are allowed)" % k
+                f"key '{k}' contains invalid characters"
+                f" (only numbers, letters, '.', '_', and '-' are allowed)"
             )
         # value must be a string or a CompressedValue or a file reference
         # (tuple (string|file [, bool, [, max_size [, fail_on_empty]]]))
@@ -753,8 +747,8 @@ class ProblemReport(collections.UserDict):
             )
         ):
             raise TypeError(
-                "value for key %s must be a string, CompressedValue,"
-                " or a file reference" % k
+                f"value for key {k} must be a string, CompressedValue,"
+                f" or a file reference"
             )
 
         return self.data.__setitem__(k, v)

--- a/setup.py
+++ b/setup.py
@@ -109,7 +109,7 @@ class install_fix_hashbangs(DistUtilsExtra.auto.install_auto):
     def run(self):
         DistUtilsExtra.auto.install_auto.run(self)
         self._fix_symlinks_in_bash_completion()
-        new_hashbang = "#!%s\n" % sys.executable.rsplit(".", 1)[0]
+        new_hashbang = f"#!{sys.executable.rsplit('.', 1)[0]}\n"
 
         for d in (
             os.path.join(self.install_data, "share", "apport"),

--- a/tests/integration/test_apport_valgrind.py
+++ b/tests/integration/test_apport_valgrind.py
@@ -142,10 +142,10 @@ void makeleak(void){
         logpath = os.path.join(self.workdir, "unpackaged-exe.log")
 
         cmd = ["apport-valgrind", "--no-sandbox", "-l", logpath, exepath]
-        self.assertEqual(self._call(cmd), (0, os.getcwd() + "\n", ""))
+        self.assertEqual(self._call(cmd), (0, f"{os.getcwd()}\n", ""))
         self.assertTrue(
             os.path.exists(logpath),
-            "A log file %s should exist but does not" % logpath,
+            f"A log file {logpath} should exist but does not",
         )
 
         with open(logpath, encoding="utf-8") as log_file:

--- a/tests/integration/test_crash_digger.py
+++ b/tests/integration/test_crash_digger.py
@@ -32,6 +32,7 @@ class T(unittest.TestCase):
 
         crashdb_conf = os.path.join(self.workdir, "crashdb.conf")
         with open(crashdb_conf, "w", encoding="utf-8") as f:
+            # pylint: disable=consider-using-f-string
             f.write(
                 textwrap.dedent(
                     """\
@@ -106,7 +107,7 @@ class T(unittest.TestCase):
                 self.lock_file,
             ]
         )
-        self.assertEqual(err, "", "no error messages:\n" + err)
+        self.assertEqual(err, "", f"no error messages:\n{err}")
         self.assertIn("Available releases: ['Testux 1.0', 'Testux 2.2']", out)
         self.assertIn("retracing #0", out)
         self.assertIn("retracing #1", out)
@@ -135,7 +136,7 @@ class T(unittest.TestCase):
     def test_crashes_error(self):
         """Crash retracing if apport-retrace fails on bug #1."""
         # make apport-retrace fail on bug 1
-        os.rename(self.apport_retrace, self.apport_retrace + ".bak")
+        os.rename(self.apport_retrace, f"{self.apport_retrace}.bak")
         with open(self.apport_retrace, "w", encoding="utf-8") as f:
             f.write(
                 textwrap.dedent(
@@ -187,12 +188,12 @@ class T(unittest.TestCase):
         self.assertIn("dup.db -v 2\n", retrace_log)
         self.assertFalse(os.path.exists(self.lock_file))
 
-        os.rename(self.apport_retrace + ".bak", self.apport_retrace)
+        os.rename(f"{self.apport_retrace}.bak", self.apport_retrace)
 
     def test_crashes_transient_error(self):
         """Crash retracing if apport-retrace reports a transient error."""
         # make apport-retrace fail on bug 1
-        os.rename(self.apport_retrace, self.apport_retrace + ".bak")
+        os.rename(self.apport_retrace, f"{self.apport_retrace}.bak")
         with open(self.apport_retrace, "w", encoding="utf-8") as f:
             f.write(
                 textwrap.dedent(
@@ -249,7 +250,7 @@ class T(unittest.TestCase):
                 self.lock_file,
             ]
         )
-        self.assertEqual(err, "", "no error messages:\n" + err)
+        self.assertEqual(err, "", f"no error messages:\n{err}")
         self.assertNotIn("#1", out, "signal crashes are not retraced")
         self.assertNotIn("#2", out, "signal crashes are not retraced")
         self.assertIn("checking #3 for duplicate", out)
@@ -274,7 +275,7 @@ class T(unittest.TestCase):
                 self.lock_file,
             ]
         )
-        self.assertEqual(err, "", "no error messages:\n" + err)
+        self.assertEqual(err, "", f"no error messages:\n{err}")
         self.assertIn("ApportRetraceError", out)
 
     def test_publish_db(self):
@@ -293,7 +294,7 @@ class T(unittest.TestCase):
                 os.path.join(self.workdir, "dupdb"),
             ]
         )
-        self.assertEqual(err, "", "no error messages:\n" + err)
+        self.assertEqual(err, "", f"no error messages:\n{err}")
         self.assertIn("retracing #0", out)
 
         self.assertTrue(
@@ -315,7 +316,7 @@ class T(unittest.TestCase):
                 "empty",
             ]
         )
-        self.assertEqual(err, "", "no error messages:\n" + err)
+        self.assertEqual(err, "", f"no error messages:\n{err}")
         self.assertNotIn("retracing #", out)
         self.assertNotIn("crash is", out)
         self.assertNotIn("failed with status", out)
@@ -333,6 +334,6 @@ class T(unittest.TestCase):
                 "nonexisting",
             ]
         )
-        self.assertEqual(out, "", "no output messages:\n" + out)
+        self.assertEqual(out, "", f"no output messages:\n{out}")
         self.assertNotIn("Traceback", err)
         self.assertIn("nonexisting", err)

--- a/tests/integration/test_fileutils.py
+++ b/tests/integration/test_fileutils.py
@@ -116,24 +116,24 @@ class T(unittest.TestCase):
             self.assertEqual(
                 apport.fileutils.find_package_desktopfile(nodesktop),
                 None,
-                "no-desktop package %s" % nodesktop,
+                f"no-desktop package {nodesktop}",
             )
         if multidesktop:
             self.assertEqual(
                 apport.fileutils.find_package_desktopfile(multidesktop),
                 None,
-                "multi-desktop package %s" % multidesktop,
+                f"multi-desktop package {multidesktop}",
             )
         if onedesktop:
             d = apport.fileutils.find_package_desktopfile(onedesktop)
-            self.assertNotEqual(d, None, "one-desktop package %s" % onedesktop)
+            self.assertNotEqual(d, None, f"one-desktop package {onedesktop}")
             self.assertTrue(os.path.exists(d))
             self.assertTrue(d.endswith(".desktop"))
         if nodisplay:
             self.assertEqual(
                 apport.fileutils.find_package_desktopfile(nodisplay),
                 None,
-                "NoDisplay package %s" % nodisplay,
+                f"NoDisplay package {nodisplay}",
             )
 
     def test_find_file_package(self):
@@ -176,7 +176,7 @@ class T(unittest.TestCase):
         pr["ExecutablePath"] = "/bin/bash"
         apport.fileutils.mark_hanging_process(pr, "1")
         uid = str(os.getuid())
-        base = "_bin_bash.%s.1.hanging" % uid
+        base = f"_bin_bash.{uid}.1.hanging"
         expected = os.path.join(apport.fileutils.report_dir, base)
         self.assertTrue(os.path.exists(expected))
 
@@ -305,7 +305,7 @@ class T(unittest.TestCase):
         with apport.fileutils.make_report_file(pr) as f:
             path = f.name
             self.assertTrue(
-                path.startswith("%s/bash" % apport.fileutils.report_dir), path
+                path.startswith(f"{apport.fileutils.report_dir}/bash"), path
             )
             os.unlink(path)
 
@@ -313,7 +313,7 @@ class T(unittest.TestCase):
         with apport.fileutils.make_report_file(pr) as f:
             path = f.name
             self.assertTrue(
-                path.startswith("%s/_bin_bash" % apport.fileutils.report_dir),
+                path.startswith(f"{apport.fileutils.report_dir}/_bin_bash"),
                 path,
             )
 
@@ -337,10 +337,9 @@ class T(unittest.TestCase):
         # use one relative and one absolute path in checksums file
         with open(sumfile, "w", encoding="utf-8") as fd:
             fd.write(
-                """2e41290da2fa3f68bd3313174467e3b5  %s
-f6423dfbc4faf022e58b4d3f5ff71a70  %s
+                f"""2e41290da2fa3f68bd3313174467e3b5  {f1[1:]}
+f6423dfbc4faf022e58b4d3f5ff71a70  {f2}
 """
-                % (f1[1:], f2)
             )
         self.assertEqual(
             apport.fileutils.check_files_md5(sumfile), [], "correct md5sums"
@@ -492,7 +491,7 @@ f6423dfbc4faf022e58b4d3f5ff71a70  %s
         (core_name, core_path) = apport.fileutils.get_core_path(
             pid=123, exe="/usr/bin/test", uid=234, timestamp=222222
         )
-        expected = "core._usr_bin_test.234." + boot_id + ".123.222222"
+        expected = f"core._usr_bin_test.234.{boot_id}.123.222222"
         expected_path = os.path.join(apport.fileutils.core_dir, expected)
         self.assertEqual(core_name, expected)
         self.assertEqual(core_path, expected_path)
@@ -501,7 +500,7 @@ f6423dfbc4faf022e58b4d3f5ff71a70  %s
         (core_name, core_path) = apport.fileutils.get_core_path(
             pid=123, exe="/usr/bin/test.sh", uid=234, timestamp=222222
         )
-        expected = "core._usr_bin_test_sh.234." + boot_id + ".123.222222"
+        expected = f"core._usr_bin_test_sh.234.{boot_id}.123.222222"
         expected_path = os.path.join(apport.fileutils.core_dir, expected)
         self.assertEqual(core_name, expected)
         self.assertEqual(core_path, expected_path)
@@ -510,7 +509,7 @@ f6423dfbc4faf022e58b4d3f5ff71a70  %s
         (core_name, core_path) = apport.fileutils.get_core_path(
             pid=123, exe=None, uid=234, timestamp=222222
         )
-        expected = "core.unknown.234." + boot_id + ".123.222222"
+        expected = f"core.unknown.234.{boot_id}.123.222222"
         expected_path = os.path.join(apport.fileutils.core_dir, expected)
         self.assertEqual(core_name, expected)
         self.assertEqual(core_path, expected_path)
@@ -520,11 +519,7 @@ f6423dfbc4faf022e58b4d3f5ff71a70  %s
             pid=123, exe="/usr/bin/test", uid=None, timestamp=222222
         )
         expected = (
-            "core._usr_bin_test."
-            + str(os.getuid())
-            + "."
-            + boot_id
-            + ".123.222222"
+            f"core._usr_bin_test.{str(os.getuid())}.{boot_id}.123.222222"
         )
         expected_path = os.path.join(apport.fileutils.core_dir, expected)
         self.assertEqual(core_name, expected)

--- a/tests/integration/test_hooks.py
+++ b/tests/integration/test_hooks.py
@@ -80,7 +80,7 @@ class T(unittest.TestCase):
 
         self.assertEqual(r["ProblemType"], "Package")
         self.assertEqual(
-            r["Package"], "bash " + apport.packaging.get_version("bash")
+            r["Package"], f"bash {apport.packaging.get_version('bash')}"
         )
         self.assertEqual(r["ErrorMessage"], "something is wrong")
 
@@ -105,7 +105,7 @@ class T(unittest.TestCase):
             r.load(f)
 
         self.assertEqual(r["ProblemType"], "Package")
-        self.assertEqual(r["Package"], pkg + " (not installed)")
+        self.assertEqual(r["Package"], f"{pkg} (not installed)")
         self.assertEqual(r["ErrorMessage"], "something is wrong")
 
     def test_package_hook_logs(self):
@@ -252,7 +252,7 @@ class T(unittest.TestCase):
         vmcore_dir = os.path.join(apport.fileutils.report_dir, timedir)
         os.mkdir(vmcore_dir)
 
-        dmesgfile = os.path.join(vmcore_dir, "dmesg." + timedir)
+        dmesgfile = os.path.join(vmcore_dir, f"dmesg.{timedir}")
         with open(dmesgfile, "wt", encoding="utf-8") as dmesg:
             dmesg.write("1" * 100)
 
@@ -326,7 +326,7 @@ class T(unittest.TestCase):
         vmcore_dir = os.path.join(apport.fileutils.report_dir, timedir)
         os.mkdir(vmcore_dir)
 
-        dmesgfile = os.path.join(vmcore_dir, "dmesg." + timedir)
+        dmesgfile = os.path.join(vmcore_dir, f"dmesg.{timedir}")
         os.symlink("../kernel.crash", dmesgfile)
 
         self.assertNotEqual(
@@ -347,13 +347,13 @@ class T(unittest.TestCase):
             datetime.datetime.now(), "%Y%m%d%H%M"
         )
         vmcore_dir = os.path.join(apport.fileutils.report_dir, timedir)
-        os.mkdir(vmcore_dir + ".real")
+        os.mkdir(f"{vmcore_dir}.real")
         # pretend that a user tries information disclosure by pre-creating a
         # symlink to another dir
-        os.symlink(vmcore_dir + ".real", vmcore_dir)
+        os.symlink(f"{vmcore_dir}.real", vmcore_dir)
         os.lchown(vmcore_dir, 65534, 65534)
 
-        dmesgfile = os.path.join(vmcore_dir, "dmesg." + timedir)
+        dmesgfile = os.path.join(vmcore_dir, f"dmesg.{timedir}")
         with open(dmesgfile, "wt", encoding="utf-8") as dmesg:
             dmesg.write("1" * 100)
 
@@ -384,11 +384,11 @@ class T(unittest.TestCase):
         ver_fields = gcc.stdout.splitlines()[0].split()[3].split(".")
         # try major/minor first
         gcc_ver = ".".join(ver_fields[:2])
-        gcc_path = "/usr/bin/gcc-" + gcc_ver
+        gcc_path = f"/usr/bin/gcc-{gcc_ver}"
         if not os.path.exists(gcc_path):
             # fall back to only major
             gcc_ver = ver_fields[0]
-            gcc_path = "/usr/bin/gcc-" + gcc_ver
+            gcc_path = f"/usr/bin/gcc-{gcc_ver}"
 
         subprocess.run(
             [gcc_path, "--version"], check=True, stdout=subprocess.PIPE
@@ -432,7 +432,7 @@ class T(unittest.TestCase):
 
             r.add_package_info()
 
-        self.assertEqual(r["Package"].split()[0], "gcc-" + gcc_version)
+        self.assertEqual(r["Package"].split()[0], f"gcc-{gcc_version}")
         self.assertNotEqual(r["Package"].split()[1], "")  # has package version
         self.assertIn("libc", r["Dependencies"])
 
@@ -495,7 +495,7 @@ class T(unittest.TestCase):
 
         r.add_package_info()
 
-        self.assertEqual(r["Package"].split()[0], "gcc-" + gcc_version)
+        self.assertEqual(r["Package"].split()[0], f"gcc-{gcc_version}")
 
     def test_kernel_oops_hook(self):
         test_source = """------------[ cut here ]------------

--- a/tests/integration/test_hookutils.py
+++ b/tests/integration/test_hookutils.py
@@ -32,7 +32,7 @@ class T(unittest.TestCase):
         def _build_ko(license_name):
             ko_filename = os.path.join(self.workdir, f"{license_name}.ko")
             with tempfile.NamedTemporaryFile(
-                mode="w+", prefix="%s-" % (license_name), suffix=".S"
+                mode="w+", prefix=f"{license_name}-", suffix=".S"
             ) as asm:
                 asm.write(
                     f'.section .modinfo\n.string "license={license_name}"\n'
@@ -381,7 +381,7 @@ class T(unittest.TestCase):
         data = apport.hookutils.recent_syslog(re.compile("kernel"), path=log)
         mem_after = self._get_mem_usage()
         delta_kb = mem_after - mem_before
-        sys.stderr.write("[Δ %i kB] " % delta_kb)
+        sys.stderr.write(f"[Δ {delta_kb} kB] ")
         self.assertLess(delta_kb, 5000)
 
         self.assertTrue(

--- a/tests/integration/test_java_crashes.py
+++ b/tests/integration/test_java_crashes.py
@@ -104,8 +104,8 @@ class TestJavaCrashes(unittest.TestCase):
             )
         )
         if ".jar!" in main_file:
-            self.assertEqual(report["MainClassUrl"], "jar:file:" + main_file)
+            self.assertEqual(report["MainClassUrl"], f"jar:file:{main_file}")
         else:
-            self.assertEqual(report["MainClassUrl"], "file:" + main_file)
+            self.assertEqual(report["MainClassUrl"], f"file:{main_file}")
         self.assertIn("DistroRelease", report)
         self.assertIn("ProcCwd", report)

--- a/tests/integration/test_packaging_apt_dpkg.py
+++ b/tests/integration/test_packaging_apt_dpkg.py
@@ -185,7 +185,7 @@ class T(unittest.TestCase):
             os.makedirs(mapdir)
             with gzip.open(
                 os.path.join(
-                    mapdir, "Contents-%s.gz" % impl.get_system_architecture()
+                    mapdir, f"Contents-{impl.get_system_architecture()}.gz"
                 ),
                 "w",
             ) as f:
@@ -200,12 +200,12 @@ bin/true                                                admin/superutils
 
             # test Contents.gz for -updates pocket
             mapdir = os.path.join(
-                basedir, "dists", impl.get_distro_codename() + "-updates"
+                basedir, "dists", f"{impl.get_distro_codename()}-updates"
             )
             os.makedirs(mapdir)
             with gzip.open(
                 os.path.join(
-                    mapdir, "Contents-%s.gz" % impl.get_system_architecture()
+                    mapdir, f"Contents-{impl.get_system_architecture()}.gz"
                 ),
                 "w",
             ) as f:
@@ -215,7 +215,7 @@ bin/true                                                admin/superutils
                 )
 
             # use this as a mirror
-            impl.set_mirror("file://" + basedir)
+            impl.set_mirror(f"file://{basedir}")
 
             self.assertEqual(
                 impl.get_file_package("usr/bin/frob", False), None
@@ -242,7 +242,7 @@ bin/true                                                admin/superutils
             )
 
             # valid mirror, test cache directory
-            impl.set_mirror("file://" + basedir)
+            impl.set_mirror(f"file://{basedir}")
             cache_dir = os.path.join(basedir, "cache")
             os.mkdir(cache_dir)
             self.assertEqual(
@@ -321,7 +321,7 @@ usr/bin/frob                                            foo/frob
                 )
 
             # use this as a mirror
-            impl.set_mirror("file://" + basedir)
+            impl.set_mirror(f"file://{basedir}")
 
             # must not match system architecture
             self.assertEqual(
@@ -400,7 +400,7 @@ usr/bin/frob                                            foo/frob
             )
 
             # valid mirror, test caching
-            impl.set_mirror("file://" + basedir)
+            impl.set_mirror(f"file://{basedir}")
             cache_dir = os.path.join(basedir, "cache")
             os.mkdir(cache_dir)
             self.assertEqual(

--- a/tests/integration/test_python_crashes.py
+++ b/tests/integration/test_python_crashes.py
@@ -149,7 +149,7 @@ func(42)
             pr["ExecutableTimestamp"], str(int(os.stat(script).st_mtime))
         )
         self.assertEqual(
-            pr["PythonArgs"], "['%s', 'testarg1', 'testarg2']" % script
+            pr["PythonArgs"], f"['{script}', 'testarg1', 'testarg2']"
         )
         self.assertTrue(pr["Traceback"].startswith("Traceback"))
         self.assertIn(
@@ -304,7 +304,7 @@ func(42)
         """Assert that there are no crash reports."""
         reports = apport.fileutils.get_new_reports()
         self.assertEqual(
-            len(reports), 0, "no crash reports present (cwd: %s)" % os.getcwd()
+            len(reports), 0, f"no crash reports present (cwd: {os.getcwd()})"
         )
 
     def test_deleted_working_directory(self):
@@ -485,9 +485,7 @@ func(42)
         pr = self._load_report()
         # we expect it to append errno
         exe = pr["ExecutablePath"]
-        self.assertEqual(
-            pr.crash_signature(), "%s:OSError(99):%s@11:g" % (exe, exe)
-        )
+        self.assertEqual(pr.crash_signature(), f"{exe}:OSError(99):{exe}@11:g")
 
     def test_generic_os_error_no_errno(self):
         """Raise OSError without errno and no known subclass."""
@@ -504,9 +502,7 @@ func(42)
         pr = self._load_report()
         # we expect it to not stumble over the missing errno
         exe = pr["ExecutablePath"]
-        self.assertEqual(
-            pr.crash_signature(), "%s:OSError:%s@11:g" % (exe, exe)
-        )
+        self.assertEqual(pr.crash_signature(), f"{exe}:OSError:{exe}@11:g")
 
     def test_getcwd_error(self):
         """Raise FileNotFoundError on os.getcwd() call."""
@@ -549,7 +545,7 @@ func(42)
         # in the subclass
         exe = pr["ExecutablePath"]
         self.assertEqual(
-            pr.crash_signature(), "%s:FileNotFoundError:%s@11:g" % (exe, exe)
+            pr.crash_signature(), f"{exe}:FileNotFoundError:{exe}@11:g"
         )
 
     def _load_report(self):

--- a/tests/integration/test_recoverable_problem.py
+++ b/tests/integration/test_recoverable_problem.py
@@ -79,7 +79,7 @@ class TestRecoverableProblem(unittest.TestCase):
             report = apport.report.Report()
             report.load(report_path)
             self.assertEqual(report["hello"], "there")
-            self.assertIn("Pid:\t%d" % os.getpid(), report["ProcStatus"])
+            self.assertIn(f"Pid:\t{os.getpid()}", report["ProcStatus"])
 
     def test_recoverable_problem_dupe_sig(self):
         """recoverable_problem duplicate signature includes ExecutablePath"""
@@ -89,10 +89,8 @@ class TestRecoverableProblem(unittest.TestCase):
             report = apport.report.Report()
             report.load(report_path)
             exec_path = report.get("ExecutablePath")
-            self.assertEqual(
-                report["DuplicateSignature"], "%s:ds" % (exec_path)
-            )
-            self.assertIn("Pid:\t%d" % os.getpid(), report["ProcStatus"])
+            self.assertEqual(report["DuplicateSignature"], f"{exec_path}:ds")
+            self.assertIn(f"Pid:\t{os.getpid()}", report["ProcStatus"])
 
     def test_invalid_data(self):
         """recoverable_problem with invalid data"""

--- a/tests/integration/test_report.py
+++ b/tests/integration/test_report.py
@@ -1561,9 +1561,9 @@ int main() { return f(42); }
             r = apport.report.Report()
             r["Package"] = "foo-bin 0.2"
             r["SourcePackage"] = "foo"
-            r["ExecutablePath"] = (
-                "%s/foolabs.example.com/foo/bin/frob" % apport.report._opt_dir
-            )
+            r[
+                "ExecutablePath"
+            ] = f"{apport.report._opt_dir}/foolabs.example.com/foo/bin/frob"
 
             self.assertEqual(r.add_hooks_info(), False)
             self.assertEqual(r["SourceHook"], "1")
@@ -1850,14 +1850,15 @@ int main() { return f(42); }
         self.assertEqual(report.obsolete_packages(), ["coreutils", "cron"])
 
         report["Dependencies"] = (
-            "coreutils %s [modified: /bin/mount]\ncron 0\n"
-            % apport.packaging.get_available_version("coreutils")
+            f"coreutils {apport.packaging.get_available_version('coreutils')}"
+            f" [modified: /bin/mount]\ncron 0\n"
         )
         self.assertEqual(report.obsolete_packages(), ["cron"])
 
-        report["Dependencies"] = "coreutils %s\ncron %s\n" % (
-            apport.packaging.get_available_version("coreutils"),
-            apport.packaging.get_available_version("cron"),
+        report["Dependencies"] = (
+            f"coreutils"
+            f" {apport.packaging.get_available_version('coreutils')}\n"
+            f"cron {apport.packaging.get_available_version('cron')}\n"
         )
         self.assertEqual(report.obsolete_packages(), [])
 
@@ -1896,7 +1897,7 @@ int main() { return f(42); }
 
     def test_get_logind_session_fd(self):
         proc_pid_fd = os.open(
-            "/proc/%s" % os.getpid(), os.O_RDONLY | os.O_PATH | os.O_DIRECTORY
+            f"/proc/{os.getpid()}", os.O_RDONLY | os.O_PATH | os.O_DIRECTORY
         )
         self.addCleanup(os.close, proc_pid_fd)
         ret = apport.Report.get_logind_session(proc_pid_fd=proc_pid_fd)

--- a/tests/integration/test_signal_crashes.py
+++ b/tests/integration/test_signal_crashes.py
@@ -178,7 +178,7 @@ class T(unittest.TestCase):
             pr["ProcCmdline"],
             " ".join([self.TEST_EXECUTABLE] + self.TEST_ARGS),
         )
-        self.assertEqual(pr["Signal"], "%i" % signal.SIGSEGV)
+        self.assertEqual(pr["Signal"], f"{signal.SIGSEGV}")
 
         # check safe environment subset
         allowed_vars = [
@@ -363,8 +363,7 @@ class T(unittest.TestCase):
         )
 
         leak = os.path.join(
-            apport.fileutils.report_dir,
-            "_usr_bin_perl.%i.crash" % (os.getuid()),
+            apport.fileutils.report_dir, f"_usr_bin_perl.{os.getuid()}.crash"
         )
         pr = apport.Report()
         with open(leak, "rb") as f:
@@ -379,7 +378,7 @@ class T(unittest.TestCase):
         """Limitation of crash report flood."""
         count = 0
         while count < 7:
-            sys.stderr.write("%i " % count)
+            sys.stderr.write(f"{count} ")
             sys.stderr.flush()
             self.do_crash()
             reports = apport.fileutils.get_new_reports()
@@ -463,7 +462,7 @@ class T(unittest.TestCase):
         # as that allows us to intercept and replace the report and tinker with
         # the core dump
 
-        inject_report = self.test_report + ".inject"
+        inject_report = f"{self.test_report}.inject"
         with open(inject_report, "w", encoding="utf-8") as f:
             # \x01pwned
             f.write(
@@ -962,7 +961,7 @@ class T(unittest.TestCase):
         if args is None:
             args = self.TEST_ARGS
 
-        assert os.access(command, os.X_OK), command + " is not executable"
+        assert os.access(command, os.X_OK), f"{command} is not executable"
 
         env = os.environ.copy()
         # set UTF-8 environment variable, to check proper parsing in apport
@@ -975,7 +974,7 @@ class T(unittest.TestCase):
 
         # wait until child process has execv()ed properly
         while True:
-            with open("/proc/%i/cmdline" % process.pid, encoding="utf-8") as f:
+            with open(f"/proc/{process.pid}/cmdline", encoding="utf-8") as f:
                 cmdline = f.read()
             if "test_signal" in cmdline:
                 time.sleep(0.1)
@@ -1106,8 +1105,8 @@ class T(unittest.TestCase):
                     os.unlink(core_path)
                 except OSError as error:
                     sys.stderr.write(
-                        "WARNING: cannot clean up core file %s: %s\n"
-                        % (core_path, str(error))
+                        f"WARNING: cannot clean up core file {core_path}:"
+                        f" {str(error)}\n"
                     )
 
                 self.fail("leaves unexpected core file behind")

--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -391,7 +391,7 @@ class T(unittest.TestCase):
         # test with only ProcCmdline
         p = os.path.join(apport.fileutils.report_dir, "ProcCmdline")
         r = os.path.join(apport.fileutils.report_dir, "Custom")
-        self.report["ProcCmdline"] = "touch " + p
+        self.report["ProcCmdline"] = f"touch {p}"
         self.update_report_file()
         self.ui.load_report(self.report_file.name)
 
@@ -402,7 +402,7 @@ class T(unittest.TestCase):
         os.unlink(p)
 
         # test with RespawnCommand
-        self.report["RespawnCommand"] = "touch " + r
+        self.report["RespawnCommand"] = f"touch {r}"
         self.update_report_file()
         self.ui.load_report(self.report_file.name)
 
@@ -654,7 +654,7 @@ class T(unittest.TestCase):
         """run_report_bug() as "ubuntu-bug" with version argument"""
         self.ui = UserInterfaceMock(["ubuntu-bug", "-v"])
         self.assertEqual(self.ui.run_argv(), True)
-        self.assertEqual(stdout_mock.getvalue(), apport.ui.__version__ + "\n")
+        self.assertEqual(stdout_mock.getvalue(), f"{apport.ui.__version__}\n")
 
     def test_file_report_nodelay(self):
         """file_report() happy path without polling"""
@@ -727,7 +727,7 @@ class T(unittest.TestCase):
         self.assertTrue(self.ui.present_details_shown)
         self.assertEqual(
             self.ui.opened_url,
-            "http://bash.bugs.example.com/%i" % self.ui.crashdb.latest_id(),
+            f"http://bash.bugs.example.com/{self.ui.crashdb.latest_id()}",
         )
 
         self.assertTrue(self.ui.ic_progress_pulses > 0)
@@ -770,8 +770,7 @@ class T(unittest.TestCase):
         self.assertEqual(self.ui.msg_title, None)
         self.assertEqual(
             self.ui.opened_url,
-            "http://coreutils.bugs.example.com/%i"
-            % self.ui.crashdb.latest_id(),
+            f"http://coreutils.bugs.example.com/{self.ui.crashdb.latest_id()}",
         )
         self.assertTrue(self.ui.present_details_shown)
         self.assertTrue(self.ui.ic_progress_pulses > 0)
@@ -976,8 +975,7 @@ class T(unittest.TestCase):
         self.assertEqual(self.ui.msg_title, None)
         self.assertEqual(
             self.ui.opened_url,
-            "http://coreutils.bugs.example.com/%i"
-            % self.ui.crashdb.latest_id(),
+            f"http://coreutils.bugs.example.com/{self.ui.crashdb.latest_id()}",
         )
         self.assertFalse(self.ui.ic_progress_active)
         self.assertNotEqual(self.ui.ic_progress_pulses, 0)
@@ -1099,7 +1097,7 @@ class T(unittest.TestCase):
         self.assertIn(
             "It stinks.",
             self.ui.msg_text,
-            "%s: %s" % (self.ui.msg_title, self.ui.msg_text),
+            f"{self.ui.msg_title}: {self.ui.msg_text}",
         )
         self.assertEqual(self.ui.msg_severity, "info")
 
@@ -1125,7 +1123,7 @@ class T(unittest.TestCase):
         self.assertIn(
             "It stinks.",
             self.ui.msg_text,
-            "%s: %s" % (self.ui.msg_title, self.ui.msg_text),
+            f"{self.ui.msg_title}: {self.ui.msg_text}",
         )
         self.assertEqual(self.ui.msg_severity, "info")
 
@@ -1183,7 +1181,7 @@ class T(unittest.TestCase):
             )
             bad_hook.flush()
 
-            self.report["ExecutablePath"] = "/opt/../" + hook_dir
+            self.report["ExecutablePath"] = f"/opt/../{hook_dir}"
             self.report["Package"] = os.path.splitext(bad_hook.name)[
                 0
             ].replace(hook_dir, "")
@@ -1227,7 +1225,7 @@ class T(unittest.TestCase):
         self.assertIn(
             "memory",
             self.ui.msg_text,
-            "%s: %s" % (self.ui.msg_title, self.ui.msg_text),
+            f"{self.ui.msg_title}: {self.ui.msg_text}",
         )
 
     def test_run_crash_preretraced(self):
@@ -1254,12 +1252,8 @@ class T(unittest.TestCase):
         self.assertEqual(
             self.ui.msg_severity,
             None,
-            "has %s message: %s: %s"
-            % (
-                self.ui.msg_severity,
-                str(self.ui.msg_title),
-                str(self.ui.msg_text),
-            ),
+            f"has {self.ui.msg_severity} message:"
+            f" {self.ui.msg_title}: {self.ui.msg_text}",
         )
         self.assertEqual(self.ui.msg_title, None)
         self.assertTrue(self.ui.present_details_shown)
@@ -1292,12 +1286,8 @@ class T(unittest.TestCase):
         self.assertEqual(
             self.ui.msg_severity,
             None,
-            "has %s message: %s: %s"
-            % (
-                self.ui.msg_severity,
-                str(self.ui.msg_title),
-                str(self.ui.msg_text),
-            ),
+            f"has {self.ui.msg_severity} message:"
+            f" {self.ui.msg_title}: {self.ui.msg_text}",
         )
         self.assertTrue(
             self.ui.opened_url.startswith("http://coreutils.bugs.example.com")
@@ -1377,12 +1367,12 @@ class T(unittest.TestCase):
         self.assertIn(
             self.ui.report["ExecutablePath"],
             self.ui.msg_text,
-            "%s: %s" % (self.ui.msg_title, self.ui.msg_text),
+            f"{self.ui.msg_title}: {self.ui.msg_text}",
         )
         self.assertIn(
             "changed",
             self.ui.msg_text,
-            "%s: %s" % (self.ui.msg_title, self.ui.msg_text),
+            f"{self.ui.msg_title}: {self.ui.msg_text}",
         )
         self.assertEqual(self.ui.msg_severity, "info")
 
@@ -1421,7 +1411,7 @@ class T(unittest.TestCase):
         self.assertEqual(self.ui.msg_title, None)
         self.assertEqual(
             self.ui.opened_url,
-            "http://bash.bugs.example.com/%i" % self.ui.crashdb.latest_id(),
+            f"http://bash.bugs.example.com/{self.ui.crashdb.latest_id()}",
         )
         self.assertTrue(self.ui.present_details_shown)
 
@@ -1475,7 +1465,7 @@ class T(unittest.TestCase):
         self.assertEqual(
             self.ui.msg_severity,
             None,
-            "error: %s - %s" % (self.ui.msg_title, self.ui.msg_text),
+            f"error: {self.ui.msg_title} - {self.ui.msg_text}",
         )
         self.assertEqual(self.ui.msg_title, None)
         self.assertEqual(self.ui.opened_url, None)
@@ -1491,13 +1481,12 @@ class T(unittest.TestCase):
         self.assertEqual(
             self.ui.msg_severity,
             None,
-            str(self.ui.msg_title) + " " + str(self.ui.msg_text),
+            f"{str(self.ui.msg_title)} {str(self.ui.msg_text)}",
         )
         self.assertEqual(self.ui.msg_title, None)
         self.assertEqual(
             self.ui.opened_url,
-            "http://%s.bugs.example.com/%i"
-            % (src_pkg, self.ui.crashdb.latest_id()),
+            f"http://{src_pkg}.bugs.example.com/{self.ui.crashdb.latest_id()}",
         )
         self.assertTrue(self.ui.present_details_shown)
 
@@ -1546,14 +1535,12 @@ class T(unittest.TestCase):
         for s in self._get_sensitive_strings():
             self.assertIsNone(
                 re.search(rf"\b{re.escape(s)}\b", report),
-                "dump contains sensitive word '%s':\n%s" % (s, report),
+                f"dump contains sensitive word '{s}':\n{report}",
             )
             if s == "ubuntu" or len(s) < 5 and "/" not in s:
                 continue
             self.assertNotIn(
-                s,
-                report,
-                "dump contains sensitive string: %s:\n%s" % (s, report),
+                s, report, f"dump contains sensitive string: {s}:\n{report}"
             )
 
     def test_run_crash_anonymity_order(self):
@@ -1729,8 +1716,7 @@ class T(unittest.TestCase):
         self.ui.run_crash(report_file)
         self.assertEqual(
             self.ui.opened_url,
-            "http://coreutils.bugs.example.com/%i"
-            % self.ui.crashdb.latest_id(),
+            f"http://coreutils.bugs.example.com/{self.ui.crashdb.latest_id()}",
         )
         # internal key should not be uploaded to the crash db
         r = self.ui.crashdb.download(self.ui.crashdb.latest_id())
@@ -1893,7 +1879,7 @@ class T(unittest.TestCase):
         self.ui.present_details_response = apport.ui.Action(report=True)
 
         with open(
-            os.path.join(self.hookdir, "source_%s.py" % source_pkg),
+            os.path.join(self.hookdir, f"source_{source_pkg}.py"),
             "w",
             encoding="utf-8",
         ) as f:
@@ -1907,7 +1893,7 @@ class T(unittest.TestCase):
 
         self.assertTrue(self.ui.ic_progress_pulses > 0)
         self.assertEqual(
-            self.ui.report["Package"], "%s (not installed)" % source_pkg
+            self.ui.report["Package"], f"{source_pkg} (not installed)"
         )
         self.assertEqual(self.ui.report["MachineType"], "Laptop")
         self.assertIn("ProcEnviron", self.ui.report)
@@ -1918,7 +1904,7 @@ class T(unittest.TestCase):
         ) as hook:
             hook.write(
                 "def add_info(report, ui):\n%s\n"
-                % "\n".join(["    " + line for line in code.splitlines()])
+                % "\n".join([f"    {line}" for line in code.splitlines()])
             )
         self.ui.args.package = "coreutils"
         self.ui.run_report_bug()
@@ -2299,12 +2285,12 @@ class T(unittest.TestCase):
         for suffix in (".crash", ".apport"):
             _chk(
                 "apport-cli",
-                "/tmp/f oo" + suffix,
+                f"/tmp/f oo{suffix}",
                 {
                     "filebug": False,
                     "package": None,
                     "pid": None,
-                    "crash_file": "/tmp/f oo" + suffix,
+                    "crash_file": f"/tmp/f oo{suffix}",
                     "symptom": None,
                     "update_report": None,
                     "save": None,
@@ -2458,12 +2444,12 @@ class T(unittest.TestCase):
         # .crash/.apport files; check correct handling of spaces
         for suffix in (".crash", ".apport"):
             _chk(
-                ["/tmp/f oo" + suffix],
+                [f"/tmp/f oo{suffix}"],
                 {
                     "filebug": False,
                     "package": None,
                     "pid": None,
-                    "crash_file": "/tmp/f oo" + suffix,
+                    "crash_file": f"/tmp/f oo{suffix}",
                     "symptom": None,
                     "update_report": None,
                     "save": None,
@@ -2565,7 +2551,7 @@ class T(unittest.TestCase):
             )
             # this will only work for running the tests in the source tree
             if os.access(os.path.join(src_bindir, "apport-retrace"), os.X_OK):
-                os.environ["PATH"] += src_bindir + ":" + orig_path
+                os.environ["PATH"] += f"{src_bindir}:{orig_path}"
                 self.assertEqual(self.ui.can_examine_locally(), True)
             else:
                 # if we run tests in installed system, we just check that

--- a/tests/system/test_apport_valgrind.py
+++ b/tests/system/test_apport_valgrind.py
@@ -57,11 +57,10 @@ class TestApportValgrind(unittest.TestCase):
 
         self.assertTrue(
             os.path.exists(sandbox),
-            "A sandbox directory %s was specified but was not created"
-            % sandbox,
+            f"A sandbox directory {sandbox} was specified but was not created",
         )
 
         self.assertTrue(
             os.path.exists(cache),
-            "A cache directory %s was specified but was not created" % cache,
+            f"A cache directory {cache} was specified but was not created",
         )

--- a/tests/system/test_packaging_apt_dpkg.py
+++ b/tests/system/test_packaging_apt_dpkg.py
@@ -111,7 +111,7 @@ class T(unittest.TestCase):
         self.assertIn(f"libc6-dbg {wanted['libc6']}", pkglist)
         self.assertIn(f"libcurl4 {wanted['libcurl4']}", pkglist)
         self.assertIn(f"libcurl4-dbgsym {wanted['libcurl4']}", pkglist)
-        self.assertIn("tzdata " + sandbox_ver("tzdata"), pkglist)
+        self.assertIn(f"tzdata {sandbox_ver('tzdata')}", pkglist)
         self.assertEqual(len(pkglist), 7, str(pkglist))
 
         # does not clobber config dir
@@ -797,7 +797,7 @@ class T(unittest.TestCase):
         # changes
         self.assertTrue(
             res.endswith("/base-files-12ubuntu4"),
-            "unexpected version: " + res.split("/")[-1],
+            f"unexpected version: {res.split('/')[-1]}",
         )
 
     @unittest.skipUnless(has_internet(), "online test")
@@ -826,7 +826,7 @@ class T(unittest.TestCase):
         upstream_version = wanted_version.split("-", maxsplit=1)[0]
         self.assertTrue(
             res.endswith(f"/{wanted_package}-{upstream_version}"),
-            "unexpected version: " + res.split("/")[-1],
+            f"unexpected version: {res.split('/')[-1]}",
         )
 
     @skip_if_command_is_missing("gpg")
@@ -844,7 +844,7 @@ class T(unittest.TestCase):
         )
         with open(
             os.path.join(
-                self.rootdir, "etc", "apt", "sources.list.d", ppa + ".list"
+                self.rootdir, "etc", "apt", "sources.list.d", f"{ppa}.list"
             ),
             encoding="utf-8",
         ) as f:
@@ -900,7 +900,7 @@ class T(unittest.TestCase):
         )
         with open(
             os.path.join(
-                self.rootdir, "etc", "apt", "sources.list.d", ppa + ".list"
+                self.rootdir, "etc", "apt", "sources.list.d", f"{ppa}.list"
             ),
             encoding="utf-8",
         ) as f:
@@ -950,11 +950,11 @@ class T(unittest.TestCase):
             os.path.join(self.configdir, release, "sources.list"),
             "ubuntu",
             "jammy",
-            origins=["LP-PPA-%s" % ppa],
+            origins=[f"LP-PPA-{ppa}"],
         )
         with open(
             os.path.join(
-                self.rootdir, "etc", "apt", "sources.list.d", ppa + ".list"
+                self.rootdir, "etc", "apt", "sources.list.d", f"{ppa}.list"
             ),
             encoding="utf-8",
         ) as f:
@@ -1068,7 +1068,7 @@ class T(unittest.TestCase):
         with open(
             os.path.join(config_release_dir, "codename"), "w", encoding="utf-8"
         ) as f:
-            f.write("%s" % release)
+            f.write(f"{release}")
 
         # install GPG key for ddebs
         keyring_dir = os.path.join(config_release_dir, "trusted.gpg.d")
@@ -1172,6 +1172,6 @@ class T(unittest.TestCase):
         self.assertIn(
             archmap[expected],
             machine,
-            '%s has unexpected machine type "%s" for architecture %s'
-            % (path, machine, expected),
+            f'{path} has unexpected machine type "{machine}"'
+            f" for architecture {expected}",
         )

--- a/tests/system/test_signal_crashes.py
+++ b/tests/system/test_signal_crashes.py
@@ -101,7 +101,7 @@ class T(unittest.TestCase):
 
         # move aside current ignore file
         if os.path.exists(self.ifpath):
-            os.rename(self.ifpath, self.ifpath + ".apporttest")
+            os.rename(self.ifpath, f"{self.ifpath}.apporttest")
 
         # do not write core files by default
         resource.setrlimit(resource.RLIMIT_CORE, (0, -1))
@@ -124,7 +124,7 @@ class T(unittest.TestCase):
         # clean up our ignore file
         if os.path.exists(self.ifpath):
             os.unlink(self.ifpath)
-        orig_ignore_file = self.ifpath + ".apporttest"
+        orig_ignore_file = f"{self.ifpath}.apporttest"
         if os.path.exists(orig_ignore_file):
             os.rename(orig_ignore_file, self.ifpath)
 
@@ -267,7 +267,7 @@ class T(unittest.TestCase):
         if args is None:
             args = self.TEST_ARGS
 
-        assert os.access(command, os.X_OK), command + " is not executable"
+        assert os.access(command, os.X_OK), f"{command} is not executable"
 
         env = os.environ.copy()
         # set UTF-8 environment variable, to check proper parsing in apport
@@ -280,7 +280,7 @@ class T(unittest.TestCase):
 
         # wait until child process has execv()ed properly
         while True:
-            with open("/proc/%i/cmdline" % process.pid, encoding="utf-8") as f:
+            with open(f"/proc/{process.pid}/cmdline", encoding="utf-8") as f:
                 cmdline = f.read()
             if "test_signal" in cmdline:
                 time.sleep(0.1)

--- a/tests/system/test_ui_gtk.py
+++ b/tests/system/test_ui_gtk.py
@@ -1041,9 +1041,7 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
         self.assertEqual(
             self.app.report["SourcePackage"], apport.packaging.get_source(pkg)
         )
-        self.assertEqual(
-            self.app.report["Package"], "%s (not installed)" % pkg
-        )
+        self.assertEqual(self.app.report["Package"], f"{pkg} (not installed)")
 
     @unittest.mock.patch.object(
         GTKUserInterface, "open_url", unittest.mock.MagicMock()
@@ -1104,7 +1102,7 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
 
         # create source package hook, as otherwise there is nothing to collect
         with open(
-            os.path.join(self.hook_dir, "source_%s.py" % source_pkg),
+            os.path.join(self.hook_dir, f"source_{source_pkg}.py"),
             "w",
             encoding="utf-8",
         ) as f:

--- a/tests/system/test_ui_kde.py
+++ b/tests/system/test_ui_kde.py
@@ -679,9 +679,7 @@ class T(unittest.TestCase):
         self.assertEqual(
             self.app.report["SourcePackage"], apport.packaging.get_source(pkg)
         )
-        self.assertEqual(
-            self.app.report["Package"], "%s (not installed)" % pkg
-        )
+        self.assertEqual(self.app.report["Package"], f"{pkg} (not installed)")
 
     @unittest.mock.patch.object(
         MainUserInterface, "open_url", unittest.mock.MagicMock()
@@ -740,7 +738,7 @@ class T(unittest.TestCase):
 
         # create source package hook, as otherwise there is nothing to collect
         with open(
-            os.path.join(self.hook_dir, "source_%s.py" % source_pkg),
+            os.path.join(self.hook_dir, f"source_{source_pkg}.py"),
             "w",
             encoding="utf-8",
         ) as f:

--- a/tests/unit/test_crashdb.py
+++ b/tests/unit/test_crashdb.py
@@ -17,7 +17,7 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
         self.workdir = tempfile.mkdtemp()
         self.dupdb_dir = os.path.join(self.workdir, "dupdb")
         self.crashes = CrashDatabase(
-            None, {"sample_data": "1", "dupdb_url": "file://" + self.dupdb_dir}
+            None, {"sample_data": "1", "dupdb_url": f"file://{self.dupdb_dir}"}
         )
 
         self.assertEqual(

--- a/tests/unit/test_parse_segv.py
+++ b/tests/unit/test_parse_segv.py
@@ -450,7 +450,7 @@ class TestHookParseSegv(unittest.TestCase):
 
     def test_segv_src_missing(self):
         """Handle source in missing VMA."""
-        reg = REGS + "ecx            0x0006af24   0xbfc6af24"
+        reg = f"{REGS}ecx            0x0006af24   0xbfc6af24"
         disasm = "0x08083547 <main+7>:    pushl  -0x4(%ecx)"
 
         # Valid crash
@@ -477,7 +477,7 @@ class TestHookParseSegv(unittest.TestCase):
 
     def test_segv_src_null(self):
         """Handle source in NULL VMA."""
-        reg = REGS + "ecx            0x00000024   0xbfc6af24"
+        reg = f"{REGS}ecx            0x00000024   0xbfc6af24"
         disasm = "0x08083547 <main+7>:    pushl  -0x4(%ecx)"
 
         segv = parse_segv.ParseSegv(reg, disasm, MAPS)
@@ -492,7 +492,7 @@ class TestHookParseSegv(unittest.TestCase):
 
     def test_segv_src_not_readable(self):
         """Handle source not in readable VMA."""
-        reg = REGS + "ecx            0x0026c080   0xbfc6af24"
+        reg = f"{REGS}ecx            0x0026c080   0xbfc6af24"
         disasm = "0x08083547 <main+7>:    pushl  -0x4(%ecx)"
         segv = parse_segv.ParseSegv(reg, disasm, MAPS)
         understood, reason, details = segv.report()
@@ -507,7 +507,7 @@ class TestHookParseSegv(unittest.TestCase):
 
     def test_segv_dest_missing(self):
         """Handle destination in missing VMA."""
-        reg = REGS + "esp            0x0006af24   0xbfc6af24"
+        reg = f"{REGS}esp            0x0006af24   0xbfc6af24"
         disasm = "0x08083547 <main+7>:    pushl  -0x4(%ecx)"
 
         segv = parse_segv.ParseSegv(reg, disasm, MAPS)
@@ -522,7 +522,7 @@ class TestHookParseSegv(unittest.TestCase):
 
     def test_segv_dest_null(self):
         """Handle destination in NULL VMA."""
-        reg = REGS + "esp            0x00000024   0xbfc6af24"
+        reg = f"{REGS}esp            0x00000024   0xbfc6af24"
         disasm = "0x08083547 <main+7>:    pushl  -0x4(%ecx)"
 
         segv = parse_segv.ParseSegv(reg, disasm, MAPS)
@@ -537,7 +537,7 @@ class TestHookParseSegv(unittest.TestCase):
 
     def test_segv_dest_not_writable(self):
         """Handle destination not in writable VMA."""
-        reg = REGS + "esp            0x08048080   0xbfc6af24"
+        reg = f"{REGS}esp            0x08048080   0xbfc6af24"
         disasm = "0x08083547 <main+7>:    pushl  -0x4(%ecx)"
         segv = parse_segv.ParseSegv(reg, disasm, MAPS)
         understood, reason, details = segv.report()
@@ -561,7 +561,7 @@ class TestHookParseSegv(unittest.TestCase):
     def test_segv_stack_failure(self):
         """Handle walking off the stack."""
         # Triggered via "push"
-        reg = REGS + "esp            0xbfc56ff0   0xbfc56ff0"
+        reg = f"{REGS}esp            0xbfc56ff0   0xbfc56ff0"
         disasm = "0x08083547 <main+7>:    push  %eax"
         segv = parse_segv.ParseSegv(reg, disasm, MAPS)
         understood, _, details = segv.report()
@@ -573,7 +573,7 @@ class TestHookParseSegv(unittest.TestCase):
         )
 
         # Triggered via "call"
-        reg = REGS + "esp            0xbfc56fff   0xbfc56fff"
+        reg = f"{REGS}esp            0xbfc56fff   0xbfc56fff"
         disasm = "0x08083547 <main+7>:    callq  0x08083540"
         segv = parse_segv.ParseSegv(reg, disasm, MAPS)
         understood, _, details = segv.report()
@@ -586,7 +586,7 @@ class TestHookParseSegv(unittest.TestCase):
         self.assertIn("Stack memory exhausted", details)
 
         # Triggered via unknown reason
-        reg = REGS + "esp            0xdfc56000   0xdfc56000"
+        reg = f"{REGS}esp            0xdfc56000   0xdfc56000"
         disasm = """0x08083540 <main+0>:    mov    $1,%rcx"""
         segv = parse_segv.ParseSegv(reg, disasm, MAPS)
         understood, _, details = segv.report()

--- a/tests/unit/test_problem_report.py
+++ b/tests/unit/test_problem_report.py
@@ -450,11 +450,11 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
 
         # still small enough for inline text
         pr["Largeline"] = "A" * 999
-        pr["LargeMultiline"] = "A" * 120 + "\n" + "B" * 90
+        pr["LargeMultiline"] = f"{'A' * 120}\n{'B' * 90}"
 
         # too big for inline text, these become attachments
         pr["Hugeline"] = "A" * 10000
-        pr["HugeMultiline"] = "A" * 900 + "\n" + "B" * 900 + "\n" + "C" * 900
+        pr["HugeMultiline"] = f"{'A' * 900}\n{'B' * 900}\n{'C' * 900}"
         out = io.BytesIO()
         pr.write_mime(out)
         out.seek(0)

--- a/tests/unit/test_rethread.py
+++ b/tests/unit/test_rethread.py
@@ -53,7 +53,7 @@ class T(unittest.TestCase):
         )
         self.assertTrue(
             exc[-1].startswith("ZeroDivisionError"),
-            "not a ZeroDivisionError:" + str(exc),
+            f"not a ZeroDivisionError:{str(exc)}",
         )
         self.assertIn("\n    return x / y\n", exc[-2])
 


### PR DESCRIPTION
Use [flynt](https://github.com/ikamensh/flynt) to convert the code from old `%`-formatted and `.format(...)` strings into Python 3.6+'s "f-strings". Not all instances were converted by flynt. The remaining ones were converted manually.