### PR TITLE
fix: Fix spelling mistakes found by codespell

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -357,7 +357,7 @@ detailed list of changes, please see the git history.
 
 2.20.11 (2019-05-16)
 --------------------
-  * SECURITY UPDATE: Ensure that we propely handle crashes that originate from
+  * SECURITY UPDATE: Ensure that we properly handle crashes that originate from
     a PID namespace. Thanks to Sander Bos for discovering this issue.
     (CVE-2018-6552, [LP: #1746668](https://launchpad.net/bugs/1746668))
   * backends/packaging-apt-dpkg.py: switch to using python3-launchpadlib to
@@ -370,7 +370,7 @@ detailed list of changes, please see the git history.
   * apport/ui.py: Handle old reports generated pre-apport with "remember"
     option. If the option isn't there, consider as false.
     ([LP: #1791324](https://launchpad.net/bugs/1791324))
-  * apport/report.py: End our gdb batch script with a separator, to accomodate
+  * apport/report.py: End our gdb batch script with a separator, to accommodate
     new exit codes from gdb 8.2.50. Thanks Steve Langasek!
   * data/apport: Introduce support for non-positional arguments so we
     can easily extend core_pattern in the future
@@ -592,7 +592,7 @@ detailed list of changes, please see the git history.
 2.20.3 (2016-07-28)
 -------------------
  * problem_report.py: Fail with proper exception when trying to assign a list
-   to a report key, or when trying to assing a tuple with more than 4 entries.
+   to a report key, or when trying to assign a tuple with more than 4 entries.
    ([LP: #1596713](https://launchpad.net/bugs/1596713))
  * test_backend_apt_dpkg.py: Install GPG key for ddebs.ubuntu.com to avoid apt
    authentication errors.
@@ -728,7 +728,7 @@ detailed list of changes, please see the git history.
 -------------------
  * test_hooks.py: Adjust for gcc executable names that don't include the minor
    version number.
- * When determinining the logind session and $XDG_SESSION_ID is not set, fall
+ * When determining the logind session and $XDG_SESSION_ID is not set, fall
    back to reading it from /proc/pid/cgroup.
  * whoopsie-upload-all: Intercept OSError too (e. g. "No space left on
    device"). ([LP: #1476258](https://launchpad.net/bugs/1476258))
@@ -799,7 +799,7 @@ detailed list of changes, please see the git history.
    privileges.
    Thanks to Philip Pettersson for discovering this issue!
    (CVE-2015-1325, [LP: #1453900](https://launchpad.net/bugs/1453900))
- * apportcheckresume: Fix "occured" typo, thanks Matthew Paul Thomas.
+ * apportcheckresume: Fix typo of "occurred", thanks Matthew Paul Thomas.
    ([LP: #1448636](https://launchpad.net/bugs/1448636))
  * signal_crashes test: Fix test_crash_setuid_* to look at whether
    suid_dumpable was enabled.
@@ -1245,7 +1245,7 @@ Bug fixes:
  * ui.py: Check if options for updating and reporting a new bug get used
    together, and give a proper error message in this case.
    ([LP: #1071905](https://launchpad.net/bugs/1071905))
- * apport: Fix "Exectuable" typo, leading to reports not being synced on
+ * apport: Fix typo of "Executable", leading to reports not being synced on
    upstart crashes. Thanks James Hunt.
    ([LP: #1203744](https://launchpad.net/bugs/1203744))
  * Rename apport-gtk-mime.desktop to apport-gtk.desktop and drop the
@@ -1621,7 +1621,7 @@ Improvements:
    the bug creation from a blob by manually creating the comment and
    attachments ourselves, and just assume that storeblob works on production.
    Also change the structure to allow running every test individually.
- * crash-digger: Add --crash-db option to specify a non-default crash databae
+ * crash-digger: Add --crash-db option to specify a non-default crash database
    name. ([LP: #1003506](https://launchpad.net/bugs/1003506))
  * apport-gtk: Add --hanging option to specify the process ID of a hanging
    application. If the user chooses to report this error, apport will terminate
@@ -1636,7 +1636,7 @@ Bug fixes:
  * Fix PEP-8 violations picked up by latest pep8 checker.
  * ui.py: Do not ignore certain exceptions during upload which are not likely
    to be a network error.
- * launchpad.py: Recongize Launchpad projects for bug query and marking
+ * launchpad.py: Recognize Launchpad projects for bug query and marking
    operations. ([LP: #1003506](https://launchpad.net/bugs/1003506))
  * packaging-apt-dpkg.py: Fix get_source_tree() to work with apt sandboxes.
  * apport-retrace: Turn StacktraceSource generation back on, now that it works
@@ -1682,7 +1682,7 @@ Bug fixes:
 2.2.3 (2012-06-15):
 -------------------
 Bug fixes:
- * test/run: Do not run pep8 and pyflakes when running against the sytem
+ * test/run: Do not run pep8 and pyflakes when running against the system
    installed Apport.
  * test_backend_apt_dpkg.py: For the "are we online" check, verify that we can
    download from http://ddebs.ubuntu.com/, not just whether we have a default
@@ -2361,7 +2361,7 @@ Bug fixes:
  - apport-retrace: Pass correct executable path to gdb in --gdb with --sandbox
    mode.
  - apport-retrace: Do not leave behind temporary directories on errors.
- - apport-retrace: Drop assertion failure for existance of "Stacktrace". This
+ - apport-retrace: Drop assertion failure for existence of "Stacktrace". This
    isn't present in the case of gdb crashing, and there is not much we can do
    about it. This should not break the retracer.
  - apport/report.py: Unwind XError() from stack traces for the "StacktraceTop"
@@ -2388,7 +2388,7 @@ Bug fixes:
    own. This ensures that the apt and dpkg status is up to date, and avoids
    downloading the package indexes multiple times.
    ([LP: #847951](https://launchpad.net/bugs/847951))
- - apport-retrace: Give proper error mesage instead of AssertionError crash if
+ - apport-retrace: Give proper error message instead of AssertionError crash if
    a report does not contain standard Apport format data.
    ([LP: #843221](https://launchpad.net/bugs/843221))
  - fileutils.py, get_new_reports(): Fix crash if report file disappears in the
@@ -3135,7 +3135,7 @@ New features:
    packages.
  - KDE frontend implementation of ui_question_userpass(), for crash databases
    which need to ask for credentials.
- - hookutils.py: New funtion attach_wifi() to add wireless network related
+ - hookutils.py: New function attach_wifi() to add wireless network related
    information to reports.
 
 Important bug fixes:

--- a/apport/crashdb_impl/launchpad.py
+++ b/apport/crashdb_impl/launchpad.py
@@ -79,7 +79,7 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
         - project: Name of the project in Launchpad
           (Note that exactly one of "distro" or "project" must be given.)
         - launchpad_instance: If set, this uses the given launchpad instance
-          instead of production (optional). This can be overriden or set by
+          instead of production (optional). This can be overridden or set by
           $APPORT_LAUNCHPAD_INSTANCE environment. For example: "qastaging" or
           "staging".
         - cache_dir: Path to a permanent cache directory; by default it uses a
@@ -1388,7 +1388,7 @@ if __name__ == "__main__":
 
             # add some binary gibberish which isn't UTF-8
             r["ShortGibberish"] = ' "]\xb6"\n'
-            r["LongGibberish"] = "a\nb\nc\nd\ne\n\xff\xff\xff\n\f"
+            r["LongGibberish"] = "a\nb\nc\ne\nf\n\xff\xff\xff\n\f"
 
             # create a bug for the report
             bug_target = self._get_bug_target(self.crashdb, r)
@@ -1635,7 +1635,7 @@ and more
             r[
                 "ThreadStacktrace"
             ] = '"]\xb6"\n'  # not interpretable as UTF-8, LP #353805
-            r["StacktraceSource"] = "a\nb\nc\nd\ne\n\xff\xff\xff\n\f"
+            r["StacktraceSource"] = "a\nb\nc\ne\nf\n\xff\xff\xff\n\f"
             self.crashdb.update_traces(self.get_segv_report(), r, "tests")
 
         def test_get_comment_url(self):
@@ -2146,7 +2146,7 @@ and more
                 title=report.get("Title", report.standard_title()),
             )
 
-            # nwo add the attachments
+            # now add the attachments
             for part in msg_iter:
                 assert not part.is_multipart()
                 bug.addAttachment(

--- a/apport/hookutils.py
+++ b/apport/hookutils.py
@@ -562,7 +562,7 @@ def attach_root_command_outputs(report, command_map):
     Just like root_command_output, this passes the command through pkexec,
     unless the caller is already root.
 
-    This is preferrable to using root_command_output() multiple times, as that
+    This is preferable to using root_command_output() multiple times, as that
     will ask for the password every time.
     """
     wrapper_path = os.path.join(

--- a/apport/report.py
+++ b/apport/report.py
@@ -512,7 +512,7 @@ class Report(problem_report.ProblemReport):
 
         Parse project (e.g. 'subiquity') or source package string
         (e.g. 'ubuntu/+source/gnome-calculator') from snap 'contact'.
-        Additionaly, extract any tag/tags defined in the contact URL.
+        Additionally, extract any tag/tags defined in the contact URL.
         """
         # Launchpad
         p = (

--- a/apport/sandboxutils.py
+++ b/apport/sandboxutils.py
@@ -149,7 +149,7 @@ def make_sandbox(
     some extra ones, for the distro release and architecture of the report.
 
     For unpackaged executables, there are no Dependencies. Packages for shared
-    libaries are unpacked.
+    libraries are unpacked.
 
     report is an apport.Report object to build a sandbox for. Presence of the
     Package field determines whether to determine dependencies through

--- a/apport/ui.py
+++ b/apport/ui.py
@@ -965,7 +965,7 @@ class UserInterface:
     def run_argv(self):
         # TODO: Split into smaller functions/methods
         # pylint: disable=too-many-return-statements
-        """Call appopriate run_* method according to command line arguments.
+        """Call appropriate run_* method according to command line arguments.
 
         Return True if at least one report has been processed, and False
         otherwise.

--- a/apport_python_hook.py
+++ b/apport_python_hook.py
@@ -20,7 +20,7 @@ def enabled():
     # This doesn't use apport.packaging.enabled() because it is too heavyweight
     # See LP: #528355
     try:
-        # pylint: disable=import-outside-toplevel; for Python starup time
+        # pylint: disable=import-outside-toplevel; for Python startup time
         import re
 
         with open(CONFIG, encoding="utf-8") as config_file:
@@ -156,7 +156,7 @@ def apport_excepthook(binary, exc_type, exc_obj, exc_tb):
 def dbus_service_unknown_analysis(exc_obj, report):
     # TODO: Split into smaller functions/methods
     # pylint: disable=too-many-locals
-    # pylint: disable=import-outside-toplevel; for Python starup time
+    # pylint: disable=import-outside-toplevel; for Python startup time
     import re
     import subprocess
     from configparser import ConfigParser, NoOptionError, NoSectionError
@@ -217,7 +217,7 @@ def install():
     # Record before the program can mutate sys.argv and can call os.chdir().
     binary = sys.argv[0]
     if binary and not binary.startswith("/"):
-        # pylint: disable=import-outside-toplevel; for Python starup time
+        # pylint: disable=import-outside-toplevel; for Python startup time
         import os
 
         try:

--- a/data/general-hooks/generic.py
+++ b/data/general-hooks/generic.py
@@ -33,7 +33,7 @@ def add_info(report: ProblemReport, ui: apport.ui.HookUI) -> None:
     home = os.getenv("HOME")
     if home:
         mounts[home] = "home"
-    treshold = 50
+    threshold = 50
 
     for mount, mount_name in mounts.items():
         try:
@@ -42,7 +42,7 @@ def add_info(report: ProblemReport, ui: apport.ui.HookUI) -> None:
             continue
         free_mb = stat.f_bavail * stat.f_frsize / 1000000
 
-        if free_mb < treshold:
+        if free_mb < threshold:
             report["UnreportableReason"] = (
                 f"Your {mount_name} partition has less than {free_mb} MB"
                 f" of free space available, which leads to problems using"

--- a/doc/crashdb-conf.md
+++ b/doc/crashdb-conf.md
@@ -110,7 +110,7 @@ Crash database implementations
    - `project`: Name of the project in Launchpad
      (Note that exactly one of `distro` or `project` must be given.)
    - `launchpad_instance`: If set, this uses the given launchpad instance
-     instead of production (optional). This can be overriden or set by
+     instead of production (optional). This can be overridden or set by
      `APPORT_LAUNCHPAD_INSTANCE` environment. For example: `qastaging` or
      `staging`.
    - `cache_dir`: Path to a permanent cache directory; by default it uses a

--- a/doc/data-format.tex
+++ b/doc/data-format.tex
@@ -181,7 +181,7 @@ environment.
     `SYS_GID_MAX` (specified in `/etc/login.defs` which defaults to 999 on
     Debian based systems), no groups which belong to other real users.
 
-    \item [Tags:] (optional) A space-delimited list of tage that may be passed
+    \item [Tags:] (optional) A space-delimited list of tags that may be passed
     to the crash database, depending on which one is used.
 \end{description}
 

--- a/man/dupdb-admin.1
+++ b/man/dupdb-admin.1
@@ -23,7 +23,7 @@ dupdb\-admin \- Manage the duplicate database for apport\-retrace.
 .SH DESCRIPTION
 
 .BR apport\-retrace (1)
-has the capability of checking for duplicate bugs (amonst other
+has the capability of checking for duplicate bugs (amongst other
 things). It uses an SQLite database for keeping track of master bugs.
 .B dupdb\-admin
 is a small tool to manage that database.

--- a/problem_report.py
+++ b/problem_report.py
@@ -225,7 +225,7 @@ class ProblemReport(collections.UserDict):
         extracts directly files without loading the report into memory.
         """
         self._assert_bin_mode(file)
-        # support singe key and collection of keys
+        # support single key and collection of keys
         if isinstance(bin_keys, str):
             bin_keys = [bin_keys]
         key = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,10 @@
 [tool.black]
 line-length = 79
 
+[tool.codespell]
+skip = ".git,*.click,*.gif,*.po,*.png"
+ignore-words-list = "buildd"
+
 [tool.isort]
 line_length = 79
 profile = "black"

--- a/tests/integration/test_problem_report.py
+++ b/tests/integration/test_problem_report.py
@@ -141,7 +141,7 @@ class T(unittest.TestCase):
             pr.extract_keys,
             report,
             "Bin",
-            os.path.join(self.workdir, "nonexistant"),
+            os.path.join(self.workdir, "nonexistent"),
         )
         # Test exception handling: Non-binary and nonexistent key
         tests = [

--- a/tests/integration/test_report.py
+++ b/tests/integration/test_report.py
@@ -1720,7 +1720,7 @@ int main() { return f(42); }
         orig_denylist_dir = apport.report._DENYLIST_DIR
         apport.report._DENYLIST_DIR = tempfile.mkdtemp()
         orig_ignore_file = apport.report._ignore_file
-        apport.report._ignore_file = "/nonexistant"
+        apport.report._ignore_file = "/nonexistent"
         try:
             bash_rep = apport.report.Report()
             bash_rep["ExecutablePath"] = "/bin/bash"
@@ -1778,7 +1778,7 @@ int main() { return f(42); }
         orig_allowlist_dir = apport.report._ALLOWLIST_DIR
         apport.report._ALLOWLIST_DIR = tempfile.mkdtemp()
         orig_ignore_file = apport.report.apport.report._ignore_file
-        apport.report.apport.report._ignore_file = "/nonexistant"
+        apport.report.apport.report._ignore_file = "/nonexistent"
         try:
             bash_rep = apport.report.Report()
             bash_rep["ExecutablePath"] = "/bin/bash"

--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -2614,7 +2614,7 @@ class T(unittest.TestCase):
         self.assertIn("ProcEnviron", self.ui.report)
         self.assertEqual(self.ui.report["ProblemType"], "Bug")
 
-        # no upload happend
+        # no upload happened
         self.assertEqual(self.ui.opened_url, None)
         self.assertEqual(self.ui.upload_progress_pulses, 0)
         self.assertEqual(self.ui.crashdb.latest_id(), latest_id_before)

--- a/tests/system/test_packaging_apt_dpkg.py
+++ b/tests/system/test_packaging_apt_dpkg.py
@@ -631,7 +631,7 @@ class T(unittest.TestCase):
         # Wanted are superseded versions from -updates or -security.
         wanted = {
             "distro-info-data": "0.43ubuntu1.9",  # arch all
-            "libc6": "2.31-0ubuntu9.4",  # -dbg, arch specfic
+            "libc6": "2.31-0ubuntu9.4",  # -dbg, arch specific
             "qemu-utils": "1:4.2-3ubuntu6.1",  # -dbgsym, arch specific
         }
         obsolete = impl.install_packages(

--- a/tests/unit/test_crashdb.py
+++ b/tests/unit/test_crashdb.py
@@ -349,7 +349,7 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
         # now mark the python crash as fixed
         self.crashes.reports[3]["fixed_version"] = "4.1"
 
-        # ID#4 is dup of ID#3, but happend in version 5 -> regression
+        # ID#4 is dup of ID#3, but happened in version 5 -> regression
         self.crashes.close_duplicate(
             self.crashes.download(4), 4, None
         )  # reset

--- a/tests/unit/test_parse_segv.py
+++ b/tests/unit/test_parse_segv.py
@@ -506,7 +506,7 @@ class TestHookParseSegv(unittest.TestCase):
         self.assertNotIn("Stack pointer not within stack segment", details)
 
     def test_segv_dest_missing(self):
-        """Handle destintation in missing VMA."""
+        """Handle destination in missing VMA."""
         reg = REGS + "esp            0x0006af24   0xbfc6af24"
         disasm = "0x08083547 <main+7>:    pushl  -0x4(%ecx)"
 
@@ -521,7 +521,7 @@ class TestHookParseSegv(unittest.TestCase):
         self.assertIn("writing unknown VMA", reason)
 
     def test_segv_dest_null(self):
-        """Handle destintation in NULL VMA."""
+        """Handle destination in NULL VMA."""
         reg = REGS + "esp            0x00000024   0xbfc6af24"
         disasm = "0x08083547 <main+7>:    pushl  -0x4(%ecx)"
 

--- a/tests/unit/test_problem_report.py
+++ b/tests/unit/test_problem_report.py
@@ -92,16 +92,16 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
         self.assertRaises(TypeError, pr.__setitem__, "a", 1)
         self.assertRaises(TypeError, pr.__setitem__, "a", (1,))
         self.assertRaises(
-            TypeError, pr.__setitem__, "a", ("/tmp/nonexistant", "")
+            TypeError, pr.__setitem__, "a", ("/tmp/nonexistent", "")
         )
         self.assertRaises(
             TypeError,
             pr.__setitem__,
             "a",
-            ("/tmp/nonexistant", False, 0, True, "bogus"),
+            ("/tmp/nonexistent", False, 0, True, "bogus"),
         )
-        self.assertRaises(TypeError, pr.__setitem__, "a", ["/tmp/nonexistant"])
-        self.assertRaises(KeyError, pr.__getitem__, "Nonexistant")
+        self.assertRaises(TypeError, pr.__setitem__, "a", ["/tmp/nonexistent"])
+        self.assertRaises(KeyError, pr.__getitem__, "Nonexistent")
 
     def test_write(self):
         """write() and proper formatting."""

--- a/tests/unit/test_report.py
+++ b/tests/unit/test_report.py
@@ -760,7 +760,6 @@ PID: 0      TASK: c073c180  CPU: 0   COMMAND: "swapper"
    2192      1   1  f65b3ed0  IN   0.0    1976    532  dd
    2194      1   1  f6b5a5b0  IN   0.1    3996   2712  klogd
    2217      1   0  f6b74b60  IN   0.1    3008   1120  dbus-daemon
-   2248      1   0  f65b7110  IN   0.2    6896   4304  hald
    2251      1   1  f65b3240  IN   0.1   19688   2604  console-kit-dae
 RUNQUEUES[0]: c6002320
  RT PRIO_ARRAY: c60023c0


### PR DESCRIPTION
`codespell .` finds several spelling mistakes. Address all of them (except for two false positives that can be addressed later).