### PR TITLE
test: Run mypy with --disallow-incomplete-defs

### DIFF
--- a/apport/crashdb_impl/github.py
+++ b/apport/crashdb_impl/github.py
@@ -12,6 +12,7 @@
 import json
 import time
 from dataclasses import dataclass
+from typing import Any, Callable, Optional
 
 import requests
 
@@ -40,7 +41,7 @@ class Github:
             string = f"{string}&{key}={value}"
         return string
 
-    def _post(self, url: str, data: str):
+    def _post(self, url: str, data: str) -> Any:
         """Posts the given data to the given URL.
         Uses auth token if available"""
         headers = {"Accept": "application/vnd.github.v3+json"}
@@ -61,10 +62,10 @@ class Github:
         result.raise_for_status()  # Not using UI: the user can't do much here
         return json.loads(result.text)
 
-    def api_authentication(self, url: str, data: dict):
+    def api_authentication(self, url: str, data: dict) -> Any:
         return self._post(url, self._stringify(data))
 
-    def api_open_issue(self, owner: str, repo: str, data: dict):
+    def api_open_issue(self, owner: str, repo: str, data: dict) -> Any:
         url = f"https://api.github.com/repos/{owner}/{repo}/issues"
         return self._post(url, json.dumps(data))
 
@@ -99,7 +100,7 @@ class Github:
 
         return self
 
-    def __exit__(self, *_) -> None:
+    def __exit__(self, *_: Any) -> None:
         self.__authentication_data = None
         self.__cooldown = 0
         self.__expiry = 0
@@ -178,7 +179,10 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
             return github
 
     def upload(
-        self, report: apport.Report, progress_callback=None, user_message_callback=None
+        self,
+        report: apport.Report,
+        progress_callback: Optional[Callable] = None,
+        user_message_callback: Optional[Callable] = None,
     ) -> IssueHandle:
         """Upload given problem report return a handle for it.
         In Github, we open an issue.

--- a/apport/fileutils.py
+++ b/apport/fileutils.py
@@ -28,6 +28,7 @@ import stat
 import subprocess
 import time
 import typing
+from typing import Optional
 
 from apport.packaging_impl import impl as packaging
 from problem_report import ProblemReport
@@ -696,7 +697,7 @@ def shared_libraries(path):
     return libs
 
 
-def should_skip_crash(report: ProblemReport, filename: str) -> typing.Optional[str]:
+def should_skip_crash(report: ProblemReport, filename: str) -> Optional[str]:
     """Check if the crash should be skipped for flood protection.
 
     In case the crash should be skipped return a string with the reason.

--- a/apport/fileutils.py
+++ b/apport/fileutils.py
@@ -575,7 +575,7 @@ def get_process_environ(proc_pid_fd: int) -> dict[str, str]:
     Raises an OSError in case the environ file could not been read.
     """
 
-    def opener(path, flags: int) -> int:
+    def opener(path: typing.Union[str, os.PathLike[str]], flags: int) -> int:
         return os.open(path, flags, dir_fd=proc_pid_fd)
 
     with open(

--- a/apport/hookutils.py
+++ b/apport/hookutils.py
@@ -30,6 +30,7 @@ import tempfile
 
 import apport.fileutils
 from apport.packaging_impl import impl as packaging
+from problem_report import ProblemReport
 
 _invalid_key_chars_re = re.compile(r"[^0-9a-zA-Z_.-]")
 _AGENT = None
@@ -778,7 +779,7 @@ def attach_gsettings_package(report, package):
         attach_gsettings_schema(report, schema)
 
 
-def attach_journal_errors(report, time_window=10) -> None:
+def attach_journal_errors(report: ProblemReport, time_window: int = 10) -> None:
     """Attach journal warnings and errors.
 
     If the report contains a date, get the journal logs around that

--- a/apport/report.py
+++ b/apport/report.py
@@ -37,6 +37,7 @@ import urllib.request
 import xml.dom
 import xml.dom.minidom
 import xml.parsers.expat
+from typing import Optional
 
 import apport.fileutils
 import apport.logging
@@ -154,9 +155,7 @@ def _read_maps(proc_pid_fd):
 
 
 def _command_output(
-    command: list[str],
-    env: typing.Optional[dict[str, str]] = None,
-    timeout: float = 1800,
+    command: list[str], env: Optional[dict[str, str]] = None, timeout: float = 1800
 ) -> str:
     """Run command and capture its output.
 
@@ -1078,9 +1077,9 @@ class Report(problem_report.ProblemReport):
 
     def add_hooks_info(
         self,
-        ui: typing.Optional[HookUI] = None,
-        package: typing.Optional[str] = None,
-        srcpackage: typing.Optional[str] = None,
+        ui: Optional[HookUI] = None,
+        package: Optional[str] = None,
+        srcpackage: Optional[str] = None,
     ) -> bool:
         """Run hook script for collecting package specific data.
 
@@ -1100,10 +1099,7 @@ class Report(problem_report.ProblemReport):
         return ret
 
     def _add_hooks_info(
-        self,
-        ui: HookUI,
-        package: typing.Optional[str],
-        srcpackage: typing.Optional[str],
+        self, ui: HookUI, package: Optional[str], srcpackage: Optional[str]
     ) -> bool:
         # TODO: Split into smaller functions/methods
         # pylint: disable=too-many-branches

--- a/apport/report.py
+++ b/apport/report.py
@@ -1081,7 +1081,7 @@ class Report(problem_report.ProblemReport):
         ui: typing.Optional[HookUI] = None,
         package: typing.Optional[str] = None,
         srcpackage: typing.Optional[str] = None,
-    ):
+    ) -> bool:
         """Run hook script for collecting package specific data.
 
         A hook script needs to be in PACKAGE_HOOK_DIR/<Package>.py or in
@@ -1104,7 +1104,7 @@ class Report(problem_report.ProblemReport):
         ui: HookUI,
         package: typing.Optional[str],
         srcpackage: typing.Optional[str],
-    ):
+    ) -> bool:
         # TODO: Split into smaller functions/methods
         # pylint: disable=too-many-branches
 
@@ -1116,14 +1116,14 @@ class Report(problem_report.ProblemReport):
             package = package.split()[0]
             if "/" in package:
                 self["UnreportableReason"] = f"invalid Package: {package}"
-                return None
+                return False
         if not srcpackage:
             srcpackage = self.get("SourcePackage")
         if srcpackage:
             srcpackage = srcpackage.split()[0]
             if "/" in srcpackage:
                 self["UnreportableReason"] = f"invalid SourcePackage: {package}"
-                return None
+                return False
 
         hook_dirs = [PACKAGE_HOOK_DIR]
         # also search hooks in /opt, when program is from there

--- a/apport/ui.py
+++ b/apport/ui.py
@@ -44,6 +44,7 @@ import urllib.error
 import webbrowser
 import zlib
 from gettext import gettext as _
+from typing import Optional
 
 import apport.crashdb
 import apport.fileutils
@@ -67,9 +68,7 @@ def get_pid(report):
         return None
 
 
-def _get_env_int(
-    key: str, default: typing.Optional[int] = None
-) -> typing.Optional[int]:
+def _get_env_int(key: str, default: Optional[int] = None) -> Optional[int]:
     """Get an environment variable as integer.
 
     Return None if it doesn't exist or failed to convert to integer.
@@ -81,7 +80,7 @@ def _get_env_int(
         return default
 
 
-def _get_newest_process_for_user(name: str, uid: int) -> typing.Optional[int]:
+def _get_newest_process_for_user(name: str, uid: int) -> Optional[int]:
     process = subprocess.run(
         ["pgrep", "-n", "-x", "-u", str(uid), name],
         capture_output=True,
@@ -337,8 +336,8 @@ class UserInterface:
     def __init__(self, argv: list[str]):
         """Initialize program state and parse command line options."""
         self.gettext_domain = "apport"
-        self.report: typing.Optional[apport.report.Report] = None
-        self.report_file: typing.Optional[str] = None
+        self.report: Optional[apport.report.Report] = None
+        self.report_file: Optional[str] = None
         self.cur_package = None
         self.offer_restart = False
         self.specified_a_pkg = False
@@ -2027,7 +2026,7 @@ class UserInterface:
         """
         raise NotImplementedError("this function must be overridden by subclasses")
 
-    def ui_set_upload_progress(self, progress: typing.Optional[float]) -> None:
+    def ui_set_upload_progress(self, progress: Optional[float]) -> None:
         """Update data upload progress bar.
 
         Set the progress bar in the debug data upload progress window to the

--- a/apport/ui.py
+++ b/apport/ui.py
@@ -44,7 +44,7 @@ import urllib.error
 import webbrowser
 import zlib
 from gettext import gettext as _
-from typing import Optional
+from typing import Any, Optional
 
 import apport.crashdb
 import apport.fileutils
@@ -120,7 +120,9 @@ def _get_users_environ(uid: int) -> dict[str, str]:
     }
 
 
-def run_as_real_user(args: list[str], *, get_user_env: bool = False, **kwargs) -> None:
+def run_as_real_user(
+    args: list[str], *, get_user_env: bool = False, **kwargs: Any
+) -> None:
     """Call subprocess.run as real user if called via sudo/pkexec.
 
     If we are called through pkexec/sudo, determine the real user ID and
@@ -1980,7 +1982,7 @@ class UserInterface:
     #
 
     def ui_present_report_details(
-        self, allowed_to_report=True, modal_for=None
+        self, allowed_to_report: bool = True, modal_for: Optional[str] = None
     ) -> Action:
         """Show details of the bug report.
 

--- a/bin/apport-cli
+++ b/bin/apport-cli
@@ -213,7 +213,7 @@ class CLIUserInterface(apport.ui.UserInterface):
         return report_file
 
     def ui_present_report_details(
-        self, allowed_to_report=True, modal_for=None
+        self, allowed_to_report: bool = True, modal_for: Optional[str] = None
     ) -> apport.ui.Action:
         dialog = CLIDialog(
             _("Send problem report to the developers?"),

--- a/bin/apport-cli
+++ b/bin/apport-cli
@@ -25,8 +25,8 @@ import subprocess
 import sys
 import tempfile
 import termios
-import typing
 from gettext import gettext as _
+from typing import Optional
 
 import apport.ui
 
@@ -305,7 +305,7 @@ class CLIUserInterface(apport.ui.UserInterface):
         )
         self.progress.show()
 
-    def ui_set_upload_progress(self, progress: typing.Optional[float]) -> None:
+    def ui_set_upload_progress(self, progress: Optional[float]) -> None:
         assert self.progress is not None
         self.progress.set(progress)
 

--- a/data/apport
+++ b/data/apport
@@ -67,7 +67,7 @@ class ProcPid(contextlib.ContextDecorator):
             os.close(self.fd)
         return False
 
-    def _opener(self, path, flags: int) -> int:
+    def _opener(self, path: typing.Union[str, os.PathLike[str]], flags: int) -> int:
         return os.open(path, flags, dir_fd=self.fd)
 
     def open(self, file: str) -> io.TextIOWrapper:
@@ -155,7 +155,7 @@ def get_apport_starttime() -> int:
     return apport.fileutils.get_starttime(contents)
 
 
-def drop_privileges(crash_user: UserGroupID):
+def drop_privileges(crash_user: UserGroupID) -> None:
     """Change effective user and group to crash user/group ID"""
     # Drop any supplemental groups, or we'll still be in the root group
     if os.getuid() == 0:
@@ -659,7 +659,7 @@ def stop_apport() -> None:
     write_to_proc_sys("kernel/core_pattern", "core")
 
 
-def parse_arguments(args: list[str]):
+def parse_arguments(args: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser()
 
     parser.add_argument("-p", "--pid", type=int, help="process id (%%p)")

--- a/data/apport
+++ b/data/apport
@@ -42,6 +42,7 @@ import sys
 import time
 import traceback
 import typing
+from typing import Optional
 
 import apport.fileutils
 import apport.report
@@ -53,9 +54,9 @@ LOG_FORMAT = "%(levelname)s: apport (pid %(process)s) %(asctime)s: %(message)s"
 class ProcPid(contextlib.ContextDecorator):
     """Context manager to access /proc/<pid>."""
 
-    def __init__(self, pid: int, path: typing.Optional[str] = None) -> None:
+    def __init__(self, pid: int, path: Optional[str] = None) -> None:
         self.path = path or f"/proc/{pid}"
-        self.fd: typing.Optional[int] = None
+        self.fd: Optional[int] = None
 
     def __enter__(self):
         self.fd = os.open(self.path, os.O_RDONLY | os.O_PATH | os.O_DIRECTORY)
@@ -112,7 +113,7 @@ def get_core_path(
     options: argparse.Namespace,
     crash_user: UserGroupID,
     proc_pid: ProcPid,
-    timestamp: typing.Optional[int] = None,
+    timestamp: Optional[int] = None,
 ) -> str:
     """Get the path to the core file."""
     return apport.fileutils.get_core_path(

--- a/data/apport
+++ b/data/apport
@@ -232,8 +232,8 @@ def write_user_coredump(
     proc_pid: ProcPid,
     crash_user: UserGroupID,
     pidstat: os.stat_result,
-    coredump_fd=None,
-    from_report=None,
+    coredump_fd: Optional[int] = None,
+    from_report: Optional[typing.BinaryIO] = None,
 ) -> None:
     # pylint: disable=too-many-arguments
     """Write the core into a directory if ulimit requests it."""
@@ -286,6 +286,7 @@ def write_user_coredump(
         logger.info("writing core dump %s of size %i", core_path, core_size)
         os.write(core_file, r["CoreDump"])
     else:
+        assert coredump_fd is not None
         block = os.read(coredump_fd, 1048576)
 
         while True:

--- a/gtk/apport-gtk
+++ b/gtk/apport-gtk
@@ -18,8 +18,8 @@ import os
 import re
 import subprocess
 import sys
-import typing
 from gettext import gettext as _
+from typing import Optional
 
 import apport
 import apport.ui
@@ -474,7 +474,7 @@ class GTKUserInterface(apport.ui.UserInterface):
         while Gtk.events_pending():
             Gtk.main_iteration_do(False)
 
-    def ui_set_upload_progress(self, progress: typing.Optional[float]) -> None:
+    def ui_set_upload_progress(self, progress: Optional[float]) -> None:
         """Set the progress bar in the debug data upload progress
         window to the given ratio (between 0 and 1, or None for indefinite
         progress).

--- a/gtk/apport-gtk
+++ b/gtk/apport-gtk
@@ -226,7 +226,7 @@ class GTKUserInterface(apport.ui.UserInterface):
         gdk_window.set_modal_hint(True)
 
     def ui_present_report_details(
-        self, allowed_to_report=True, modal_for=None
+        self, allowed_to_report: bool = True, modal_for: Optional[str] = None
     ) -> apport.ui.Action:
         # TODO: Split into smaller functions/methods
         # pylint: disable=too-many-branches,too-many-locals,too-many-statements

--- a/kde/apport-kde
+++ b/kde/apport-kde
@@ -19,8 +19,8 @@ import os
 import shutil
 import subprocess
 import sys
-import typing
 from gettext import gettext as _
+from typing import Optional
 
 import apport.logging
 import apport.ui
@@ -121,7 +121,7 @@ class ProgressDialog(Dialog):
         if self.sender().buttonRole(button) == QDialogButtonBox.RejectRole:
             sys.exit(0)
 
-    def set(self, value: typing.Optional[float] = None) -> None:
+    def set(self, value: Optional[float] = None) -> None:
         progress = self.findChild(QProgressBar, "progress")
         assert isinstance(progress, QProgressBar)
         if not value:
@@ -359,8 +359,8 @@ class MainUserInterface(apport.ui.UserInterface):
         apport.ui.UserInterface.__init__(self, argv)
         self.ui_data_path = os.path.dirname(argv[0])
         # Help unit tests get at the dialog.
-        self.dialog: typing.Optional[ReportDialog] = None
-        self.progress: typing.Optional[ProgressDialog] = None
+        self.dialog: Optional[ReportDialog] = None
+        self.progress: Optional[ProgressDialog] = None
 
     #
     # ui_* implementation of abstract UserInterface classes
@@ -499,7 +499,7 @@ class MainUserInterface(apport.ui.UserInterface):
         )
         self.progress.show()
 
-    def ui_set_upload_progress(self, progress: typing.Optional[float]) -> None:
+    def ui_set_upload_progress(self, progress: Optional[float]) -> None:
         assert self.progress
         if progress:
             self.progress.set(progress)

--- a/kde/apport-kde
+++ b/kde/apport-kde
@@ -397,7 +397,7 @@ class MainUserInterface(apport.ui.UserInterface):
                 QTreeWidgetItem(keyitem, [_("(binary data)")])
 
     def ui_present_report_details(
-        self, allowed_to_report=True, modal_for=None
+        self, allowed_to_report: bool = True, modal_for: Optional[str] = None
     ) -> apport.ui.Action:
         desktop_info = self.get_desktop_entry()
         self.dialog = ReportDialog(self.report, allowed_to_report, self, desktop_info)

--- a/problem_report.py
+++ b/problem_report.py
@@ -27,6 +27,7 @@ import struct
 import time
 import typing
 import zlib
+from typing import Optional
 
 # magic number (0x1F 0x8B) and compression method (0x08 for DEFLATE)
 GZIP_HEADER_START = b"\037\213\010"
@@ -278,7 +279,7 @@ class ProblemReport(collections.UserDict):
             return set()
         return set(self["Tags"].split(" "))
 
-    def get_timestamp(self) -> typing.Optional[int]:
+    def get_timestamp(self) -> Optional[int]:
         """Get timestamp (seconds since epoch) from Date field.
 
         Return None if it is not present.

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -12,7 +12,7 @@ import typing
 import unittest.mock
 import urllib.error
 import urllib.request
-from typing import Optional
+from typing import Any, Optional
 
 
 def get_init_system() -> str:
@@ -39,7 +39,7 @@ def has_internet() -> bool:
         return False
 
 
-def import_module_from_file(path: pathlib.Path):
+def import_module_from_file(path: pathlib.Path) -> Any:
     """Import a module by its filename."""
     name = path.stem.replace("-", "_")
     spec = importlib.util.spec_from_loader(
@@ -83,7 +83,7 @@ def _id(obj):
     return obj
 
 
-def skip_if_command_is_missing(cmd: str):
+def skip_if_command_is_missing(cmd: str) -> typing.Callable:
     """Skip a test if the command is not found."""
     if shutil.which(cmd) is None:
         return unittest.skip(f"{cmd} not installed")

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -12,6 +12,7 @@ import typing
 import unittest.mock
 import urllib.error
 import urllib.request
+from typing import Optional
 
 
 def get_init_system() -> str:
@@ -65,7 +66,7 @@ def pidof(program):
     return set(int(pid) for pid in stdout.decode().split())
 
 
-def read_shebang(command: str) -> typing.Optional[str]:
+def read_shebang(command: str) -> Optional[str]:
     """Return the shebang of the given file.
 
     If the given file is a script, return the executable from the

--- a/tests/integration/test_apport_checkreports.py
+++ b/tests/integration/test_apport_checkreports.py
@@ -13,8 +13,8 @@ import os
 import shutil
 import subprocess
 import tempfile
-import typing
 import unittest
+from typing import Optional
 
 import apport.report
 from tests.paths import get_data_directory, local_test_environment
@@ -35,7 +35,7 @@ class TestApportCheckreports(unittest.TestCase):
 
     def _call(
         self,
-        args: typing.Optional[list] = None,
+        args: Optional[list] = None,
         expected_returncode: int = 0,
         expected_stdout: str = "",
     ) -> None:

--- a/tests/integration/test_dupdb_admin.py
+++ b/tests/integration/test_dupdb_admin.py
@@ -15,6 +15,7 @@ import subprocess
 import tempfile
 import typing
 import unittest
+from typing import Optional
 
 from apport.crashdb_impl.memory import CrashDatabase
 from tests.paths import local_test_environment
@@ -40,7 +41,7 @@ class TestDupdbAdmin(unittest.TestCase):
         self,
         args: list,
         expected_returncode: int = 0,
-        expected_stdout: typing.Optional[str] = "",
+        expected_stdout: Optional[str] = "",
     ) -> typing.Tuple[str, str]:
         cmd = ["dupdb-admin", "-f", self.db_file] + args
         process = subprocess.run(

--- a/tests/integration/test_report.py
+++ b/tests/integration/test_report.py
@@ -33,7 +33,7 @@ class T(unittest.TestCase):
     def tearDownClass(cls):
         restore_data_dir(apport.report, cls.orig_data_dir)
 
-    def wait_for_proc_cmdline(self, pid: int, timeout_sec=10.0) -> None:
+    def wait_for_proc_cmdline(self, pid: int, timeout_sec: float = 10.0) -> None:
         assert pid
         elapsed_time = 0.0
         while elapsed_time < timeout_sec:

--- a/tests/integration/test_signal_crashes.py
+++ b/tests/integration/test_signal_crashes.py
@@ -808,7 +808,11 @@ class T(unittest.TestCase):
     ) -> None:
         orig_os_open = os.open
 
-        def _mocked_os_open(path, flags: int, dir_fd: Optional[int] = None) -> int:
+        def _mocked_os_open(
+            path: typing.Union[str, os.PathLike[str]],
+            flags: int,
+            dir_fd: Optional[int] = None,
+        ) -> int:
             if path == "root/run/apport.socket":
                 return orig_os_open(socket_path, flags)
             return orig_os_open(path, flags, dir_fd=dir_fd)
@@ -930,20 +934,21 @@ class T(unittest.TestCase):
         time.sleep(0.3)  # needs some more setup time
         return process
 
+    # pylint: disable-next=too-many-arguments
     def do_crash(
         self,
-        expect_corefile=False,
-        sig=signal.SIGSEGV,
-        command=None,
-        expected_command=None,
-        uid=None,
-        expect_corefile_owner=None,
-        args=None,
+        expect_corefile: bool = False,
+        sig: int = signal.SIGSEGV,
+        command: Optional[str] = None,
+        expected_command: Optional[str] = None,
+        uid: Optional[int] = None,
+        expect_corefile_owner: Optional[str] = None,
+        args: Optional[list[str]] = None,
         suid_dumpable: int = 1,
-        hook_before_apport=None,
+        hook_before_apport: Optional[typing.Callable] = None,
         expect_report: bool = True,
         via_socket: bool = False,
-    ):  # pylint: disable=too-many-arguments
+    ) -> None:
         # TODO: Split into smaller functions/methods
         # pylint: disable=too-many-branches,too-many-locals,too-many-statements
         """Generate a test crash.

--- a/tests/integration/test_signal_crashes.py
+++ b/tests/integration/test_signal_crashes.py
@@ -27,6 +27,7 @@ import textwrap
 import time
 import typing
 import unittest
+from typing import Optional
 
 import psutil
 
@@ -807,9 +808,7 @@ class T(unittest.TestCase):
     ) -> None:
         orig_os_open = os.open
 
-        def _mocked_os_open(
-            path, flags: int, dir_fd: typing.Optional[int] = None
-        ) -> int:
+        def _mocked_os_open(path, flags: int, dir_fd: Optional[int] = None) -> int:
             if path == "root/run/apport.socket":
                 return orig_os_open(socket_path, flags)
             return orig_os_open(path, flags, dir_fd=dir_fd)
@@ -878,7 +877,7 @@ class T(unittest.TestCase):
         self.assertNotEqual(gdb.stdout.strip(), "")
 
     def _check_report(
-        self, expect_report: bool = True, expected_owner: typing.Optional[int] = None
+        self, expect_report: bool = True, expected_owner: Optional[int] = None
     ) -> None:
         if not expect_report:
             self.assertEqual(apport.fileutils.get_all_reports(), [])

--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -21,7 +21,7 @@ import typing
 import unittest
 import unittest.mock
 import urllib.error
-from typing import Optional
+from typing import Any, Optional
 
 import apport.crashdb_impl.memory
 import apport.packaging
@@ -37,7 +37,7 @@ logind_session = apport.Report.get_logind_session(os.getpid())
 
 
 def mock_run_calls_except_pgrep(
-    args: list[str], check: bool = False, **kwargs
+    args: list[str], check: bool = False, **kwargs: Any
 ) -> subprocess.CompletedProcess:
     """Wrap subprocess.run() doing no-ops except for pgrep."""
     if args[0] == "pgrep":
@@ -118,7 +118,7 @@ class UserInterfaceMock(apport.ui.UserInterface):
         self.msg_choices = None
 
     def ui_present_report_details(
-        self, allowed_to_report=True, modal_for=None
+        self, allowed_to_report: bool = True, modal_for: Optional[str] = None
     ) -> apport.ui.Action:
         self.present_details_shown = True
         assert self.present_details_response

--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -21,6 +21,7 @@ import typing
 import unittest
 import unittest.mock
 import urllib.error
+from typing import Optional
 
 import apport.crashdb_impl.memory
 import apport.packaging
@@ -48,7 +49,7 @@ class UserInterfaceMock(apport.ui.UserInterface):
     # pylint: disable=too-many-instance-attributes
     """Concrete apport.ui.UserInterface suitable for automatic testing"""
 
-    def __init__(self, argv: typing.Optional[list[str]] = None):
+    def __init__(self, argv: Optional[list[str]] = None):
         # use our memory crashdb which is designed for testing
         # closed in __del__, pylint: disable=consider-using-with
         self.crashdb_conf = tempfile.NamedTemporaryFile()
@@ -148,7 +149,7 @@ class UserInterfaceMock(apport.ui.UserInterface):
         self.upload_progress_pulses = 0
         self.upload_progress_active = True
 
-    def ui_set_upload_progress(self, progress: typing.Optional[float]) -> None:
+    def ui_set_upload_progress(self, progress: Optional[float]) -> None:
         assert self.upload_progress_active
         self.upload_progress_pulses += 1
 
@@ -273,9 +274,7 @@ class T(unittest.TestCase):
 
     @contextlib.contextmanager
     def _run_test_executable(
-        self,
-        exename: typing.Optional[str] = None,
-        env: typing.Optional[dict[str, str]] = None,
+        self, exename: Optional[str] = None, env: Optional[dict[str, str]] = None
     ) -> typing.Generator[int, None, None]:
         if not exename:
             exename = self.TEST_EXECUTABLE
@@ -464,7 +463,7 @@ class T(unittest.TestCase):
         self.ui.report = apport.Report("Bug")
         self.ui.cur_package = "bash"
 
-        def search_bug_patterns(url: str) -> typing.Optional[str]:
+        def search_bug_patterns(url: str) -> Optional[str]:
             progress_pulses = self.ui.ic_progress_pulses
             # wait for ui_pulse_info_collection_progress() call
             while self.ui.ic_progress_pulses == progress_pulses:
@@ -509,7 +508,7 @@ class T(unittest.TestCase):
         self.assertTrue(os.stat(self.report_file.name).st_mode & stat.S_IRGRP)
 
     def _write_crashdb_config_hook(
-        self, crashdb: str, bash_hook: typing.Optional[str] = None
+        self, crashdb: str, bash_hook: Optional[str] = None
     ) -> None:
         """Write source_bash.py hook that sets CrashDB"""
         with open(

--- a/tests/integration/test_unkillable_shutdown.py
+++ b/tests/integration/test_unkillable_shutdown.py
@@ -18,6 +18,7 @@ import subprocess
 import tempfile
 import typing
 import unittest
+from typing import Optional
 
 from tests.paths import get_data_directory, local_test_environment
 
@@ -39,7 +40,7 @@ class TestUnkillableShutdown(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.report_dir)
 
-    def _call(self, omit: typing.Optional[list] = None) -> None:
+    def _call(self, omit: Optional[list] = None) -> None:
         cmd = [self.data_dir / "unkillable_shutdown"]
         if omit:
             cmd += [arg for pid in omit for arg in ["-o", str(pid)]]

--- a/tests/paths.py
+++ b/tests/paths.py
@@ -1,6 +1,7 @@
 import os
 import pathlib
 import typing
+from typing import Optional
 
 _SRCDIR = pathlib.Path(__file__).absolute().parent.parent
 _BINDIR = _SRCDIR / "bin"
@@ -8,7 +9,7 @@ _CRASHDB_CONF = _SRCDIR / "etc" / "apport" / "crashdb.conf"
 _DATADIR = _SRCDIR / "data"
 
 
-def get_data_directory(local_path: typing.Optional[str] = None) -> pathlib.Path:
+def get_data_directory(local_path: Optional[str] = None) -> pathlib.Path:
     """Return absolute path for apport's data directory.
 
     If the tests are executed in the local source code directory,
@@ -47,7 +48,7 @@ def local_test_environment() -> typing.Mapping[str, str]:
     }
 
 
-def patch_data_dir(report) -> typing.Optional[typing.Mapping[str, str]]:
+def patch_data_dir(report) -> Optional[typing.Mapping[str, str]]:
     """Patch APPORT_DATA_DIR in apport.report for local tests."""
     if not is_local_source_directory():
         return None
@@ -67,7 +68,7 @@ def patch_data_dir(report) -> typing.Optional[typing.Mapping[str, str]]:
     return orig
 
 
-def restore_data_dir(report, orig: typing.Optional[typing.Mapping[str, str]]) -> None:
+def restore_data_dir(report, orig: Optional[typing.Mapping[str, str]]) -> None:
     """Restore APPORT_DATA_DIR in apport.report from local tests.
 
     The parameter orig is the result from the patch_data_dir() call.

--- a/tests/paths.py
+++ b/tests/paths.py
@@ -1,7 +1,7 @@
 import os
 import pathlib
 import typing
-from typing import Optional
+from typing import Any, Optional
 
 _SRCDIR = pathlib.Path(__file__).absolute().parent.parent
 _BINDIR = _SRCDIR / "bin"
@@ -48,7 +48,7 @@ def local_test_environment() -> typing.Mapping[str, str]:
     }
 
 
-def patch_data_dir(report) -> Optional[typing.Mapping[str, str]]:
+def patch_data_dir(report: Any) -> Optional[typing.Mapping[str, str]]:
     """Patch APPORT_DATA_DIR in apport.report for local tests."""
     if not is_local_source_directory():
         return None
@@ -68,7 +68,7 @@ def patch_data_dir(report) -> Optional[typing.Mapping[str, str]]:
     return orig
 
 
-def restore_data_dir(report, orig: Optional[typing.Mapping[str, str]]) -> None:
+def restore_data_dir(report: Any, orig: Optional[typing.Mapping[str, str]]) -> None:
     """Restore APPORT_DATA_DIR in apport.report from local tests.
 
     The parameter orig is the result from the patch_data_dir() call.

--- a/tests/run-linters
+++ b/tests/run-linters
@@ -62,9 +62,9 @@ fi
 
 if type mypy >/dev/null 2>&1; then
     echo "Running mypy..."
-    mypy --ignore-missing-imports ${PYTHON_FILES}
+    mypy --disallow-incomplete-defs --ignore-missing-imports ${PYTHON_FILES}
     for script in $PYTHON_SCRIPTS; do
-        mypy --ignore-missing-imports "$script"
+        mypy --disallow-incomplete-defs --ignore-missing-imports "$script"
     done
 else
     echo "Skipping mypy tests, mypy is not installed"

--- a/tests/system/test_packaging_apt_dpkg.py
+++ b/tests/system/test_packaging_apt_dpkg.py
@@ -985,7 +985,7 @@ def _setup_foonux_config(
     updates: bool = False,
     release: str = "jammy",
     ppa: bool = False,
-):
+) -> str:
     """Set up directories and configuration for install_packages()
 
     If ppa is True, then a sources.list file for a PPA will be created


### PR DESCRIPTION
Some functions/methods were only partially anotated with types. Complete those annotations. Use `typing.Any` for too complicated cases. This could be refined in the future.

Fix two issues found:
* `Report.add_hooks_info` could return `None` despite the docstring that this methods return a boolean. So return `False` in the `None` case.
* apport: Assert that coredump_fd is set before using it

When annotating function they should be annotated completely (for consistency). So use `--disallow-incomplete-defs` from the set of strict rules.

