### PR TITLE
tests: Run mypy on Python modules

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,10 +27,11 @@ jobs:
         run: >
           apt-get update
           && apt-get install --no-install-recommends --yes
-          black gir1.2-gtk-3.0 gir1.2-wnck-3.0 isort pycodestyle pydocstyle
-          pyflakes3 pylint python3 python3-apt python3-dbus
+          black gir1.2-gtk-3.0 gir1.2-wnck-3.0 isort mypy pycodestyle
+          pydocstyle pyflakes3 pylint python3 python3-apt python3-dbus
           python3-distutils-extra python3-gi python3-launchpadlib
-          python3-psutil python3-rpm python3-yaml python3-requests
+          python3-psutil python3-rpm python3-typeshed python3-yaml
+          python3-requests
       - name: Run linter tests
         run: tests/run-linters
 

--- a/apport/ui.py
+++ b/apport/ui.py
@@ -152,11 +152,12 @@ def run_as_real_user(
     if get_user_env:
         env |= _get_users_environ(uid)
     env["HOME"] = pwuid.pw_dir
+    # mypy on Ubuntu 22.04 and 22.10 does not know user and groups
     subprocess.run(
         args,
         check=False,
         env=env,
-        user=uid,
+        user=uid,  # type: ignore
         group=gid,
         extra_groups=os.getgrouplist(pwuid.pw_name, gid),
         **kwargs,

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ class build_java_subdir(distutils.core.Command):
     """Java crash handler build command."""
 
     description = "Compile java components of Apport"
-    user_options = []
+    user_options: list[tuple[str, str, str]] = []
 
     def initialize_options(self):
         pass
@@ -137,7 +137,7 @@ class install_fix_hashbangs(DistUtilsExtra.auto.install_auto):
 #
 
 optional_data_files = []
-cmdclass = {"install": install_fix_hashbangs}
+cmdclass: dict[str, object] = {"install": install_fix_hashbangs}
 
 # if we have Java available, build the Java crash handler
 try:

--- a/tests/integration/test_apport_unpack.py
+++ b/tests/integration/test_apport_unpack.py
@@ -20,6 +20,8 @@ from tests.paths import local_test_environment
 
 
 class TestApportUnpack(unittest.TestCase):
+    env: dict[str, str]
+
     @classmethod
     def setUpClass(cls):
         cls.env = (

--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -698,8 +698,14 @@ class T(unittest.TestCase):
         with unittest.mock.patch.object(
             self.ui.crashdb, "upload"
         ) as upload_mock:
+            # False positive for hdrs in urllib.error.HTTPError
+            # See https://github.com/python/typeshed/issues/10092
             upload_mock.side_effect = urllib.error.HTTPError(
-                "https://example.com/", 502, "Bad Gateway", {}, None
+                "https://example.com/",
+                502,
+                "Bad Gateway",
+                {},  # type: ignore
+                fp=None,
             )
             self.ui.file_report()
         self.assertEqual(self.ui.msg_severity, "error")

--- a/tests/run-linters
+++ b/tests/run-linters
@@ -60,6 +60,13 @@ else
     echo "Skipping pyflakes3 tests, pyflakes3 is not installed"
 fi
 
+if type mypy >/dev/null 2>&1; then
+    echo "Running mypy..."
+    mypy --ignore-missing-imports ${PYTHON_FILES}
+else
+    echo "Skipping mypy tests, mypy is not installed"
+fi
+
 if type pylint >/dev/null 2>&1; then
     echo "Running pylint..."
     pylint ${PYTHON_FILES} ${PYTHON_SCRIPTS}


### PR DESCRIPTION
Add type hints for mypy and run mypy on the Python modules as part of `tests/run-linters`. Install mypy and python3-typeshed for the linter CI test.