### PR TITLE
Migrate the APT tests to pytest

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,8 +30,8 @@ jobs:
           black gir1.2-gtk-3.0 gir1.2-wnck-3.0 isort mypy pycodestyle
           pydocstyle pyflakes3 pylint python3 python3-apt python3-dbus
           python3-distutils-extra python3-gi python3-launchpadlib
-          python3-psutil python3-rpm python3-typeshed python3-yaml
-          python3-requests
+          python3-psutil python3-pytest python3-rpm python3-typeshed
+          python3-yaml python3-requests
       - name: Run linter tests
         run: tests/run-linters
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -23,12 +23,6 @@ at most) and do not interact with the outside system. All outside access is
 mocked. The unit tests can be run from the top directory by calling:
 
 ```
-python3 -m unittest tests/unit/test_*.py
-```
-
-or with pytest:
-
-```
 python3 -m pytest tests/unit/
 ```
 
@@ -41,12 +35,6 @@ execute relatively quickly (a few seconds per test at most) and interact with
 the outside system in a non invasive manner. Temporary directories are created
 in case the test needs to write to them. The integration tests can be run from
 the top directory by calling:
-
-```
-python3 -m unittest tests/integration/test_*.py
-```
-
-or with pytest:
 
 ```
 python3 -m pytest tests/integration/
@@ -64,12 +52,6 @@ These tests can be skipped by setting the environment variable
 [test_python_crashes.py](./system/test_python_crashes.py) need a running D-Bus
 daemon. Whit a D-Bus daemon running, the system tests can be run from the top
 directory by calling:
-
-```
-GDK_BACKEND=x11 xvfb-run python3 -m unittest tests/system/test_*.py
-```
-
-or with pytest:
 
 ```
 GDK_BACKEND=x11 xvfb-run python3 -m pytest tests/system/

--- a/tests/system/test_packaging_apt_dpkg.py
+++ b/tests/system/test_packaging_apt_dpkg.py
@@ -8,1056 +8,993 @@ import os
 import shutil
 import subprocess
 import tempfile
-import unittest
 
+import pytest
 from apt import apt_pkg
 
 from apport.packaging_impl.apt_dpkg import impl
 from tests.helper import has_internet, skip_if_command_is_missing
 
+if shutil.which("dpkg") is None:
+    pytest.skip("dpkg not installed", allow_module_level=True)
 
-@skip_if_command_is_missing("dpkg")
-class T(unittest.TestCase):
+
+@pytest.fixture(name="workdir")
+def fixture_workdir():
+    workdir = tempfile.mkdtemp()
+    yield workdir
+    shutil.rmtree(workdir)
+
+
+@pytest.fixture(name="cachedir")
+def fixture_cachedir(workdir):
+    ret = os.path.join(workdir, "cache")
+    os.makedirs(ret)
+    return ret
+
+
+@pytest.fixture(name="rootdir")
+def fixture_rootdir(workdir):
+    ret = os.path.join(workdir, "root")
+    os.makedirs(ret)
+    return ret
+
+
+@pytest.fixture(name="configdir")
+def fixture_configdir(workdir):
+    ret = os.path.join(workdir, "config")
+    os.makedirs(ret)
+    return ret
+
+
+@pytest.fixture(autouse=True)
+def environment(workdir):
+    orig_environ = os.environ.copy()
+    os.environ["HOME"] = workdir
+    yield
+    os.environ.clear()
+    os.environ.update(orig_environ)
+
+
+@pytest.fixture(autouse=True)
+def reset_impl():
     # pylint: disable=protected-access
+    orig_conf = impl.configuration
+    impl._apt_cache = None
+    impl._sandbox_apt_cache = None
+    yield
+    impl.configuration = orig_conf
 
-    def setUp(self):
-        # save and restore configuration file
-        self.orig_conf = impl.configuration
-        self.orig_environ = os.environ.copy()
-        self.workdir = tempfile.mkdtemp()
-        os.environ["HOME"] = self.workdir
-        self.cachedir = os.path.join(self.workdir, "cache")
-        self.rootdir = os.path.join(self.workdir, "root")
-        self.configdir = os.path.join(self.workdir, "config")
-        # reset internal caches between tests
-        impl._apt_cache = None
-        impl._sandbox_apt_cache = None
 
-    def tearDown(self):
-        impl.configuration = self.orig_conf
-        os.environ.clear()
-        os.environ.update(self.orig_environ)
-        shutil.rmtree(self.workdir)
+@pytest.mark.skipif(not has_internet(), reason="online test")
+def test_install_packages_versioned(configdir, cachedir, rootdir):
+    # TODO: Split into smaller functions/methods
+    # pylint: disable=too-many-locals,too-many-statements
+    """install_packages() with versions and with cache"""
+    release = _setup_foonux_config(configdir, updates=True)
+    wanted = {
+        "coreutils": "8.32-4.1ubuntu1",
+        "libc6": "2.35-0ubuntu3",
+        "libcurl4": "7.81.0-1",  # should not come from -updates
+        "tzdata": None,  # should come from -updates, > 2022a
+    }
+    obsolete = impl.install_packages(
+        rootdir, configdir, release, list(wanted.items()), False, cachedir
+    )
 
-    @unittest.skipUnless(has_internet(), "online test")
-    def test_install_packages_versioned(self):
-        # TODO: Split into smaller functions/methods
-        # pylint: disable=too-many-locals,too-many-statements
-        """install_packages() with versions and with cache"""
-        release = self._setup_foonux_config(updates=True)
-        wanted = {
-            "coreutils": "8.32-4.1ubuntu1",
-            "libc6": "2.35-0ubuntu3",
-            "libcurl4": "7.81.0-1",  # should not come from -updates
-            "tzdata": None,  # should come from -updates, > 2022a
-        }
-        obsolete = impl.install_packages(
-            self.rootdir,
-            self.configdir,
-            release,
-            list(wanted.items()),
-            False,
-            self.cachedir,
-        )
+    def sandbox_ver(pkg):
+        with gzip.open(
+            os.path.join(rootdir, "usr/share/doc", pkg, "changelog.Debian.gz")
+        ) as f:
+            return f.readline().decode().split()[1][1:-1]
 
-        def sandbox_ver(pkg):
-            with gzip.open(
-                os.path.join(self.rootdir, "usr/share/doc", pkg, "changelog.Debian.gz")
-            ) as f:
-                return f.readline().decode().split()[1][1:-1]
+    assert obsolete == ""
 
-        self.assertEqual(obsolete, "")
+    # packages get installed
+    assert os.path.exists(os.path.join(rootdir, "usr/bin/stat"))
+    assert_elf_arch(
+        os.path.join(rootdir, "usr/bin/stat"), impl.get_system_architecture()
+    )
+    assert os.path.exists(os.path.join(rootdir, "usr/lib/debug/.build-id"))
+    assert os.path.exists(os.path.join(rootdir, "usr/share/zoneinfo/zone.tab"))
+    for library in ("libc6", "libcurl4"):
+        copyright_filename = f"usr/share/doc/{library}/copyright"
+        assert os.path.exists(os.path.join(rootdir, copyright_filename))
 
-        # packages get installed
-        self.assertTrue(os.path.exists(os.path.join(self.rootdir, "usr/bin/stat")))
-        self.assert_elf_arch(
-            os.path.join(self.rootdir, "usr/bin/stat"), impl.get_system_architecture()
-        )
-        self.assertTrue(
-            os.path.exists(os.path.join(self.rootdir, "usr/lib/debug/.build-id"))
-        )
-        self.assertTrue(
-            os.path.exists(os.path.join(self.rootdir, "usr/share/zoneinfo/zone.tab"))
-        )
-        for library in ("libc6", "libcurl4"):
-            copyright_filename = f"usr/share/doc/{library}/copyright"
-            self.assertTrue(
-                os.path.exists(os.path.join(self.rootdir, copyright_filename))
-            )
+    # their versions are as expected
+    assert sandbox_ver("coreutils") == wanted["coreutils"]
+    assert sandbox_ver("libc6") == wanted["libc6"]
+    assert sandbox_ver("libc6-dbg") == wanted["libc6"]
+    assert sandbox_ver("libcurl4") == wanted["libcurl4"]
+    assert sandbox_ver("tzdata") > "2022a"
 
-        # their versions are as expected
-        self.assertEqual(sandbox_ver("coreutils"), wanted["coreutils"])
-        self.assertEqual(sandbox_ver("libc6"), wanted["libc6"])
-        self.assertEqual(sandbox_ver("libc6-dbg"), wanted["libc6"])
-        self.assertEqual(sandbox_ver("libcurl4"), wanted["libcurl4"])
-        self.assertGreater(sandbox_ver("tzdata"), "2022a")
+    with open(os.path.join(rootdir, "packages.txt"), encoding="utf-8") as f:
+        pkglist = f.read().splitlines()
+    assert f"coreutils {wanted['coreutils']}" in pkglist
+    assert f"coreutils-dbgsym {wanted['coreutils']}" in pkglist
+    assert f"libc6 {wanted['libc6']}" in pkglist
+    assert f"libc6-dbg {wanted['libc6']}" in pkglist
+    assert f"libcurl4 {wanted['libcurl4']}" in pkglist
+    assert f"libcurl4-dbgsym {wanted['libcurl4']}" in pkglist
+    assert f"tzdata {sandbox_ver('tzdata')}" in pkglist
+    assert len(pkglist) == 7
 
-        with open(os.path.join(self.rootdir, "packages.txt"), encoding="utf-8") as f:
-            pkglist = f.read().splitlines()
-        self.assertIn(f"coreutils {wanted['coreutils']}", pkglist)
-        self.assertIn(f"coreutils-dbgsym {wanted['coreutils']}", pkglist)
-        self.assertIn(f"libc6 {wanted['libc6']}", pkglist)
-        self.assertIn(f"libc6-dbg {wanted['libc6']}", pkglist)
-        self.assertIn(f"libcurl4 {wanted['libcurl4']}", pkglist)
-        self.assertIn(f"libcurl4-dbgsym {wanted['libcurl4']}", pkglist)
-        self.assertIn(f"tzdata {sandbox_ver('tzdata')}", pkglist)
-        self.assertEqual(len(pkglist), 7, str(pkglist))
+    # does not clobber config dir
+    assert os.listdir(configdir) == [release]
+    assert sorted(os.listdir(os.path.join(configdir, release))) == [
+        "armhf",
+        "codename",
+        "sources.list",
+        "trusted.gpg.d",
+    ]
+    assert sorted(os.listdir(os.path.join(configdir, release, "armhf"))) == [
+        "sources.list",
+        "trusted.gpg.d",
+    ]
 
-        # does not clobber config dir
-        self.assertEqual(os.listdir(self.configdir), [release])
-        self.assertEqual(
-            sorted(os.listdir(os.path.join(self.configdir, release))),
-            ["armhf", "codename", "sources.list", "trusted.gpg.d"],
-        )
-        self.assertEqual(
-            sorted(os.listdir(os.path.join(self.configdir, release, "armhf"))),
-            ["sources.list", "trusted.gpg.d"],
-        )
+    # caches packages, and their versions are as expected
+    cache = os.listdir(
+        os.path.join(cachedir, release, "apt", "var", "cache", "apt", "archives")
+    )
+    cache_versions = {}
+    for p in cache:
+        try:
+            (name, ver) = p.split("_")[:2]
+            cache_versions[name] = ver
+        except ValueError:
+            pass  # not a .deb, ignore
+    assert cache_versions["coreutils"] == wanted["coreutils"]
+    assert cache_versions["coreutils-dbgsym"] == wanted["coreutils"]
+    assert cache_versions["libc6"] == wanted["libc6"]
+    assert cache_versions["libc6-dbg"] == wanted["libc6"]
+    assert cache_versions["libcurl4"] == wanted["libcurl4"]
+    assert "tzdata" in cache_versions
 
-        # caches packages, and their versions are as expected
-        cache = os.listdir(
-            os.path.join(
-                self.cachedir, release, "apt", "var", "cache", "apt", "archives"
-            )
-        )
-        cache_versions = {}
-        for p in cache:
-            try:
-                (name, ver) = p.split("_")[:2]
-                cache_versions[name] = ver
-            except ValueError:
-                pass  # not a .deb, ignore
-        self.assertEqual(cache_versions["coreutils"], wanted["coreutils"])
-        self.assertEqual(cache_versions["coreutils-dbgsym"], wanted["coreutils"])
-        self.assertEqual(cache_versions["libc6"], wanted["libc6"])
-        self.assertEqual(cache_versions["libc6-dbg"], wanted["libc6"])
-        self.assertEqual(cache_versions["libcurl4"], wanted["libcurl4"])
-        self.assertIn("tzdata", cache_versions)
+    # installs cached packages
+    os.unlink(os.path.join(rootdir, "usr/bin/stat"))
+    os.unlink(os.path.join(rootdir, "packages.txt"))
+    obsolete = impl.install_packages(
+        rootdir,
+        configdir,
+        release,
+        [("coreutils", wanted["coreutils"])],
+        False,
+        cachedir,
+    )
+    assert obsolete == ""
+    assert os.path.exists(os.path.join(rootdir, "usr/bin/stat"))
 
-        # installs cached packages
-        os.unlink(os.path.join(self.rootdir, "usr/bin/stat"))
-        os.unlink(os.path.join(self.rootdir, "packages.txt"))
-        obsolete = impl.install_packages(
-            self.rootdir,
-            self.configdir,
-            release,
-            [("coreutils", wanted["coreutils"])],
-            False,
-            self.cachedir,
-        )
-        self.assertEqual(obsolete, "")
-        self.assertTrue(os.path.exists(os.path.join(self.rootdir, "usr/bin/stat")))
+    # complains about obsolete packages
+    result = impl.install_packages(rootdir, configdir, release, [("aspell-doc", "1.1")])
+    assert "aspell-doc version 1.1 required, but 0.60.8-4build1" in result
+    # ... but installs the current version anyway
+    assert os.path.exists(os.path.join(rootdir, "usr/share/info/aspell.info.gz"))
+    assert sandbox_ver("aspell-doc") >= "0.60.8"
 
-        # complains about obsolete packages
-        result = impl.install_packages(
-            self.rootdir, self.configdir, release, [("aspell-doc", "1.1")]
-        )
-        self.assertIn("aspell-doc version 1.1 required, but 0.60.8-4build1", result)
-        # ... but installs the current version anyway
-        self.assertTrue(
-            os.path.exists(os.path.join(self.rootdir, "usr/share/info/aspell.info.gz"))
-        )
-        self.assertGreaterEqual(sandbox_ver("aspell-doc"), "0.60.8")
+    # does not crash on nonexisting packages
+    result = impl.install_packages(
+        rootdir, configdir, release, [("buggerbogger", None)]
+    )
+    assert len(result.splitlines()) == 1
+    assert "buggerbogger" in result
+    assert "not exist" in result
 
-        # does not crash on nonexisting packages
-        result = impl.install_packages(
-            self.rootdir, self.configdir, release, [("buggerbogger", None)]
-        )
-        self.assertEqual(len(result.splitlines()), 1)
-        self.assertIn("buggerbogger", result)
-        self.assertIn("not exist", result)
+    # can interleave with other operations
+    dpkg = subprocess.run(
+        ["dpkg-query", "-Wf${Version}", "dash"], check=True, stdout=subprocess.PIPE
+    )
+    dash_version = dpkg.stdout.decode()
 
-        # can interleave with other operations
-        dpkg = subprocess.run(
-            ["dpkg-query", "-Wf${Version}", "dash"], check=True, stdout=subprocess.PIPE
-        )
-        dash_version = dpkg.stdout.decode()
+    assert impl.get_version("dash") == dash_version
+    with pytest.raises(ValueError):
+        impl.get_available_version("buggerbogger")
 
-        self.assertEqual(impl.get_version("dash"), dash_version)
-        self.assertRaises(ValueError, impl.get_available_version, "buggerbogger")
+    # still installs packages after above operations
+    os.unlink(os.path.join(rootdir, "usr/bin/stat"))
+    os.unlink(os.path.join(rootdir, "packages.txt"))
+    impl.install_packages(
+        rootdir,
+        configdir,
+        release,
+        [("coreutils", wanted["coreutils"]), ("dpkg", None)],
+        False,
+        cachedir,
+    )
+    assert os.path.exists(os.path.join(rootdir, "usr/bin/stat"))
+    assert os.path.exists(os.path.join(rootdir, "usr/bin/dpkg"))
 
-        # still installs packages after above operations
-        os.unlink(os.path.join(self.rootdir, "usr/bin/stat"))
-        os.unlink(os.path.join(self.rootdir, "packages.txt"))
+
+@pytest.mark.skipif(not has_internet(), reason="online test")
+def test_install_packages_unversioned(configdir, cachedir, rootdir):
+    """install_packages() without versions and no cache"""
+    release = _setup_foonux_config(configdir)
+    obsolete = impl.install_packages(
+        rootdir,
+        configdir,
+        release,
+        [("coreutils", None), ("tzdata", None)],
+        False,
+        None,
+    )
+
+    assert obsolete == ""
+    assert os.path.exists(os.path.join(rootdir, "usr/bin/stat"))
+    assert_elf_arch(
+        os.path.join(rootdir, "usr/bin/stat"), impl.get_system_architecture()
+    )
+    assert os.path.exists(os.path.join(rootdir, "usr/lib/debug/.build-id"))
+    assert os.path.exists(os.path.join(rootdir, "usr/share/zoneinfo/zone.tab"))
+
+    # does not clobber config dir
+    assert os.listdir(configdir) == [release]
+    assert sorted(os.listdir(os.path.join(configdir, release))) == [
+        "armhf",
+        "codename",
+        "sources.list",
+        "trusted.gpg.d",
+    ]
+    assert sorted(os.listdir(os.path.join(configdir, release, "armhf"))) == [
+        "sources.list",
+        "trusted.gpg.d",
+    ]
+
+    # no cache
+    assert os.listdir(cachedir) == []
+
+    # keeps track of package versions
+    with open(os.path.join(rootdir, "packages.txt"), encoding="utf-8") as f:
+        pkglist = f.read().splitlines()
+    assert "coreutils 8.32-4.1ubuntu1" in pkglist
+    assert "coreutils-dbgsym 8.32-4.1ubuntu1" in pkglist
+    assert "tzdata 2022a-0ubuntu1" in pkglist
+    assert len(pkglist), 3 == str(pkglist)
+
+
+@pytest.mark.skipif(not has_internet(), reason="online test")
+def test_install_packages_dependencies(configdir, rootdir):
+    """Test install packages's dependencies."""
+    release = _setup_foonux_config(configdir)
+    # coreutils should always depend on libc6
+    result = impl.install_packages(
+        rootdir,
+        configdir,
+        release,
+        [("coreutils", None)],
+        False,
+        None,
+        install_deps=True,
+    )
+
+    # check packages.txt for a dependency
+    with open(os.path.join(rootdir, "packages.txt"), encoding="utf-8") as f:
+        pkglist = f.read().splitlines()
+    assert "coreutils 8.32-4.1ubuntu1" in pkglist
+    assert "libc6 2.35-0ubuntu3" in pkglist
+
+    # ensure obsolete packages doesn't include libc6
+    assert "libc6" not in result
+
+
+@pytest.mark.skipif(not has_internet(), reason="online test")
+def test_install_packages_system(cachedir, workdir, rootdir):
+    """install_packages() with system configuration"""
+    # trigger an unrelated package query here to get the cache set up,
+    # reproducing an install failure when the internal caches are not
+    # reset properly
+    impl.get_version("dash")
+
+    release = " ".join(impl.get_os_version())
+    cachedir = os.path.join(workdir, "cache")
+    rootdir = os.path.join(workdir, "root")
+
+    result = impl.install_packages(
+        rootdir,
+        None,
+        release,
+        [("coreutils", impl.get_version("coreutils")), ("tzdata", "1.1")],
+        False,
+        cachedir,
+    )
+
+    assert os.path.exists(os.path.join(rootdir, "usr/bin/stat"))
+    assert os.path.exists(os.path.join(rootdir, "usr/share/zoneinfo/zone.tab"))
+
+    # complains about obsolete packages
+    assert len(result.splitlines()) == 1
+    assert "tzdata" in result
+    assert "1.1" in result
+
+    # caches packages
+    cache = os.listdir(
+        os.path.join(cachedir, "system", "apt", "var", "cache", "apt", "archives")
+    )
+    cache_names = [p.split("_")[0] for p in cache]
+    assert "coreutils" in cache_names
+    assert "coreutils-dbgsym" in cache_names
+    assert "tzdata" in cache_names
+
+    # works with relative paths and existing cache
+    os.unlink(os.path.join(rootdir, "usr/bin/stat"))
+    os.unlink(os.path.join(rootdir, "packages.txt"))
+    orig_cwd = os.getcwd()
+    try:
+        os.chdir(workdir)
+        impl.install_packages("root", None, None, [("coreutils", None)], False, "cache")
+    finally:
+        os.chdir(orig_cwd)
+        assert os.path.exists(os.path.join(rootdir, "usr/bin/stat"))
+
+
+@pytest.mark.skipif(not has_internet(), reason="online test")
+def test_install_packages_error(configdir, cachedir, rootdir):
+    """install_packages() with errors"""
+    # sources.list with invalid format
+    release = _setup_foonux_config(configdir)
+    with open(
+        os.path.join(configdir, release, "sources.list"), "w", encoding="utf-8"
+    ) as f:
+        f.write("bogus format")
+
+    with pytest.raises(SystemError) as exc_info:
         impl.install_packages(
-            self.rootdir,
-            self.configdir,
-            release,
-            [("coreutils", wanted["coreutils"]), ("dpkg", None)],
-            False,
-            self.cachedir,
+            rootdir, configdir, release, [("tzdata", None)], False, cachedir
         )
-        self.assertTrue(os.path.exists(os.path.join(self.rootdir, "usr/bin/stat")))
-        self.assertTrue(os.path.exists(os.path.join(self.rootdir, "usr/bin/dpkg")))
+    exc_info.match("^E:Type 'bogus' is not known .* sources could not be read.$")
 
-    @unittest.skipUnless(has_internet(), "online test")
-    def test_install_packages_unversioned(self):
-        """install_packages() without versions and no cache"""
-        release = self._setup_foonux_config()
-        obsolete = impl.install_packages(
-            self.rootdir,
-            self.configdir,
-            release,
-            [("coreutils", None), ("tzdata", None)],
-            False,
-            None,
+    # sources.list with wrong server
+    with open(
+        os.path.join(configdir, release, "sources.list"), "w", encoding="utf-8"
+    ) as f:
+        f.write("deb http://archive.ubuntu.com/nosuchdistro/ jammy main\n")
+
+    with pytest.raises(SystemError) as exc_info:
+        impl.install_packages(
+            rootdir, configdir, release, [("tzdata", None)], False, cachedir
         )
+    exc_info.match(
+        "^E:The repository 'http://archive.ubuntu.com/nosuchdistro"
+        " jammy.*' does not have a Release file.$"
+    )
 
-        self.assertEqual(obsolete, "")
-        self.assertTrue(os.path.exists(os.path.join(self.rootdir, "usr/bin/stat")))
-        self.assert_elf_arch(
-            os.path.join(self.rootdir, "usr/bin/stat"), impl.get_system_architecture()
-        )
-        self.assertTrue(
-            os.path.exists(os.path.join(self.rootdir, "usr/lib/debug/.build-id"))
-        )
-        self.assertTrue(
-            os.path.exists(os.path.join(self.rootdir, "usr/share/zoneinfo/zone.tab"))
-        )
 
-        # does not clobber config dir
-        self.assertEqual(os.listdir(self.configdir), [release])
-        self.assertEqual(
-            sorted(os.listdir(os.path.join(self.configdir, release))),
-            ["armhf", "codename", "sources.list", "trusted.gpg.d"],
-        )
-        self.assertEqual(
-            sorted(os.listdir(os.path.join(self.configdir, release, "armhf"))),
-            ["sources.list", "trusted.gpg.d"],
-        )
+@pytest.mark.skipif(not has_internet(), reason="online test")
+def test_install_packages_permanent_sandbox(configdir, cachedir, rootdir):
+    """install_packages() with a permanent sandbox"""
+    release = _setup_foonux_config(configdir)
+    zonetab = os.path.join(rootdir, "usr/share/zoneinfo/zone.tab")
 
-        # no cache
-        self.assertEqual(os.listdir(self.cachedir), [])
+    impl.install_packages(
+        rootdir,
+        configdir,
+        release,
+        [("tzdata", None)],
+        False,
+        cachedir,
+        permanent_rootdir=True,
+    )
 
-        # keeps track of package versions
-        with open(os.path.join(self.rootdir, "packages.txt"), encoding="utf-8") as f:
-            pkglist = f.read().splitlines()
-        self.assertIn("coreutils 8.32-4.1ubuntu1", pkglist)
-        self.assertIn("coreutils-dbgsym 8.32-4.1ubuntu1", pkglist)
-        self.assertIn("tzdata 2022a-0ubuntu1", pkglist)
-        self.assertEqual(len(pkglist), 3, str(pkglist))
+    # This will now be using a Cache with our rootdir.
+    archives = apt_pkg.config.find_dir("Dir::Cache::archives")
+    tzdata = glob.glob(os.path.join(archives, "tzdata*.deb"))
+    assert tzdata
+    tzdata_written = os.path.getctime(tzdata[0])
+    zonetab_written = os.path.getctime(zonetab)
 
-    @unittest.skipUnless(has_internet(), "online test")
-    def test_install_packages_dependencies(self):
-        """Test install packages's dependencies."""
-        release = self._setup_foonux_config()
-        # coreutils should always depend on libc6
-        result = impl.install_packages(
-            self.rootdir,
-            self.configdir,
-            release,
-            [("coreutils", None)],
-            False,
-            None,
-            install_deps=True,
-        )
+    impl.install_packages(
+        rootdir,
+        configdir,
+        release,
+        [("coreutils", None), ("tzdata", None)],
+        False,
+        cachedir,
+        permanent_rootdir=True,
+    )
 
-        # check packages.txt for a dependency
-        with open(os.path.join(self.rootdir, "packages.txt"), encoding="utf-8") as f:
-            pkglist = f.read().splitlines()
-        self.assertIn("coreutils 8.32-4.1ubuntu1", pkglist)
-        self.assertIn("libc6 2.35-0ubuntu3", pkglist)
+    # Check if the deb was downloaded
+    assert glob.glob(os.path.join(archives, "coreutils*.deb"))
+    assert os.path.getctime(tzdata[0]) == tzdata_written
+    assert zonetab_written == os.path.getctime(zonetab)
+    assert os.path.exists(os.path.join(rootdir, "usr/bin/stat"))
 
-        # ensure obsolete packages doesn't include libc6
-        self.assertNotIn("libc6", result)
+    # Prevent packages from downloading.
+    orig_apt_proxy = apt_pkg.config.get("Acquire::http::Proxy")
+    apt_pkg.config.set("Acquire::http::Proxy", "http://nonexistent")
+    orig_http_proxy = os.environ.get("http_proxy")
+    os.environ["http_proxy"] = "http://nonexistent"
+    try:
+        orig_no_proxy = os.environ["no_proxy"]
+        del os.environ["no_proxy"]
+    except KeyError:
+        orig_no_proxy = None
 
-    @unittest.skipUnless(has_internet(), "online test")
-    def test_install_packages_system(self):
-        """install_packages() with system configuration"""
-        # trigger an unrelated package query here to get the cache set up,
-        # reproducing an install failure when the internal caches are not
-        # reset properly
-        impl.get_version("dash")
-
-        release = " ".join(impl.get_os_version())
-        cachedir = os.path.join(self.workdir, "cache")
-        rootdir = os.path.join(self.workdir, "root")
-
-        result = impl.install_packages(
+    with pytest.raises(SystemExit):
+        impl.install_packages(
             rootdir,
-            None,
-            release,
-            [("coreutils", impl.get_version("coreutils")), ("tzdata", "1.1")],
-            False,
-            cachedir,
-        )
-
-        self.assertTrue(os.path.exists(os.path.join(rootdir, "usr/bin/stat")))
-        self.assertTrue(
-            os.path.exists(os.path.join(rootdir, "usr/share/zoneinfo/zone.tab"))
-        )
-
-        # complains about obsolete packages
-        self.assertGreaterEqual(len(result.splitlines()), 1)
-        self.assertIn("tzdata", result)
-        self.assertIn("1.1", result)
-
-        # caches packages
-        cache = os.listdir(
-            os.path.join(cachedir, "system", "apt", "var", "cache", "apt", "archives")
-        )
-        cache_names = [p.split("_")[0] for p in cache]
-        self.assertIn("coreutils", cache_names)
-        self.assertIn("coreutils-dbgsym", cache_names)
-        self.assertIn("tzdata", cache_names)
-
-        # works with relative paths and existing cache
-        os.unlink(os.path.join(rootdir, "usr/bin/stat"))
-        os.unlink(os.path.join(rootdir, "packages.txt"))
-        orig_cwd = os.getcwd()
-        try:
-            os.chdir(self.workdir)
-            impl.install_packages(
-                "root", None, None, [("coreutils", None)], False, "cache"
-            )
-        finally:
-            os.chdir(orig_cwd)
-            self.assertTrue(os.path.exists(os.path.join(rootdir, "usr/bin/stat")))
-
-    @unittest.skipUnless(has_internet(), "online test")
-    def test_install_packages_error(self):
-        """install_packages() with errors"""
-        # sources.list with invalid format
-        release = self._setup_foonux_config()
-        with open(
-            os.path.join(self.configdir, release, "sources.list"), "w", encoding="utf-8"
-        ) as f:
-            f.write("bogus format")
-
-        with self.assertRaisesRegex(
-            SystemError, "^E:Type 'bogus' is not known .* sources could not be read.$"
-        ):
-            impl.install_packages(
-                self.rootdir,
-                self.configdir,
-                release,
-                [("tzdata", None)],
-                False,
-                self.cachedir,
-            )
-
-        # sources.list with wrong server
-        with open(
-            os.path.join(self.configdir, release, "sources.list"), "w", encoding="utf-8"
-        ) as f:
-            f.write("deb http://archive.ubuntu.com/nosuchdistro/ jammy main\n")
-
-        with self.assertRaisesRegex(
-            SystemError,
-            "^E:The repository 'http://archive.ubuntu.com/nosuchdistro"
-            " jammy.*' does not have a Release file.$",
-        ):
-            impl.install_packages(
-                self.rootdir,
-                self.configdir,
-                release,
-                [("tzdata", None)],
-                False,
-                self.cachedir,
-            )
-
-    @unittest.skipUnless(has_internet(), "online test")
-    def test_install_packages_permanent_sandbox(self):
-        """install_packages() with a permanent sandbox"""
-        release = self._setup_foonux_config()
-        zonetab = os.path.join(self.rootdir, "usr/share/zoneinfo/zone.tab")
-
-        impl.install_packages(
-            self.rootdir,
-            self.configdir,
-            release,
-            [("tzdata", None)],
-            False,
-            self.cachedir,
-            permanent_rootdir=True,
-        )
-
-        # This will now be using a Cache with our rootdir.
-        archives = apt_pkg.config.find_dir("Dir::Cache::archives")
-        tzdata = glob.glob(os.path.join(archives, "tzdata*.deb"))
-        self.assertTrue(tzdata, "tzdata was not downloaded")
-        tzdata_written = os.path.getctime(tzdata[0])
-        zonetab_written = os.path.getctime(zonetab)
-
-        impl.install_packages(
-            self.rootdir,
-            self.configdir,
-            release,
-            [("coreutils", None), ("tzdata", None)],
-            False,
-            self.cachedir,
-            permanent_rootdir=True,
-        )
-
-        self.assertTrue(
-            glob.glob(os.path.join(archives, "coreutils*.deb")),
-            "coreutils was not downloaded.",
-        )
-        self.assertEqual(
-            os.path.getctime(tzdata[0]), tzdata_written, "tzdata downloaded twice."
-        )
-        self.assertEqual(
-            zonetab_written, os.path.getctime(zonetab), "zonetab written twice."
-        )
-        self.assertTrue(os.path.exists(os.path.join(self.rootdir, "usr/bin/stat")))
-
-        # Prevent packages from downloading.
-        orig_apt_proxy = apt_pkg.config.get("Acquire::http::Proxy")
-        apt_pkg.config.set("Acquire::http::Proxy", "http://nonexistent")
-        orig_http_proxy = os.environ.get("http_proxy")
-        os.environ["http_proxy"] = "http://nonexistent"
-        try:
-            orig_no_proxy = os.environ["no_proxy"]
-            del os.environ["no_proxy"]
-        except KeyError:
-            orig_no_proxy = None
-
-        self.assertRaises(
-            SystemExit,
-            impl.install_packages,
-            self.rootdir,
-            self.configdir,
+            configdir,
             release,
             [("libc6", None)],
             False,
-            self.cachedir,
+            cachedir,
             permanent_rootdir=True,
         )
 
-        # These packages exist, so attempting to install them should not fail.
-        impl.install_packages(
-            self.rootdir,
-            self.configdir,
-            release,
-            [("coreutils", None), ("tzdata", None)],
-            False,
-            self.cachedir,
-            permanent_rootdir=True,
-        )
-        # even without cached debs, trying to install the same versions should
-        # be a no-op and succeed
-        for f in glob.glob(
-            f"{self.cachedir}/{release}/apt/var/cache/apt/archives/coreutils*"
-        ):
-            os.unlink(f)
-        impl.install_packages(
-            self.rootdir,
-            self.configdir,
-            release,
-            [("coreutils", None)],
-            False,
-            self.cachedir,
-            permanent_rootdir=True,
-        )
+    # These packages exist, so attempting to install them should not fail.
+    impl.install_packages(
+        rootdir,
+        configdir,
+        release,
+        [("coreutils", None), ("tzdata", None)],
+        False,
+        cachedir,
+        permanent_rootdir=True,
+    )
+    # even without cached debs, trying to install the same versions should
+    # be a no-op and succeed
+    for f in glob.glob(f"{cachedir}/{release}/apt/var/cache/apt/archives/coreutils*"):
+        os.unlink(f)
+    impl.install_packages(
+        rootdir,
+        configdir,
+        release,
+        [("coreutils", None)],
+        False,
+        cachedir,
+        permanent_rootdir=True,
+    )
 
-        # trying to install another package should fail, though
-        self.assertRaises(
-            SystemExit,
-            impl.install_packages,
-            self.rootdir,
-            self.configdir,
+    # trying to install another package should fail, though
+    with pytest.raises(SystemExit):
+        impl.install_packages(
+            rootdir,
+            configdir,
             release,
             [("aspell-doc", None)],
             False,
-            self.cachedir,
+            cachedir,
             permanent_rootdir=True,
         )
 
-        # restore original proxy settings
-        if orig_http_proxy:
-            os.environ["http_proxy"] = orig_http_proxy
-        else:
-            del os.environ["http_proxy"]
-        if orig_no_proxy:
-            os.environ["no_proxy"] = orig_no_proxy
-        apt_pkg.config.set("Acquire::http::Proxy", orig_apt_proxy)
+    # restore original proxy settings
+    if orig_http_proxy:
+        os.environ["http_proxy"] = orig_http_proxy
+    else:
+        del os.environ["http_proxy"]
+    if orig_no_proxy:
+        os.environ["no_proxy"] = orig_no_proxy
+    apt_pkg.config.set("Acquire::http::Proxy", orig_apt_proxy)
 
-    @unittest.skipUnless(has_internet(), "online test")
-    def test_install_packages_permanent_sandbox_repack(self):
-        # Both packages needs to conflict with each other, because they
-        # ship the same file.
-        release = self._setup_foonux_config()
-        impl.install_packages(
-            self.rootdir,
-            self.configdir,
-            release,
-            [("libcurl4-gnutls-dev", None)],
-            False,
-            self.cachedir,
-            permanent_rootdir=True,
-        )
-        curl_library = self._get_library_path("libcurl.so", self.rootdir)
-        self.assertEqual("libcurl-gnutls.so", os.readlink(curl_library))
 
-        impl.install_packages(
-            self.rootdir,
-            self.configdir,
-            release,
-            [("libcurl4-nss-dev", None)],
-            False,
-            self.cachedir,
-            permanent_rootdir=True,
-        )
-        self.assertEqual("libcurl-nss.so", os.readlink(curl_library))
-
-        impl.install_packages(
-            self.rootdir,
-            self.configdir,
-            release,
-            [("libcurl4-gnutls-dev", None)],
-            False,
-            self.cachedir,
-            permanent_rootdir=True,
-        )
-        self.assertEqual("libcurl-gnutls.so", os.readlink(curl_library))
-
-    @unittest.skipUnless(has_internet(), "online test")
-    @unittest.skipIf(
-        impl.get_system_architecture() == "armhf", "native armhf architecture"
+@pytest.mark.skipif(not has_internet(), reason="online test")
+def test_install_packages_permanent_sandbox_repack(configdir, cachedir, rootdir):
+    # Both packages needs to conflict with each other, because they
+    # ship the same file.
+    release = _setup_foonux_config(configdir)
+    impl.install_packages(
+        rootdir,
+        configdir,
+        release,
+        [("libcurl4-gnutls-dev", None)],
+        False,
+        cachedir,
+        permanent_rootdir=True,
     )
-    def test_install_packages_armhf(self):
-        """install_packages() for foreign architecture armhf"""
-        release = self._setup_foonux_config()
-        wanted_version = "2.35-0ubuntu0"
-        got_version = "2.35-0ubuntu3"
-        obsolete = impl.install_packages(
-            self.rootdir,
-            self.configdir,
-            release,
-            [("coreutils", None), ("libc6", wanted_version)],
-            False,
-            self.cachedir,
-            architecture="armhf",
+    curl_library = _get_library_path("libcurl.so", rootdir)
+    assert "libcurl-gnutls.so" == os.readlink(curl_library)
+
+    impl.install_packages(
+        rootdir,
+        configdir,
+        release,
+        [("libcurl4-nss-dev", None)],
+        False,
+        cachedir,
+        permanent_rootdir=True,
+    )
+    assert "libcurl-nss.so" == os.readlink(curl_library)
+
+    impl.install_packages(
+        rootdir,
+        configdir,
+        release,
+        [("libcurl4-gnutls-dev", None)],
+        False,
+        cachedir,
+        permanent_rootdir=True,
+    )
+    assert "libcurl-gnutls.so" == os.readlink(curl_library)
+
+
+@pytest.mark.skipif(not has_internet(), reason="online test")
+@pytest.mark.skipif(
+    impl.get_system_architecture() == "armhf", reason="native armhf architecture"
+)
+def test_install_packages_armhf(configdir, cachedir, rootdir):
+    """install_packages() for foreign architecture armhf"""
+    release = _setup_foonux_config(configdir)
+    wanted_version = "2.35-0ubuntu0"
+    got_version = "2.35-0ubuntu3"
+    obsolete = impl.install_packages(
+        rootdir,
+        configdir,
+        release,
+        [("coreutils", None), ("libc6", wanted_version)],
+        False,
+        cachedir,
+        architecture="armhf",
+    )
+
+    assert (
+        obsolete == f"libc6 version {wanted_version} required,"
+        f" but {got_version} is available\n"
+    )
+    assert os.path.exists(os.path.join(rootdir, "usr/bin/stat"))
+    assert_elf_arch(os.path.join(rootdir, "usr/bin/stat"), "armhf")
+    assert os.path.exists(os.path.join(rootdir, "usr/share/doc/libc6/copyright"))
+    # caches packages
+    cache = os.listdir(
+        os.path.join(
+            cachedir, release, "armhf", "apt", "var", "cache", "apt", "archives"
         )
+    )
+    assert "coreutils_8.32-4.1ubuntu1_armhf.deb" in cache
+    assert f"libc6_{got_version}_armhf.deb" in cache
 
-        self.assertEqual(
-            obsolete,
-            f"libc6 version {wanted_version} required,"
-            f" but {got_version} is available\n",
-        )
 
-        self.assertTrue(os.path.exists(os.path.join(self.rootdir, "usr/bin/stat")))
-        self.assert_elf_arch(os.path.join(self.rootdir, "usr/bin/stat"), "armhf")
-        self.assertTrue(
-            os.path.exists(os.path.join(self.rootdir, "usr/share/doc/libc6/copyright"))
-        )
-        # caches packages
-        cache = os.listdir(
-            os.path.join(
-                self.cachedir,
-                release,
-                "armhf",
-                "apt",
-                "var",
-                "cache",
-                "apt",
-                "archives",
-            )
-        )
-        self.assertIn("coreutils_8.32-4.1ubuntu1_armhf.deb", cache)
-        self.assertIn(f"libc6_{got_version}_armhf.deb", cache)
+@pytest.mark.skipif(not has_internet(), reason="online test")
+def test_install_packages_from_launchpad(configdir, cachedir, rootdir):
+    """install_packages() using packages only available on Launchpad"""
+    release = _setup_foonux_config(configdir, release="focal")
+    # Wanted are superseded versions from -updates or -security.
+    wanted = {
+        "distro-info-data": "0.43ubuntu1.9",  # arch all
+        "libc6": "2.31-0ubuntu9.4",  # -dbg, arch specific
+        "qemu-utils": "1:4.2-3ubuntu6.1",  # -dbgsym, arch specific
+    }
+    obsolete = impl.install_packages(
+        rootdir, configdir, release, list(wanted.items()), False, cachedir
+    )
 
-    @unittest.skipUnless(has_internet(), "online test")
-    def test_install_packages_from_launchpad(self):
-        """install_packages() using packages only available on Launchpad"""
-        release = self._setup_foonux_config(release="focal")
-        # Wanted are superseded versions from -updates or -security.
-        wanted = {
-            "distro-info-data": "0.43ubuntu1.9",  # arch all
-            "libc6": "2.31-0ubuntu9.4",  # -dbg, arch specific
-            "qemu-utils": "1:4.2-3ubuntu6.1",  # -dbgsym, arch specific
-        }
-        obsolete = impl.install_packages(
-            self.rootdir,
-            self.configdir,
-            release,
-            list(wanted.items()),
-            False,
-            self.cachedir,
-        )
-
-        def sandbox_ver(pkg, debian=True):
-            if debian:
-                changelog = "changelog.Debian.gz"
-            else:
-                changelog = "changelog.gz"
-            with gzip.open(
-                os.path.join(self.rootdir, "usr/share/doc", pkg, changelog)
-            ) as f:
-                return f.readline().decode().split()[1][1:-1]
-
-        self.assertEqual(obsolete, "")
-
-        # packages get installed
-        self.assertTrue(
-            os.path.exists(
-                os.path.join(self.rootdir, "usr/share/distro-info/ubuntu.csv")
-            )
-        )
-        self.assertTrue(
-            os.path.exists(os.path.join(self.rootdir, "usr/lib/debug/.build-id"))
-        )
-        self.assertTrue(os.path.exists(os.path.join(self.rootdir, "usr/bin/qemu-img")))
-
-        # their versions are as expected
-        self.assertEqual(
-            sandbox_ver("distro-info-data", debian=False), wanted["distro-info-data"]
-        )
-        self.assertEqual(sandbox_ver("libc6"), wanted["libc6"])
-        self.assertEqual(sandbox_ver("libc6-dbg"), wanted["libc6"])
-
-        # keeps track of package versions
-        with open(os.path.join(self.rootdir, "packages.txt"), encoding="utf-8") as f:
-            pkglist = f.read().splitlines()
-        self.assertIn(f"distro-info-data {wanted['distro-info-data']}", pkglist)
-        self.assertIn(f"libc6 {wanted['libc6']}", pkglist)
-        self.assertIn(f"libc6-dbg {wanted['libc6']}", pkglist)
-        self.assertIn(f"qemu-utils {wanted['qemu-utils']}", pkglist)
-        self.assertIn(f"qemu-utils-dbgsym {wanted['qemu-utils']}", pkglist)
-
-        # caches packages, and their versions are as expected
-        cache = os.listdir(
-            os.path.join(
-                self.cachedir, release, "apt", "var", "cache", "apt", "archives"
-            )
-        )
-
-        # archive and launchpad versions of packages exist in the cache,
-        # so use a list
-        cache_versions = []
-        for p in cache:
-            try:
-                (name, ver) = p.split("_")[:2]
-                cache_versions.append((name, ver))
-            except ValueError:
-                pass  # not a .deb, ignore
-        self.assertIn(("distro-info-data", wanted["distro-info-data"]), cache_versions)
-        self.assertIn(("libc6-dbg", wanted["libc6"]), cache_versions)
-        self.assertIn(
-            ("qemu-utils-dbgsym", self._strip_epoch(wanted["qemu-utils"])),
-            cache_versions,
-        )
-
-    @unittest.skipUnless(has_internet(), "online test")
-    def test_install_old_packages(self):
-        """Sandbox will install older package versions from launchpad."""
-        release = self._setup_foonux_config()
-        wanted_package = "libcurl4"
-        wanted_version = "7.81.0-1"  # pre-release version
-        obsolete = impl.install_packages(
-            self.rootdir,
-            self.configdir,
-            release,
-            [(wanted_package, wanted_version)],
-            False,
-            self.cachedir,
-        )
-
-        self.assertEqual(obsolete, "")
-
-        def sandbox_ver(pkg):
-            with gzip.open(
-                os.path.join(self.rootdir, "usr/share/doc", pkg, "changelog.Debian.gz")
-            ) as f:
-                return f.readline().decode().split()[1][1:-1]
-
-        # the version is as expected
-        self.assertEqual(sandbox_ver(wanted_package), wanted_version)
-
-        # keeps track of package version
-        with open(os.path.join(self.rootdir, "packages.txt"), encoding="utf-8") as f:
-            pkglist = f.read().splitlines()
-        self.assertIn(f"{wanted_package} {wanted_version}", pkglist)
-
-        wanted_version = "7.74.0-1.3ubuntu3"
-        obsolete = impl.install_packages(
-            self.rootdir,
-            self.configdir,
-            release,
-            [(wanted_package, wanted_version)],
-            False,
-            self.cachedir,
-        )
-
-        self.assertEqual(obsolete, "")
-
-        # the old version is installed
-        self.assertEqual(sandbox_ver(wanted_package), wanted_version)
-
-        # the old versions is tracked
-        with open(os.path.join(self.rootdir, "packages.txt"), encoding="utf-8") as f:
-            pkglist = f.read().splitlines()
-        self.assertIn(f"{wanted_package} {wanted_version}", pkglist)
-
-    @unittest.skipUnless(has_internet(), "online test")
-    def test_get_source_tree_sandbox(self):
-        release = self._setup_foonux_config()
-        out_dir = os.path.join(self.workdir, "out")
-        os.mkdir(out_dir)
-        impl._build_apt_sandbox(
-            self.rootdir,
-            os.path.join(self.configdir, release, "sources.list"),
-            "ubuntu",
-            "jammy",
-            origins=None,
-        )
-        res = impl.get_source_tree("base-files", out_dir, sandbox=self.rootdir)
-        self.assertTrue(os.path.isdir(os.path.join(res, "debian")))
-        # this needs to be updated when the release in _setup_foonux_config
-        # changes
-        self.assertTrue(
-            res.endswith("/base-files-12ubuntu4"),
-            f"unexpected version: {res.split('/')[-1]}",
-        )
-
-    @unittest.skipUnless(has_internet(), "online test")
-    def test_get_source_tree_lp_sandbox(self):
-        release = self._setup_foonux_config()
-        wanted_package = "curl"
-        wanted_version = "7.81.0-1ubuntu1.2"  # superseded -security version
-        out_dir = os.path.join(self.workdir, "out")
-        os.mkdir(out_dir)
-        impl._build_apt_sandbox(
-            self.rootdir,
-            os.path.join(self.configdir, release, "sources.list"),
-            "ubuntu",
-            "jammy",
-            origins=None,
-        )
-        res = impl.get_source_tree(
-            wanted_package, out_dir, version=wanted_version, sandbox=self.rootdir
-        )
-        self.assertTrue(os.path.isdir(os.path.join(res, "debian")))
-        # this needs to be updated when the release in _setup_foonux_config
-        # changes
-        upstream_version = wanted_version.split("-", maxsplit=1)[0]
-        self.assertTrue(
-            res.endswith(f"/{wanted_package}-{upstream_version}"),
-            f"unexpected version: {res.split('/')[-1]}",
-        )
-
-    @skip_if_command_is_missing("gpg")
-    @unittest.skipUnless(has_internet(), "online test")
-    def test_create_sources_for_a_named_ppa(self):
-        """Add sources.list entries for a named PPA."""
-        ppa = "LP-PPA-daisy-pluckers-daisy-seeds"
-        release = self._setup_foonux_config()
-        impl._build_apt_sandbox(
-            self.rootdir,
-            os.path.join(self.configdir, release, "sources.list"),
-            "ubuntu",
-            "jammy",
-            origins=[ppa],
-        )
-        with open(
-            os.path.join(self.rootdir, "etc", "apt", "sources.list.d", f"{ppa}.list"),
-            encoding="utf-8",
-        ) as f:
-            sources = f.read().splitlines()
-        self.assertIn(
-            "deb http://ppa.launchpad.net/daisy-pluckers/daisy-seeds/ubuntu"
-            " jammy main main/debug",
-            sources,
-        )
-        self.assertIn(
-            "deb-src http://ppa.launchpad.net"
-            "/daisy-pluckers/daisy-seeds/ubuntu jammy main",
-            sources,
-        )
-
-        gpg = subprocess.run(
-            [
-                "gpg",
-                "--no-options",
-                "--no-default-keyring",
-                "--no-auto-check-trustdb",
-                "--trust-model",
-                "always",
-                "--batch",
-                "--list-keys",
-                "--keyring",
-                os.path.join(
-                    self.rootdir,
-                    "etc",
-                    "apt",
-                    "trusted.gpg.d",
-                    "LP-PPA-daisy-pluckers-daisy-seeds.gpg",
-                ),
-            ],
-            check=True,
-            stdout=subprocess.PIPE,
-        )
-        apt_keys = gpg.stdout.decode()
-        self.assertIn("Launchpad PPA for Daisy Pluckers", apt_keys)
-
-    @skip_if_command_is_missing("gpg")
-    @unittest.skipUnless(has_internet(), "online test")
-    def test_create_sources_for_an_unnamed_ppa(self):
-        """Add sources.list entries for an unnamed PPA."""
-        ppa = "LP-PPA-apport-hackers-apport-autopkgtests"
-        release = self._setup_foonux_config(ppa=True)
-        impl._build_apt_sandbox(
-            self.rootdir,
-            os.path.join(self.configdir, release, "sources.list"),
-            "ubuntu",
-            "jammy",
-            origins=[ppa],
-        )
-        with open(
-            os.path.join(self.rootdir, "etc", "apt", "sources.list.d", f"{ppa}.list"),
-            encoding="utf-8",
-        ) as f:
-            sources = f.read().splitlines()
-        self.assertIn(
-            "deb http://ppa.launchpad.net"
-            "/apport-hackers/apport-autopkgtests/ubuntu jammy main main/debug",
-            sources,
-        )
-        self.assertIn(
-            "deb-src http://ppa.launchpad.net"
-            "/apport-hackers/apport-autopkgtests/ubuntu jammy main",
-            sources,
-        )
-
-        gpg = subprocess.run(
-            [
-                "gpg",
-                "--no-options",
-                "--no-default-keyring",
-                "--no-auto-check-trustdb",
-                "--trust-model",
-                "always",
-                "--batch",
-                "--list-keys",
-                "--keyring",
-                os.path.join(
-                    self.rootdir,
-                    "etc",
-                    "apt",
-                    "trusted.gpg.d",
-                    "LP-PPA-apport-hackers.gpg",
-                ),
-            ],
-            check=True,
-            stdout=subprocess.PIPE,
-        )
-        apt_keys = gpg.stdout.decode()
-        self.assertEqual("", apt_keys)
-
-    def test_use_sources_for_a_ppa(self):
-        """Use a sources.list.d file for a PPA."""
-        ppa = "fooser-bar-ppa"
-        release = self._setup_foonux_config(ppa=True)
-        impl._build_apt_sandbox(
-            self.rootdir,
-            os.path.join(self.configdir, release, "sources.list"),
-            "ubuntu",
-            "jammy",
-            origins=[f"LP-PPA-{ppa}"],
-        )
-        with open(
-            os.path.join(self.rootdir, "etc", "apt", "sources.list.d", f"{ppa}.list"),
-            encoding="utf-8",
-        ) as f:
-            sources = f.read().splitlines()
-        self.assertIn(
-            "deb http://ppa.launchpad.net/fooser/bar-ppa/ubuntu"
-            " jammy main main/debug",
-            sources,
-        )
-        self.assertIn(
-            "deb-src http://ppa.launchpad.net/fooser/bar-ppa/ubuntu jammy main", sources
-        )
-
-    @unittest.skipUnless(has_internet(), "online test")
-    def test_install_package_from_a_ppa(self):
-        """Install a package from a PPA."""
-        # Needs apport package in https://launchpad.net
-        # /~apport-hackers/+archive/ubuntu/apport-autopkgtests
-        ppa = "LP-PPA-apport-hackers-apport-autopkgtests"
-        release = self._setup_foonux_config()
-        wanted_package = "apport"
-        wanted_version = "2.20.11-0ubuntu82.1~ppa2"
-        obsolete = impl.install_packages(
-            self.rootdir,
-            self.configdir,
-            release,
-            [(wanted_package, wanted_version)],
-            False,
-            self.cachedir,
-            origins=[ppa],
-        )
-
-        self.assertEqual(obsolete, "")
-
-        def sandbox_ver(pkg):
-            with gzip.open(
-                os.path.join(self.rootdir, "usr/share/doc", pkg, "changelog.Debian.gz")
-            ) as f:
-                return f.readline().decode().split()[1][1:-1]
-
-        self.assertEqual(sandbox_ver(wanted_package), wanted_version)
-
-    def _get_library_path(self, library_name: str, root_dir: str = "/") -> str:
-        """Find library path regardless of the architecture."""
-        libraries = glob.glob(os.path.join(root_dir, "usr/lib/*", library_name))
-        self.assertEqual(len(libraries), 1, f"glob for {library_name}: {libraries!r}")
-        return libraries[0]
-
-    @staticmethod
-    def _ubuntu_archive_uri(arch=None):
-        """Return archive URI for the given architecture."""
-        if arch is None:
-            arch = impl.get_system_architecture()
-        if arch in ("amd64", "i386"):
-            return "http://archive.ubuntu.com/ubuntu"
-        return "http://ports.ubuntu.com/ubuntu-ports"
-
-    def _setup_foonux_config(self, updates=False, release="jammy", ppa=False):
-        """Set up directories and configuration for install_packages()
-
-        If ppa is True, then a sources.list file for a PPA will be created
-        in sources.list.d used to test copying of a sources.list file to a
-        sandbox.
-
-        Return name and version of the operating system (DistroRelease
-        field in crash report).
-        """
-        versions = {"focal": "20.04", "jammy": "22.04"}
-        distro_release = f"Foonux {versions[release]}"
-        config_release_dir = os.path.join(self.configdir, distro_release)
-        os.mkdir(self.cachedir)
-        os.mkdir(self.rootdir)
-        os.mkdir(self.configdir)
-        os.mkdir(config_release_dir)
-        self._write_source_file(
-            os.path.join(config_release_dir, "sources.list"),
-            self._ubuntu_archive_uri(),
-            release,
-            updates,
-        )
-        if ppa:
-            os.mkdir(os.path.join(config_release_dir, "sources.list.d"))
-            with open(
-                os.path.join(
-                    config_release_dir, "sources.list.d", "fooser-bar-ppa.list"
-                ),
-                "w",
-                encoding="utf-8",
-            ) as f:
-                f.write(
-                    f"deb http://ppa.launchpad.net/fooser/bar-ppa/ubuntu"
-                    f" {release} main main/debug\n"
-                    f"deb-src http://ppa.launchpad.net/fooser/bar-ppa/ubuntu"
-                    f" {release} main\n"
-                )
-        os.mkdir(os.path.join(config_release_dir, "armhf"))
-        self._write_source_file(
-            os.path.join(config_release_dir, "armhf", "sources.list"),
-            self._ubuntu_archive_uri("armhf"),
-            release,
-            updates,
-        )
-        with open(
-            os.path.join(config_release_dir, "codename"), "w", encoding="utf-8"
-        ) as f:
-            f.write(f"{release}")
-
-        # install GPG key for ddebs
-        keyring_dir = os.path.join(config_release_dir, "trusted.gpg.d")
-        self._copy_ubuntu_keyrings(keyring_dir)
-        # Create an architecture specific symlink, otherwise it cannot be
-        # found for armhf in __AptDpkgPackageInfo._build_apt_sandbox() as
-        # that looks for trusted.gpg.d relative to sources.list.
-        keyring_arch_dir = os.path.join(config_release_dir, "armhf", "trusted.gpg.d")
-        os.symlink("../trusted.gpg.d", keyring_arch_dir)
-        return distro_release
-
-    @staticmethod
-    def _strip_epoch(version: str) -> str:
-        """Strip epoch from Debian package version."""
-        return version.split(":", maxsplit=1)[-1]
-
-    def _copy_ubuntu_keyrings(self, keyring_dir: str) -> None:
-        """Copy the archive and debug symbol archive keyring."""
-        os.makedirs(keyring_dir, exist_ok=True)
-        try:
-            shutil.copy("/usr/share/keyrings/ubuntu-archive-keyring.gpg", keyring_dir)
-        except FileNotFoundError as error:  # pragma: no cover
-            self.skipTest(f"{error.filename} missing. Please install ubuntu-keyring!")
-
-        dbgsym_keyring = "/usr/share/keyrings/ubuntu-dbgsym-keyring.gpg"
-        if not os.path.isfile(dbgsym_keyring):
-            self.skipTest(  # pragma: no cover
-                f"{dbgsym_keyring} missing. " f"Please install ubuntu-dbgsym-keyring!"
-            )
-        # Convert from GPG keybox database format to OpenPGP Public Key format
-        output_dbgsym_keyring = os.path.join(
-            keyring_dir, os.path.basename(dbgsym_keyring)
-        )
-        try:
-            with open(output_dbgsym_keyring, "wb") as gpg_key:
-                gpg_cmd = [
-                    "gpg",
-                    "--no-default-keyring",
-                    "--keyring",
-                    dbgsym_keyring,
-                    "--export",
-                ]
-                subprocess.check_call(gpg_cmd, stdout=gpg_key)
-        except FileNotFoundError as error:  # pragma: no cover
-            self.skipTest(f"{error.filename} not available")
-
-    @staticmethod
-    def _write_source_file(
-        sources_filename: str, uri: str, release: str, updates: bool
-    ) -> None:
-        """Write sources.list file."""
-        with open(sources_filename, "w", encoding="utf-8") as sources_file:
-            sources_file.write(
-                f"deb {uri} {release} main\n"
-                f"deb-src {uri} {release} main\n"
-                f"deb http://ddebs.ubuntu.com/ {release} main\n"
-            )
-            if updates:
-                sources_file.write(
-                    f"deb {uri} {release}-updates main\n"
-                    f"deb-src {uri} {release}-updates main\n"
-                    f"deb http://ddebs.ubuntu.com/ {release}-updates main\n"
-                )
-
-    def assert_elf_arch(self, path, expected):
-        """Assert that an ELF file is for an expected machine type.
-
-        Expected is a Debian-style architecture (i386, amd64, armhf)
-        """
-        archmap = {
-            "amd64": "X86-64",
-            "arm64": "AArch64",
-            "armhf": "ARM",
-            "i386": "80386",
-            "ppc64el": "PowerPC64",
-            "s390x": "IBM S/390",
-        }
-
-        # get ELF machine type
-        readelf = subprocess.run(
-            ["readelf", "-e", path],
-            check=True,
-            env={},
-            stdout=subprocess.PIPE,
-            text=True,
-        )
-        for line in readelf.stdout.splitlines():
-            if line.startswith("  Machine:"):
-                machine = line.split(None, 1)[1]
-                break
+    def sandbox_ver(pkg, debian=True):
+        if debian:
+            changelog = "changelog.Debian.gz"
         else:
-            self.fail("could not find Machine: in readelf output")
+            changelog = "changelog.gz"
+        with gzip.open(os.path.join(rootdir, "usr/share/doc", pkg, changelog)) as f:
+            return f.readline().decode().split()[1][1:-1]
 
-        self.assertIn(
-            archmap[expected],
-            machine,
-            f'{path} has unexpected machine type "{machine}"'
-            f" for architecture {expected}",
+    assert obsolete == ""
+
+    # packages get installed
+    assert os.path.exists(os.path.join(rootdir, "usr/share/distro-info/ubuntu.csv"))
+    assert os.path.exists(os.path.join(rootdir, "usr/lib/debug/.build-id"))
+    assert os.path.exists(os.path.join(rootdir, "usr/bin/qemu-img"))
+
+    # their versions are as expected
+    assert sandbox_ver("distro-info-data", debian=False) == wanted["distro-info-data"]
+    assert sandbox_ver("libc6") == wanted["libc6"]
+    assert sandbox_ver("libc6-dbg") == wanted["libc6"]
+
+    # keeps track of package versions
+    with open(os.path.join(rootdir, "packages.txt"), encoding="utf-8") as f:
+        pkglist = f.read().splitlines()
+    assert f"distro-info-data {wanted['distro-info-data']}" in pkglist
+    assert f"libc6 {wanted['libc6']}" in pkglist
+    assert f"libc6-dbg {wanted['libc6']}" in pkglist
+    assert f"qemu-utils {wanted['qemu-utils']}" in pkglist
+    assert f"qemu-utils-dbgsym {wanted['qemu-utils']}" in pkglist
+
+    # caches packages, and their versions are as expected
+    cache = os.listdir(
+        os.path.join(cachedir, release, "apt", "var", "cache", "apt", "archives")
+    )
+
+    # archive and launchpad versions of packages exist in the cache,
+    # so use a list
+    cache_versions = []
+    for p in cache:
+        try:
+            (name, ver) = p.split("_")[:2]
+            cache_versions.append((name, ver))
+        except ValueError:
+            pass  # not a .deb, ignore
+    assert ("distro-info-data", wanted["distro-info-data"]) in cache_versions
+    assert ("libc6-dbg", wanted["libc6"]) in cache_versions
+    assert ("qemu-utils-dbgsym", _strip_epoch(wanted["qemu-utils"])) in cache_versions
+
+
+@pytest.mark.skipif(not has_internet(), reason="online test")
+def test_install_old_packages(configdir, cachedir, rootdir):
+    """Sandbox will install older package versions from launchpad."""
+    release = _setup_foonux_config(configdir)
+    wanted_package = "libcurl4"
+    wanted_version = "7.81.0-1"  # pre-release version
+    obsolete = impl.install_packages(
+        rootdir, configdir, release, [(wanted_package, wanted_version)], False, cachedir
+    )
+
+    assert obsolete == ""
+
+    def sandbox_ver(pkg):
+        with gzip.open(
+            os.path.join(rootdir, "usr/share/doc", pkg, "changelog.Debian.gz")
+        ) as f:
+            return f.readline().decode().split()[1][1:-1]
+
+    # the version is as expected
+    assert sandbox_ver(wanted_package) == wanted_version
+
+    # keeps track of package version
+    with open(os.path.join(rootdir, "packages.txt"), encoding="utf-8") as f:
+        pkglist = f.read().splitlines()
+    assert f"{wanted_package} {wanted_version}" in pkglist
+
+    wanted_version = "7.74.0-1.3ubuntu3"
+    obsolete = impl.install_packages(
+        rootdir, configdir, release, [(wanted_package, wanted_version)], False, cachedir
+    )
+
+    assert obsolete == ""
+
+    # the old version is installed
+    assert sandbox_ver(wanted_package) == wanted_version
+
+    # the old versions is tracked
+    with open(os.path.join(rootdir, "packages.txt"), encoding="utf-8") as f:
+        pkglist = f.read().splitlines()
+    assert f"{wanted_package} {wanted_version}" in pkglist
+
+
+@pytest.mark.skipif(not has_internet(), reason="online test")
+def test_get_source_tree_sandbox(configdir, workdir, rootdir):
+    release = _setup_foonux_config(configdir)
+    out_dir = os.path.join(workdir, "out")
+    os.mkdir(out_dir)
+    # pylint: disable=protected-access
+    impl._build_apt_sandbox(
+        rootdir,
+        os.path.join(configdir, release, "sources.list"),
+        "ubuntu",
+        "jammy",
+        origins=None,
+    )
+    res = impl.get_source_tree("base-files", out_dir, sandbox=rootdir)
+    assert os.path.isdir(os.path.join(res, "debian"))
+    # this needs to be updated when the release in _setup_foonux_config
+    # changes
+    assert res.endswith("/base-files-12ubuntu4")
+
+
+@pytest.mark.skipif(not has_internet(), reason="online test")
+def test_get_source_tree_lp_sandbox(configdir, workdir, rootdir):
+    release = _setup_foonux_config(configdir)
+    wanted_package = "curl"
+    wanted_version = "7.81.0-1ubuntu1.2"  # superseded -security version
+    out_dir = os.path.join(workdir, "out")
+    os.mkdir(out_dir)
+    # pylint: disable=protected-access
+    impl._build_apt_sandbox(
+        rootdir,
+        os.path.join(configdir, release, "sources.list"),
+        "ubuntu",
+        "jammy",
+        origins=None,
+    )
+    res = impl.get_source_tree(
+        wanted_package, out_dir, version=wanted_version, sandbox=rootdir
+    )
+    assert os.path.isdir(os.path.join(res, "debian"))
+    # this needs to be updated when the release in _setup_foonux_config
+    # changes
+    upstream_version = wanted_version.split("-", maxsplit=1)[0]
+    assert res.endswith(f"/{wanted_package}-{upstream_version}")
+
+
+@skip_if_command_is_missing("gpg")
+@pytest.mark.skipif(not has_internet(), reason="online test")
+def test_create_sources_for_a_named_ppa(configdir, rootdir):
+    """Add sources.list entries for a named PPA."""
+    ppa = "LP-PPA-daisy-pluckers-daisy-seeds"
+    release = _setup_foonux_config(configdir)
+    # pylint: disable=protected-access
+    impl._build_apt_sandbox(
+        rootdir,
+        os.path.join(configdir, release, "sources.list"),
+        "ubuntu",
+        "jammy",
+        origins=[ppa],
+    )
+    with open(
+        os.path.join(rootdir, "etc", "apt", "sources.list.d", f"{ppa}.list"),
+        encoding="utf-8",
+    ) as f:
+        sources = f.read().splitlines()
+    assert (
+        "deb http://ppa.launchpad.net/daisy-pluckers/daisy-seeds/ubuntu"
+        " jammy main main/debug" in sources
+    )
+    assert (
+        "deb-src http://ppa.launchpad.net"
+        "/daisy-pluckers/daisy-seeds/ubuntu jammy main" in sources
+    )
+
+    gpg = subprocess.run(
+        [
+            "gpg",
+            "--no-options",
+            "--no-default-keyring",
+            "--no-auto-check-trustdb",
+            "--trust-model",
+            "always",
+            "--batch",
+            "--list-keys",
+            "--keyring",
+            os.path.join(
+                rootdir,
+                "etc",
+                "apt",
+                "trusted.gpg.d",
+                "LP-PPA-daisy-pluckers-daisy-seeds.gpg",
+            ),
+        ],
+        check=True,
+        stdout=subprocess.PIPE,
+    )
+    apt_keys = gpg.stdout.decode()
+    assert "Launchpad PPA for Daisy Pluckers" in apt_keys
+
+
+@skip_if_command_is_missing("gpg")
+@pytest.mark.skipif(not has_internet(), reason="online test")
+def test_create_sources_for_an_unnamed_ppa(configdir, rootdir):
+    """Add sources.list entries for an unnamed PPA."""
+    ppa = "LP-PPA-apport-hackers-apport-autopkgtests"
+    release = _setup_foonux_config(configdir, ppa=True)
+    # pylint: disable=protected-access
+    impl._build_apt_sandbox(
+        rootdir,
+        os.path.join(configdir, release, "sources.list"),
+        "ubuntu",
+        "jammy",
+        origins=[ppa],
+    )
+    with open(
+        os.path.join(rootdir, "etc", "apt", "sources.list.d", f"{ppa}.list"),
+        encoding="utf-8",
+    ) as f:
+        sources = f.read().splitlines()
+    assert (
+        "deb http://ppa.launchpad.net"
+        "/apport-hackers/apport-autopkgtests/ubuntu jammy main main/debug" in sources
+    )
+    assert (
+        "deb-src http://ppa.launchpad.net"
+        "/apport-hackers/apport-autopkgtests/ubuntu jammy main" in sources
+    )
+
+    gpg = subprocess.run(
+        [
+            "gpg",
+            "--no-options",
+            "--no-default-keyring",
+            "--no-auto-check-trustdb",
+            "--trust-model",
+            "always",
+            "--batch",
+            "--list-keys",
+            "--keyring",
+            os.path.join(
+                rootdir, "etc", "apt", "trusted.gpg.d", "LP-PPA-apport-hackers.gpg"
+            ),
+        ],
+        check=True,
+        stdout=subprocess.PIPE,
+    )
+    apt_keys = gpg.stdout.decode()
+    assert "" == apt_keys
+
+
+def test_use_sources_for_a_ppa(configdir, rootdir):
+    """Use a sources.list.d file for a PPA."""
+    ppa = "fooser-bar-ppa"
+    release = _setup_foonux_config(configdir, ppa=True)
+    # pylint: disable=protected-access
+    impl._build_apt_sandbox(
+        rootdir,
+        os.path.join(configdir, release, "sources.list"),
+        "ubuntu",
+        "jammy",
+        origins=[f"LP-PPA-{ppa}"],
+    )
+    with open(
+        os.path.join(rootdir, "etc", "apt", "sources.list.d", f"{ppa}.list"),
+        encoding="utf-8",
+    ) as f:
+        sources = f.read().splitlines()
+    assert (
+        "deb http://ppa.launchpad.net/fooser/bar-ppa/ubuntu"
+        " jammy main main/debug" in sources
+    )
+    assert (
+        "deb-src http://ppa.launchpad.net/fooser/bar-ppa/ubuntu"
+        " jammy main" in sources
+    )
+
+
+@pytest.mark.skipif(not has_internet(), reason="online test")
+def test_install_package_from_a_ppa(configdir, cachedir, rootdir):
+    """Install a package from a PPA."""
+    # Needs apport package in https://launchpad.net
+    # /~apport-hackers/+archive/ubuntu/apport-autopkgtests
+    ppa = "LP-PPA-apport-hackers-apport-autopkgtests"
+    release = _setup_foonux_config(configdir)
+    wanted_package = "apport"
+    wanted_version = "2.20.11-0ubuntu82.1~ppa2"
+    obsolete = impl.install_packages(
+        rootdir,
+        configdir,
+        release,
+        [(wanted_package, wanted_version)],
+        False,
+        cachedir,
+        origins=[ppa],
+    )
+
+    assert obsolete == ""
+
+    def sandbox_ver(pkg):
+        with gzip.open(
+            os.path.join(rootdir, "usr/share/doc", pkg, "changelog.Debian.gz")
+        ) as f:
+            return f.readline().decode().split()[1][1:-1]
+
+    assert sandbox_ver(wanted_package) == wanted_version
+
+
+def _get_library_path(library_name: str, root_dir: str = "/") -> str:
+    """Find library path regardless of the architecture."""
+    libraries = glob.glob(os.path.join(root_dir, "usr/lib/*", library_name))
+    assert len(libraries) == 1
+    return libraries[0]
+
+
+def _ubuntu_archive_uri(arch=None):
+    """Return archive URI for the given architecture."""
+    if arch is None:
+        arch = impl.get_system_architecture()
+    if arch in ("amd64", "i386"):
+        return "http://archive.ubuntu.com/ubuntu"
+    return "http://ports.ubuntu.com/ubuntu-ports"
+
+
+def _setup_foonux_config(configdir, updates=False, release="jammy", ppa=False):
+    """Set up directories and configuration for install_packages()
+
+    If ppa is True, then a sources.list file for a PPA will be created
+    in sources.list.d used to test copying of a sources.list file to a
+    sandbox.
+
+    Return name and version of the operating system (DistroRelease
+    field in crash report).
+    """
+    versions = {"focal": "20.04", "jammy": "22.04"}
+    distro_release = f"Foonux {versions[release]}"
+    config_release_dir = os.path.join(configdir, distro_release)
+    os.mkdir(config_release_dir)
+    _write_source_file(
+        os.path.join(config_release_dir, "sources.list"),
+        _ubuntu_archive_uri(),
+        release,
+        updates,
+    )
+    if ppa:
+        os.mkdir(os.path.join(config_release_dir, "sources.list.d"))
+        with open(
+            os.path.join(config_release_dir, "sources.list.d", "fooser-bar-ppa.list"),
+            "w",
+            encoding="utf-8",
+        ) as f:
+            f.write(
+                f"deb http://ppa.launchpad.net/fooser/bar-ppa/ubuntu"
+                f" {release} main main/debug\n"
+                f"deb-src http://ppa.launchpad.net/fooser/bar-ppa/ubuntu"
+                f" {release} main\n"
+            )
+    os.mkdir(os.path.join(config_release_dir, "armhf"))
+    _write_source_file(
+        os.path.join(config_release_dir, "armhf", "sources.list"),
+        _ubuntu_archive_uri("armhf"),
+        release,
+        updates,
+    )
+    with open(os.path.join(config_release_dir, "codename"), "w", encoding="utf-8") as f:
+        f.write(f"{release}")
+
+    # install GPG key for ddebs
+    keyring_dir = os.path.join(config_release_dir, "trusted.gpg.d")
+    _copy_ubuntu_keyrings(keyring_dir)
+    # Create an architecture specific symlink, otherwise it cannot be
+    # found for armhf in __AptDpkgPackageInfo._build_apt_sandbox() as
+    # that looks for trusted.gpg.d relative to sources.list.
+    keyring_arch_dir = os.path.join(config_release_dir, "armhf", "trusted.gpg.d")
+    os.symlink("../trusted.gpg.d", keyring_arch_dir)
+    return distro_release
+
+
+def _strip_epoch(version: str) -> str:
+    """Strip epoch from Debian package version."""
+    return version.split(":", maxsplit=1)[-1]
+
+
+def _copy_ubuntu_keyrings(keyring_dir: str) -> None:
+    """Copy the archive and debug symbol archive keyring."""
+    os.makedirs(keyring_dir, exist_ok=True)
+    try:
+        shutil.copy("/usr/share/keyrings/ubuntu-archive-keyring.gpg", keyring_dir)
+    except FileNotFoundError as error:  # pragma: no cover
+        pytest.skip(f"{error.filename} missing. Please install ubuntu-keyring!")
+
+    dbgsym_keyring = "/usr/share/keyrings/ubuntu-dbgsym-keyring.gpg"
+    if not os.path.isfile(dbgsym_keyring):
+        pytest.skip(  # pragma: no cover
+            f"{dbgsym_keyring} missing. " f"Please install ubuntu-dbgsym-keyring!"
         )
+    # Convert from GPG keybox database format to OpenPGP Public Key format
+    output_dbgsym_keyring = os.path.join(keyring_dir, os.path.basename(dbgsym_keyring))
+    try:
+        with open(output_dbgsym_keyring, "wb") as gpg_key:
+            gpg_cmd = [
+                "gpg",
+                "--no-default-keyring",
+                "--keyring",
+                dbgsym_keyring,
+                "--export",
+            ]
+            subprocess.check_call(gpg_cmd, stdout=gpg_key)
+    except FileNotFoundError as error:  # pragma: no cover
+        pytest.skip(f"{error.filename} not available")
+
+
+def _write_source_file(
+    sources_filename: str, uri: str, release: str, updates: bool
+) -> None:
+    """Write sources.list file."""
+    with open(sources_filename, "w", encoding="utf-8") as sources_file:
+        sources_file.write(
+            f"deb {uri} {release} main\n"
+            f"deb-src {uri} {release} main\n"
+            f"deb http://ddebs.ubuntu.com/ {release} main\n"
+        )
+        if updates:
+            sources_file.write(
+                f"deb {uri} {release}-updates main\n"
+                f"deb-src {uri} {release}-updates main\n"
+                f"deb http://ddebs.ubuntu.com/ {release}-updates main\n"
+            )
+
+
+def assert_elf_arch(path, expected):
+    """Assert that an ELF file is for an expected machine type.
+
+    Expected is a Debian-style architecture (i386, amd64, armhf)
+    """
+    archmap = {
+        "amd64": "X86-64",
+        "arm64": "AArch64",
+        "armhf": "ARM",
+        "i386": "80386",
+        "ppc64el": "PowerPC64",
+        "s390x": "IBM S/390",
+    }
+
+    # get ELF machine type
+    readelf = subprocess.run(
+        ["readelf", "-e", path], check=True, env={}, stdout=subprocess.PIPE, text=True
+    )
+    for line in readelf.stdout.splitlines():
+        if line.startswith("  Machine:"):
+            machine = line.split(None, 1)[1]
+            break
+    else:
+        pytest.fail("could not find Machine: in readelf output")
+
+    assert archmap[expected] in machine


### PR DESCRIPTION
Using idiomatic pytest is more concise than Python's builtin unittest framework, and will allow us to use some of pytest goodies, such as test parametrization, which is used to great effect in #193 

I also updated the testing README to remove any mention of `unittest`, as I expect this PR will shine the way to a new, unittest-free world ;)