### PR TITLE
tests: ui: fix hangup on test failure

### DIFF
--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -288,8 +288,10 @@ class T(unittest.TestCase):
         with subprocess.Popen([exename] + self.TEST_ARGS, env=env) as test_process:
             # give the execv() some time to finish
             time.sleep(0.5)
-            yield test_process.pid
-            test_process.kill()
+            try:
+                yield test_process.pid
+            finally:
+                test_process.kill()
 
     @staticmethod
     def _write_symptom_script(script_name: str, content: str) -> None:


### PR DESCRIPTION
Our context manager improperly failed to deal with exceptions thrown in the block under context, resulting in the test process never being killed.

See https://github.com/pytest-dev/pytest/issues/3365