### PR TITLE
Implement APT deb822 support (FR-4091)

### DIFF
--- a/tests/system/test_packaging_apt_dpkg.py
+++ b/tests/system/test_packaging_apt_dpkg.py
@@ -717,19 +717,43 @@ def test_create_sources_for_a_named_ppa(configdir, rootdir, apt_style):
     impl._build_apt_sandbox(
         rootdir, os.path.join(configdir, release), "ubuntu", "jammy", origins=[ppa]
     )
-    with open(
-        os.path.join(rootdir, "etc", "apt", "sources.list.d", f"{ppa}.list"),
-        encoding="utf-8",
-    ) as f:
-        sources = f.read().splitlines()
-    assert (
-        "deb http://ppa.launchpad.net/daisy-pluckers/daisy-seeds/ubuntu"
-        " jammy main main/debug" in sources
-    )
-    assert (
-        "deb-src http://ppa.launchpad.net"
-        "/daisy-pluckers/daisy-seeds/ubuntu jammy main" in sources
-    )
+    if WITH_DEB822_SUPPORT:
+        ppasource = os.path.join(
+            rootdir, "etc", "apt", "sources.list.d", f"{ppa}.sources"
+        )
+        entries = _parse_deb822_sources(ppasource)
+        assert [
+            e
+            for e in entries
+            if {"deb", "deb-src"} == set(e.types)
+            and "jammy" in e.suites
+            and "main" in e.comps
+            and "http://ppa.launchpad.net/"
+            "daisy-pluckers/daisy-seeds/ubuntu" in e.uris
+        ]
+        assert [
+            e
+            for e in entries
+            if "deb" in e.types
+            and "jammy" in e.suites
+            and "main/debug" in e.comps
+            and "http://ppa.launchpad.net/"
+            "daisy-pluckers/daisy-seeds/ubuntu" in e.uris
+        ]
+    else:
+        with open(
+            os.path.join(rootdir, "etc", "apt", "sources.list.d", f"{ppa}.list"),
+            encoding="utf-8",
+        ) as f:
+            sources = f.read().splitlines()
+        assert (
+            "deb http://ppa.launchpad.net/daisy-pluckers/daisy-seeds/ubuntu"
+            " jammy main main/debug" in sources
+        )
+        assert (
+            "deb-src http://ppa.launchpad.net/daisy-pluckers/daisy-seeds/ubuntu"
+            " jammy main" in sources
+        )
 
     gpg = subprocess.run(
         [
@@ -767,19 +791,43 @@ def test_create_sources_for_an_unnamed_ppa(configdir, rootdir, apt_style):
     impl._build_apt_sandbox(
         rootdir, os.path.join(configdir, release), "ubuntu", "jammy", origins=[ppa]
     )
-    with open(
-        os.path.join(rootdir, "etc", "apt", "sources.list.d", f"{ppa}.list"),
-        encoding="utf-8",
-    ) as f:
-        sources = f.read().splitlines()
-    assert (
-        "deb http://ppa.launchpad.net"
-        "/apport-hackers/apport-autopkgtests/ubuntu jammy main main/debug" in sources
-    )
-    assert (
-        "deb-src http://ppa.launchpad.net"
-        "/apport-hackers/apport-autopkgtests/ubuntu jammy main" in sources
-    )
+    if WITH_DEB822_SUPPORT:
+        ppasource = os.path.join(
+            rootdir, "etc", "apt", "sources.list.d", f"{ppa}.sources"
+        )
+        entries = _parse_deb822_sources(ppasource)
+        assert [
+            e
+            for e in entries
+            if {"deb", "deb-src"} == set(e.types)
+            and "jammy" in e.suites
+            and "main" in e.comps
+            and "http://ppa.launchpad.net/"
+            "apport-hackers/apport-autopkgtests/ubuntu" in e.uris
+        ]
+        assert [
+            e
+            for e in entries
+            if "deb" in e.types
+            and "jammy" in e.suites
+            and "main/debug" in e.comps
+            and "http://ppa.launchpad.net/"
+            "apport-hackers/apport-autopkgtests/ubuntu" in e.uris
+        ]
+    else:
+        with open(
+            os.path.join(rootdir, "etc", "apt", "sources.list.d", f"{ppa}.list"),
+            encoding="utf-8",
+        ) as f:
+            sources = f.read().splitlines()
+        assert (
+            "deb http://ppa.launchpad.net/apport-hackers/apport-autopkgtests/ubuntu"
+            " jammy main main/debug" in sources
+        )
+        assert (
+            "deb-src http://ppa.launchpad.net/apport-hackers/apport-autopkgtests/ubuntu"
+            " jammy main" in sources
+        )
 
     gpg = subprocess.run(
         [


### PR DESCRIPTION
There's a (somewhat) new format for sources definition supported by APT, based on the deb822 syntax that's widely used in the Debian world. The APT developpers would like to make that new format the default (there are plenty of good reasons), and for that we need to support it.

Luckily some of the heavy lifting has already been done in `python-apt`.

Note that in order to easily test the new format, I migrated `tests/system/test_packaging_apt_dpkg.py` from using the unittest API to directly use pytest's API, since we're already using it as test runner anyway (split off in #194). This allowed me to simply parameterize the tests over the source format, ensuring a good test coverage. Said migration should account for a good chunk of the test file diff.