### PR TITLE
tests: Also run mypy on all Python scripts

### DIFF
--- a/data/apport
+++ b/data/apport
@@ -938,6 +938,9 @@ def process_crash_with_proc_pid(options: argparse.Namespace, proc_pid: ProcPid) 
     info = apport.report.Report("Crash")
     info["Signal"] = str(options.signal_number)
     core_size_limit = usable_ram() * 3 / 4
+    # sys.stdin has type io.TextIOWrapper, not the claimed io.TextIO.
+    # See https://github.com/python/typeshed/issues/10093
+    assert isinstance(sys.stdin, io.TextIOWrapper)
     # read binary data from stdio
     info["CoreDump"] = (sys.stdin.detach(), True, core_size_limit, True)
 

--- a/kde/apport-kde
+++ b/kde/apport-kde
@@ -67,7 +67,7 @@ def translate(self, prop, notr=None):
 
 
 # pylint: disable=protected-access
-uic.properties.Properties._string = translate
+uic.properties.Properties._string = translate  # type: ignore[assignment]
 # pylint: enable=protected-access
 
 

--- a/tests/run-linters
+++ b/tests/run-linters
@@ -63,6 +63,9 @@ fi
 if type mypy >/dev/null 2>&1; then
     echo "Running mypy..."
     mypy --ignore-missing-imports ${PYTHON_FILES}
+    for script in $PYTHON_SCRIPTS; do
+        mypy --ignore-missing-imports "$script"
+    done
 else
     echo "Skipping mypy tests, mypy is not installed"
 fi


### PR DESCRIPTION
mypy claims that `sys.stdin` has the type `io.TextIO` to ease redefining it. So assert that `sys.stdin` is still `io.TextIOWrapper` to make mypy happy.

Run mypy on the Python scripts. This needs to be done separately for each script because there is only one entry point allowed by mypy.