### PR TITLE
ui: Fix translating the web browser opening error message

### DIFF
--- a/apport/ui.py
+++ b/apport/ui.py
@@ -1735,7 +1735,7 @@ class UserInterface:
             status = os.wait()[1]
             if status:
                 title = _("Unable to start web browser")
-                error = _(f"Unable to start web browser to open {url}.")
+                error = _("Unable to start web browser to open %s.") % url
                 message = os.fdopen(r).readline()
                 if message:
                     error += "\n" + message


### PR DESCRIPTION
The formatting string needs to be passed gettext before replacing the dynamic parts. This has been broken for several years.

Fixes: 300552f44369ff06647f30ab79072af6ebfc5ac9 ("merge recent changes from trunk")