### PR TITLE
refactor(apport): Use UserGroupID data class

### DIFF
--- a/data/apport
+++ b/data/apport
@@ -45,6 +45,7 @@ import typing
 
 import apport.fileutils
 import apport.report
+from apport.user_group import UserGroupID
 
 LOG_FORMAT = "%(levelname)s: apport (pid %(process)s) %(asctime)s: %(message)s"
 
@@ -109,25 +110,30 @@ def check_lock():
         signal.signal(signal.SIGALRM, original_handler)
 
 
-(pidstat, crash_uid, crash_gid) = (None, None, None)
+pidstat = None
 
 
 def get_core_path(
     options: argparse.Namespace,
+    crash_user: UserGroupID,
     proc_pid: ProcPid,
     timestamp: typing.Optional[int] = None,
 ) -> str:
     """Get the path to the core file."""
     return apport.fileutils.get_core_path(
-        options.pid, options.executable_path, crash_uid, timestamp, proc_pid.fd
+        options.pid,
+        options.executable_path,
+        crash_user.uid,
+        timestamp,
+        proc_pid.fd,
     )[1]
 
 
-def get_pid_info(proc_pid: ProcPid) -> None:
+def get_pid_info(proc_pid: ProcPid) -> UserGroupID:
     """Read /proc information about pid"""
 
     # pylint: disable=global-statement
-    global pidstat, crash_uid, crash_gid
+    global pidstat
 
     # unhandled exceptions on missing or invalidly formatted files are okay
     # here -- we want to know in the log file
@@ -142,6 +148,7 @@ def get_pid_info(proc_pid: ProcPid) -> None:
 
     assert crash_uid is not None, "failed to parse Uid"
     assert crash_gid is not None, "failed to parse Gid"
+    return UserGroupID(crash_uid, crash_gid)
 
 
 def get_process_starttime(proc_pid: ProcPid) -> int:
@@ -160,16 +167,16 @@ def get_apport_starttime() -> int:
     return apport.fileutils.get_starttime(contents)
 
 
-def drop_privileges():
-    """Change effective user and group to crash_[ug]id"""
+def drop_privileges(crash_user: UserGroupID):
+    """Change effective user and group to crash user/group ID"""
     # Drop any supplemental groups, or we'll still be in the root group
     if os.getuid() == 0:
         os.setgroups([])
         assert os.getgroups() == []
-    os.setregid(-1, crash_gid)
-    os.setreuid(-1, crash_uid)
-    assert os.getegid() == crash_gid
-    assert os.geteuid() == crash_uid
+    os.setregid(-1, crash_user.gid)
+    os.setreuid(-1, crash_user.uid)
+    assert os.getegid() == crash_user.gid
+    assert os.geteuid() == crash_user.uid
 
 
 def recover_privileges():
@@ -235,6 +242,7 @@ def write_user_coredump(
     core_path: str,
     limit: int,
     proc_pid: ProcPid,
+    crash_user: UserGroupID,
     coredump_fd=None,
     from_report=None,
 ) -> None:
@@ -256,7 +264,7 @@ def write_user_coredump(
     # /proc/pid/stat is owned by root (or the user suid'ed to), but we already
     # changed to the crashed process' uid
     assert pidstat, "pidstat not initialized"
-    if pidstat.st_uid != crash_uid or pidstat.st_gid != crash_gid:
+    if UserGroupID(pidstat.st_uid, pidstat.st_gid) != crash_user:
         logger.error("disabling core dump for suid/sgid/unreadable executable")
         return
 
@@ -266,7 +274,7 @@ def write_user_coredump(
 
     try:
         # Limit number of core files to prevent DoS
-        apport.fileutils.clean_core_directory(crash_uid)
+        apport.fileutils.clean_core_directory(crash_user.uid)
         core_file = os.open(
             core_path,
             os.O_WRONLY | os.O_CREAT | os.O_EXCL,
@@ -320,7 +328,7 @@ def write_user_coredump(
             block = os.read(coredump_fd, 1048576)
 
     # Make sure the user can read it
-    os.fchown(core_file, crash_uid, -1)
+    os.fchown(core_file, crash_user.uid, -1)
     os.close(core_file)
 
 
@@ -389,7 +397,7 @@ def _run_with_output_limit_and_timeout(
     return stdout, stderr
 
 
-def is_closing_session(proc_pid: ProcPid) -> bool:
+def is_closing_session(proc_pid: ProcPid, crash_user: UserGroupID) -> bool:
     """Check if pid is in a closing user session.
 
     During that, crashes are common as the session D-BUS and X.org are going
@@ -424,8 +432,8 @@ def is_closing_session(proc_pid: ProcPid) -> bool:
     real_uid = os.getuid()
     real_gid = os.getgid()
     try:
-        os.setresgid(crash_gid, crash_gid, real_gid)
-        os.setresuid(crash_uid, crash_uid, real_uid)
+        os.setresgid(crash_user.gid, crash_user.gid, real_gid)
+        os.setresuid(crash_user.uid, crash_user.uid, real_uid)
         out, err = _run_with_output_limit_and_timeout(
             [
                 "/usr/bin/gdbus",
@@ -882,7 +890,10 @@ def receive_arguments_via_socket() -> argparse.Namespace:
 
 
 def consistency_checks(
-    options: argparse.Namespace, process_start: int, proc_pid: ProcPid
+    options: argparse.Namespace,
+    process_start: int,
+    proc_pid: ProcPid,
+    crash_user: UserGroupID,
 ) -> bool:
     """Run consistency checks and return True if all pass."""
     logger = logging.getLogger()
@@ -898,7 +909,7 @@ def consistency_checks(
     # Make sure the process uid/gid match the ones provided by the kernel
     # if available, if not, it may have been replaced
     if (options.uid is not None) and (options.gid is not None):
-        if (options.uid != crash_uid) or (options.gid != crash_gid):
+        if UserGroupID(options.uid, options.gid) != crash_user:
             logger.error("process uid/gid doesn't match expected, ignoring")
             return False
 
@@ -962,10 +973,10 @@ def process_crash_with_proc_pid(
     logger = logging.getLogger()
 
     coredump_fd = sys.stdin.fileno()
-    get_pid_info(proc_pid)
+    crash_user = get_pid_info(proc_pid)
 
     process_start = get_process_starttime(proc_pid)
-    if not consistency_checks(options, process_start, proc_pid):
+    if not consistency_checks(options, process_start, proc_pid, crash_user):
         return 0
 
     logger.info(
@@ -978,11 +989,13 @@ def process_crash_with_proc_pid(
 
     core_ulimit = refine_core_ulimit(options)
 
-    core_path = get_core_path(options, proc_pid, process_start)
+    core_path = get_core_path(options, crash_user, proc_pid, process_start)
 
     # ignore SIGQUIT (it's usually deliberately generated by users)
     if options.signal_number == int(signal.SIGQUIT):
-        write_user_coredump(core_path, core_ulimit, proc_pid, coredump_fd)
+        write_user_coredump(
+            core_path, core_ulimit, proc_pid, crash_user, coredump_fd
+        )
         return 0
 
     info = apport.report.Report("Crash")
@@ -1003,7 +1016,7 @@ def process_crash_with_proc_pid(
     # Drop privileges temporarily to make sure that we don't
     # include information in the crash report that the user should
     # not be allowed to access.
-    drop_privileges()
+    drop_privileges(crash_user)
 
     info.add_proc_info(proc_pid_fd=proc_pid.fd)
 
@@ -1042,7 +1055,9 @@ def process_crash_with_proc_pid(
             logger.error("executable does not belong to a package, ignoring")
             # check if the user wants a core dump
             recover_privileges()
-            write_user_coredump(core_path, core_ulimit, proc_pid, coredump_fd)
+            write_user_coredump(
+                core_path, core_ulimit, proc_pid, crash_user, coredump_fd
+            )
             return 0
 
     # ignore SIGXCPU and SIGXFSZ since this indicates some external
@@ -1053,7 +1068,9 @@ def process_crash_with_proc_pid(
             options.signal_number,
         )
         recover_privileges()
-        write_user_coredump(core_path, core_ulimit, proc_pid, coredump_fd)
+        write_user_coredump(
+            core_path, core_ulimit, proc_pid, crash_user, coredump_fd
+        )
         return 0
 
     if info.check_ignored():
@@ -1067,7 +1084,7 @@ def process_crash_with_proc_pid(
     recover_privileges()
 
     # Do not check closing session for root processes
-    if crash_uid != 0 and crash_gid != 0 and is_closing_session(proc_pid):
+    if not crash_user.is_root() and is_closing_session(proc_pid, crash_user):
         logger.error("happens for shutting down session, ignoring")
         return 0
 
@@ -1091,7 +1108,7 @@ def process_crash_with_proc_pid(
             if skip_msg:
                 logger.error("%s", skip_msg)
                 write_user_coredump(
-                    core_path, core_ulimit, proc_pid, coredump_fd
+                    core_path, core_ulimit, proc_pid, crash_user, coredump_fd
                 )
                 return 0
             # remove the old file, so that we can create the new one
@@ -1114,7 +1131,7 @@ def process_crash_with_proc_pid(
         return 1
 
     # Drop privileges before writing out the reportfile.
-    drop_privileges()
+    drop_privileges(crash_user)
 
     info.add_user_info()
     info.add_os_info()
@@ -1150,7 +1167,7 @@ def process_crash_with_proc_pid(
     # than the core size.
     reportfile.seek(0)
     write_user_coredump(
-        core_path, core_ulimit, proc_pid, from_report=reportfile
+        core_path, core_ulimit, proc_pid, crash_user, from_report=reportfile
     )
     return 0
 


### PR DESCRIPTION
Group user and group ID in a `UserGroupID` data class and hand around that data class instead of using a global variable.