### PR TITLE
Bump the lowest Debian version to Bookworm in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,7 @@ jobs:
       fail-fast: false
       matrix:
         container:
-          - debian:bullseye-slim
+          - debian:bookworm-slim
           - debian:testing-slim
           - ubuntu:jammy
           - ubuntu:kinetic

--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ Please see https://wiki.ubuntu.com/Apport for more details and further links.
 The files in [doc/](./doc/) document particular details such as package hooks,
 crash database configuration, or the internal data format.
 
+Platform requirements
+---------------------
+
+The absolute minimum requirements for your distribution are Python 3.10 or
+above. Depending on which features you want enabled, various Python packages
+also need to be available.
+
+TODO: document the Python dependencies
+
 Temporarily enabling apport
 ===========================
 

--- a/apport/packaging_impl/__init__.py
+++ b/apport/packaging_impl/__init__.py
@@ -1,12 +1,13 @@
 import importlib
 import os
+import platform
 
-from apport.packaging import PackageInfo, freedesktop_os_release
+from apport.packaging import PackageInfo
 
 
 def determine_packaging_implementation() -> str:
     """Determine the packaging implementation for the host."""
-    info = freedesktop_os_release()
+    info = platform.freedesktop_os_release()
     assert info is not None
     ids = set([info["ID"]]) | set(info.get("ID_LIKE", "").split(" "))
     if "debian" in ids:

--- a/apport/packaging_impl/apt_dpkg.py
+++ b/apport/packaging_impl/apt_dpkg.py
@@ -26,6 +26,7 @@ import json
 import logging
 import os
 import pickle
+import platform
 import shutil
 import stat
 import subprocess
@@ -40,7 +41,7 @@ import apt
 import aptsources.sourceslist
 
 import apport.logging
-from apport.packaging import PackageInfo, freedesktop_os_release
+from apport.packaging import PackageInfo
 
 
 class __AptDpkgPackageInfo(PackageInfo):
@@ -1761,7 +1762,7 @@ class __AptDpkgPackageInfo(PackageInfo):
         """Get "lsb_release -sc", cache the result."""
         if self._distro_codename is None:
             try:
-                info = freedesktop_os_release()
+                info = platform.freedesktop_os_release()
                 self._distro_codename = info["VERSION_CODENAME"]
             except (KeyError, OSError):
                 # Fall back to query lsb_release

--- a/tests/unit/test_packaging_impl.py
+++ b/tests/unit/test_packaging_impl.py
@@ -7,7 +7,7 @@ from apport.packaging_impl import determine_packaging_implementation
 
 
 class TestPackagingImpl(unittest.TestCase):
-    @unittest.mock.patch("apport.packaging_impl.freedesktop_os_release")
+    @unittest.mock.patch("platform.freedesktop_os_release")
     def test_determine_ubuntu(self, os_release_mock):
         os_release_mock.return_value = {
             "PRETTY_NAME": "Ubuntu 22.04.1 LTS",
@@ -21,7 +21,7 @@ class TestPackagingImpl(unittest.TestCase):
         self.assertEqual(determine_packaging_implementation(), "apt_dpkg")
         os_release_mock.assert_called_once_with()
 
-    @unittest.mock.patch("apport.packaging_impl.freedesktop_os_release")
+    @unittest.mock.patch("platform.freedesktop_os_release")
     def test_determine_debian_unstable(self, os_release_mock):
         os_release_mock.return_value = {
             "PRETTY_NAME": "Debian GNU/Linux bookworm/sid",


### PR DESCRIPTION
The latest Debian stable is Bookworm, not Bullseye anymore. 