### PR TITLE
refactor: Move pylint's missing-docstring overrides to affected files

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -27,11 +27,7 @@ good-names=i,j,k,lp,ui,_
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use "--disable=all --enable=classes
 # --disable=W".
-disable=bad-option-value,fixme,
-  # TODO: Fix all following disabled checks!
-  duplicate-code,
-  missing-class-docstring,
-  missing-function-docstring,
+disable=bad-option-value,duplicate-code,fixme
 
 
 [REPORTS]

--- a/apport/__init__.py
+++ b/apport/__init__.py
@@ -20,6 +20,7 @@ __all__ = [
 
 
 def unicode_gettext(message):
+    """Return the localized translation of message."""
     warnings.warn(
         "apport.unicode_gettext() is deprecated."
         " Please use gettext.gettext() directly instead.",

--- a/apport/crashdb.py
+++ b/apport/crashdb.py
@@ -31,6 +31,8 @@ def _u(string):
 
 
 class CrashDatabase:
+    """Crash database interface."""
+
     # TODO: Check if some methods can be made private
     # pylint: disable=too-many-public-methods
     def __init__(self, auth_file, options):

--- a/apport/crashdb_impl/github.py
+++ b/apport/crashdb_impl/github.py
@@ -63,9 +63,11 @@ class Github:
         return json.loads(result.text)
 
     def api_authentication(self, url: str, data: dict) -> Any:
+        """Authenticate against the GitHub API."""
         return self._post(url, self._stringify(data))
 
     def api_open_issue(self, owner: str, repo: str, data: dict) -> Any:
+        """Open a new issue on the GitHub project."""
         url = f"https://api.github.com/repos/{owner}/{repo}/issues"
         return self._post(url, json.dumps(data))
 
@@ -141,7 +143,7 @@ class Github:
 
 
 @dataclass(frozen=True)
-class IssueHandle:
+class IssueHandle:  # pylint: disable=missing-class-docstring
     url: str
 
 

--- a/apport/crashdb_impl/launchpad.py
+++ b/apport/crashdb_impl/launchpad.py
@@ -12,7 +12,7 @@
 
 # pylint: disable=too-many-lines
 # TODO: Address following pylint complaints
-# pylint: disable=invalid-name
+# pylint: disable=invalid-name,missing-function-docstring
 
 import atexit
 import email
@@ -192,6 +192,7 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
 
     @property
     def lp_distro(self):
+        """Return Launchpad distribution (e.g. ubuntu)."""
         if self.__lp_distro is None:
             if self.distro:
                 self.__lp_distro = self.launchpad.distributions[self.distro]
@@ -1194,6 +1195,9 @@ class HTTPSProgressConnection(http.client.HTTPSConnection):
 
 
 class HTTPSProgressHandler(urllib.request.HTTPSHandler):
+    """Implement a HTTPSHandler with an optional callback function for
+    upload progress."""
+
     def https_open(self, req):
         return self.do_open(HTTPSProgressConnection, req)
 

--- a/apport/fileutils.py
+++ b/apport/fileutils.py
@@ -10,7 +10,7 @@
 # the full text of the license.
 
 # TODO: Address following pylint complaints
-# pylint: disable=invalid-name
+# pylint: disable=invalid-name,missing-docstring
 
 import configparser
 import contextlib

--- a/apport/hookutils.py
+++ b/apport/hookutils.py
@@ -229,6 +229,7 @@ def attach_dmesg(report):
 
 
 def attach_dmi(report):
+    """Attach Desktop Management Interface (DMI) information to the report."""
     dmi_dir = "/sys/class/dmi/id"
     if os.path.isdir(dmi_dir):
         for f in os.listdir(dmi_dir):
@@ -490,6 +491,7 @@ def _spawn_pkttyagent():
 
 
 def kill_pkttyagent():
+    """Kill pkttyagent (from PolicyKit) if it was started by Apport."""
     global _AGENT  # pylint: disable=global-statement
 
     if _AGENT is None:

--- a/apport/packaging.py
+++ b/apport/packaging.py
@@ -16,6 +16,8 @@ import sys
 
 
 class PackageInfo:
+    """Abstraction of packaging operations."""
+
     # default global configuration file
     configuration = "/etc/default/apport"
 

--- a/apport/packaging_impl/apt_dpkg.py
+++ b/apport/packaging_impl/apt_dpkg.py
@@ -341,6 +341,7 @@ class __AptDpkgPackageInfo(PackageInfo):
 
     @staticmethod
     def get_lp_binary_package(release, package, version, arch):
+        """Get Launchpad URL and SHA1 sum for the given binary package version."""
         # allow unauthenticated downloads
         apt.apt_pkg.config.set("APT::Get::AllowUnauthenticated", "True")
         # pylint: disable=import-outside-toplevel
@@ -407,6 +408,7 @@ class __AptDpkgPackageInfo(PackageInfo):
 
     @staticmethod
     def get_lp_source_package(package, version):
+        """Get files from Launchpad for the given source package version."""
         # pylint: disable=import-outside-toplevel
         from launchpadlib.launchpad import Launchpad
 

--- a/apport/ui.py
+++ b/apport/ui.py
@@ -61,6 +61,7 @@ PF_KTHREAD = 0x200000
 
 
 def get_pid(report):
+    """Extract process ID from report."""
     try:
         pid = re.search("Pid:\t(.*)\n", report.get("ProcStatus", "")).group(1)
         return int(pid)
@@ -162,6 +163,7 @@ def run_as_real_user(
 
 
 def still_running(pid):
+    """Check if the process with the given ID is still running."""
     try:
         os.kill(int(pid), 0)
     except OSError as error:
@@ -317,6 +319,13 @@ def thread_collect_info(
 
 @dataclasses.dataclass
 class Action:
+    """Action to take on a problem report.
+
+    Possible actions: examine the crash ('examine'), report the crash
+    ('report'), restart the crashed application ('restart'), or ignore further
+    crashes ('ignore').
+    """
+
     examine: bool = False
     ignore: bool = False
     remember: bool = False
@@ -623,6 +632,7 @@ class UserInterface:
 
     @staticmethod
     def kill_segv(pid):
+        """Kill process with signal SIGSEGV."""
         os.kill(int(pid), signal.SIGSEGV)
 
     def run_report_bug(self, symptom_script=None):

--- a/apport_python_hook.py
+++ b/apport_python_hook.py
@@ -153,6 +153,7 @@ def apport_excepthook(binary, exc_type, exc_obj, exc_tb):
 
 
 def dbus_service_unknown_analysis(exc_obj, report):
+    """Analyze D-Bus service error and add analysis to report."""
     # TODO: Split into smaller functions/methods
     # pylint: disable=too-many-locals
     # pylint: disable=import-outside-toplevel; for Python startup time

--- a/bin/apport-cli
+++ b/bin/apport-cli
@@ -16,7 +16,7 @@
 #    elinks: works
 
 # TODO: Address following pylint complaints
-# pylint: disable=invalid-name
+# pylint: disable=invalid-name,missing-function-docstring
 
 import errno
 import os

--- a/bin/apport-retrace
+++ b/bin/apport-retrace
@@ -323,6 +323,7 @@ def print_traces(report):
         print(report["StacktraceSource"])
 
 
+# pylint: disable-next=missing-function-docstring
 def main():
     # TODO: Split into smaller functions/methods
     # pylint: disable=too-many-branches,too-many-locals,too-many-nested-blocks

--- a/bin/apport-unpack
+++ b/bin/apport-unpack
@@ -35,6 +35,7 @@ def parse_args():
 
 
 def load_report(report_filename: str) -> problem_report.ProblemReport:
+    """Load problem report from given filename."""
     report = problem_report.ProblemReport()
     if report_filename == "-":
         report.load(sys.stdin, binary=False)
@@ -47,6 +48,7 @@ def load_report(report_filename: str) -> problem_report.ProblemReport:
     return report
 
 
+# pylint: disable-next=missing-function-docstring
 def main():
     gettext.textdomain("apport")
     args = parse_args()

--- a/bin/crash-digger
+++ b/bin/crash-digger
@@ -26,6 +26,7 @@ import apport
 from apport.crashdb import get_crashdb
 
 
+# pylint: disable-next=missing-class-docstring
 class CrashDigger:  # pylint: disable=too-many-instance-attributes
     def __init__(
         self,
@@ -293,6 +294,7 @@ def parse_options():
     return args
 
 
+# pylint: disable-next=missing-function-docstring
 def main():
     opts = parse_options()
 

--- a/bin/dupdb-admin
+++ b/bin/dupdb-admin
@@ -93,6 +93,7 @@ def parse_args():
     return parser.parse_args()
 
 
+# pylint: disable-next=missing-function-docstring
 def main():
     args = parse_args()
 

--- a/data/apport
+++ b/data/apport
@@ -19,7 +19,7 @@ See https://wiki.ubuntu.com/Apport for details."""
 # See bug https://github.com/PyCQA/pylint/issues/7093
 # pylint: disable=c-extension-no-member,no-name-in-module,not-callable
 # TODO: Address following pylint complaints
-# pylint: disable=invalid-name
+# pylint: disable=invalid-name,missing-function-docstring
 
 import argparse
 import array
@@ -698,6 +698,7 @@ def parse_arguments(args: list[str]) -> argparse.Namespace:
     return options
 
 
+# pylint: disable-next=missing-function-docstring
 def main(args: list[str]) -> int:
     init_error_log()
     logging.basicConfig(format=LOG_FORMAT, level=logging.INFO)

--- a/data/apportcheckresume
+++ b/data/apportcheckresume
@@ -26,6 +26,7 @@ from apport.hookutils import attach_file_if_exists
 from apport.packaging_impl import impl as packaging
 
 
+# pylint: disable-next=missing-function-docstring
 def main(argv=None):
     if argv is None:
         argv = sys.argv

--- a/data/general-hooks/generic.py
+++ b/data/general-hooks/generic.py
@@ -21,6 +21,7 @@ from problem_report import ProblemReport
 
 
 def add_info(report: ProblemReport, ui: apport.ui.HookUI) -> None:
+    """Add generic, general information to the problem report."""
     # TODO: Split into smaller functions/methods
     # pylint: disable=too-many-branches,too-many-locals
     nonfree_modules = apport.hookutils.nonfree_kernel_modules()

--- a/data/general-hooks/parse_segv.py
+++ b/data/general-hooks/parse_segv.py
@@ -14,7 +14,7 @@ of a segfault.  Currently very very simplistic, and only finds commonly
 understood situations for x86/x86_64."""
 
 # TODO: Address following pylint complaints
-# pylint: disable=invalid-name
+# pylint: disable=invalid-name,missing-class-docstring,missing-function-docstring
 
 import logging
 import re
@@ -387,6 +387,7 @@ def add_info(report):
         report["SegvAnalysis"] = f"Failure: {str(error)}"
 
 
+# pylint: disable-next=missing-function-docstring
 def main():
     if len(sys.argv) != 4 or sys.argv[1] in ["-h", "--help"]:
         print("To run self-test, run without any arguments (or with -v)")

--- a/data/java_uncaught_exception
+++ b/data/java_uncaught_exception
@@ -23,12 +23,14 @@ from apport.packaging_impl import impl as packaging
 
 
 def make_title(report):
+    """Construct crash title from stack trace."""
     lines = report["StackTrace"].split("\n")
     message = lines[0].strip()
     stackframe = lines[1].strip()
     return f"{message} in {stackframe}"
 
 
+# pylint: disable-next=missing-function-docstring
 def main():
     if not packaging.enabled():
         return 1

--- a/data/package-hooks/source_apport.py
+++ b/data/package-hooks/source_apport.py
@@ -14,6 +14,7 @@ APPORT_LOG = "/var/log/apport.log"
 
 
 def add_info(report):
+    """Add Apport logs to the problem report."""
     apport.hookutils.attach_file_if_exists(report, APPORT_LOG, "ApportLog")
     reports = glob.glob("/var/crash/*")
     if reports:

--- a/data/package_hook
+++ b/data/package_hook
@@ -60,6 +60,7 @@ def parse_args():
     return args
 
 
+# pylint: disable-next=missing-function-docstring
 def main():
     # parse command line arguments
     options = parse_args()

--- a/data/recoverable_problem
+++ b/data/recoverable_problem
@@ -22,6 +22,7 @@ import sys
 import apport.report
 
 
+# pylint: disable-next=missing-function-docstring
 def main():
     # Check parameters
     argparser = argparse.ArgumentParser("%(prog) [options]")

--- a/data/whoopsie-upload-all
+++ b/data/whoopsie-upload-all
@@ -192,6 +192,7 @@ def wait_uploaded(stamps, timeout):
     return False
 
 
+# pylint: disable-next=missing-function-docstring
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Noninteractively upload all "

--- a/gtk/apport-gtk
+++ b/gtk/apport-gtk
@@ -11,8 +11,8 @@
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
 
-# TODO: Address following pylint complaints
 # pylint: disable=invalid-name
+# pylint: enable=invalid-name
 
 import os
 import re
@@ -53,6 +53,8 @@ def find_xid_for_pid(pid):
 
 
 class GTKUserInterface(apport.ui.UserInterface):
+    # TODO: Address following pylint complaints
+    # pylint: disable=invalid-name,missing-function-docstring
     """GTK UserInterface."""
 
     def w(self, widget):

--- a/kde/apport-kde
+++ b/kde/apport-kde
@@ -13,7 +13,7 @@
 # the full text of the license.
 
 # TODO: Address following pylint complaints
-# pylint: disable=invalid-name
+# pylint: disable=invalid-name,missing-function-docstring
 
 import os
 import shutil

--- a/problem_report.py
+++ b/problem_report.py
@@ -106,6 +106,8 @@ class CompressedValue:
 
 
 class ProblemReport(collections.UserDict):
+    """Class to store, load, and handle problem reports."""
+
     def __init__(self, problem_type="Crash", date=None):
         """Initialize a fresh problem report.
 

--- a/tests/integration/test_apport_checkreports.py
+++ b/tests/integration/test_apport_checkreports.py
@@ -21,6 +21,7 @@ from tests.paths import get_data_directory, local_test_environment
 
 
 class TestApportCheckreports(unittest.TestCase):
+    # pylint: disable=missing-function-docstring
     """Test apport-checkreports"""
 
     def setUp(self):

--- a/tests/integration/test_apport_unpack.py
+++ b/tests/integration/test_apport_unpack.py
@@ -20,6 +20,7 @@ from tests.paths import local_test_environment
 
 
 class TestApportUnpack(unittest.TestCase):
+    # pylint: disable=missing-class-docstring,missing-function-docstring
     env: dict[str, str]
 
     @classmethod

--- a/tests/integration/test_apport_valgrind.py
+++ b/tests/integration/test_apport_valgrind.py
@@ -21,6 +21,8 @@ from tests.paths import local_test_environment
 
 @skip_if_command_is_missing("valgrind")
 class TestApportValgrind(unittest.TestCase):
+    """Integration tests for bin/apport-valgrind."""
+
     @classmethod
     def setUpClass(cls):
         cls.env = os.environ | local_test_environment()

--- a/tests/integration/test_crash_digger.py
+++ b/tests/integration/test_crash_digger.py
@@ -25,6 +25,8 @@ from tests.paths import local_test_environment
 
 
 class T(unittest.TestCase):
+    """Test crash-digger"""
+
     def setUp(self):
         """Set up config dir, crashdb.conf, and apport-retrace for testing"""
         self.env = os.environ | local_test_environment()

--- a/tests/integration/test_dupdb_admin.py
+++ b/tests/integration/test_dupdb_admin.py
@@ -22,6 +22,7 @@ from tests.paths import local_test_environment
 
 
 class TestDupdbAdmin(unittest.TestCase):
+    # pylint: disable=missing-function-docstring
     """Test dupdb-admin"""
 
     def setUp(self):

--- a/tests/integration/test_fileutils.py
+++ b/tests/integration/test_fileutils.py
@@ -19,6 +19,7 @@ import problem_report
 
 class T(unittest.TestCase):
     # pylint: disable=protected-access
+    """Integration tests for the apport.fileutils module."""
 
     def setUp(self):
         self.orig_core_dir = apport.fileutils.core_dir

--- a/tests/integration/test_github.py
+++ b/tests/integration/test_github.py
@@ -22,6 +22,7 @@ except ImportError as error:
 
 @unittest.skipIf(IMPORT_ERROR, f"module not available: {IMPORT_ERROR}")
 class TestGitHub(unittest.TestCase):
+    # pylint: disable=missing-class-docstring,missing-function-docstring
     # pylint: disable=protected-access
 
     def setUp(self):

--- a/tests/integration/test_helper.py
+++ b/tests/integration/test_helper.py
@@ -8,6 +8,8 @@ from tests.helper import pidof, read_shebang
 
 
 class TestHelper(unittest.TestCase):
+    # pylint: disable=missing-class-docstring,missing-function-docstring
+
     def test_pidof_non_existing_program(self):
         self.assertEqual(pidof("non-existing"), set())
 

--- a/tests/integration/test_hooks.py
+++ b/tests/integration/test_hooks.py
@@ -27,6 +27,7 @@ from tests.paths import get_data_directory, local_test_environment
 
 
 class T(unittest.TestCase):
+    # pylint: disable=missing-class-docstring,missing-function-docstring
     data_dir: pathlib.Path
     env: dict[str, str]
 

--- a/tests/integration/test_hookutils.py
+++ b/tests/integration/test_hookutils.py
@@ -20,6 +20,8 @@ from tests.helper import skip_if_command_is_missing
 
 
 class T(unittest.TestCase):
+    """Integration tests for the apport.hookutils module."""
+
     def setUp(self):
         self.workdir = tempfile.mkdtemp()
 
@@ -492,6 +494,7 @@ GdkPixbuf-CRITICAL **: gdk_pixbuf_scale_simple: another standard glib assertion
         apport.hookutils.attach_default_grub(report)
 
     def test_command_output(self):
+        """Test apport.hookutils.command_output."""
         orig_lcm = os.environ.get("LC_MESSAGES")
         os.environ["LC_MESSAGES"] = "en_US.UTF-8"
         try:

--- a/tests/integration/test_java_crashes.py
+++ b/tests/integration/test_java_crashes.py
@@ -23,6 +23,8 @@ from tests.paths import get_data_directory, local_test_environment
 
 @skip_if_command_is_missing("java")
 class TestJavaCrashes(unittest.TestCase):
+    """Integration tests for the Java crash collection support."""
+
     def setUp(self):
         self.env = os.environ | local_test_environment()
         datadir = get_data_directory()

--- a/tests/integration/test_packaging.py
+++ b/tests/integration/test_packaging.py
@@ -9,6 +9,8 @@ import apport.packaging
 
 
 class T(unittest.TestCase):
+    """Integration tests for the apport.packaging module."""
+
     def test_get_uninstalled_package(self):
         """get_uninstalled_package()"""
         p = apport.packaging.get_uninstalled_package()

--- a/tests/integration/test_packaging_apt_dpkg.py
+++ b/tests/integration/test_packaging_apt_dpkg.py
@@ -18,6 +18,7 @@ from tests.helper import skip_if_command_is_missing
 
 @skip_if_command_is_missing("dpkg")
 class T(unittest.TestCase):
+    # pylint: disable=missing-class-docstring,missing-function-docstring
     # pylint: disable=protected-access
 
     def setUp(self):

--- a/tests/integration/test_packaging_rpm.py
+++ b/tests/integration/test_packaging_rpm.py
@@ -15,6 +15,8 @@ except ImportError:
 @unittest.skipUnless(HAS_RPM, "rpm module not available")
 @skip_if_command_is_missing("rpm")
 class TestPackagingRpm(unittest.TestCase):
+    """Integration tests for the apport.packaging_impl.rpm module."""
+
     def test_get_dependencies(self):
         """get_dependencies()."""
         deps = impl.get_dependencies("bash")

--- a/tests/integration/test_problem_report.py
+++ b/tests/integration/test_problem_report.py
@@ -19,6 +19,8 @@ bin_data = b"ABABABABAB\0\0\0Z\x01\x02"
 
 
 class T(unittest.TestCase):
+    # pylint: disable=missing-class-docstring,missing-function-docstring
+
     def setUp(self):
         self.workdir = tempfile.mkdtemp()
 

--- a/tests/integration/test_python_crashes.py
+++ b/tests/integration/test_python_crashes.py
@@ -30,6 +30,8 @@ from tests.paths import local_test_environment
 
 
 class T(unittest.TestCase):
+    """Test apport_python_hook.py."""
+
     maxDiff = None
 
     @classmethod

--- a/tests/integration/test_report.py
+++ b/tests/integration/test_report.py
@@ -25,7 +25,9 @@ from tests.paths import patch_data_dir, restore_data_dir
 
 
 class T(unittest.TestCase):
+    # pylint: disable=missing-function-docstring
     # pylint: disable=protected-access,too-many-public-methods
+    """Test apport.report module."""
 
     @classmethod
     def setUpClass(cls):

--- a/tests/integration/test_signal_crashes.py
+++ b/tests/integration/test_signal_crashes.py
@@ -60,6 +60,7 @@ required_fields = [
 
 
 class T(unittest.TestCase):
+    # pylint: disable=missing-class-docstring,missing-function-docstring
     # pylint: disable=protected-access,too-many-public-methods
     TEST_EXECUTABLE = os.path.realpath("/bin/sleep")
     TEST_ARGS = ["86400"]

--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -113,6 +113,7 @@ class UserInterfaceMock(apport.ui.UserInterface):
         self.crashdb_conf.close()
 
     def clear_msg(self):
+        """Clear the recorded messages"""
         # last message box
         self.msg_title = None
         self.msg_text = None
@@ -186,7 +187,10 @@ class UserInterfaceMock(apport.ui.UserInterface):
     "apport.hookutils._root_command_prefix", unittest.mock.MagicMock(return_value=[])
 )
 class T(unittest.TestCase):
-    # pylint: disable=too-many-instance-attributes,too-many-public-methods
+    # pylint: disable=missing-function-docstring,too-many-instance-attributes
+    # pylint: disable=too-many-public-methods
+    """Integration tests for apport.ui."""
+
     TEST_EXECUTABLE = os.path.realpath("/bin/sleep")
     TEST_ARGS = ["86400"]
 

--- a/tests/integration/test_ui_cli.py
+++ b/tests/integration/test_ui_cli.py
@@ -27,6 +27,7 @@ apport_cli = import_module_from_file(pathlib.Path(APPORT_CLI_PATH))
 
 
 class TestApportCli(unittest.TestCase):
+    # pylint: disable=missing-function-docstring
     """Test apport-cli."""
 
     @classmethod

--- a/tests/system/test_apport_valgrind.py
+++ b/tests/system/test_apport_valgrind.py
@@ -27,6 +27,8 @@ with open("/proc/meminfo", encoding="utf-8") as f:
 
 @skip_if_command_is_missing("valgrind")
 class TestApportValgrind(unittest.TestCase):
+    """System tests for bin/apport-valgrind."""
+
     @classmethod
     def setUpClass(cls):
         cls.env = os.environ | local_test_environment()

--- a/tests/system/test_github_query.py
+++ b/tests/system/test_github_query.py
@@ -16,6 +16,8 @@ SOME_ID = "a654870577ad2a2ab5b1"
 
 @unittest.skipIf(IMPORT_ERROR, f"module not available: {IMPORT_ERROR}")
 class TestGitHubQuery(unittest.TestCase):
+    """System tests for the apport.crashdb_impl.github module."""
+
     def setUp(self):
         self.crashdb = self._get_gh_database("Lorem", "Ipsum")
         self.message_cb = Mock()

--- a/tests/system/test_packaging_apt_dpkg.py
+++ b/tests/system/test_packaging_apt_dpkg.py
@@ -1,6 +1,6 @@
 """System tests for the apport.packaging_impl.apt_dpkg module."""
 
-# pylint: disable=too-many-lines
+# pylint: disable=missing-function-docstring,too-many-lines
 # TODO: Address following pylint complaints
 # pylint: disable=invalid-name
 

--- a/tests/system/test_python_crashes.py
+++ b/tests/system/test_python_crashes.py
@@ -35,6 +35,8 @@ from tests.paths import local_test_environment
 
 @unittest.skipUnless(HAS_DBUS, "dbus Python module not installed")
 class T(unittest.TestCase):
+    """Test apport_python_hook.py"""
+
     @classmethod
     def setUpClass(cls):
         cls.env = os.environ | local_test_environment()

--- a/tests/system/test_signal_crashes.py
+++ b/tests/system/test_signal_crashes.py
@@ -24,6 +24,7 @@ from tests.paths import (
 
 
 class T(unittest.TestCase):
+    # pylint: disable=missing-class-docstring,missing-function-docstring
     # pylint: disable=protected-access
     TEST_EXECUTABLE = os.path.realpath("/bin/sleep")
     TEST_ARGS = ["86400"]

--- a/tests/system/test_ui_gtk.py
+++ b/tests/system/test_ui_gtk.py
@@ -52,6 +52,7 @@ else:
 
 @unittest.skipIf(GI_IMPORT_ERROR, f"gi Python module not available: {GI_IMPORT_ERROR}")
 class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
+    # pylint: disable=missing-class-docstring,missing-function-docstring
     POLLING_INTERVAL_MS = 10
 
     @classmethod

--- a/tests/system/test_ui_kde.py
+++ b/tests/system/test_ui_kde.py
@@ -45,6 +45,7 @@ else:
 
 @unittest.skipIf(PYQT5_IMPORT_ERROR, f"PyQt/PyKDE not available: {PYQT5_IMPORT_ERROR}")
 class T(unittest.TestCase):
+    # pylint: disable=missing-class-docstring,missing-function-docstring
     COLLECTING_DIALOG = unittest.mock.call(
         str(apport_kde_path.parent),
         "Collecting Problem Information",

--- a/tests/unit/test_crashdb.py
+++ b/tests/unit/test_crashdb.py
@@ -15,6 +15,7 @@ from apport.crashdb_impl.memory import CrashDatabase
 
 
 class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
+    # pylint: disable=missing-class-docstring,missing-function-docstring
     def setUp(self):
         self.workdir = tempfile.mkdtemp()
         self.dupdb_dir = os.path.join(self.workdir, "dupdb")

--- a/tests/unit/test_fileutils.py
+++ b/tests/unit/test_fileutils.py
@@ -1,7 +1,7 @@
 """Unit tests for the apport.fileutils module."""
 
 # TODO: Address following pylint complaints
-# pylint: disable=invalid-name
+# pylint: disable=invalid-name,missing-class-docstring,missing-function-docstring
 
 import io
 import time

--- a/tests/unit/test_helper.py
+++ b/tests/unit/test_helper.py
@@ -1,5 +1,7 @@
 """Test test helper functions. Test inception for the win!"""
 
+# pylint: disable=missing-class-docstring,missing-function-docstring
+
 import unittest
 
 from tests.helper import get_init_system, wrap_object

--- a/tests/unit/test_hookutils.py
+++ b/tests/unit/test_hookutils.py
@@ -10,6 +10,9 @@ import apport.hookutils
 
 
 class TestHookutils(unittest.TestCase):
+    # pylint: disable=missing-function-docstring
+    """Test apport.hookutils module."""
+
     @unittest.mock.patch("apport.hookutils.root_command_output")
     def test_attach_dmesg(self, root_command_output_mock):
         """attach_dmesg()"""
@@ -82,24 +85,24 @@ class TestHookutils(unittest.TestCase):
     @unittest.mock.patch("subprocess.Popen")
     @unittest.mock.patch("os.path.exists", unittest.mock.MagicMock(return_value=True))
     def test_recent_syslog_journald_cmd(self, popen_mock):
-        class SkipPopen(Exception):
+        class _SkipPopen(Exception):
             pass
 
-        popen_mock.side_effect = SkipPopen
+        popen_mock.side_effect = _SkipPopen
 
         cmd = ["journalctl", "--quiet", "-b", "-a"]
         cmd_system_only = cmd + ["--system"]
 
-        with self.assertRaises(SkipPopen):
+        with self.assertRaises(_SkipPopen):
             apport.hookutils.recent_syslog(re.compile("."))
         popen_mock.assert_called_once_with(cmd_system_only, stdout=unittest.mock.ANY)
 
         popen_mock.reset_mock()
-        with self.assertRaises(SkipPopen):
+        with self.assertRaises(_SkipPopen):
             apport.hookutils.recent_syslog(re.compile("."), journald_only_system=True)
         popen_mock.assert_called_once_with(cmd_system_only, stdout=unittest.mock.ANY)
 
         popen_mock.reset_mock()
-        with self.assertRaises(SkipPopen):
+        with self.assertRaises(_SkipPopen):
             apport.hookutils.recent_syslog(re.compile("."), journald_only_system=False)
         popen_mock.assert_called_once_with(cmd, stdout=unittest.mock.ANY)

--- a/tests/unit/test_packaging_apt_dpkg.py
+++ b/tests/unit/test_packaging_apt_dpkg.py
@@ -103,6 +103,7 @@ Components: main
 """,
     )
     def test_parse_deb822_sources_extra_lines(self, mock_file):
+        """Test _parse_deb822_sources with multiple lines separating blocks."""
         entries = _parse_deb822_sources("foo_bar.sources")
         mock_file.assert_called_with("foo_bar.sources", encoding="utf-8")
         self.assertEqual(len(entries), 2)

--- a/tests/unit/test_packaging_impl.py
+++ b/tests/unit/test_packaging_impl.py
@@ -7,6 +7,9 @@ from apport.packaging_impl import determine_packaging_implementation
 
 
 class TestPackagingImpl(unittest.TestCase):
+    # pylint: disable=missing-function-docstring
+    """Test functions in apport/packaging_impl/__init__.py."""
+
     @unittest.mock.patch("platform.freedesktop_os_release")
     def test_determine_ubuntu(self, os_release_mock):
         os_release_mock.return_value = {

--- a/tests/unit/test_problem_report.py
+++ b/tests/unit/test_problem_report.py
@@ -16,6 +16,8 @@ bin_data = b"ABABABABAB\0\0\0Z\x01\x02"
 
 
 class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
+    """Unit tests for the problem_report module."""
+
     def test_add_tags(self):
         """Test ProblemReport.add_tags()."""
         report = problem_report.ProblemReport()

--- a/tests/unit/test_report.py
+++ b/tests/unit/test_report.py
@@ -14,6 +14,7 @@ import apport.report
 
 
 class T(unittest.TestCase):
+    # pylint: disable=missing-class-docstring,missing-function-docstring
     # pylint: disable=protected-access
 
     def test_has_useful_stacktrace(self):

--- a/tests/unit/test_rethread.py
+++ b/tests/unit/test_rethread.py
@@ -22,6 +22,8 @@ def div(x, y):
 
 
 class T(unittest.TestCase):
+    """Unit tests for the apport.REThread module."""
+
     def test_return_value(self):
         """Return value works properly."""
         t = apport.REThread.REThread(target=div, args=(42, 2))


### PR DESCRIPTION
Move pylint's missing-docstring overrides to affected files to allow getting this alert for new cases. Address the pylint complains for files that only have a few complains. Make some functions private to not need to document them. Do not expect main functions and test functions to be documented.