### PR TITLE
fix(apport-kde): Add notr parameter to translate function

### DIFF
--- a/kde/apport-kde
+++ b/kde/apport-kde
@@ -60,17 +60,21 @@ except ImportError as error:
 
 
 # TODO: Avoid fiddling with internals of Qt to add translation support
-# pylint: disable=protected-access
-def translate(self, prop):
+def translate(self, prop, notr=None):
+    # pylint: disable=unused-argument
     """Reimplement method from uic to change it to use gettext."""
+    text = prop.text
 
-    if prop.get("notr", None) == "true":
-        return self._cstring(prop)
-    if prop.text is None:
+    if text is None:
         return ""
+
+    if prop.get("notr", notr) == "true":
+        return text
+
     return _(prop.text)
 
 
+# pylint: disable=protected-access
 uic.properties.Properties._string = translate
 # pylint: enable=protected-access
 


### PR DESCRIPTION
mypy complains:

```
kde/apport-kde:74: error: Incompatible types in assignment (expression has type "Callable[[Any, Any], Any]", variable has type "Callable[[Properties, Any, Any], Any]")  [assignment]
```

`PyQt5.uic.properties.Properties._string` has the additional parameter `notr` since at least PyQt 5.10.1 (tested on Ubuntu 18.04 "bionic"). The `_string` method has not been changed since then (tested PyQt5 5.15.9 on Ubuntu 23.04 "lunar").

Add `notr` parameter to the `translate` function and make the code more similar to the upstream code.