### PR TITLE
apport-cli: Move gettext call out of f-string

### DIFF
--- a/bin/apport-cli
+++ b/bin/apport-cli
@@ -262,7 +262,7 @@ class CLIUserInterface(apport.ui.UserInterface):
                 # we do not already have a report file if we report a bug
                 if not self.report_file:
                     self.report_file = self._save_report_in_temp_directory()
-                print(f"{_('Problem report file:')} {self.report_file}")
+                print(_("Problem report file:") + f" {self.report_file}")
 
             return return_value
 


### PR DESCRIPTION
intltool fails to extract the gettext call inside a f-string (see https://savannah.gnu.org/bugs/?61596). So move the gettext call out of
the f-string.

Fixes: 5a504336b2f6bafd82f268c5dc5e9a4db4cc9bcd ("refactor: Use f-strings everywhere")