### PR TITLE
Add missing module docstrings

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -30,7 +30,8 @@ good-names=i,j,k,lp,ui,_
 disable=bad-option-value,fixme,
   # TODO: Fix all following disabled checks!
   duplicate-code,
-  missing-docstring,
+  missing-class-docstring,
+  missing-function-docstring,
 
 
 [REPORTS]

--- a/apport/__init__.py
+++ b/apport/__init__.py
@@ -1,3 +1,5 @@
+"""Apport Python module."""
+
 import gettext
 import warnings
 

--- a/apport/logging.py
+++ b/apport/logging.py
@@ -1,3 +1,5 @@
+"""Legacy logging functions."""
+
 import os
 import sys
 import time

--- a/apport/packaging_impl/__init__.py
+++ b/apport/packaging_impl/__init__.py
@@ -1,3 +1,5 @@
+"""Platform-specific apport.packaging implementation."""
+
 import importlib
 import os
 import platform

--- a/bin/apport-retrace
+++ b/bin/apport-retrace
@@ -1,8 +1,5 @@
 #!/usr/bin/python3
 
-# Use the coredump in a crash report to regenerate the stack traces. This is
-# helpful to get a trace with debug symbols.
-#
 # Copyright (c) 2006 - 2011 Canonical Ltd.
 # Author: Martin Pitt <martin.pitt@ubuntu.com>
 #
@@ -11,6 +8,9 @@
 # Free Software Foundation; either version 2 of the License, or (at your
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
+
+"""Use the coredump in a crash report to regenerate the stack traces. This is
+helpful to get a trace with debug symbols."""
 
 # TODO: Address following pylint complaints
 # pylint: disable=invalid-name

--- a/bin/apport-unpack
+++ b/bin/apport-unpack
@@ -1,8 +1,5 @@
 #!/usr/bin/python3
 
-# Extract the fields of a problem report into separate files into a new or
-# empty directory.
-#
 # Copyright (c) 2006 Canonical Ltd.
 # Author: Martin Pitt <martin.pitt@ubuntu.com>
 #
@@ -11,6 +8,9 @@
 # Free Software Foundation; either version 2 of the License, or (at your
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
+
+"""Extract the fields of a problem report into separate files into a new or
+empty directory."""
 
 # pylint: disable=invalid-name
 # pylint: enable=invalid-name

--- a/bin/apport-valgrind
+++ b/bin/apport-valgrind
@@ -1,8 +1,5 @@
 #!/usr/bin/python3
 
-# Use the coredump in a crash report to regenerate the stack traces. This is
-# helpful to get a trace with debug symbols.
-#
 # Copyright (c) 2006 - 2013 Canonical Ltd.
 # Authors: Alex Chiang <alex.chiang@canonical.com>
 #          Kyle Nitzsche <kyle.nitzsche@canonical.com>
@@ -13,6 +10,9 @@
 # Free Software Foundation; either version 2 of the License, or (at your
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
+
+"""Use the coredump in a crash report to regenerate the stack traces. This is
+helpful to get a trace with debug symbols."""
 
 # TODO: Address following pylint complaints
 # pylint: disable=invalid-name

--- a/bin/crash-digger
+++ b/bin/crash-digger
@@ -9,6 +9,8 @@
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
 
+"""Do duplicate check and retrace crashes in the crash database."""
+
 # pylint: disable=invalid-name
 # pylint: enable=invalid-name
 

--- a/bin/dupdb-admin
+++ b/bin/dupdb-admin
@@ -1,7 +1,5 @@
 #!/usr/bin/python3
 
-# CLI for maintaining the duplicate database
-#
 # Copyright (c) 2007 - 2012 Canonical Ltd.
 # Author: Martin Pitt <martin.pitt@ubuntu.com>
 #
@@ -10,6 +8,8 @@
 # Free Software Foundation; either version 2 of the License, or (at your
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
+
+"""CLI for maintaining the duplicate database"""
 
 # pylint: disable=invalid-name
 # pylint: enable=invalid-name

--- a/data/apport
+++ b/data/apport
@@ -1,9 +1,5 @@
 #!/usr/bin/python3
 
-# Collect information about a crash and create a report in the directory
-# specified by apport.fileutils.report_dir.
-# See https://wiki.ubuntu.com/Apport for details.
-#
 # Copyright (c) 2006 - 2016 Canonical Ltd.
 # Author: Martin Pitt <martin.pitt@ubuntu.com>
 #
@@ -12,6 +8,10 @@
 # Free Software Foundation; either version 2 of the License, or (at your
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
+
+"""Collect information about a crash and create a report in the directory
+specified by apport.fileutils.report_dir.
+See https://wiki.ubuntu.com/Apport for details."""
 
 # pylint: disable=too-many-lines
 

--- a/data/apport-checkreports
+++ b/data/apport-checkreports
@@ -1,8 +1,5 @@
 #!/usr/bin/python3
 
-# Check if there are new reports for the invoking user. Exit with 0 if new
-# reports are available, or with 1 if not.
-#
 # Copyright (c) 2006 Canonical Ltd.
 # Author: Martin Pitt <martin.pitt@ubuntu.com>
 #
@@ -11,6 +8,9 @@
 # Free Software Foundation; either version 2 of the License, or (at your
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
+
+"""Check if there are new reports for the invoking user. Exit with 0 if new
+reports are available, or with 1 if not."""
 
 # pylint: disable=invalid-name
 # pylint: enable=invalid-name

--- a/data/apportcheckresume
+++ b/data/apportcheckresume
@@ -9,6 +9,13 @@
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
 
+"""Detect and report suspend/hibernate/resume failures.
+
+If a suspend/hibernate is marked as still in progress during a normal
+system boot we know that that operation has failed.  Use that to
+generate an apport bug report.
+"""
+
 import datetime
 import os
 import sys

--- a/data/dump_acpi_tables.py
+++ b/data/dump_acpi_tables.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python3
 
+"""Dump ACPI tables."""
+
 # TODO: Address following pylint complaints
 # pylint: disable=invalid-name
 

--- a/data/gcc_ice_hook
+++ b/data/gcc_ice_hook
@@ -1,7 +1,5 @@
 #!/usr/bin/python3
 #
-# Collect information about a gcc internal compiler exception (ICE).
-#
 # Copyright (c) 2007 Canonical Ltd.
 # Author: Martin Pitt <martin.pitt@ubuntu.com>
 #
@@ -10,6 +8,8 @@
 # Free Software Foundation; either version 2 of the License, or (at your
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
+
+"""Collect information about a gcc internal compiler exception (ICE)."""
 
 import sys
 

--- a/data/general-hooks/parse_segv.py
+++ b/data/general-hooks/parse_segv.py
@@ -1,7 +1,4 @@
 #!/usr/bin/python3
-# Examine the crash files saved by apport to attempt to determine the cause
-# of a segfault.  Currently very very simplistic, and only finds commonly
-# understood situations for x86/x86_64.
 #
 # Copyright 2009-2010  Canonical, Ltd.
 # Author: Kees Cook <kees@ubuntu.com>
@@ -11,6 +8,10 @@
 # Free Software Foundation; either version 2 of the License, or (at your
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
+
+"""Examine the crash files saved by apport to attempt to determine the cause
+of a segfault.  Currently very very simplistic, and only finds commonly
+understood situations for x86/x86_64."""
 
 # TODO: Address following pylint complaints
 # pylint: disable=invalid-name

--- a/data/iwlwifi_error_dump
+++ b/data/iwlwifi_error_dump
@@ -1,7 +1,5 @@
 #!/usr/bin/python3
 #
-# Collect information about an iwlwifi firmware error dump.
-#
 # Copyright (c) 2014 Canonical Ltd.
 # Author: Seth Forshee <seth.forshee@canonical.com>
 #
@@ -10,6 +8,8 @@
 # Free Software Foundation; either version 2 of the License, or (at your
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
+
+"""Collect information about an iwlwifi firmware error dump."""
 
 import os
 import re

--- a/data/kernel_crashdump
+++ b/data/kernel_crashdump
@@ -1,7 +1,5 @@
 #!/usr/bin/python3
 #
-# Collect information about a kernel oops.
-#
 # Copyright (c) 2007 Canonical Ltd.
 # Author: Martin Pitt <martin.pitt@ubuntu.com>
 #
@@ -10,6 +8,8 @@
 # Free Software Foundation; either version 2 of the License, or (at your
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
+
+"""Collect information about a kernel oops."""
 
 import glob
 import os

--- a/data/kernel_oops
+++ b/data/kernel_oops
@@ -1,7 +1,5 @@
 #!/usr/bin/python3
 #
-# Collect information about a kernel oops.
-#
 # Copyright (c) 2008 Canonical Ltd.
 # Author: Matt Zimmerman <mdz@canonical.com>
 #
@@ -10,6 +8,8 @@
 # Free Software Foundation; either version 2 of the License, or (at your
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
+
+"""Collect information about a kernel oops."""
 
 # TODO: Address following pylint complaints
 # pylint: disable=invalid-name

--- a/data/package_hook
+++ b/data/package_hook
@@ -1,7 +1,5 @@
 #!/usr/bin/python3
 #
-# Collect information about a package installation/upgrade failure.
-#
 # Copyright (c) 2007 - 2009 Canonical Ltd.
 # Author: Martin Pitt <martin.pitt@ubuntu.com>
 #
@@ -10,6 +8,8 @@
 # Free Software Foundation; either version 2 of the License, or (at your
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
+
+"""Collect information about a package installation/upgrade failure."""
 
 import argparse
 import os

--- a/data/unkillable_shutdown
+++ b/data/unkillable_shutdown
@@ -1,9 +1,5 @@
 #!/usr/bin/python3
 #
-# Collect information about processes which are still running after sending
-# SIGTERM to them (which happens during computer shutdown in
-# /etc/init.d/sendsigs in Debian/Ubuntu)
-#
 # Copyright (c) 2010 Canonical Ltd.
 # Author: Martin Pitt <martin.pitt@ubuntu.com>
 #
@@ -12,6 +8,10 @@
 # Free Software Foundation; either version 2 of the License, or (at your
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
+
+"""Collect information about processes which are still running after sending
+SIGTERM to them (which happens during computer shutdown in
+/etc/init.d/sendsigs in Debian/Ubuntu)"""
 
 import argparse
 import errno

--- a/data/whoopsie-upload-all
+++ b/data/whoopsie-upload-all
@@ -1,9 +1,5 @@
 #!/usr/bin/python3
 
-# Process all pending crashes and mark them for whoopsie upload, but do not
-# upload them to any other crash database. Wait until whoopsie is done
-# uploading.
-#
 # Copyright (c) 2013 Canonical Ltd.
 # Author: Martin Pitt <martin.pitt@ubuntu.com>
 #
@@ -12,6 +8,10 @@
 # Free Software Foundation; either version 2 of the License, or (at your
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
+
+"""Process all pending crashes and mark them for whoopsie upload, but do not
+upload them to any other crash database. Wait until whoopsie is done
+uploading."""
 
 # TODO: Address following pylint complaints
 # pylint: disable=invalid-name

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python3
 
+"""Installer script for Apport."""
+
 # TODO: Address following pylint complaints
 # pylint: disable=invalid-name
 

--- a/tests/integration/test_apport_valgrind.py
+++ b/tests/integration/test_apport_valgrind.py
@@ -7,6 +7,8 @@
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
 
+"""Integration tests for bin/apport-valgrind."""
+
 import os
 import shutil
 import subprocess

--- a/tests/integration/test_fileutils.py
+++ b/tests/integration/test_fileutils.py
@@ -1,3 +1,5 @@
+"""Integration tests for the apport.fileutils module."""
+
 # TODO: Address following pylint complaints
 # pylint: disable=invalid-name
 

--- a/tests/integration/test_github.py
+++ b/tests/integration/test_github.py
@@ -7,6 +7,8 @@
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
 
+"""Integration tests for the apport.crashdb_impl.github module."""
+
 import unittest
 from unittest.mock import ANY, Mock, patch
 

--- a/tests/integration/test_hookutils.py
+++ b/tests/integration/test_hookutils.py
@@ -1,3 +1,5 @@
+"""Integration tests for the apport.hookutils module."""
+
 # TODO: Address following pylint complaints
 # pylint: disable=invalid-name
 

--- a/tests/integration/test_java_crashes.py
+++ b/tests/integration/test_java_crashes.py
@@ -7,6 +7,8 @@
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
 
+"""Integration tests for the Java crash collection support."""
+
 import os
 import shutil
 import subprocess

--- a/tests/integration/test_packaging.py
+++ b/tests/integration/test_packaging.py
@@ -1,3 +1,5 @@
+"""Integration tests for the apport.packaging module."""
+
 # TODO: Address following pylint complaints
 # pylint: disable=invalid-name
 

--- a/tests/integration/test_packaging_apt_dpkg.py
+++ b/tests/integration/test_packaging_apt_dpkg.py
@@ -1,3 +1,5 @@
+"""Integration tests for the apport.packaging_impl.apt_dpkg module."""
+
 # TODO: Address following pylint complaints
 # pylint: disable=invalid-name
 

--- a/tests/integration/test_packaging_rpm.py
+++ b/tests/integration/test_packaging_rpm.py
@@ -1,3 +1,5 @@
+"""Integration tests for the apport.packaging_impl.rpm module."""
+
 import unittest
 
 from tests.helper import skip_if_command_is_missing

--- a/tests/integration/test_problem_report.py
+++ b/tests/integration/test_problem_report.py
@@ -1,3 +1,5 @@
+"""Integration tests for the problem_report module."""
+
 # TODO: Address following pylint complaints
 # pylint: disable=invalid-name
 

--- a/tests/integration/test_python_crashes.py
+++ b/tests/integration/test_python_crashes.py
@@ -1,5 +1,3 @@
-# Test apport_python_hook.py
-#
 # Copyright (c) 2006 - 2011 Canonical Ltd.
 # Authors: Robert Collins <robert@ubuntu.com>
 #          Martin Pitt <martin.pitt@ubuntu.com>
@@ -9,6 +7,8 @@
 # Free Software Foundation; either version 2 of the License, or (at your
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
+
+"""Test apport_python_hook.py."""
 
 # TODO: Address following pylint complaints
 # pylint: disable=invalid-name

--- a/tests/integration/test_report.py
+++ b/tests/integration/test_report.py
@@ -1,3 +1,5 @@
+"""Integration tests for the apport.report module."""
+
 # pylint: disable=too-many-lines
 # TODO: Address following pylint complaints
 # pylint: disable=invalid-name

--- a/tests/integration/test_signal_crashes.py
+++ b/tests/integration/test_signal_crashes.py
@@ -7,6 +7,8 @@
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
 
+"""Integration tests for data/apport."""
+
 # pylint: disable=too-many-lines
 # TODO: Address following pylint complaints
 # pylint: disable=invalid-name

--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -1,3 +1,5 @@
+"""Integration tests for the apport.ui module."""
+
 # pylint: disable=too-many-lines
 # TODO: Address following pylint complaints
 # pylint: disable=invalid-name

--- a/tests/paths.py
+++ b/tests/paths.py
@@ -1,3 +1,5 @@
+"""Test helper functions around modifying paths."""
+
 import os
 import pathlib
 import typing

--- a/tests/system/test_apport_valgrind.py
+++ b/tests/system/test_apport_valgrind.py
@@ -7,6 +7,8 @@
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
 
+"""System tests for bin/apport-valgrind."""
+
 import os
 import shutil
 import subprocess

--- a/tests/system/test_github_query.py
+++ b/tests/system/test_github_query.py
@@ -1,3 +1,5 @@
+"""System tests for the apport.crashdb_impl.github module."""
+
 import unittest
 from unittest.mock import Mock
 

--- a/tests/system/test_packaging_apt_dpkg.py
+++ b/tests/system/test_packaging_apt_dpkg.py
@@ -1,3 +1,5 @@
+"""System tests for the apport.packaging_impl.apt_dpkg module."""
+
 # pylint: disable=too-many-lines
 # TODO: Address following pylint complaints
 # pylint: disable=invalid-name

--- a/tests/system/test_python_crashes.py
+++ b/tests/system/test_python_crashes.py
@@ -1,5 +1,3 @@
-# Test apport_python_hook.py
-#
 # Copyright (c) 2006 - 2011 Canonical Ltd.
 # Authors: Robert Collins <robert@ubuntu.com>
 #          Martin Pitt <martin.pitt@ubuntu.com>
@@ -9,6 +7,8 @@
 # Free Software Foundation; either version 2 of the License, or (at your
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
+
+"""Test apport_python_hook.py"""
 
 # TODO: Address following pylint complaints
 # pylint: disable=invalid-name

--- a/tests/system/test_signal_crashes.py
+++ b/tests/system/test_signal_crashes.py
@@ -1,3 +1,5 @@
+"""System tests for data/apport."""
+
 # TODO: Address following pylint complaints
 # pylint: disable=invalid-name
 

--- a/tests/unit/test_crashdb.py
+++ b/tests/unit/test_crashdb.py
@@ -1,3 +1,5 @@
+"""Unit tests for the apport.crashdb module."""
+
 # TODO: Address following pylint complaints
 # pylint: disable=invalid-name
 

--- a/tests/unit/test_fileutils.py
+++ b/tests/unit/test_fileutils.py
@@ -1,3 +1,5 @@
+"""Unit tests for the apport.fileutils module."""
+
 # TODO: Address following pylint complaints
 # pylint: disable=invalid-name
 

--- a/tests/unit/test_hookutils.py
+++ b/tests/unit/test_hookutils.py
@@ -1,3 +1,5 @@
+"""Unit tests for the apport.hookutils module."""
+
 import re
 import subprocess
 import time

--- a/tests/unit/test_parse_segv.py
+++ b/tests/unit/test_parse_segv.py
@@ -1,3 +1,5 @@
+"""Unit tests for the parse_segv general hook."""
+
 import unittest
 
 from tests.helper import import_module_from_file

--- a/tests/unit/test_problem_report.py
+++ b/tests/unit/test_problem_report.py
@@ -1,3 +1,5 @@
+"""Unit tests for the problem_report module."""
+
 # TODO: Address following pylint complaints
 # pylint: disable=invalid-name
 

--- a/tests/unit/test_report.py
+++ b/tests/unit/test_report.py
@@ -1,3 +1,5 @@
+"""Unit tests for the apport.report module."""
+
 # pylint: disable=too-many-lines
 # TODO: Address following pylint complaints
 # pylint: disable=invalid-name

--- a/tests/unit/test_rethread.py
+++ b/tests/unit/test_rethread.py
@@ -1,3 +1,5 @@
+"""Unit tests for the apport.REThread module."""
+
 # TODO: Address following pylint complaints
 # pylint: disable=invalid-name
 


### PR DESCRIPTION
Add missing module docstrings to all Python modules. Convert comments into docstrings where possible.