### PR TITLE
remove dependency on python-requests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
           black gir1.2-gtk-3.0 gir1.2-wnck-3.0 isort pycodestyle pydocstyle
           pyflakes3 pylint python3 python3-apt python3-dbus
           python3-distutils-extra python3-gi python3-launchpadlib
-          python3-psutil python3-rpm python3-yaml python3-requests
+          python3-psutil python3-rpm python3-yaml
       - name: Run linter tests
         run: tests/run-linters
 
@@ -136,7 +136,7 @@ jobs:
           bash binutils default-jdk-headless dpkg-dev gcc gdb iputils-ping kmod
           libc6-dev pkg-config python3 python3-apt python3-distutils-extra
           python3-launchpadlib python3-psutil python3-pytest python3-pytest-cov
-          python3-requests python3-systemd valgrind
+          python3-systemd valgrind
       - name: Build Java subdir
         run: >
           python3 -m coverage run ./setup.py build_java_subdir
@@ -253,7 +253,7 @@ jobs:
           dbus dbus-x11 dirmngr dpkg-dev gcc gdb gir1.2-gtk-3.0 gir1.2-wnck-3.0
           gnome-icon-theme gpg gvfs-daemons psmisc python3 python3-apt
           python3-dbus python3-gi python3-launchpadlib python3-pyqt5
-          python3-pytest python3-pytest-cov python3-requests
+          python3-pytest python3-pytest-cov
           ubuntu-dbgsym-keyring ubuntu-keyring valgrind xvfb
       - name: Start D-Bus daemon
         run: mkdir -p /run/dbus && dbus-daemon --system --fork

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -216,13 +216,14 @@ jobs:
         run: >
           apt-get update
           && apt-get install --no-install-recommends --yes
-          python3 python3-apt python3-psutil python3-pytest python3-pytest-cov
+          ca-certificates python3 python3-apt python3-psutil python3-pytest
+          python3-pytest-cov
       - name: Run all tests (to check if they are skipped or succeed)
         run: python3 -m pytest -ra --cov=$(pwd) --cov-report=xml tests/
       - name: Install dependencies for Codecov
         run: >
           apt-get install --no-install-recommends --yes
-          ca-certificates curl git
+          curl git
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/apport/crashdb_impl/github.py
+++ b/apport/crashdb_impl/github.py
@@ -43,11 +43,6 @@ class Github:
         )
         try:
             with urllib.request.urlopen(request, timeout=5.0) as response:
-                if 400 <= response.status < 600:
-                    # Not using UI: the user can't do much here
-                    raise urllib.request.HTTPError(
-                        url, response.status, "", headers, None
-                    )
                 return json.loads(response.read())
         except urllib.error.URLError as err:
             self.message_callback(

--- a/apport/crashdb_impl/github.py
+++ b/apport/crashdb_impl/github.py
@@ -11,9 +11,9 @@
 
 import json
 import time
+import urllib.parse
+import urllib.request
 from dataclasses import dataclass
-
-import requests
 
 import apport
 import apport.crashdb
@@ -32,25 +32,18 @@ class Github:
         self.__expiry = None
         self.message_callback = message_callback
 
-    @staticmethod
-    def _stringify(data: dict) -> str:
-        """Takes a dict and returns it as a string for POSTing."""
-        string = ""
-        for key, value in data.items():
-            string = f"{string}&{key}={value}"
-        return string
-
     def _post(self, url: str, data: str):
         """Posts the given data to the given URL.
         Uses auth token if available"""
         headers = {"Accept": "application/vnd.github.v3+json"}
         if self.__access_token:
             headers["Authorization"] = f"token {self.__access_token}"
+        request = urllib.request.Request(
+            url, data=data.encode("utf-8"), headers=headers, method="POST"
+        )
         try:
-            result = requests.post(
-                url, headers=headers, data=data, timeout=5.0
-            )
-        except requests.RequestException as err:
+            response = urllib.request.urlopen(request, timeout=5.0)
+        except urllib.error.URLError as err:
             self.message_callback(
                 "Failed connection",
                 f"Failed connection to {url}.\n"
@@ -60,11 +53,14 @@ class Github:
         finally:
             self.__last_request = time.time()
 
-        result.raise_for_status()  # Not using UI: the user can't do much here
-        return json.loads(result.text)
+        if 400 <= response.status < 600:
+            # Not using UI: the user can't do much here
+            raise urllib.request.HTTPError(code=response.status)
+
+        return json.loads(response.read())
 
     def api_authentication(self, url: str, data: dict):
-        return self._post(url, self._stringify(data))
+        return self._post(url, urllib.parse.urlencode(data))
 
     def api_open_issue(self, owner: str, repo: str, data: dict):
         url = f"https://api.github.com/repos/{owner}/{repo}/issues"


### PR DESCRIPTION
217b68a2c57cbacf56a389a41c99f2498608e4e9 removed apport's dependency on python3-requests, but this was reversed by #26. This removes it again.

Unfortunately I wasn't able to test this fully because I keep getting a 404 from `https://github.com/login/device/code`, even under the `main` branch:

```
Traceback (most recent call last):
  File "/data/shivaram/workspace/apport/apport/crashdb_impl/./github.py", line 190, in <module>
    sys.exit(main())
  File "/data/shivaram/workspace/apport/apport/crashdb_impl/./github.py", line 185, in main
    with Github('slingamn', cb) as gh:
  File "/data/shivaram/workspace/apport/apport/crashdb_impl/./github.py", line 74, in __enter__
    response = self.api_authentication(url, data)
  File "/data/shivaram/workspace/apport/apport/crashdb_impl/./github.py", line 64, in api_authentication
    return self._post(url, self._stringify(data))
  File "/data/shivaram/workspace/apport/apport/crashdb_impl/./github.py", line 60, in _post
    result.raise_for_status()  # Not using UI: the user can't do much here
  File "/usr/lib/python3/dist-packages/requests/models.py", line 943, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 404 Client Error: Not Found for url: https://github.com/login/device/code
```

I was hoping you could advise? Thanks very much for your time.