### PR TITLE
gcc_ice_hook: Disable buggy pylint check

### DIFF
--- a/data/gcc_ice_hook
+++ b/data/gcc_ice_hook
@@ -25,6 +25,7 @@ if len(sys.argv) != 3:
     )
     sys.exit(1)
 
+# workaround pylint-dev/pylint#7710, pylint: disable-next=unbalanced-tuple-unpacking
 (exename, sourcefile) = sys.argv[1:3]
 
 # create report


### PR DESCRIPTION
This line bugs out once in a while in pylint ever since we enabled parallelism. Since the parallel gains are substantial, let's just disable the check there.