### PR TITLE
feat: Import translation updates from Ubuntu 23.10 (mantic)

### DIFF
--- a/po/af.po
+++ b/po/af.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2020-05-24 20:31+0000\n"
 "Last-Translator: Bernard Stafford <Unknown>\n"
 "Language-Team: Afrikaans <af@li.org>\n"
@@ -40,11 +40,11 @@ msgstr ""
 "Sleutel asseblief jou wagwoord in om toegang te verkry tot probleemberigte "
 "van stelselprogramme"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "Dit lyk nie asof hierdie pakket korrek geïnstalleer is nie"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -55,7 +55,7 @@ msgstr ""
 "opdater die indekse van beskikbare pakkette, indien daardie doen nie werk "
 "dan verwyder verwante pakkette derde party en probeer weer."
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -68,21 +68,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "onbekende program"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Jammer, die program \"%s\" het onverwags gesluit"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Probleem in %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -90,65 +85,70 @@ msgstr ""
 "Jou rekenaar beskik nie oor genoegsame gratis geheue om die outomaties te "
 "probleem-analiseer en te raporteer aan die ontwikkelaars nie."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Probleem in %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Ongeldige probleem verslag"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "Jy word nie toegelaat om toegang tot hierdie -probleem verslag."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Fout"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 "Daar -is nie genoeg skyfspasie beskikbare om die verwerking van dit verslag."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr "Geen PID gespesifiseerde"
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr "Jy behoefte om gespesifiseerde 'n PID. Sien --help vir meer inligting."
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "Ongeldige PID"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr "Die gespesifiseerde proses-ID bestaan nie."
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr "Nie u PID nie"
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr "Die gespesifiseerde proses-ID behoort nie aan u nie."
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "Geen pakket gespesifiseer nie"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Jy nodig het om 'n pakket of 'n PID spesifiseer. Sien --hulp vir meer "
 "inligting."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Toestemming gewyer"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -156,30 +156,30 @@ msgstr ""
 "Die spesifieke proses behoort nie aan jou nie. Laat die program loop as "
 "proseseienaar of as wortel."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "Die gespesifiseerde proses-ID behoort nie aan 'n program nie."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Simptometeks %s kon geen geaffekteerde pakket bepaal nie"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Pakket %s bestaan nie"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "Kan nie verslag skep nie"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "Opdateer probleemverslag"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -191,7 +191,7 @@ msgstr ""
 "\n"
 "Skep asseblief 'n nuwe verslag met behulp van \"apport-bug\"."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -212,24 +212,24 @@ msgstr ""
 "\n"
 "Wil jy regtig om voortgaan?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "Geen addisionele inligting ingesamel."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "Watter tipe probleem probeer jy rapporteer?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Onbekende simptoom"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Die simptoom \"%s\" is onbekend"
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -248,7 +248,7 @@ msgstr ""
 "voer. In die Prosesse-oortjie, scroll totdat jy die regte toepassing vind. "
 "Die proses-ID is die nommer wat in die ID-kolom gelys word."
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -256,32 +256,32 @@ msgstr ""
 "Nadat u hierdie boodskap gesluit het, klik op die toepassingsvenster om 'n "
 "probleem daaroor te rapporteer."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop nagelaat om proses bepaal ID van die venster"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr "%(prog)s <report number>"
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "Spesifiseer pakket naam."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Voeg 'n ekstra tag by die verslag. Kan verskeie kere gespesifiseer word."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -291,15 +291,15 @@ msgstr ""
 "pid. Indien geeneen verskaf word nie, vertoon 'n lys van bekende simptome. "
 "(By implkasie dat 'n enkele argument gegewe is."
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "Klik 'n venster as teiken vir indiening 'n probleem verslag."
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "Begin in bug opdatering modus. Kan 'n opsionele --pakket vat."
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -307,7 +307,7 @@ msgstr ""
 "Handig 'n bug rapport in oor 'n simptoom. (By implikasie dat 'n stelselnaam "
 "gegee word as die enigste argument.)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -316,7 +316,7 @@ msgstr ""
 "pid gespesifiseer is. (By implikasie dat 'n pakketnaam as die enogste "
 "argument gegee word.)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -326,11 +326,11 @@ msgstr ""
 "die bug verslag sal bevat meer inligting.\r\n"
 "(Geïmpliseer indien pid slegs as enigste argument.)"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "Die voorsien pid is 'n hang toepassing."
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -340,7 +340,7 @@ msgstr ""
 "van die afwagtende verlsae in %s. (By implikasie dat die lêer as enigste "
 "agrument gegee word.)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -350,50 +350,50 @@ msgstr ""
 "verslagdoening dit. Hierdie lêer kan dan wees berig later op van 'n "
 "verskillende masjien."
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Druk die Apport weergawe nommer."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Hierdie sal launch apport-retrace in 'n terminale venster te ondersoek die "
 "crash."
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "Hardloop gdb sessie"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Hardloop gdb sessie sonder aflaai debug simbole"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Opdateer %s met ten volle simboliese stapel spoor"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr "Kan nie onthou nie sturr verslag statusse instellings"
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 "Spaar crash verslagdoening staat misluk. Kan nie stel outo of nooit "
 "verslagdoening wyse."
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr "Kan nie onthou nie sturr verslag statusse instellings"
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 "Hierdie probleemverslag is van toepassing op 'n program wat nie-geïnstalleer "
 "is enige meer nie"
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
@@ -402,20 +402,22 @@ msgstr ""
 "Die probleem gebeur met die program %s watter verander sedert die crash het "
 "voorgekom."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Hierdie probleemverslag is beskadig en kan nie verwerk word nie."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr "Hierdie verslag handel oor 'n pakket dat is nie geïnstalleer."
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr ""
 "'N fout het voorgekom terwyl probeer te proses hierdie probleem verslag."
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
@@ -423,23 +425,23 @@ msgstr ""
 "Jy het twee weergawes van hierdie aansoek geïnstalleer is, watter een doen "
 "jy wil om rapporteer 'n bug teen?"
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr "%s snap"
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr "%s deb pakket"
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s is verskaf deur 'n snap gepubliseer deur %s. Kontak hulle via %s vir hulp."
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -448,41 +450,41 @@ msgstr ""
 "%s is verskaf deur 'n snap gepubliseer deur %s. Geen kontak adres het was "
 "verskaf; besoek die forum by https://forum.snapcraft.io/ vir hulp."
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "Kon nie die pakket of bronpakket naam bepaal nie."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "Kan nie die webblaaier begin nie"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Kan nie die webblaaier begin om oop %s."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Netwerkprobleem"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Kon nie verbind met die crash-databasis nie, gaan asseblief jou "
 "internetkonneksie na."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Netwerkprobleem"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Geheue uitputting"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Jou stelsel het nie genoeg geheue beskikbaar om die ineenstortingsverslag te "
 "prosseseer nie."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -493,11 +495,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "Probleem reeds bekend"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -507,38 +509,37 @@ msgstr ""
 "webblaaier. Gaan asseblief na of enige verdere informasie bygevoeg kan word "
 "wat tot hulp van die ontwikkelaars kan wees."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Hierdie probleem is reeds aan ontwikkelaars gerapporteer. Dankie!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Druk enige sleutel om voort te gaan..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "Wat wil jy graag doen? Kies uit die opsies:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Kies asseblief (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i bytes)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(binêre data)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Stuur die probleemverslag aan die ontwikkelaars?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -547,52 +548,52 @@ msgstr ""
 "die\n"
 "outomaties oop webblaaier."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "&Stuur verslag (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "&Examine plaaslik"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "&Beskou verslag"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr "&Hou verslag lêer vir later stuur of kopiëring na 'n ander plek"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr ""
 "Kanselleer en &ignoreer toekomstige ineenstortings van hierdie program "
 "weergawe"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Kanselleer"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Probleemverslaglêer:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&Bevestig"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Fout: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "Versamel probleeminformasie"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -601,11 +602,11 @@ msgstr ""
 "verbeter die\n"
 "toepassing. Dit mag 'n paar minute neem."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "Oplaai tans probleem informasie"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -613,40 +614,40 @@ msgstr ""
 "Die versamelde informasie word tans gestuur aan die bug sporingstelsel.\n"
 "Dit mag 'n paar minute duur."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Klaar"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "geeneen"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "Gekies: %s. Veelvuldige keuses:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Keuses:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "Pad na lêer (Betree om te kanselleer):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "Lêer bestaan nie."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "Hierdie is 'n directory."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "Om voort te gaan, moet jy die volgende besoek URL:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -654,15 +655,15 @@ msgstr ""
 "Jy kan nou 'n blaaier oopmaak of hierdie URL kopiëer na 'n blaaier op 'n "
 "ander rekenaar."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Maak  'n blaaier oop nou"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr "Geen hangende crash verslae nie. Probeer --hulp vir meer inligting."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 "Moenie put die nuwe traces in te die verslag, maar skryf hulle aan stdout."
@@ -682,29 +683,29 @@ msgstr ""
 "Skryf gewysigde verslag na 'n gegewe lêer in plaas daarvan om die "
 "oorspronklike verander verslag"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 "Verwyder die kernstorting vanuit die verslag na die hergenerasie van die "
 "stapelspoor"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "Oorskryf die verslag se Kernlêer"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "Oorskryf die verslag se Uitvoerbare Pad"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "Oorskryf die verslag se ProcMaps"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "Herbou die verslag se Pakket informasie"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -721,7 +722,7 @@ msgstr ""
 "net in staat wees om te herspoor omvalle wat gebeur het op die huidig "
 "lopende vrystelling."
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
@@ -731,26 +732,26 @@ msgstr ""
 "met dieselfde vrystelling as die verslag eerder as wat die weergawe van gdb "
 "jy geïnstalleer het."
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 "Verslag aflaai/installeer vordering wanneer die installering van pakkette in "
 "sandbox"
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr "Prepend tydstempels om boodskappe aan te teken, vir die bondel werking"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr "Skep en gebruik derde party repositories van oorsprong in verslae"
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr "Kas gids vir pakkette afgelaai in die sandbox"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -758,14 +759,14 @@ msgstr ""
 "Gids vir uitgepak pakkette. Toekomstige lopies sal aanvaar dat enige reeds "
 "afgelaai pakket is ook onttrek om hierdie sandbox."
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 "Installeer 'n ekstra pakket in die sandbox (kan gespesifiseer word verskeie "
 "kere)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -775,7 +776,7 @@ msgstr ""
 "Dit word gebruik as 'n crash ID ann oplaai van die retraced stapelspore "
 "(slegs as nie een van -g, -o nie -s is gespesifiseer)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -783,32 +784,32 @@ msgstr ""
 "Vertoon retraced stapelspore en vra vir bevestiging voordat hulle na die "
 "ongelukdatabasis gestuur word."
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 "Pad na die gedupliseerde sqlite databasis(verstek: geen duplikaatkontrole "
 "nie)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr "Moenie StacktraceSource by die verslag voeg nie."
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "Jy kan nie gebruik -C sonder -S. Stop tans."
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "OK om stuur as bylaes? [y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr "%(prog)s <report> <target directory>"
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr "Rapporteer lêer om uit te pak"
 
@@ -816,19 +817,19 @@ msgstr "Rapporteer lêer om uit te pak"
 msgid "directory to unpack report to"
 msgstr "gids om die verslag na uit te pak"
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "Bestemming gids bestaan ​​en is nie leeg nie."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "Sien die man bladsy vir besonderhede."
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "Spesifiseer die log lêernaam wat deur valgrind"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
@@ -836,7 +837,7 @@ msgstr ""
 "hergebruik 'n voorheen geskep sandbox systemapps (SDIR) of, indien dit nie "
 "bestaan nie, skep dit"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -844,7 +845,7 @@ msgstr ""
 "moenie skep of hergebruik 'n sandbox gids vir addisionele ontfout simbole "
 "maar net staatmaak op geïnstalleerde ontfout simbole."
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
@@ -852,13 +853,13 @@ msgstr ""
 "hergebruik 'n voorheen geskep kas systemapps (CDIR) of, indien dit nie "
 "bestaan nie, skep dit"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 "verslag aflaai/installeer vordering wanneer die installering van pakkette in "
 "sandbox"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
@@ -866,12 +867,12 @@ msgstr ""
 "die uitvoerbare wat is hardloop onder valgrind's memcheck instrument vir "
 "opsporing van geheuelek"
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Fout: %s is nie 'n uitvoerbare. Stop tans."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -879,7 +880,7 @@ msgstr ""
 "Hierdie het tydens 'n vorige opskort voorgekom en het verhoed dat die "
 "stelsel hervatting ordentlik."
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -887,7 +888,7 @@ msgstr ""
 "Dit het tydens 'n vorige winterslaap plaasgevind, en het verhoed dat die "
 "stelsel hervatting ordentlik."
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -895,7 +896,7 @@ msgstr ""
 "Die hervat verwerking gehang baie naby die einde en sal het verskyn "
 "normaalweg voltooi het."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 "Jou stelsel mag dalk nou onstabiel raak en dit kan nodig wees om herbegin."
@@ -910,76 +911,76 @@ msgstr "Raporteer 'n probleem..."
 msgid "Report a malfunction to the developers"
 msgstr "Rapporteer 'n wanfunksioneer aan die ontwikkelaars"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "Jammer, die toepassing %s het onverwags gestop het."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "Jammer, %s het onverwags gesluit het."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "Jammer, %s het ervaar 'n inwendige fout."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Stuur"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Wys Besonderhede"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Voortgaan"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "Die toepassing %s het opgehou reageer het."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "Die program \"%s\" het ophou reageer."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Pakket: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "Jammer, 'n probleem voorgekom terwyl sagteware installeer."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "Die toepassing %s het ervare 'n interne fout."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "Die toepassing %s gesluit het onverwags."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr "As jy verdere probleme opmerk, probeer om die rekenaar te herbegin."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "Ignoreer toekomstige probleme van hierdie tipe"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Versteek Details"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -1035,7 +1036,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>Oplaai tans probleem informasie</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -1047,27 +1048,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Apport ineenstortingslêer"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "Verlaat Toegemaak"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Relaunch"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Gebruikernaam:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Wagwoord:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "Insameling Probleem Inligting"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1075,6 +1076,6 @@ msgstr ""
 "Die Versamelde inligting kan aan die ontwikkelaars gestuur word om die "
 "toepassing te verbeter. Dit kan 'n paar minute duur."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "Uplaai tans Probleem Inligting"

--- a/po/am.po
+++ b/po/am.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2017-04-24 01:43+0000\n"
 "Last-Translator: samson <Unknown>\n"
 "Language-Team: Amharic <am@li.org>\n"
@@ -36,11 +36,11 @@ msgstr "የ ስርአት ችግር መግለጫ"
 msgid "Please enter your password to access problem reports of system programs"
 msgstr "እባክዎን የ እርስዎን የ መግቢያ ቃል ያስገቡ የ ስርአቱ ፕሮግራም ችግር ጋር ለ መድረስ"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "ይህ ጥቅል በ ትክክል አልተገጠመም"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -61,112 +61,112 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "ያልታወቀ ፕሮግራም"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "አዝናለሁ ፕሮግራሙ \"%s\" በድንገት ተዘግቷል"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "ችግር በ %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
 msgstr ""
 "የ እርስዎ ኮምፒዩተር በቂ የሆነ ነፃ ቦታ የለውም ራሱ በራሱ ችግሩን ለ መመርመር እና መግለጫ ለ አበልፃጊዎች ለ መላክ"
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "ችግር በ %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "ዋጋ የሌለው የ ችግር መግለጫ"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "እርስዎ እዚህ የ ችግር መግለጫ ጋር ለ መድረስ አይችሉም"
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "ስህተት"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "ይህን መግለጫ ለማስኬድ ዝግጁ የሆነ በቂ የሆነ የ ዲስክ ቦታ የለም"
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "ዋጋ የሌለው PID"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "ምንም ጥቅል አልተመረጠም"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "ፍቃድ ተከልክሏል"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 msgstr ""
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr ""
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "ጥቅሉ %s አልተገኘም"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "መግለጫ መፍጠር አልተቻለም"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "የ ችግር መግለጫ ማሻሻያ"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -174,7 +174,7 @@ msgid ""
 "Please create a new report using \"apport-bug\"."
 msgstr ""
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -186,24 +186,24 @@ msgid ""
 "Do you really want to proceed?"
 msgstr ""
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "የተሰበሰበ ተጨማሪ መረጃ የለም"
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "ምን አይነት ችግር ነው ማሳወቅ የሚፈልጉት?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "ያልታወቀ ምልክት"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "ምልክቱ \"%s\" አይታወቅም"
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -214,202 +214,204 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "የጥቅሉን ስም ይግለጹ"
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "ተጨማሪ ማብራሪያ ከ መግለጫ ጋር ይጨምሩ: በርካታ ጊዜ መግለጽ ይቻላል"
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "መስኮቱን ይጫኑ እንደ ኢላማ የ ችግሩን መግለጫ ለ መሙላት"
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr ""
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr ""
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr ""
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr ""
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr ""
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr ""
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "ድር መቃኛውን ማስጀመር አልተቻለም"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "የ ዌብ መቃኛ ማስጀመር አልተቻለም ለ መክፈት %s."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "የኔትዎርክ ችግር"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr "ከ ግጭት ዳታቤዝ ጋር መገናኘት አልተቻለም: እባክዎን የ እርስዎን ኢንተርኔት ግንኙነት ይመርምሩ"
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "የኔትዎርክ ችግር"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr ""
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "የ እርስዎ ስርአት ይህን የ ግጭት መግለጫ ለመላክ በቂ ማስታወሻ የለውም"
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -420,162 +422,161 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "ይህ ችግር ቀደም ብሎ የታወቀ ነው"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 msgstr ""
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "ይህ ችግር ቀደም ብሎ ለ አበልፃጊዎች ተልኳል: እናመሰግናለን!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "ለመቀጠል ማናቸውንም ቁልፍ ይጫኑ..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "ምን ማድረግ ነው የሚፈልጉት? ያለው ምርጫው ይህ ነው:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "እባክዎን ይምረጡ (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i ባይቶች)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(ባይነሪ ዳታ)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "የ ችግሩን መግለጫ ለ አበልጻጊዎቹ ልላክ?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
 msgstr ""
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "መግለጫ &መላኪያ (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "አካባቢ &መመርመሪያ"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "መግለጫ &መመልከቻ"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "ለዚህ ፕሮግራም እትም የ ወደፊት ግጭቶችን መሰረዣ እና መተው"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&መሰረዣ"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "የ ችግር መግለጫ ፋይል:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&ማረጋገጫ"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "ስህተት: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "የችግሩን መረጃ በማሰባሰብ ላይ"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
 msgstr ""
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "የችግሩን መረጃ በመጫን ላይ"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
 msgstr ""
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&ጨርሷል"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "ምንም"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "ተመርጧል: %s. በርካታ ምርጫዎች:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "ምርጫዎች :"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "መንገድ ወደ ፋይል (ያስገቡ ለ መሰረዝ):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "ፋይሉ አልነበረም"
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "ይህ ዳይሬክቶሪ ነው"
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "እርስዎ ለ መቀጠል የሚቀጥለውን URL መጎብኘት አለብዎት:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
 msgstr ""
 "እርስዎ አሁን መቃኛ ማስጀመር ይችላሉ: ወይንም ይህን URL ኮፒ ያድርጉ እና በሌላ ኮምፒዩተር መቃኛ ውስጥ ይለጥፉ:"
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "መቃኛ አሁን ማስጀመሪያ"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr "ምንም የ ግጭት መግለጫ የሚጠብቅ የለም: ይህን --እርዳታ ለ በለጠ መረጃ ይሞክሩ"
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 
@@ -590,27 +591,27 @@ msgid ""
 "Write modified report to given file instead of changing the original report"
 msgstr ""
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr ""
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr ""
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr ""
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "የ ጥቅል መረጃ መግለጫ እንደገና መገንቢያ"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -620,78 +621,78 @@ msgid ""
 "be able to retrace crashes that happened on the currently running release."
 msgstr ""
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
 "have installed."
 msgstr ""
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr ""
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr "መፍጠሪያ እና መጠቀሚያ ከ ሶስተኛ-አካል ማጠራቀሚያዎች በ መግለጫው ከ ተገለጸው መሰረት ውስጥ"
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
 msgstr ""
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr "ተጨማሪ ጥቅል በ አሸዋ ሳጥን ውስጥ መግጠሚያ (በርካታ ጊዜ መግለጽ ይቻላል)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
 "neither -g, -o, nor -s are specified)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
 msgstr ""
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr ""
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr ""
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "እሺ ይህን ማያያዣ ልላክ? [አዎ/አይ]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -699,70 +700,70 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "ለ ዝርዝር ይህን የ man ገጽ ይመልከቱ"
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "የ መግቢያ ፋይል ስም ይወስኑ የ ተፈጠረውን በ valgrind"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
 msgstr "በቅድሚያ የ ተፈጠረውን የ አሸዋ ሳጥን ዳይሬክቶሪ መጠቀሚያ (SDIR) ወይንም ካልነበረ አዲስ መፍጠሪያ"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
 msgstr "በቅድሚያ የ ተፈጠረውን የ ማስታወሻ ዳይሬክቶሪ እንደገና መጠቀሚያ (CDIR) ወይንም ካልነበረ አዲስ መፍጠሪያ"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "ስህተት: %s ይህን መፈጸም አይቻልም: በማስቆም ላይ"
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
 msgstr ""
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr "የ እርስዎ ስርአት አሁን ያልተረጋጋ ሊሆን ይችላል እና እንደገና ማስነሳት ይፈልጋል"
 
@@ -776,76 +777,76 @@ msgstr "ችግሩን ያመልክቱ"
 msgid "Report a malfunction to the developers"
 msgstr "ችግሩን ለ አበልጻጊዎች ማሳወቂያ"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "አዝናለሁ መተግበሪያው %s በ ድንገት ተቋርጧል"
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "አዝናለሁ %s በ ድንገት ተዘግቷል"
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "አዝናለሁ, %s የ ውስጥ ስህተት ተፈጥሯል"
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "መላኪያ"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "ዝርዝሮች ማሳያ"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "ይቀጥሉ"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "መተግበሪያው %s አይመልስም"
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "ፕሮግራሙ %s አይመልስም"
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "ጥቅል: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "አዝናለሁ, ሶፍትዌሩ በሚገጠም ጊዜ ችግር ተፈጥሯል"
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "መተግበሪያው %s የ ውስጥ ችግር ገጥሞታል"
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "መተግበሪያው %s በ ድንገት ተዘግቷል"
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr "ተጨማሪ ችግር ከ ገጠምዎት: ኮምፒዩተሩን እንደገና ያስነሱ"
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "ለ ወደፊት እንዲህ አይነቱን ችግር ተወው"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "ዝርዝሮች መደበቂያ"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "የ ተፈጠረው"
 
@@ -899,7 +900,7 @@ msgstr "የ እርስዎ መግለጫ መረጃ እየተሰበሰበ ነው: �
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>የችግሩን መረጃ በመጫን ላይ</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -909,32 +910,32 @@ msgstr "የ ተሰበሰበው መረጃ ለ አበልጻጊዎች እየተላ�
 msgid "Apport crash file"
 msgstr ""
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "እንደ ተዘጋ መተው"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "እንደገና ማስጀመሪያ"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "የተጠቃሚ ስም:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "የመግቢያ ቃል :"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "የችግሩን መረጃ በማሰባሰብ ላይ"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
 msgstr "የ ተሰበሰበው መረጃ ለ አበልጻጊዎች ይላካል መተግበሪያውን ለ ማሻሻል: ይህ ትንሽ ጊዜ ይወስዳል"
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "የችግሩን መረጃ በመጫን ላይ"

--- a/po/an.po
+++ b/po/an.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2011-05-03 12:15+0000\n"
 "Last-Translator: Daniel Martinez <entaltoaragon@gmail.com>\n"
 "Language-Team: Aragonese <an@li.org>\n"
@@ -36,11 +36,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr ""
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -57,111 +57,111 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "programa desconoxiu"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr ""
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Problema en %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
 msgstr ""
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Problema en %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr ""
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr ""
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Error"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "PID incorrecto"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr ""
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr ""
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 msgstr ""
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr ""
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr ""
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr ""
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr ""
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -169,7 +169,7 @@ msgid ""
 "Please create a new report using \"apport-bug\"."
 msgstr ""
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -181,24 +181,24 @@ msgid ""
 "Do you really want to proceed?"
 msgstr ""
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr ""
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr ""
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr ""
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr ""
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -209,202 +209,204 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr ""
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr ""
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr ""
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr ""
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr ""
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr ""
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr ""
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "No ye posible encetar o navegador web"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "No ye posible encetar o navegador web ta ubrir %s."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Problemas con o rete"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Problemas con o rete"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr ""
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -412,161 +414,160 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr ""
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 msgstr ""
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Prete una tecla ta continar..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr ""
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Por favor trie (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i bytes)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr ""
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr ""
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
 msgstr ""
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr ""
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr ""
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr ""
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr ""
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Cancelar"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr ""
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr ""
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Error: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr ""
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
 msgstr ""
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr ""
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
 msgstr ""
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Feito"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr ""
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr ""
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Opcions:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr ""
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr ""
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "Isto ye un directorio."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr ""
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
 msgstr ""
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr ""
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 
@@ -581,27 +582,27 @@ msgid ""
 "Write modified report to given file instead of changing the original report"
 msgstr ""
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr ""
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr ""
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr ""
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr ""
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -611,78 +612,78 @@ msgid ""
 "be able to retrace crashes that happened on the currently running release."
 msgstr ""
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
 "have installed."
 msgstr ""
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr ""
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
 msgstr ""
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
 "neither -g, -o, nor -s are specified)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
 msgstr ""
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr ""
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr ""
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr ""
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -690,70 +691,70 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr ""
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
 msgstr ""
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 
@@ -767,76 +768,76 @@ msgstr ""
 msgid "Report a malfunction to the developers"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr ""
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr ""
 
@@ -890,7 +891,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr ""
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -900,32 +901,32 @@ msgstr ""
 msgid "Apport crash file"
 msgstr ""
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr ""
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr ""
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr ""
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr ""
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr ""
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
 msgstr ""
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr ""

--- a/po/apport.pot
+++ b/po/apport.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -35,11 +35,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr ""
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -47,7 +47,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -56,111 +56,111 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr ""
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr ""
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr ""
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
 msgstr ""
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr ""
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr ""
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr ""
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr ""
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr ""
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr ""
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr ""
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 msgstr ""
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr ""
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr ""
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr ""
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr ""
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -168,7 +168,7 @@ msgid ""
 "Please create a new report using \"apport-bug\"."
 msgstr ""
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -180,24 +180,24 @@ msgid ""
 "Do you really want to proceed?"
 msgstr ""
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr ""
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr ""
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr ""
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr ""
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -208,202 +208,204 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr ""
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr ""
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr ""
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr ""
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr ""
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr ""
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr ""
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr ""
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr ""
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr ""
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr ""
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr ""
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -411,161 +413,160 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr ""
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 msgstr ""
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr ""
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr ""
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr ""
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr ""
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr ""
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr ""
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
 msgstr ""
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr ""
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr ""
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr ""
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr ""
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr ""
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr ""
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr ""
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr ""
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr ""
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
 msgstr ""
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr ""
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
 msgstr ""
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr ""
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr ""
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr ""
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr ""
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr ""
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr ""
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr ""
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr ""
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
 msgstr ""
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr ""
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 
@@ -580,27 +581,27 @@ msgid ""
 "Write modified report to given file instead of changing the original report"
 msgstr ""
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr ""
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr ""
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr ""
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr ""
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -610,78 +611,78 @@ msgid ""
 "be able to retrace crashes that happened on the currently running release."
 msgstr ""
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
 "have installed."
 msgstr ""
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr ""
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
 msgstr ""
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
 "neither -g, -o, nor -s are specified)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
 msgstr ""
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr ""
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr ""
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr ""
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -689,70 +690,70 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr ""
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
 msgstr ""
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 
@@ -766,76 +767,76 @@ msgstr ""
 msgid "Report a malfunction to the developers"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr ""
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr ""
 
@@ -889,7 +890,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr ""
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -899,32 +900,32 @@ msgstr ""
 msgid "Apport crash file"
 msgstr ""
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr ""
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr ""
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr ""
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr ""
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr ""
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
 msgstr ""
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr ""

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2012-09-25 10:51+0000\n"
 "Last-Translator: Ibrahim Saed <ibraheem5000@gmail.com>\n"
 "Language-Team: Arabic <ar@li.org>\n"
@@ -36,11 +36,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr "برجاء إدخال كلمة سرك للنفاذ إلى تقارير المشاكل لبرامج النظام"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "هذه الحزمة لا تبدو مثبّتة بشكل صحيح"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -61,84 +61,84 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "برنامج مجهول"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "عُذرًا، أُغلق برنامج \"%s\" فجأة"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "مشكلة في %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
 msgstr ""
 "لا توجد ذاكرة خالية كافية على الجهاز لتحليل المشكلة وإبلاغ المطورين آليا."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "مشكلة في %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "بلاغ مشكلة غير صالح"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "غير مسموح لك بالنفاذ إلى بلاغ المشكلة هذا."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "خطأ"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "لا توجد مساحة قرص كافية لمعالجة هذا البلاغ."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "رقم عملية(PID)غير صحيح"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "لم تُحدد حزمة"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "تحتاج إلى تحديد حزمة أو معرف عملية (PID). أطلع على --help لمزيد من المعلومات."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "رُفض التّصريح"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -146,30 +146,30 @@ msgstr ""
 "العملية المحددة لا تخصك. من فضلك شغل هذا البرنامج بنفس المستخدم مالك العملية "
 "أو كجذر."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "رقم تعريف العملية المحدد لا ينتمي ﻷي برنامج."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "الحزمة %s غير موجودة"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "تعذّر إنشاء التقرير"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "يُحدّث تقرير المشكلة"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -181,7 +181,7 @@ msgstr ""
 "\n"
 "من فضلك أنشئ تقريرًا جديدًا باستخدام \"apport-bug\"."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -200,24 +200,24 @@ msgstr ""
 "\n"
 "هل تود المتابعة حقًا؟"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "لم تُجمع معلومات إضافية."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "ما نوع المشكلة التي تود الإبلاغ عنها؟"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "عَرَض غير معروف"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "العَرَض\"%s\" غير معروف."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -228,7 +228,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -236,75 +236,75 @@ msgstr ""
 "بعد إغلاق هذه الرسالة رجاءً انقر على نافذة التطبيق للإبلاغ عن المشكلة "
 "المتعلقة بذلك."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "حدد  اسم الحزمة."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "انقر على النافذة كهدف لتقديم بلاغ عن مشكلة."
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -313,122 +313,124 @@ msgstr ""
 "في نمط الإبلاغ عن علّة، احفظ المعلومات المُجمّعة في ملف بدلًا من إرسالها. هذا "
 "الملف يمكن إرساله لاحقًا من جهاز حاسوب آخر."
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr ""
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr "هذا سينفّذ أمر apport-retrace في نافذة طرفية لتحليل الانهيار."
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr ""
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr "هذا البلاغ ينطبق على برنامج لم يعد مثبتًا على حاسوبك."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 msgstr "حدثت المشكلة مع برنامج '%s' الذي تغير منذ حدوث الانهيار."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "بلاغ المشكلة هذا  تالف ولا يمكن معالجته."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr ""
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "حدث خطأ أثناء محاولة معالجة تقرير الخطأ هذا:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "تعذّر تحديد اسم الحزمة أو اسم الحزمة المصدر."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "تعذّر تشغيل المتصفح"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "تعذّر تشغيل المتصفح لفتح %s."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "مشكلة في الشبكة"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "لا يمكن الاتصال بقاعدة بيانات الانهيارات. من فضلك تحقق من اتصالك بالإنترنت."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "مشكلة في الشبكة"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "نفذت الذاكرة"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "لا توجد ذاكرة كافية في النظام لمعالجة بلاغ الانهيار هذا."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -439,11 +441,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "المشكلة معروفة"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -452,38 +454,37 @@ msgstr ""
 "بُلّغ عن هذه المشكلة مسبقًا في بلاغ العِلة المعروض في المتصفح، تحقق من فضلك مما "
 "إذا كان باستطاعتك إضافة معلومات أخرى قد تساعد المطورين."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "بُلّغ عن هذه المشكلة مُسبقًا. شكرًا لك!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "اضغط على أي مفتاح للمواصلة..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "مالذي تود أن تفعل؟ خياراتك هي:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "اختر من فضلك (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i بايتات)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(بيانات ثنائية)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "أأبلغ المطورين عن المشكلة؟"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -491,50 +492,50 @@ msgstr ""
 "بعد الإبلاغ عن المشكلة، من فضلك املأ النموذج المفتوح تلقائيا\n"
 "في متصفح شبكة الوب."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "أر&سل البلاغ (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr ""
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "اعرض ال&بلاغ"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr "ا&حتفظ بملف البلاغ لإرساله لاحقاً أو نسخه إلى مكان آخر"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "ألغ و &تجاهل الانهيارات المستقبلية لإصدارة البرنامج هذه"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "أل&غِ"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "ملف بلاغ المشكلة:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&أكد"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "خطأ: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "يجمع معلومات عن المشكلة"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -542,11 +543,11 @@ msgstr ""
 "يمكن إرسال المعلومات التي جُمِعت إلى المطورين لتحسين\n"
 "التطبيق، لكن قد يستغرق هذا بعض الدقائق."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "يرفع معلومات المشكلة"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -554,54 +555,54 @@ msgstr ""
 "يجري إرسال المعلومات التي جُمِعت إلى نظام تتبع العِلَل،\n"
 "لكن قد يستغرق هذا بضع دقائق."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&تمّ"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr ""
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr ""
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr ""
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr ""
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "الملف غير موجود."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr ""
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "للمواصلة، يجب عليك زيارة الرابط التالي:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
 msgstr "يمكنك تشغيل المتصفح الآن، أو انسخ هذا العنوان إلى متصفح على حاسوب آخر."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "شغّل المتصفح الآن"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr "لا يوجد تقارير بلاغات معلقة. جرب --help لمزيد من المعلومات."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 
@@ -616,27 +617,27 @@ msgid ""
 "Write modified report to given file instead of changing the original report"
 msgstr "اكتب تقرير مُعدّل للملف المُعطى بدلًا من تغيير التقرير الأصلي"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr ""
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr ""
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr ""
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr ""
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -646,78 +647,78 @@ msgid ""
 "be able to retrace crashes that happened on the currently running release."
 msgstr ""
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
 "have installed."
 msgstr ""
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr ""
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
 msgstr ""
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
 "neither -g, -o, nor -s are specified)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
 msgstr ""
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr ""
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr ""
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr ""
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -725,70 +726,70 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "المجلد المستهدف موجود و ليس فارغا."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr ""
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
 msgstr ""
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr "قد يصبح نظامك غير مستقر الآن وقد يحتاج لإعادة تشغيله."
 
@@ -802,76 +803,76 @@ msgstr "أبلغ عن مشكلة..."
 msgid "Report a malfunction to the developers"
 msgstr "أبلغ المطورين عن خلل"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "عُذرًا، توقف التطبيق \"%s\" فجأة"
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "عُذرًا، أُغلق \"%s\" فجأة."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "عُذرًا، واجه \"%s\" خطأ داخليا."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "أرسل"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "أظهر التفاصيل"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "واصِل"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "الحزمة: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "عُذرًا، حدث خطأ أثناء تثبيت البرنامج."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "واجه تطبيق \"%s\" خطأ داخليا."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "أُغلق تطبيق \"%s\" فجأة."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr "إذا لاحظت المزيد من المشاكل، جرّب إعادة تشغيل الحاسوب."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "تجاهل الانهيارات المستقبلية لهذا النوع"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "أخفِ التفاصيل"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr ""
 
@@ -926,7 +927,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>يرفع معلومات المشكلة</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -937,27 +938,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr ""
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "اتركه مغلقا"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "شغّله مجددا"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "اسم المستخدم:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "كلمة السر:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "يجمع معلومات عن المشكلة"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -965,6 +966,6 @@ msgstr ""
 "يمكن إرسال المعلومات التي جُمِعت إلى المطورين لتحسين التطبيق، قد يستغرق هذا "
 "بضع دقائق."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "يرفع معلومات المشكلة"

--- a/po/arn.po
+++ b/po/arn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2022-02-06 03:15+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Mapudungun <arn@li.org>\n"
@@ -36,11 +36,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr ""
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -57,111 +57,111 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr ""
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr ""
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr ""
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
 msgstr ""
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr ""
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr ""
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr ""
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Welukawvn"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr ""
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr ""
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr ""
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 msgstr ""
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr ""
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr ""
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr ""
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr ""
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -169,7 +169,7 @@ msgid ""
 "Please create a new report using \"apport-bug\"."
 msgstr ""
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -181,24 +181,24 @@ msgid ""
 "Do you really want to proceed?"
 msgstr ""
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr ""
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr ""
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr ""
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr ""
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -209,202 +209,204 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr ""
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr ""
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr ""
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr ""
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr ""
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr ""
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr ""
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr ""
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr ""
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr ""
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr ""
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr ""
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -412,161 +414,160 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr ""
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 msgstr ""
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Pvtaftuge cem rume amulealu..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "Cem kvpa femafuymi? Tvfa zujiaymi:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Zujiafuymi (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i byte)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr ""
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr ""
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
 msgstr ""
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr ""
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr ""
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr ""
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr ""
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Kaxvtun"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr ""
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr ""
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Welulkawvn: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr ""
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
 msgstr ""
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr ""
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
 msgstr ""
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Femgey"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "cem no rume"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr ""
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Zujikan:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr ""
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr ""
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr ""
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr ""
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
 msgstr ""
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr ""
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 
@@ -581,27 +582,27 @@ msgid ""
 "Write modified report to given file instead of changing the original report"
 msgstr ""
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr ""
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr ""
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr ""
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr ""
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -611,78 +612,78 @@ msgid ""
 "be able to retrace crashes that happened on the currently running release."
 msgstr ""
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
 "have installed."
 msgstr ""
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr ""
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
 msgstr ""
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
 "neither -g, -o, nor -s are specified)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
 msgstr ""
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr ""
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr ""
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr ""
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -690,70 +691,70 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr ""
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
 msgstr ""
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 
@@ -767,76 +768,76 @@ msgstr ""
 msgid "Report a malfunction to the developers"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Amupe"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr ""
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr ""
 
@@ -890,7 +891,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr ""
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -900,32 +901,32 @@ msgstr ""
 msgid "Apport crash file"
 msgstr ""
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr ""
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr ""
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Pvnekelu:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Nvlawe:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr ""
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
 msgstr ""
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr ""

--- a/po/ast.po
+++ b/po/ast.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2020-10-20 11:42+0000\n"
 "Last-Translator: Xandru Martino <Unknown>\n"
 "Language-Team: Asturian <alministradores@softastur.org>\n"
@@ -35,11 +35,11 @@ msgstr ""
 "Escribi la to contraseña p'acceder a los informes de problemes de programes "
 "del sistema"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "Esti paquete nun paez tar instaláu correcho"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -50,7 +50,7 @@ msgstr ""
 "d'anova los índices de paquetes disponibles; si nun furrula esto, desistala "
 "los paquetes de terceros venceyaos y reinténtalo."
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -63,21 +63,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "programa desconocíu"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Sentímoslo; el programa «%s» zarróse inesperadamente"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Problema en %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -85,65 +80,70 @@ msgstr ""
 "El to equipu nun tien memoria llibre suficiente p'analizar el problema "
 "automáticamente y unviar un informe a los desendolcadores."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Problema en %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Informe de problema incorreutu"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "Nun tienes permitíu acceder a esti informe de problema."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Fallu"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 "Nun hai suficiente espaciu de discu disponible pa procesar esti informe."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr "Nun s'especificó dengún PID"
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr "Hai qu'especificar un PID. Mira --help pa obtener más información."
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "PID incorreutu"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr "La ID del procesu especificáu nun esiste."
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr "Nun ye'l to PID"
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr "La ID del procesu especificáu nun te pertenez."
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "Nun s'especificó dengún paquete"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Necesites especificar un paquete o un PID. Consulta --help pa más "
 "información."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Permisu denegáu"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -151,30 +151,30 @@ msgstr ""
 "El procesu especificáu nun te pertenez. Executa esti programa como "
 "propietariu del procesu o como superusuariu."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "El ID de procesu especificáu nun pertenez a dengún programa."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "El script de síntomes %s nun determinó dengún paquete afeutáu"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "El paquete %s nun esiste"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "Nun puede crease l'informe"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "Anovando informe de fallu"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -186,7 +186,7 @@ msgstr ""
 "\n"
 "Crea un informe nuevu usando «apport-bug»."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -206,24 +206,24 @@ msgstr ""
 "\n"
 "¿Daveres quies siguir?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "Nun se collechó información adicional."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "¿De qué triba de problema quier informar?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Síntoma desconocíu"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "El síntoma «%s» ye desconocíu"
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -234,7 +234,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -242,30 +242,30 @@ msgstr ""
 "Dempués de zarrar esti mensaxe calca nuna ventana d'aplicación pa informar "
 "tocante a esti problema."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop falló al determinar la ID de procesu de la ventana"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "Especifica'l nome del paquete."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "Amiesta una etiqueta estra al informe. Pue especificase delles vegaes."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -275,18 +275,18 @@ msgstr ""
 "opcional, o sólo un --pid. Si nun s'apurre dengún, amuesa una llista de "
 "síntomes conocíos. (Implícitu si s'apurre un únicu argumentu.)"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 "Fai click nuna ventana como oxetivu pa rellenar un informe de problema."
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "Aniciar en mou d'anovamientu d'errores. Almite un parámetru --package "
 "opcional."
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -294,7 +294,7 @@ msgstr ""
 "Rellenar un informe de fallu sobre un síntoma. (Implícitu si s'apurre un "
 "nome de síntoma como únicu argumentu.)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -303,7 +303,7 @@ msgstr ""
 "pid s'especifica. (Implícitu si se dió un nome de paquete como un únicu "
 "argumentu)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -313,11 +313,11 @@ msgstr ""
 "l'informe de fallu contendrá más información.  (Implica si pid se da como un "
 "argumentu solu.)"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "El pid proporcionáu ye una aplicación colgada."
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -327,7 +327,7 @@ msgstr ""
 "llugar de los pendientes en %s. (Implícitu si s'indica el ficheru como únicu "
 "argumentu.)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -337,46 +337,46 @@ msgstr ""
 "cuenta d'unviala. Esti ficheru pue unviase más sero, dende una máquina "
 "diferente."
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Amosar el númberu de versión d'Apport"
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr "Esto executará apport-retrace nuna terminal pa desaminar el fallu."
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "Executar una sesión gdb"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Executar una sesión gdb ensin descargar símbolos de depuración"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Anovar %s con una pila de siguimientu completamente simbólica"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr "Nun se recuerda la preferencia sobro unviar estaos d'informes"
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 "Nun se pudo guardar l'estáu del informe de fallu. Nun se pue afitar el mou "
 "d'informe «auto» o «enxamás»."
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr "Nun se recuerda la preferencia sobro unviar estaos d'informes"
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr "Esti informe de problema aplícase a un programa que nun ta instaláu."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
@@ -384,19 +384,21 @@ msgid ""
 msgstr ""
 "El problema ocurrió col programa %s, que camudó dende qu'asocedió'l fallu."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "L'informe del problema ta frayáu y nun puede procesase."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr "Esti informe ye sobre un paquete que nun ta instaláu."
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "Hebo un fallu mentanto s'intentaba procesar l'informe de fallu:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
@@ -404,24 +406,24 @@ msgstr ""
 "Instaleste dos versiones d'esta aplicación. ¿De cuála ye l'informe del fallu "
 "que vas crear?"
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr "«Snap» de %s"
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr "Paquete .deb de %s"
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s ufiértase como «snap», qu'espubliza %s. Ponte en contautu con ellos per "
 "aciu de %s (n'inglés) pa obtener ayuda."
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -431,41 +433,41 @@ msgstr ""
 "de contautu; visita'l foru en https://forum.snapcraft.io (n'inglés) pa "
 "obtener ayuda."
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "Nun pudo determinase'l nome del paquete binariu o fonte."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "Nun puede arrancase'l restolador web"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Nun puede arrancase'l restolador web p'abrir %s."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Problemes cola rede"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Nun puede afitase la conexón cola base de datos d'errores, por favor, "
 "verifique la so conexón a Internet."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Problemes cola rede"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Memoria escosada"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "El to sistema nun tien la memoria suficiente pa procesar esti informe de "
 "fallu."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -476,11 +478,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "Problema yá conocíu"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -490,38 +492,37 @@ msgstr ""
 "restolador web. Por favor, comprueba si puedes amestar cualesquier "
 "información adicional que pudieres resultar d'utilidá a los desendolcadores."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Ya s'informó d'esti problema a los desendolcadores. ¡Gracies!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Calca una tecla pa siguir..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "¿Qué quies facer? Les tos opciones son:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Por favor escueye (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i bytes)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(datos binarios)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "¿Unviar un informe del problema a los desendolcadores?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -529,51 +530,51 @@ msgstr ""
 "Lluéu de que la información del problema se tenga unviao, por favor,\n"
 "completa'l formulariu que s'abrirá automáticamente nel to restolador."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "&Unviar informe (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "&Desaminar llocalmente"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "&Ver informe"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 "&Guardar l'informe pa unviar lluéu, o pa copialu en dalgún otru llugar."
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "Encaboxar ya &inorar fallos futuros d'esta versión del programa."
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Encaboxar"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Ficheru del informe del problema:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&Confirmar"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Fallu: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "Recopilando información del problema"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -581,11 +582,11 @@ msgstr ""
 "La información recopilada puede unviase a los desendolcaodres pa meyorar\n"
 "l'aplicación. Esto puede tardar unos minutos."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "Unviando la información del problema"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -594,40 +595,40 @@ msgstr ""
 "fallos.\n"
 "Esto puede tardar unos minutos."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Fecho"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "dengún"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "Esbillao: %s. Delles opciones:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Opciones:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "Camín al ficheru (Enter pa encaboxar):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "El ficheru nun esiste."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "Esto ye un direutoriu."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "Pa continuar, visite la siguiente URL:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -635,16 +636,16 @@ msgstr ""
 "Puede llanzar un restolador agora, o copiar esta URL a un restolador n'otru "
 "equipu."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Llanzar un restolador agora"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 "Nun hai informes de fallos pendientes. Intenta --help pa mas información."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 "Nun poner les traces nueves nel informe, pero escribiles na salida estándar."
@@ -664,29 +665,29 @@ msgstr ""
 "Escribir l'informe modificáu nel ficheru dau, n'arróu de camudar l'informe "
 "orixinal"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 "Desaniciar del informe el volcáu de memoria tres la rexeneración de la traza "
 "de la pila"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "Sobroscribir los informes de CoreFile"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "Sobroscribir los informes de ExecutablePath"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "Sobroscribir los informes de ProcMaps"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "Recontruyir la información d'informes de paquetes"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -703,7 +704,7 @@ msgstr ""
 "configuración del sistema, pero namái va poder volver sobre los accidentes "
 "qu'ocurrieron nel llanzamientu n'execución."
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
@@ -713,29 +714,29 @@ msgstr ""
 "dependencies usando la mesma versión que l'informe en vez de cualquier "
 "versión de gdb qu'instalares."
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 "Informar del progresu de la descarga/instalación de paquetes na caxa de "
 "sable (sanbox)"
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr ""
 "Enteponer marques de tiempu pa rexistrar mensaxes, pa operación en llote "
 "(batch)"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 "Crear y usar repositorios de terceros dende orixes especificaos n'informes"
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr "Almacenar direutorios pa paquetes descargaos na caxa de sable (sanbox)"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -744,14 +745,14 @@ msgstr ""
 "cualesquier paquete yá descargáu estráise tamién a esta caxa de sable "
 "(sandbox)."
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 "Instalar un paquete estra na caxa de sable (sanbox). Pue especificase delles "
 "vegaes"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -761,7 +762,7 @@ msgstr ""
 "fallos. Esto úsase cuando especifica un ID de fallu pa cargar una pila de "
 "rastros reconstituyíos (namái si nun s'especifiquen nin -g, nin -o nin -s"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -769,32 +770,32 @@ msgstr ""
 "Amosar la pila de rastros reconstituyíos y pidir confirmación enantes "
 "d'unviales a la base de datos d'errores"
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 "Camín a la base de datos sqlite duplicada (por omisión: ensin comprobación "
 "de duplicáu)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr "Nun amestar StacktraceSource al reporte."
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "Nun pues usar -C ensin -S. Parando."
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "¿D'alcuerdu n'unviar esto como axuntos? [y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -802,19 +803,19 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "El direutoriu de destín esiste y nun ta ermu."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "Consulta la páxina man pa tener más detalles."
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "especifica'l nome del ficheru de rexistru xeneráu por valgrind"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
@@ -822,7 +823,7 @@ msgstr ""
 "reusar un direutoriu de pruebes (SDIR) creáu anteriormente o, si nun esiste, "
 "crealu"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -830,7 +831,7 @@ msgstr ""
 "nun crear nin reusar un direutoriu de pruebes pa símbolos de depuración "
 "adicional, sinón depender namái de los símbolos de depuración instalaos."
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
@@ -838,24 +839,24 @@ msgstr ""
 "reutilizar un direutoriu caché (REDC) creáu previamente, si nun esiste, "
 "crealu"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 "informar del avance na descarga/instalación al instalar paquetes nel sistema "
 "de pruebes"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Fallu: %s nun ye un executable. Parando."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -863,7 +864,7 @@ msgstr ""
 "Esto asocedió demientres una suspensión anterior y torgó que'l sistema "
 "remaneciera correutamente."
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -871,7 +872,7 @@ msgstr ""
 "Esto asocedió demientres una hibernación anterior y torgó que'l sistema "
 "remaneciera correutamente."
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -879,7 +880,7 @@ msgstr ""
 "El procesu de reanudación colingóse cerca del final y parecerá que se "
 "completó normalmente."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 "El so sistema puede volvese inestable y ye dable que necesite reanicialu."
@@ -894,76 +895,76 @@ msgstr "Informar d'un problema..."
 msgid "Report a malfunction to the developers"
 msgstr "Notificar un mal furrulamientu a los desendolcadores"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "Sentímoslo, l'aplicación %s detúvose inesperadamente."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "Sentímoslo,  %s zarróse de manera inesperada."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "Sentímoslo, %s esperimentó un fallu internu."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Unviar"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Amosar detalles"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Siguir"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "L'aplicación %s dexó de responder."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "El programa «%s» dexó de responder."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Paquete: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "Sentímoslo, hebo un problema al instalar el software."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "L'aplicación %s esperimentó un fallu internu."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "L'aplicación %s zarróse inesperadamente."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr "Si sigues teniendo problemes, intenta rearrancar l'equipu."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "Inorar problemes futuros d'esti tipu"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Anubrir Detalles"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -1019,7 +1020,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>Unviando información del problema</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -1031,27 +1032,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Ficheru de fallu d'Apport"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "Dexar zarrada"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Rellanzar"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Nome d'usuariu:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Contraseña:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "Recopilando información del problema"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1059,6 +1060,6 @@ msgstr ""
 "La información recopilada puede unviase a los desendolcadores pa meyorar "
 "l'aplicación. Esto puede tardar dalgunos minutos."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "Unviando información del problema"

--- a/po/az.po
+++ b/po/az.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2014-07-01 14:13+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Azerbaijani <az@li.org>\n"
@@ -36,11 +36,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr ""
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -57,111 +57,111 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr ""
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr ""
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr ""
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
 msgstr ""
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr ""
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr ""
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr ""
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr ""
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr ""
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr ""
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr ""
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 msgstr ""
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr ""
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr ""
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr ""
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr ""
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -169,7 +169,7 @@ msgid ""
 "Please create a new report using \"apport-bug\"."
 msgstr ""
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -181,24 +181,24 @@ msgid ""
 "Do you really want to proceed?"
 msgstr ""
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr ""
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr ""
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr ""
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr ""
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -209,202 +209,204 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr ""
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr ""
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr ""
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr ""
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr ""
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr ""
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr ""
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr ""
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr ""
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr ""
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr ""
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr ""
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -412,161 +414,160 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr ""
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 msgstr ""
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr ""
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr ""
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr ""
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr ""
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(ikili məlumat)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Yaradıcılara problemin hesabatı göndərilsin?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
 msgstr ""
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr ""
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr ""
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr ""
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr ""
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr ""
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr ""
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr ""
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr ""
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr ""
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
 msgstr ""
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "Problem haqqında məlumat yüklənir"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
 msgstr ""
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr ""
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr ""
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr ""
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr ""
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr ""
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr ""
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr ""
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr ""
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
 msgstr ""
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr ""
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 
@@ -581,27 +582,27 @@ msgid ""
 "Write modified report to given file instead of changing the original report"
 msgstr ""
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr ""
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr ""
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr ""
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr ""
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -611,78 +612,78 @@ msgid ""
 "be able to retrace crashes that happened on the currently running release."
 msgstr ""
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
 "have installed."
 msgstr ""
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr ""
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
 msgstr ""
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
 "neither -g, -o, nor -s are specified)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
 msgstr ""
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr ""
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr ""
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr ""
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -690,70 +691,70 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr ""
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
 msgstr ""
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 
@@ -767,77 +768,77 @@ msgstr ""
 msgid "Report a malfunction to the developers"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "Bağışlayın, %s bir daxili xəta ilə üzləşdi."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Göndər"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Məlumatları göstər"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Davam"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Paket: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "Bağışlayın, proqram yüklənərkən bir problem yarandı."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "Tətbiqetmə %s bir xəta ilə üzləşdi."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "Tətbiqetmə %s gözlənilmədən bağlandı."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr ""
 "Əgər daha çox problem görsəniz kompyuteri yenidən başlatmağa cəhd edin."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "Bu tip gələcək problemləri önəmsəmə"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Məlumatları gizlət"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr ""
 
@@ -891,7 +892,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr ""
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -903,32 +904,32 @@ msgstr ""
 msgid "Apport crash file"
 msgstr ""
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr ""
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Yenidən başlat"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "İstifadəçi adı:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Şifrə:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr ""
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
 msgstr ""
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "Problem Haqqında Məlumat Yüklənir"

--- a/po/be.po
+++ b/po/be.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2015-09-17 07:37+0000\n"
 "Last-Translator: Mikola Tsekhan <mail@tsekhan.com>\n"
 "Language-Team: Belarusian <be@li.org>\n"
@@ -40,11 +40,11 @@ msgstr ""
 "Калі ласка, увядзіце пароль для доступу да справаздач пра памылкі ў "
 "сістэмных праграмах"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "Падобна на тое, што гэты пакет усталяваны неправільна"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -52,7 +52,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -65,21 +65,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "невядомая праграма"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Прабачце, праграма «%s» аварыйна завяршыла сваю работу"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Праблема ў %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -87,64 +82,69 @@ msgstr ""
 "На Вашым кампутары недастаткова вольнай памяці для таго, каб аўтаматычна "
 "прааналізаваць няспраўнасць і даслаць справаздачу распрацоўшчыкам."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Праблема ў %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Няправільная справаздача аб памылцы"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "У Вас не хапае правоў, каб паведамляць аб праблемах."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Памылка"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "Недастаткова месца на дыску для апрацоўкі дадзенай справаздачы."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "Памылковы PID"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "Не пазначаны пакет"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Неабходна пазначыць пакет альбо PID. Запусціце праграму з параметрам --help "
 "каб атрымаць дадатковую інфармацыю."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Доступ забаронены"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -152,30 +152,30 @@ msgstr ""
 "Пазначаны працэс запушчэны іншым карыстальнікам. Запусціце дадзеную праграму "
 "з правамі ўладальніка працэса альбо адміністратара сістэмы."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "Пазначаны PID належыць іншаму працэсу."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Сімптаматычны скрыпт %s ня можа вызначыць закрануты пакет"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Пакет %s не існуе"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "Нельга стварыць справаздачу"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "Абнаўленне справаздачы аб праблеме"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -185,7 +185,7 @@ msgstr ""
 "Вы не з'яўляецеся аўтарам альбо атрымальнікам гэтай справаздачы аб праблеме, "
 "магчыма яна ўжо існуе ці была зачыненая."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -205,24 +205,24 @@ msgstr ""
 "\n"
 "Вы сапраўды хочаце працягнуць?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "Не сабрана ніякай дадатковай інфармацыі."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "Пра які тып праблемы Вы хочаце паведаміць?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Невядомы сімптом"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Сімптом  \"%s\" невядомы."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -233,7 +233,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -241,31 +241,31 @@ msgstr ""
 "Пасля закрыцця гэтага паведамлення, калі ласка, націсніце на вакно "
 "прыкладання, каб паведаміць аб праблеме."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop не ўдалося вызначыць ID працэсу акна"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "Пазначце імя пакета."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Дадаць дадатковы тэг да справаздачы. Можа быць паказаны некалькі разоў."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -276,16 +276,16 @@ msgstr ""
 "адлюстроўвае спіс вядомых сімптомаў. (Ужываецца, калі перададзены адзіны "
 "параметр.)"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "Цокніце па намечаным акне каб запоўніць справаздачу аб праблеме."
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "Запусціць у рэжыме абнаўлення памылкі. Можа прымаць дадатковы ключ - package."
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -293,7 +293,7 @@ msgstr ""
 "Адправіць справаздачу аб памылцы з сімптомам. (Ужываецца, калі назва "
 "сімптома перададзена ў якасці адзінага параметра.)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -301,7 +301,7 @@ msgstr ""
 "Пазначыць імя пакета ў рэжыме --file-bug. Неабавязкова, калі пазначаны --"
 "pid. (Ужываецца, калі імя пакета перададзена ў якасці адзінага праметра.)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -311,11 +311,11 @@ msgstr ""
 "справаздача аб памылцы будзе ўтрымліваць больш інфармацыі. (Маецца на ўвазе, "
 "што пазначаны адзіны аргумент - pid.)"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "Згаданы ідэнтыфікатар належыць працэсу, які не адказвае."
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -325,7 +325,7 @@ msgstr ""
 "ччакаемых у %s. (Ужываецца, калі файл перададзены ў якасці адзінага "
 "параметра.)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -335,46 +335,46 @@ msgstr ""
 "файле замест яе адпраўкі. Гэты файл можна будзе адправіць пазней, ці з "
 "іншага кампутара."
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Раздрукаваць нумар версіі Apport ."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Будзе ажыццёўлены запуск «apport-retrace» у акне тэрміналу для праверкі "
 "аварыйнага завяршэння працы."
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "Запусціць сеанс gdb"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Запусціць сеанс gdb, абыходзячы загрузкі адладкавых сімвалаў"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Абнавіць %s з поўным адсочваннем сімвалічнага стэку"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr "Дадзеная справаздача адносіцца да праграмы, якая не ўсталявана."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
@@ -383,80 +383,82 @@ msgstr ""
 "Праблема ў праграме %s, да якой былі ўнесены змены з моманту аварыйнага "
 "завяршэння яе работы."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Дадзеная справаздача аб непаладцы пашкоджана і не можа апрацоўвацца."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr ""
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "Адбылася памылка пры спробе апрацоўкі справаздачы:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "Немагчыма вызначыць імя пакету альбо крыніцы."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "Не атрымалася запусціць вэб-браўзэр"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Немагчыма запусціць вэб-браўзэр, каб адчыніць %s."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Праблема з сеткай"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Не атрымоўваецца падлучыцца да базы дадзеных па збоях, калі ласка, праверце "
 "падлучэнне да Інтэрнэту."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Праблема з сеткай"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Нястача памяці"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "У сістэме недастаткова памяці для апрацоўкі дадзенай справаздачы аб памылцы."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -467,11 +469,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "Праблема ўжо вядомая"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -481,38 +483,37 @@ msgstr ""
 "Вашым браўзэры. Калі ласка, праверце, ці можаце Вы дадаць да яе карысную "
 "інфармацыю, якая магла бы дапамагчы распрацоўшчыкам."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Аб гэтай праблеме распрацоўнікам ужо вядома. Дзякуй!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Каб працягнуць, націсніце любую клавішу ..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "Што вы жадаеце зрабіць? Магчымыя варыянты:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Калі ласка выберыце (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i байт)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(двайковыя дадзеныя)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Даслаць распрацоўшчыкам паведамленне аб праблеме?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -520,52 +521,52 @@ msgstr ""
 "Пасля таго, як справаздача будзе дасланая, запоўніце\n"
 "форму ў акне браўзэра , што адчынілася аўтаматычна."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "&Даслаць паведамленне (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "&Локальна перевірка"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "&Паказаць справаздачу"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 "&Захаваць файл справаздачы для наступнай адпраўкі альбо капіявання куды-"
 "небудзь"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "Адмяніць і &ігнараваць будучыя збоі ў гэтай версіі праграмы"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Скасаваць"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Файл справаздачы аб праблеме:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&Пацвердзіць"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Памылка: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "Збор інфармацыі аб праблеме"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -573,11 +574,11 @@ msgstr ""
 "Сабраная інфармацыя можа быць накіравана распрацоўшчыкам для\n"
 "паляпшэння дастасавання. Гэта можа заняць некалькі хвілін."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "Перадача інфармацыі аб непаладцы"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -585,55 +586,55 @@ msgstr ""
 "Сабраная інфармацыя накіроўваецца да сістэмы адсочвання памылак.\n"
 "Гэта можа заняць некалькі хвілін."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Зроблена"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "нічога"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "Абрана: %s. Некалькі варыянтаў:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Выбар:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "Шлях да файла (Enter — адмена):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "Файл не існуе."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "Гэта - дырэкторыя."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "Каб працягнуць, Вы павінны наведаць наступны адрас:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
 msgstr ""
 "Зараз Вы можаце адкрыць браўзар ці скапіяваць URL у браўзар на іншы кампутар."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Запусціць браўзар"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr "Няма чакаючых паведамленьняў аб збоях. Паспрабуйце ключ --help."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 "Не дадаваць новыя трасіроўкі ў справаздачу, а адсылаць на стандартны вывад."
@@ -652,27 +653,27 @@ msgid ""
 msgstr ""
 "Захаваць змененую справаздачу ў файл замест змены арыгінальнай справаздачы"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr "Выдаліць дамп ядра са справаздачы пасля ўзнаўлення трасіроўкі стэка"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "Замяніць CoreFile у справаздачы"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "Замяніць ExecutablePath у справаздачы"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "Замяніць ProcMaps у справаздачы"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "Нанава пабудаваць інфармацыю аб пакетах у справаздачы"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -689,36 +690,36 @@ msgstr ""
 "ў выпадку выяўлення аварыйных сітуацый, якія адбыліся ў выпуску сістэмы, які "
 "працуе ў дадзены момант."
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
 "have installed."
 msgstr ""
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 "Паведамляць аб ходзе выканання загрузкі / ўсталёўкі пакетаў у часовае "
 "асяроддзе"
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr ""
 "Дадаваць часовыя пазнакі да паведамленняў у часопісе, для групавых аперацый"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 "Стварэнне і выкарыстанне іншых сховішчаў на аснове зыходных, указаных у "
 "справаздачах"
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr "Тэчка для захавання пакетаў, загружаных у часовае асяроддзе"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -726,14 +727,14 @@ msgstr ""
 "Дырэкторыя для распакавання пакетаў. Пры наступных запусках ўсё ўжо "
 "загружаны пакеты будуць распакоўваць ў гэта ізаляванае асяроддзе."
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 "Усталяваць у часовае асяроддзе дадатковы пакет (можа задавацца некалькі "
 "разоў)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -743,7 +744,7 @@ msgstr ""
 "Выкарыстоўваецца пры ўказанні ID збою для адпраўкі трасіровак стэка (толькі "
 "калі -g, -o ці -s не пазначаныя)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -751,32 +752,32 @@ msgstr ""
 "Адлюстраваць трасіроўкі і запытаць пацверджанне перад іх адпраўкай у базу "
 "дадзеных збояў."
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 "Шлях да дублюючай базы дадзеных sqlite (па змаўчанні: без праверкі "
 "дублікатаў)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr ""
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "Нельга выкарыстоўваць -C без -S. Прыпынак."
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "Адправіць гэтыя дастасаванні? [y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -784,19 +785,19 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "Тэчка прызначэння існуе і яна не пустая."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "Глядзіце падрабязнасці ў старонках man"
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "вызначце імя log файлу valgrind"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
@@ -804,7 +805,7 @@ msgstr ""
 "выкарыстоўваць раней створаны каталог пясочніцы (SDIR) або стварыць яго калі "
 "яго не існуе"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -812,7 +813,7 @@ msgstr ""
 "не ствараць і не выкарыстоўваць каталог пясочніцы для дадатковых сімвалаў "
 "адладкі, а спадзявацца толькі на устаноўленыя сімвалы адладкі."
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
@@ -820,22 +821,22 @@ msgstr ""
 "выкарыстоўваць раней створаны каталог кэша (CDIR) або стварыць яго калі яго "
 "не існуе"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr "паказваць прагрэс загрузкі/ўстаноўкі пры ўсталёўцы пакетаў у пясочніцу"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Памылка: %s - не выканальны файл. Прыпынак."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -843,7 +844,7 @@ msgstr ""
 "Гэта адбылося падчас папярэдняга сеансу прыпынення працы і прывяло да "
 "немагчымасці належнага аднаўлення працы сістэмы."
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -851,7 +852,7 @@ msgstr ""
 "Гэта адбылося падчас папярэдняга сеансу ўсыплення і прывяло да немагчымасці "
 "належнага аднаўлення працы сістэмы."
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -859,7 +860,7 @@ msgstr ""
 "Адбылася памылка ў працэсе стварэння справаздачы, бо сам працэс завіс перад "
 "сваім завяршэннем; для нармальнага завяршэння ён павінен быў з'явіцца."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr "Сістэма можа стаць нестабільнай, магчыма спатрэбіцца перазагрузка."
 
@@ -873,76 +874,76 @@ msgstr "Паведаміць аб праблеме..."
 msgid "Report a malfunction to the developers"
 msgstr "Паведаміць аб недапрацоўцы распрацоўшчыкам"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "Выбачайце, прылада %s нечакана прыпынілася."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "Выбачайце, %s нечакана зачынілася."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "Прабачце, у %s адбылася ўнутраная памылка."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Даслаць"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Паказаць падрабязнасці"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Працягнуць"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "Дадатак %s перастаў адказваць."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "Праграма \"%s\" перастала адказваць."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Пакет: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "Прабачце, пры ўсталяванні адбылася памылка."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "У дадатку %s адбылася ўнутраная памылка."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "Дастасаванне %s нечакана зачынілася."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr "Калі праблема з'явіцца зноў, паспрабуйце перазагрузіць кампутар."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "Ігнараваць такія праблемы ў будучыні"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Схаваць падрабязнасці"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -998,7 +999,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>Перадача звестак аб няспраўнасці</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -1010,27 +1011,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Файл справаздачы Apport"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "Пакінуць зачыненым"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Перазапусціць"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Імя карыстальніка:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Пароль:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "Збор інфармацыі аб праблеме"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1038,6 +1039,6 @@ msgstr ""
 "Сабраную інфармацыю можна даслаць распрацоўшчыкам, каб палепшыць "
 "прыкладанне. Гэта можа заняць некалькі хвілін."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "Перадача інфармацыі аб непаладцы"

--- a/po/be.po
+++ b/po/be.po
@@ -8,15 +8,15 @@ msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2023-07-21 16:31+0200\n"
-"PO-Revision-Date: 2015-09-17 07:37+0000\n"
-"Last-Translator: Mikola Tsekhan <mail@tsekhan.com>\n"
+"PO-Revision-Date: 2015-12-23 15:55+0000\n"
+"Last-Translator: XiveZ <kyrsant2008@list.ru>\n"
 "Language-Team: Belarusian <be@li.org>\n"
 "Language: be\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2022-12-07 14:36+0000\n"
-"X-Generator: Launchpad (build 41e7553f8097ce3a683f90e835708cbe7bf0006c)\n"
+"X-Launchpad-Export-Date: 2023-07-21 14:36+0000\n"
+"X-Generator: Launchpad (build 2bfac4503c7b6a57e9a8acd782035a16f97e2ddb)\n"
 
 #: ../apport/com.ubuntu.apport.policy.in.h:1
 msgid "Collect system information"
@@ -91,7 +91,7 @@ msgstr "Праблема ў %s"
 #: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
 #: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
-msgstr "Няправільная справаздача аб памылцы"
+msgstr "Няправільная справаздача пра памылку"
 
 #: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
@@ -272,9 +272,9 @@ msgid ""
 "a single argument is given.)"
 msgstr ""
 "Запуск у рэжыме адпраўкі справаздачы аб памылцы. Патрабуе параметр --package "
-"і неабавязковы --pid, або толькі --pid. Калі параметры не перададзеныя, "
-"адлюстроўвае спіс вядомых сімптомаў. (Ужываецца, калі перададзены адзіны "
-"параметр.)"
+"і неабавязковы --pid або толькі --pid. Калі параметры не перададзеныя, "
+"паказвае спіс вядомых сімптомаў. (Ужываецца, калі перададзены адзіны "
+"аргумент.)"
 
 #: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
@@ -436,7 +436,7 @@ msgstr "Не атрымалася запусціць вэб-браўзэр"
 #: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
-msgstr "Немагчыма запусціць вэб-браўзэр, каб адчыніць %s."
+msgstr "Немагчыма запусціць вэб-браўзер, каб адкрыць %s."
 
 #: ../apport/ui.py:1839
 msgid ""
@@ -572,7 +572,7 @@ msgid ""
 "application. This might take a few minutes."
 msgstr ""
 "Сабраная інфармацыя можа быць накіравана распрацоўшчыкам для\n"
-"паляпшэння дастасавання. Гэта можа заняць некалькі хвілін."
+"паляпшэння праграмы. Гэта можа заняць некалькі хвілін."
 
 #: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
@@ -682,13 +682,13 @@ msgid ""
 "\"system\", it will use the system configuration files, but will then only "
 "be able to retrace crashes that happened on the currently running release."
 msgstr ""
-"Стварыць часавае асяроддзе, затым загрузіць / ўсталяваць у яе неабходныя "
-"пакеты і адладкавыя сімвалы; без гэтага параметра прадугледжваецца, што "
-"неабходныя пакеты і адладкавыя сімвалы ў сістэме ўжо ўсталяваныя. Аргумент "
-"паказвае на базавую тэчку канфігурацыі сістэмы пакетаў; калі Вы паказалі "
-"\"system\", будуць выкарыстоўвацца сістэмныя файлы канфігурацыі, але толькі "
-"ў выпадку выяўлення аварыйных сітуацый, якія адбыліся ў выпуску сістэмы, які "
-"працуе ў дадзены момант."
+"Стварыць часовае асяроддзе, а пасля гэтага спампаваць/усталяваць у яе "
+"неабходныя пакеты і адладачныя сімвалы; без гэтага параметра мяркуецца, што "
+"неабходныя пакеты і адладачныя сімвалы ўжо ўсталяваны ў сістэме. Аргумент "
+"указвае на базавую папку канфігурацыі сістэмы пакетаў; калі вы пазначылі "
+"\"system\", то будуць выкарыстоўвацца сістэмныя файлы канфігурацыі, але "
+"толькі ў выпадку выяўлення аварыйных сітуацый, якія адбыліся ў выпуску "
+"сістэмы і якая працуе ў дадзены момант."
 
 #: ../bin/apport-retrace.py:107
 msgid ""
@@ -717,7 +717,7 @@ msgstr ""
 
 #: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
-msgstr "Тэчка для захавання пакетаў, загружаных у часовае асяроддзе"
+msgstr "Папка для захавання пакетаў, якія спампаваны ў часовае асяроддзе"
 
 #: ../bin/apport-retrace.py:143
 msgid ""
@@ -770,7 +770,7 @@ msgstr "Нельга выкарыстоўваць -C без -S. Прыпынак
 #. apport currently only checks for "y"
 #: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
-msgstr "Адправіць гэтыя дастасаванні? [y/n]"
+msgstr "Адправіць іх як далучэнні? [так/не]"
 
 #: ../bin/apport-unpack.py:31
 #, python-format
@@ -787,7 +787,7 @@ msgstr ""
 
 #: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
-msgstr "Тэчка прызначэння існуе і яна не пустая."
+msgstr "Папка прызначэння існуе і яна не пустая."
 
 #: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
@@ -1036,8 +1036,8 @@ msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
 msgstr ""
-"Сабраную інфармацыю можна даслаць распрацоўшчыкам, каб палепшыць "
-"прыкладанне. Гэта можа заняць некалькі хвілін."
+"Сабраную інфармацыю можна адправіць распрацоўшчыкам, каб палепшыць праграму. "
+"Гэта можа заняць некалькі хвілін."
 
 #: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2014-02-18 15:58+0000\n"
 "Last-Translator: Atanas Kovachki <Unknown>\n"
 "Language-Team: Bulgarian <bg@li.org>\n"
@@ -40,11 +40,11 @@ msgstr ""
 "Моля, въведете паролата си за достъп до докладите за проблеми на системни "
 "програми"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "Този пакет не изглежда да е инсталиран правилно"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -52,7 +52,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -65,21 +65,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "неизвестна програма"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Извинете, програмата «%s» аварийно се затвори"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Проблем в %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -87,62 +82,67 @@ msgstr ""
 "Вашият компютър няма достатъчно свободна памет, за да се анализира "
 "автоматично проблема и да изпрати доклада на разработчиците."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Проблем в %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Невалиден доклад с проблем"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "Нямате достъп до този доклад за проблем."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Грешка"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "Няма достатъчно свободно място за обработка на този доклад."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "Невалиден PID"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "Не е указан пакет"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr "Трябва да укажете пакет или PID. Вижте --help за повече информация."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Достъпа е отказан"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -150,30 +150,30 @@ msgstr ""
 "Указаният процес не ви принадлежи. Моля, стартирайте тази програма от името "
 "на собственика на процеса или като root потребител."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "Указания идентификатор не принадлежи на програма."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Симптомният скрипт %s не може да определи засегнат пакет"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Пакета %s не съществува"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "Не може да бъде създаден доклад"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "Актуализиране на доклада за проблема"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -184,7 +184,7 @@ msgstr ""
 "доклада да е дублиран или вече е затворен.\n"
 "Моля създайте нов доклад като използвате «apport-bug»."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -204,24 +204,24 @@ msgstr ""
 "\n"
 "Наистина ли искате да продължите?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "Не е събрана допълнителна информация."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "Какъв вид проблем искате да докладвате?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Неизвестен симптом"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Симптомът «%s» е неизвестен."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -232,7 +232,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -240,32 +240,32 @@ msgstr ""
 "След като затворите това съобщение, моля кликнете на прозореца на "
 "приложението, за да докладвате за този проблем."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop неуспя да определи идентификатора на процеса за прозореца"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "Посочете име на пакета."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Добавете допълнителен етикет към доклада си. Може да бъде указан няколко "
 "пъти."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -275,17 +275,17 @@ msgstr ""
 "pid, или само --pid. Ако не е подаден аргумент се показва списък с известни "
 "симптоми. (Стандартно ако е подаден единствен аргумент.)"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "Кликнете на целевият прозорец, за да попълните доклад за грешка."
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "Стартиране в режим на обновяване на грешка. Приема се аргумент по избор --"
 "package."
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -293,7 +293,7 @@ msgstr ""
 "Регистриране на доклад за грешка относно симптом. (Стандартно ако името на "
 "симптома е подадено като единствен аргумент.)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -301,7 +301,7 @@ msgstr ""
 "Посочете името на пакета в --file-bug режима. Това е по избор ако --pid e "
 "посочен. (Стандартно ако името на пакета е подадено като единствен аргумент.)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -311,11 +311,11 @@ msgstr ""
 "доклада за грешка ще съдържа повече информация. (Стандартно ако pid е даден "
 "като единствен аргумент.)"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "Посоченият идентификатор принадлежи на процес, който не отговаря."
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -324,7 +324,7 @@ msgstr ""
 "Докладване на срив от даден .apport или .crash файл вместо от висящите в %s. "
 "(Стандартно ако файла е подаден като единствен аргумент.)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -334,48 +334,48 @@ msgstr ""
 "вместо да я докладвате. Този файл може да бъде докладван по-късно от друг "
 "компютър."
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Отпечатай номера на версията на Apport."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Ще се стартира «apport-retrace» в терминален прозорец и ще извърши проверка "
 "на аварийното завършване на работата."
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "Стартирай gdb сесия"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 "Стартирай gdb сесия без изтегляне на символите за отстраняване на грешки"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 "Актуализирай %s с пълно проследяване на символичното трасиране на стека"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr "Проблемът се отнася за програма, която вече не е инсталирана."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
@@ -384,82 +384,84 @@ msgstr ""
 "Проблемът възникна с програмата %s, в която са внесени промени след нейното "
 "аварийно завършване на работа."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Този доклад за проблем е повреден и не може да бъде обработен."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr ""
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "Възникна грешка при обработката на този доклад за проблем:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr ""
 "Не може да бъде определено името на пакета или на пакета с изходния код."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "Не може да се стартира уеб браузъра"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Не може да се стартира уеб браузъра, за да се отвори %s."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Мрежов проблем"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Не може да се свърже с базата данни за сривове, моля проверете връзката с "
 "интернет."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Мрежов проблем"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Изчерпване на паметта"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Вашата система не разполага с достатъчно памет, за да обработи този доклад "
 "за срив."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -470,11 +472,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "Проблемът вече е известен"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -484,38 +486,37 @@ msgstr ""
 "браузъра ви. Моля, проверете дали можете да добавите друга полезна "
 "информация, която може да помогне на разработчиците."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Този проблем вече е бил докладван на разработчиците. Благодарим ви!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Натиснете някой клавиш, за да продължите..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "Какво бихте искали да направите? Вашите опции са:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Моля, изберете (%s)"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i байта)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(двоични данни)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Да се изпраща ли доклад за грешка до разработчиците?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -523,51 +524,51 @@ msgstr ""
 "След като доклада за проблема бъде изпратен, моля попълнете формата\n"
 "в браузъра, който ще се отвори след това."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "&Изпрати доклад (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "&Локална проверка"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "&Прегледай доклада"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 "&Съхрани файла на доклада за изпращане по-късно или копиране на друго място"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "Отмени и &игнорирай бъдещи сривове на тази версия на програмата"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Отмени"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Отчетен файл на проблем:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&Потвърди"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Грешка %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "Събиране на информация за проблема"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -575,11 +576,11 @@ msgstr ""
 "Събраната информация може да се изпрати на разработчиците, за да\n"
 "подобрят приложението. Това може да отнеме няколко минути."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "Прехвърляне на информация за проблема"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -587,40 +588,40 @@ msgstr ""
 "Събраната информация се изпраща на системата за следене за грешки.\n"
 "Това може да отнеме няколко минути."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Готово"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "нищо"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "Избран: %s. Множество избори:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Избори:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "Път до файл (Enter за отказ):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "Файлът не съществува."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "Това е папка."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "За да продължите, трябва да посетите следния адрес:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -628,16 +629,16 @@ msgstr ""
 "Можете да стартирате браузъра сега или да копирате връзката в браузър на "
 "друг компютър."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Стартирай сега браузъра"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 "Няма предстоящи доклади за сривове. Пробвайте --help за повече информация."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr "Не поставяйте повече трасирания в доклада, а ги запишете в stdout."
 
@@ -656,28 +657,28 @@ msgstr ""
 "Съхрани модифициран доклад с дадено име на файл вместо променяне на "
 "оригиналния доклад."
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 "Изтрий дъмпа от ядрото от доклада след регенериране трасирането на стека."
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "Замени CoreFile в доклада"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "Замени ExecutablePath в доклада"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "Замени ProcMaps в доклада"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "Изгради наново пакетната информация в доклада"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -694,33 +695,33 @@ msgstr ""
 "но само в случай на извънредни ситуации, възникнали в изданието на "
 "работещата в момента система."
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
 "have installed."
 msgstr ""
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 "Докладвай за напредъка при сваляне/инсталиране на пакети във времената среда"
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr "Добави временни отметки до съобщенията в дневника за групови операции"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr ""
 "Кеш директория за съхраняване на пакетите, изтеглени във времената среда"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -728,14 +729,14 @@ msgstr ""
 "Директория за разопаковане на пакети. Когато повторение всички вече "
 "изтеглени пакети ще се разопаковат в тази времена среда."
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 "Инсталирай във времената среда допълнителен пакет (може да се указва няколко "
 "пъти)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -746,7 +747,7 @@ msgstr ""
 "ретрасирано трасиране на стека (само ако нито един от -g, -o, nor -s са "
 "специфицирани)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -754,31 +755,31 @@ msgstr ""
 "Показване на ретрасираните трасирания на стека и искане на потвърждение "
 "преди изпращането им в базата данни със сривовете."
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 "Път към дублираната sqlite база данни (стандартно: без проверка за дублиране)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr ""
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "Не може да се използва без -C без -S. Спиране."
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "Да се изпрати ли прикаченото? [y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -786,19 +787,19 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "Крайната директория съществува и не е празна."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "Вижте повече подробности в man страницата."
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "укажете името на лог файла за valgrind"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
@@ -806,7 +807,7 @@ msgstr ""
 "използвай по-рано създадената директория за времената среда (SDIR) или я "
 "създайте, ако тя не съществува"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -815,7 +816,7 @@ msgstr ""
 "символи за отстраняване на грешки, а разчитай само на установените символи "
 "за отстраняване на грешки."
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
@@ -823,36 +824,36 @@ msgstr ""
 "използвай по-рано създадената кеш директория (CDIR) или я създаде, ако тя не "
 "съществува"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 "докладвай прогреса за сваляне/инсталиране по врене на инсталирането на "
 "пакетите в времената среда"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Грешка: %s не е изпълним файл. Спиране."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -860,7 +861,7 @@ msgstr ""
 "Продължаването заби към края, но изглежда процедурата беше завършена "
 "нормално."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 "Сега вашата система може да стане нестабилна и да се наложи да я "
@@ -876,77 +877,77 @@ msgstr "Докладвай за проблем..."
 msgid "Report a malfunction to the developers"
 msgstr "Докладвай за неизправност на разработчиците"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "Извинете, приложението %s внезапно спря."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "Извинете, %s беше затворено неочаквано."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "Извинете, възникна вътрешна грешка в %s."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Изпрати"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Покажи детайлите"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Продължи"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "Приложението «%s» престана да отговаря."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "Програмата «%s» престана да отговаря."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Пакет: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "Извинете, възникна проблем при инсталирането на софтуер."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "В приложението %s възникна вътрешна грешка."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "Приложението %s внезапно се затвори."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr ""
 "Ако се сблъскате с този проблем в бъдеще, опитайте да рестартирате компютъра."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "Игнорирай бъдещи проблеми от този тип"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Скрий детайлите"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -1002,7 +1003,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>Качване на информация за проблем</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -1014,27 +1015,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Apport файл с доклад за срив"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "Остави затворено"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Стартирай отново"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Потребителско име:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Парола:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "Събиране на информация за проблема"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1042,6 +1043,6 @@ msgstr ""
 "Събраната информация може да се изпрати на разработчиците, за да подобрят "
 "програмата. Това може да отнеме няколко минути."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "Прехвърляне на информация за проблема"

--- a/po/bn.po
+++ b/po/bn.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2022-07-03 18:34+0000\n"
 "Last-Translator: Tushar <Unknown>\n"
 "Language-Team: Bengali <ankur-bd-l10n@googlegroups.com>\n"
@@ -37,11 +37,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "এই প্যাকেজ সঠিকরূপে ইনস্টল করা যাবেনা বলে মনে হচ্ছে"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -49,7 +49,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -62,21 +62,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "অজানা প্রোগ্রাম"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "দুঃখিত, \"%s\" প্রোগ্রামটি অপ্রত্যাশিতভাবে বন্ধ হয়ে গেল"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "%s এ সমস্যা"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -84,64 +79,69 @@ msgstr ""
 "স্বয়ংক্রিয়ভাবে সমস্যাটি পর্যালোচনা করা এবং ডেভেলপারকে প্রতিবেদন করার জন্য আপনার "
 "কম্পিউটারে পর্যাপ্ত পরিমাণ খালি মেমোরি নেই।"
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "%s এ সমস্যা"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "অবৈধ সমস্যা প্রতিবেদন"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "এই সমস্যার প্রতিবেদনটিতে আপনার প্রবেশাধিকার নেই।"
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "ত্রুটি"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "এই প্রতিবেদন প্রক্রিয়া করতে যথেষ্ট ডিস্কের জায়গা বিদ্যমান নেই।"
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "অকার্যকর PID"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "কোন প্যাকেজ নির্দিষ্ট করা হয় নি"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "আপনার প্যাকেজ অথবা PID সুনির্দিষ্টভাবে উল্লেখ করা প্রয়োজন। দেখুন --আরও তথ্যের জন্য "
 "সহায়তা।"
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "অনুমতি প্রত্যাখ্যাত"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -149,30 +149,30 @@ msgstr ""
 "নির্ধারিত প্রক্রিয়াটি আপনার অন্তর্ভুক্ত নয়। অনুগ্রহ করে প্রক্রিয়ার মালিক অথবা মূল হিসেবে "
 "এই প্রোগ্রামটি সচল রাখুন।"
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "নির্ধারিত প্রক্রিয়াধীন ID প্রোগ্রামের অন্তর্ভুক্ত নয়।"
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "উপসর্গ স্ক্রিপ্ট %s প্রভাবিত প্যাকেজ নির্ধারণ করেনি"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "%s প্যাকেজের অস্তিত্ব নেই"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "প্রতিবেদন তৈরি করা যাবে না"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "সমস্যার প্রতিবেদন হালনাগাদ করা হচ্ছে"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -184,7 +184,7 @@ msgstr ""
 "\n"
 "অনুগ্রহ করে \"অ্যাপোর্ট-বাগ\" ব্যবহার করে নতুন প্রতিবেদন তৈরি করুন।"
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -203,24 +203,24 @@ msgstr ""
 "\n"
 "আপনি কি সত্যিই অগ্রসর হতে চান?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "কোনো অতিরিক্ত তথ্য সংগ্রহ হয়নি।"
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "কি ধরণের সমস্যা আপনি প্রতিবেদন করতে চান?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "অজানা লক্ষণ"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "\"%s\" লক্ষণটি পরিচিত নয়।"
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -231,7 +231,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -239,32 +239,32 @@ msgstr ""
 "এই বার্তা বন্ধের পরে অনুগ্রহ করে এটি সংক্রান্ত সমস্যা প্রতিবেদন করতে অ্যাপ্লিকেশন "
 "উইন্ডোতে ক্লিক করুন।"
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "উইন্ডোর প্রক্রিয়া ID নির্ধারণ করতে xprop ব্যর্থ"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "প্যাকেজের নাম সুনির্দিষ্টভাবে উল্লেখ করুন।"
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "প্রতিবেদনে একটি অতিরিক্ত ট্যাগ সংযুক্ত করুন। একাধিক সময় সুনির্দিষ্টভাবে উল্লেখিত হতে "
 "পারে।"
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -274,15 +274,15 @@ msgstr ""
 "যদি একটিও দেয়া না থাকে, পরিচিত উপসর্গের তালিকা প্রদর্শন করুন। (যদি একক যুক্তি দেয়া "
 "হয় সূচিত করা হবে।)"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "সমস্যার প্রতিবেদন পূরণের জন্য একটি লক্ষ্য হিসেবে উইন্ডোতে ক্লিক করুন।"
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "বাগ হালনাগাদ মোডে আরম্ভ করুন। ঐচ্ছিক --প্যাকেজ নিতে পারেন।"
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -290,7 +290,7 @@ msgstr ""
 "উপসর্গ সম্পর্কিত একটি বাগ প্রতিবেদন ফাইল করুন। (যদি উপসর্গ নাম শুধুমাত্র যুক্তি হিসাবে "
 "দেওয়া হয় তাহলে সূচিত করা হবে।)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -298,7 +298,7 @@ msgstr ""
 "সুনির্দিষ্টভাবে উল্লেখ করুন প্যাকেজের নাম --ফাইল-বাগ মোডে। এটি ঐচ্ছিক যদি --pid "
 "সুনির্দিষ্ট হয়। (যদি উপসর্গ নাম শুধুমাত্র যুক্তি হিসাবে দেওয়া হয় তাহলে সূচিত করা হবে।)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -308,11 +308,11 @@ msgstr ""
 "প্রতিবেদন আরও তথ্য ধারণ করবে। (যদি pid শুধুমাত্র যুক্তি হিসাবে দেওয়া হয় তাহলে সূচিত "
 "করা হবে।)"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -321,7 +321,7 @@ msgstr ""
 "%s তে অমীমাংসিত একটির পরিবর্তে given .apport অথবা .crash ফাইল থেকে ক্র্যাশ "
 "প্রতিবেদন দিন। (যদি ফাইল যুক্তি হিসেবে দেয়া হয় তাহলে সূচিত করা হবে।)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -330,125 +330,127 @@ msgstr ""
 "বাগ পূরণ মোডে, এটি প্রতিবেদন দেওয়ার পরিবর্তে সংগৃহীত তথ্য ফাইলে সংরক্ষণ করুন। এই "
 "ফাইলটি তখন ভিন্ন মেশিন থেকে পরবর্তীতে প্রতিবেদন করা হতে পারে।"
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "অ্যাপোর্ট সংস্করণ সংখ্যা মুদ্রণ করুন।"
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr "ক্র্যাশ পরীক্ষা করতে টার্মিনালের উইন্ডোর অ্যাপোর্ট-অনুসন্ধান চালু করা হবে।"
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "gdb সেশনে সচল"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "ডিবাগ প্রতীকে ডাউনলোড করা ছাড়া gdb সেশনে সচল"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "সম্পূর্ণ প্রতীকী স্ট্যাক ট্রেস দ্বারা %s হালনাগাদ করুন"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 "এমন একটি প্রোগ্রাম এই সমস্যার প্রতিবেদনে প্রয়োগ করা হয় যা কিনা আরও বেশি ইনস্টল করা "
 "যায় না।"
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 msgstr "প্রোগ্রাম %s দ্বারা সমস্যা ঘটেছে, ক্র্যাশ সংঘটন হতে যা পরিবর্তিত হয়েছে।"
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "এই সমস্যা প্রতিবেদন ক্ষতিগ্রস্ত এবং প্রক্রিয়াধীন করা যাবে না।"
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr ""
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "এই সমস্যা প্রতিবেদন প্রক্রিয়াকরণ প্রচেষ্টার সময় একটি ত্রুটি ঘটেছে:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "প্যাকেজ অথবা উৎস প্যাকেজের নাম নির্ধারণ করা যায় নি।"
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "ওয়েব ব্রাউজার চালু করতে অসমর্থ"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "%s খুলতে ওয়েব ব্রাউজার আরম্ভ করতে অসমর্থ।"
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "নেটওয়ার্ক সমস্যা"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "বিধস্ত ডাটাবেসে সংযোগ করতে পারছি না, অনুগ্রহ করে আপনার ইন্টারনেট সংযুক্তি পরীক্ষা "
 "করুন।"
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "নেটওয়ার্ক সমস্যা"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "মেমরি নিঃশেষিত"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "এই বিধস্ত প্রতিবেদন প্রক্রিয়াজাত করার জন্য আপনার সিস্টেমে পর্যাপ্ত মেমোরি নেই।"
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -459,11 +461,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "সমস্যাটি ইতঃপূর্ব জ্ঞাত"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -472,38 +474,37 @@ msgstr ""
 "এই সমস্যাটি ইতিমধ্যে বাগ প্রতিবেদন প্রতিবেদন করেছে যা ওয়েব ব্রাউজারে প্রদর্শিত "
 "হয়েছে। ডেভেলপারের জন্য সহায়ক হবে এমন আরো তথ্য অনুগ্রহ করে নির্বাচন করুন।"
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "এই সমস্যাটি ইতোমধ্যে ডেভেলপারকে প্রতিবেদন করা হয়েছে। আপনাকে ধন্যবাদ!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "এগিয়ে যাওয়ার জন্য যে কোন একটি কী চাপুন..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "আপনি কি করতে পছন্দ করেন? আপনার বাছাইযোগ্য তালিকা:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "অনুগ্রহ করে নির্বাচন করুন (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i বাইট)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(বাইনারি ডাটা)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "ডেভেলপারকে সমস্যার প্রতিবেদন পাঠানো হবে কি?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -511,50 +512,50 @@ msgstr ""
 "সমস্যার প্রতিবেদন পাঠানোর পরে, অনুগ্রহ করে \n"
 "স্বয়ংক্রিয়ভাবে উন্মুক্ত ওয়েব ব্রাউজারে ফর্মটি পূরণ করুন।"
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "প্রতিবেদন পাঠানো হয়েছে (%s) (&S)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "স্থানীয়ভাবে পরীক্ষা করুন (&E)"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "প্রদর্শিত রিপোর্ট (&V)"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr "রিপোর্ট ফাইল পরে পাঠানোর জন্য রাখুন অথবা অন্য কোথাও অনুলিপি করুন (&K)"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "এই প্রোগ্রাম সংস্করণের ভবিষ্যৎ ক্র্যাশ বাতিল এবং উপেক্ষা করুন ( &I)"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "বাতিল (&C)"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "রিপোর্ট ফাইলে সমস্যা:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "নিশ্চিত (&C)"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "ত্রুটি: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "সমস্যার তথ্য সংগ্রহ করা হচ্ছে"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -562,11 +563,11 @@ msgstr ""
 "সংগৃহীত তথ্য ডেভেলপারকে পাঠানো হতে পারে উন্নত করতে\n"
 "অ্যাপ্লিকেশন। এটি কয়েক মিনিট সময় নিতে পারে।"
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "সমস্যার তথ্য হালনাগাদ করা হচ্ছে"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -574,40 +575,40 @@ msgstr ""
 "সংগৃহীত তথ্য বাগ ট্র্যাকিং সিস্টেমে পাঠানো হচ্ছে।\n"
 "এটি কয়েক মিনিট সময় নিতে পারে।"
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "সম্পন্ন (&D)"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "কোনটি না"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "নির্বাচিত: %s। একাধিক পছন্দ:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "পছন্দ:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "ফাইলের পাথ (বাতিল করতে এন্টার দিন):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "ফাইল বিদ্যমান নয়।"
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "এটি একটি ডিরেক্টরি।"
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "চালিয়ে যেতে, আপনি অবশ্যই উল্লেখিত URL পরিদর্শন করুন:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -615,15 +616,15 @@ msgstr ""
 "আপনি এখন ব্রাউজার চালু করতে পারেন, অথবা অন্য কম্পিউটারের ব্রাউজারে এই URL অনুলিপি "
 "করতে পারেন।"
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "এখন ব্রাউজার চালু করুন"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr "কোনো অমীমাংসিত ক্র্যাশ প্রতিবেদন নেই। চেষ্টা করুন --আরও তথ্যের জন্য সহায়তা।"
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr "প্রতিবেদনে নতুন চিহ্ন রাখবেন না, কিন্তু stdout এ লিখুন।"
 
@@ -642,27 +643,27 @@ msgstr ""
 "পরিবর্তন করা হচ্ছে এমন প্রকৃত প্রতিবেদনের পরিবর্তে প্রদত্ত ফাইলের পরিবর্তিত প্রতিবেদন "
 "লিখুন"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr "স্ট্যাক চিহ্ন পুনরূদ্ধারের পরে প্রতিবেদন থেকে কোর ডাম্প অপসারণ করুন"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "CoreFile প্রতিবেদন অগ্রাহ্য করুন"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "ExecutablePath প্রতিবেদন অগ্রাহ্য করুন"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "ProcMaps প্রতিবেদন অগ্রাহ্য করুন"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "প্রতিবেদনের প্যাকেজ তথ্য পুনর্গঠন"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -678,42 +679,42 @@ msgstr ""
 "কনফিগারেশন ফাইলে ব্যবহৃত হবে, কিন্তু তারপর শুধুমাত্র বর্তমানে চলমান রিলিজে ঘটেছে এমন "
 "ক্র্যাশ অনুসন্ধান করা হবে।"
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
 "have installed."
 msgstr ""
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr "স্যান্ডবক্সে প্যাকেজ ইনস্টল করার সময় ডাউনলোড/ইনস্টল এর অগ্রগতির প্রতিবেদন"
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr "ব্যাচ অপারেশনের জন্য, বার্তা লগ করতে টাইমস্ট্যাম্প শুরুতে যোগ করুন"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr "স্যান্ডবক্সে প্যাকেজ ডাউনলোডের জন্য ক্যাশ ডিরেক্টরি"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
 msgstr ""
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr "স্যান্ডবক্সে অতিরিক্ত প্যাকেজ ইনস্টল করুন (একাধিক সময় উল্লেখিত হতে পারে)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -723,7 +724,7 @@ msgstr ""
 "আপলোড করতে ক্র্যাশ ID সুনির্দিষ্টভাবে উল্লেখ করার সময় এটি ব্যবহৃত হয় (শুধুমাত্র যদি "
 "কোনটি নয় -g, -o, না -s সুনির্দিষ্টভাবে উল্লেখ করা থাকে)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -731,30 +732,30 @@ msgstr ""
 "ক্র্যাশ ডাটাবেসে পাঠানোর আগে পুনরায় চিহ্নিত স্ট্যাক চিহ্ন প্রদর্শন এবং নিশ্চিতকরণের "
 "জন্য জিজ্ঞাসা করা হবে।"
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr "অনুরূপ sqlite ডাটাবেসের পাথ (পূর্বনির্ধারিত: অনুরূপ নয় এমন পরীক্ষা করা হচ্ছে)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr ""
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr ""
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "এই সংযুক্তি পাঠানো ঠিক? [y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -762,64 +763,64 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "গন্তব্য ডিরেক্টরি বিদ্যমান এবং ফাঁকা নয়।"
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr ""
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -827,7 +828,7 @@ msgstr ""
 "সারসংকলন প্রক্রিয়া শেষে এসে বন্ধ হয়ে গেছে এবং স্বাভাবিকভাবে সম্পন্ন করতে হলে এটি "
 "দৃশ্যমান হতে হবে।"
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr "আপনার পদ্ধতি এখন অস্থায়ী হতে পারে এবং পুনরায় শুরু করতে হতে পারে।"
 
@@ -841,77 +842,77 @@ msgstr "সমস্যার প্রতিবেদন..."
 msgid "Report a malfunction to the developers"
 msgstr "ডেভেলপারকে বিকৃত এর প্রতিবেদন দিন"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "দুঃখিত, %s অপ্রত্যাশিতভাবে বন্ধ হয়ে গেছে।"
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "দুঃখিত, %s অভ্যন্তরীণ ত্রুটি অভিজ্ঞ হয়েছে।"
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "পাঠান"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "বিস্তারিত প্রদর্শন করুন"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "চালিয়ে যান"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "প্যাকেজ: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "দুঃখিত, সফটওয়্যার ইন্সটল করার সময় সমস্যা হয়েছে।"
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "অ্যাপ্লিকেশন %s অপ্রত্যাশিতভাবে বন্ধ হয়ে গেছে।"
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr ""
 "যদি আপনি অতিরিক্ত কোন সমস্যা উল্লেখ করেন, কম্পিউটার পুনরায় আরম্ভ করার চেষ্টা করুন।"
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "এই ধরণের ভবিষ্যৎ সমস্যা উপেক্ষা করুন"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "বিস্তারিত আড়াল করুন"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "অ্যাপোর্ট"
 
@@ -966,7 +967,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>সমস্যার তথ্য হালনাগাদ করা হচ্ছে</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -977,27 +978,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "অ্যাপোর্ট ক্র্যাশ ফাইল"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "পরিত্যাগ পরিবেষ্টিত"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "পুনরায় আরম্ভ করুন"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "ব্যবহারকারীর নাম:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "পাসওয়ার্ড:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "সমস্যার তথ্য সংগ্রহ করা হচ্ছে"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1005,6 +1006,6 @@ msgstr ""
 "অ্যাপ্লিকেশন উন্নত করতে সংগ্রহকৃত তথ্য ডেভেলপারকে পাঠানো হতে পারে। এটি কয়েক মিনিট "
 "সময় নিতে পারে।"
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "সমস্যার তথ্য হালনাগাদ করা হচ্ছে"

--- a/po/br.po
+++ b/po/br.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2010-06-11 21:48+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Breton <br@li.org>\n"
@@ -36,11 +36,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr ""
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -57,21 +57,16 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "goulev dianav"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Digarezit, gant un doare dic'hortoz eo bet serret ar goulev \"%s\""
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Kudenn e %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -79,66 +74,71 @@ msgstr ""
 "N'eus ket memor diac'hub a-walc'h evit dielfennañ ent emgefreek ar gudenn ha "
 "kas un danevell da baotred an diorren."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Kudenn e %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Danevell a-fet kudennoù didalvoudek"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "N'hoc'h eus ket an aotre da haeziñ an danevell-mañ."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Fazi"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 "N'eus ket plas a-walc'h war ar gantenn a-benn keweriañ an danevell-mañ."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
 # PID : process ID
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "Naoudi an argerzh (PID) didalvoudek"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "Pakad erspizet ebet"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Ezhomm hoc'h eus erspizañ ur pakad pe un naoudi eus un argerzh (PID). Lennit "
 "--help evit gouzout hiroc'h."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Aotre nac'het"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -146,30 +146,30 @@ msgstr ""
 "Naoudi an argerzh (PID) erspizet n'eo ket deoc'h. Erounit ar goulev-mañ evel "
 "perc'henn an argerzh pe ardead gwrizienn (root)."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "Naoudi an argerzh (PID) erspizet n'eo ket d'ur goulev."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Skript an azon %s n'en deus ket despizet ar pakad tizhet"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Ar pakad %s n'eus ket anezhañ"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "N'hall ket krouiñ an danevell"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "O hizivaat an danevell a-zivout ar gudenn"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -177,7 +177,7 @@ msgid ""
 "Please create a new report using \"apport-bug\"."
 msgstr ""
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -189,24 +189,24 @@ msgid ""
 "Do you really want to proceed?"
 msgstr ""
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "Titouroù ouzhpenn ebet bet dastumet."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "Evit peseurt kudennoù a fell deoc'h kas un danevell ?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Azon dianav"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "N'eo ket anavezet an azon \"%s\"."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -217,202 +217,204 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr ""
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Moullañ niverenn handelv Apport."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr ""
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Mekaet eo an danevell a-zivout ar gudenn ha n'hall ket bezañ keweriet."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr ""
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr ""
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "N'hall ket despizañ ar pakad pe anv tarzh ar pakad."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "N'eo ket gouest da loc'hañ ar merdeer web"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "N'eo ket gouest da loc'hañ ar merdeer web a-benn digeriñ %s."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Kudenn gant ar rouedad"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Kudenn gant ar rouedad"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr ""
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -423,49 +425,48 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "Anavezet eo ar gudenn endeo"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 msgstr ""
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Pouezit war ur stokell (ne vern pe hini) a-benn kenderc'hel..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "petra a fell deoc'h ober ? Dibabit e-touez :"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Mar plij, dibabit (%s) :"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i a vitoù)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(roadennoù daouredel)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Kas an danevell a-fet kudennoù da baotred an diorren ?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -473,113 +474,113 @@ msgstr ""
 "Goude bezañ kaset an danevell, mar plij, leugnit ar furmskrid\n"
 "er merdeer web bet digoret gant un doare emgefreek."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "&Kas an danevell (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr ""
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "&Gwelout an danevell"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr ""
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Dilezel"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Restr an danevell a-fet kudenn :"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&Kadarnaat"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Fazi : %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "O tastumañ stlennoù ar gudenn"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
 msgstr ""
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr ""
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
 msgstr ""
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Graet"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "tra ebet"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "Diuzet : %s. Liesdibaboù :"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Dibaboù :"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr ""
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "Ar restr n'eus ket anezhi."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "Ur c'havlec'hiad eo an dra-mañ."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "Mar fell deoc'h kenderc'hel, kit da welout an URL-mañ :"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
 msgstr ""
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Luskañ ur medeer bremañ"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 
@@ -594,27 +595,27 @@ msgid ""
 "Write modified report to given file instead of changing the original report"
 msgstr ""
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr ""
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr ""
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr ""
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr ""
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -624,78 +625,78 @@ msgid ""
 "be able to retrace crashes that happened on the currently running release."
 msgstr ""
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
 "have installed."
 msgstr ""
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr ""
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
 msgstr ""
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
 "neither -g, -o, nor -s are specified)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
 msgstr ""
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr ""
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr ""
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "A-du da gas ar stagadennoù ? [y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -703,70 +704,70 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "Ar c'havlec'hiad arvoned zo anezhañ ha n'eo ket goullo."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr ""
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
 msgstr ""
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 
@@ -780,76 +781,76 @@ msgstr "Savit un danevell a-zivout ar gudenn..."
 msgid "Report a malfunction to the developers"
 msgstr "Sevel un danevell a-fet gwallac'hwelerezh da baotred an diorren"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr ""
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr ""
 
@@ -903,7 +904,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr ""
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -913,32 +914,32 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Restr sac'haden Apport"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr ""
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr ""
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr ""
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr ""
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr ""
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
 msgstr ""
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr ""

--- a/po/bs.po
+++ b/po/bs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2018-04-07 22:09+0000\n"
 "Last-Translator: Anel Mandal <Unknown>\n"
 "Language-Team: Bosnian <bs@li.org>\n"
@@ -40,11 +40,11 @@ msgstr ""
 "Molimo unesite svoju šifru kako bi pristupili izvještaju o problemima "
 "nastalim u sistemskim programima"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "Izgleda da ovaj paket nije ispravno instaliran"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -52,7 +52,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -65,21 +65,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "nepoznat program"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Izvinite, program „%s“ je neočekivano zatvoren"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Problem u %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -87,62 +82,67 @@ msgstr ""
 "Vaš računar nema dovoljno slobodne memorije da automatski analizira problem "
 "i pošalje izvještaj autorima."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Problem u %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Neispravan izvještaj o problemu"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "Nemate prava pristupa izvještavanju o problemu."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Greška"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "Nema dovoljno prostora na disku za obradu ovog izvještaja."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "Nevažeći PID"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "Nije naveden paket."
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr "Morate navesti paket ili PID. Pogledajte --help za više informacija"
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Dozvola je odbijena"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -150,30 +150,30 @@ msgstr ""
 "Navedeni proces vam ne pripada. Molim pokrenite ovaj proces kao vlasnik ili "
 "root."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "Specificirani PID ne pripada programu."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Skripta simptoma %s nije odredio nijedan poduticajni paket"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Paket %s ne postoji"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "Ne mogu da napravim izvještaj"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "Slanje izveštaja o problemu"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -185,7 +185,7 @@ msgstr ""
 "\n"
 "Molim napravite novi izvještaj koristeći \"apport-bug\"."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -204,24 +204,24 @@ msgstr ""
 "\n"
 "Da li zaista želite da nastavite?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "Nema dodatno prikupljenih informacija."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "O kakvom problemu želite da izvijestite?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Nepoznati simptom"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Simptom \"%s\" nije poznat."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -232,7 +232,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -240,30 +240,30 @@ msgstr ""
 "Nakon zatvaranja ove poruke, kliknite na prozor aplikacije da prijavite "
 "problem u vezi toga."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop nije uspio da odredi ID procesa prozora"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "Navedite ime paketa."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "Dodajte dodatnu oznaku u izvještaju. Može biti navedeno više puta."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -273,15 +273,15 @@ msgstr ""
 "opcionalan --pid, ili samo  --pid. Ako nijedan nije dat, prikaži listu "
 "poznatih simptoma. (Podrazumijeva se ako ako je dat samo jedan argument.)"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "Kliknite na prozor kao odredište za podnošenje izvještaja o problemu."
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "Pokrenuti u režimu slanja greške. Može da sadrži opcionalni --package."
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -289,7 +289,7 @@ msgstr ""
 "Popunite izvještaj greške o simptomu. (Podrazumijeva se ako je ime simptoma "
 "dato kao jedini argument.)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -298,7 +298,7 @@ msgstr ""
 "specificiran --pid. (Podrazumijeva se ako je ime paketa dato kao jedini "
 "argument.)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -308,11 +308,11 @@ msgstr ""
 "izvještaj o greškama će sadržati više informacija. (ugrađeno ako je PID kao "
 "jedini argument.)"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "Navedeni pid je viseća aplikacija"
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -321,7 +321,7 @@ msgstr ""
 "Prijavite o padu iz date .apport ili .crash datoteke umjesto jednog "
 "pripravnog u %s. (Podrazumijeva se ako je datoteka data kao jedini argument.)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -331,45 +331,45 @@ msgstr ""
 "umjesto da izvještavanja. Ova datoteka se zatim može prijaviti kasnije s "
 "druge mašine."
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Prikaži broj verzije Apport-a."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr "Ovo će pokrenuti „apport-retrace“ u prozoru terminala da ispita pad."
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "Pokreni gdb sesiju"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Pokreni gdb sesiju bez preuzimanja simbola za uklanjanje grešaka"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Ažuriraj %s potpunom simboličkim tragom gomile"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 "Ovaj izvještaj o problemu se odnosi na program koji nije više instaliran."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
@@ -377,80 +377,82 @@ msgid ""
 msgstr ""
 "Problem se desio s programom %s koji je promijenjen nakon što se dogodio pad."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Ovaj izvještaj o greški je oštećen i ne može da se obradi."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr "Ovaj izvještaj je o paketu koji nije instaliran."
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "Desila se greška u pokušaju obrade izvještaja o problemu:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "Ne mogu da utvrdim paket ili izvorno ime paketa."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "Ne mogu da pokrenem internet pretraživač"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Ne mogu da pokrenem internet pretraživač da bih otvorio %s."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Mrežni problem"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Ne mogu da uspostavim vezu sa bazom podataka o urušavanjima, molim "
 "provjerite vašu internet vezu."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Mrežni problem"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Nedostatak memorije"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Vaš sistem nema dovoljno memorije da obradi ovaj izvještaj o padu sistema."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -461,11 +463,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "Problem je već poznat"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -475,38 +477,37 @@ msgstr ""
 "pretraživaču. Molim Vas provjerite da li možete da dodate bilo kakvu dodatnu "
 "informaciju koja bi mogla da bude od pomoći autorima."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Ovaj problem je već prijavljen programerima. Hvala vam!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Pritisnite bilo koju tipku za nastavak ..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "Šta biste željeli da uradite? Vaše mogućnosti su:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Molim Vas izaberite (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i bajta)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(binarni podaci)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Želite li da pošaljete izvještaj autorima?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -514,52 +515,52 @@ msgstr ""
 "Posle slanja izvještaja o problemu, molim Vas popunite formular u\n"
 "automatski otvorenom internet pretraživaču."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "&Pošalji izvještaj (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "&Ispitaj lokalno"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "&Pogledaj izvještaj"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 "&Zadrži datoteku o izvještaju za kasnije slanje ili kopiranje na neko drugo "
 "mjesto"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "Prekini i &ignoriši buduće greške u radu ove verzije programa"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Odustani"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Datoteka izvještaja o problemu:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&Potvrdi"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Greška: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "Prikupljanje informacija o problemu"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -567,11 +568,11 @@ msgstr ""
 "Prikupljena informacija se šalje razvojnom timu da poprave \n"
 "program. Ovo može potrajati nekoliko minuta."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "Šaljem informaciju o problemu"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -579,41 +580,41 @@ msgstr ""
 "Prikupljena informacija se šalje sistemu za otkrivanje grešaka.\n"
 "Ovo može potrajati nekoliko minuta."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Gotovo"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "ništa"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "Izabrano: %s. Više izbora:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Izbori:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "Putanja do datoteke (kliknite Enter tipku za otkazivanje):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "Datoteka ne postoji."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "Ovo je direktorijum."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr ""
 "Da bi ste nastavili, morate da posjetite sledeću internet lokaciju (URL):"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -621,16 +622,16 @@ msgstr ""
 "Sada možete pokrenuti pretraživač, ili kopirati ovu internet lokaciju u "
 "pretraživaču na nekom drugom računaru."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Pokrenuti pretraživač sada"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 "Nema očekujućeg izvještaja o padu. Probajte --help za više informacija."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr "Ne unosi nove tragove u izvještaj, već ih zapisuje u ''stdout''."
 
@@ -649,27 +650,27 @@ msgstr ""
 "Zapisuje izmijenjeni izvještaj u zadatu datoteku umjesto da mijenja "
 "originalni."
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr "Uklanja prikaz jezgra iz izvještaja nakon regeneracije traga gomile"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "Zaobiđi JezgruDatoteke izvještaja"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "Zaobiđi IzvršnuPutanju izvještaja"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "Zamenjuje ProcMaps izveštaja"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "Obnavlja izveštajnu informaciju paketa"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -685,7 +686,7 @@ msgstr ""
 "biti u mogućnosti uloviti trag sistemskim padovima koji su se desili na "
 "trenutno izvršavajućoj verziji."
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
@@ -695,27 +696,27 @@ msgstr ""
 "zavisnosti upotrebom istog izdanja kao izvještaja bez obzira koju gdb "
 "verziju imate instaliranu."
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 "Prijavi napredak preuzimanja/instaliranja pri instaliranju paketa u "
 "zatvorenu kutiju"
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr "Pridodaj oznaku vremena porukama dnevnika, za grupnu radnju"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 "Kreirajte i koristite tuđe repozitorije sa izvora navedenih u izvještajima"
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr "Keš  direktorij za pakete preuzete u zatvorenu kutiju"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -723,13 +724,13 @@ msgstr ""
 "Direktorij za otpakovane pakete. Buduća pokretanja pretpostaviti da su već "
 "preuzeti paketi takođe izdvojeni u zatvorenu kutiju."
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 "Instaliraj dodatne pakete u zatvorenu kutiju (može se navesti više puta)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -739,7 +740,7 @@ msgstr ""
 "urušavanja. Ovo se koristi kada navodite ID urušavanja da biste poslali "
 "pronađene tragove steka (samo ako ni -g, ni -o, ni -s  nisu navedeni)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -747,32 +748,32 @@ msgstr ""
 "Prikazuje pronađene tragove steka i traži potvrdu prije nego što ih pošalje "
 "u bazu podataka o urušavanjima."
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 "Putanja do duplikata ''sqlite'' baze podataka (inicijalno: ne vršiti "
 "provjeru duplikata)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr ""
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "Ne možete koristiti -C bez -S. Prekidam."
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "Da li je uredu da da šaljete ovo kao prilog? [y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -780,19 +781,19 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "Odredišni direktorij postoji i nije prazan."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "Vidi man stranicu za detalje"
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "navedi log datoteku koju proizvodi valgrind"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
@@ -800,7 +801,7 @@ msgstr ""
 "iskoristi prethodno kreiran zaštićeni direktorij (SDIR) ili, ako ne postoji, "
 "kreiraj ga"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -808,7 +809,7 @@ msgstr ""
 "nemoj kreirati ili koristiti zaštićeni direktorij za debagerske simbole, ali "
 "koristi instalirane debagerske simbole"
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
@@ -816,24 +817,24 @@ msgstr ""
 "iskoristi prethodno kreirani keš direktorij (CDIR), ako ne postoji, kreiraj "
 "ga"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 "prijavi napredak o preuzimanjui/instalaciji kada se instaliraju paketi u "
 "zaštićenu kutiju"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Greška: %s nije izvršni program. Prekidam."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -841,7 +842,7 @@ msgstr ""
 "Ovo se desilo prilikom prethodnog suspendovanja i spriječilo je sistem da se "
 "ispravno obnovi."
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -849,7 +850,7 @@ msgstr ""
 "Ovo se desilo prilikom prethodne hibernacije i spriječilo je sistem da se "
 "ispravno obnovi."
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -857,7 +858,7 @@ msgstr ""
 "Proces restauriranja se ''zaledio'' pri samom kraju i sve izgleda kao da je "
 "uspješno završen."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 "Vaš sistem može postati nestabilan sada i može biti potrebno da ga "
@@ -873,76 +874,76 @@ msgstr "Prijavi problem..."
 msgid "Report a malfunction to the developers"
 msgstr "Prijavi greške u radu autorima"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "Nažalost, aplikacija %s se zaustavila neočekivano."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "Nažalost, %s je neočekivano zatvoren."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "Nažalost, u %s se desila interna greška."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Pošalji"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Prikaži detalje"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Nastavi"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "Aplikacija %s ne odgovara."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "Program \"%s\" je prestao odgovarati."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Paket: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "Nažalost, desio se problem pri instalaciji programa."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "Aplikacija %s je imala internu grešku."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "Program %s je neočekivano zatvoren."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr "Ako primjetite dodatne probleme, pokušajte ponovo pokrenuti računar."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "Ignoriši buduće probleme ove vrste"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Sakrij detalje"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -998,7 +999,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>Šaljem informaciju o problemu</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -1010,27 +1011,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Apport datoteka urušavanja"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "Ostavi zatvoreno"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Ponovo pokreni"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Korisničko ime:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Šifra:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "Prikupljanje informacija o problemu"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1038,6 +1039,6 @@ msgstr ""
 "Sakupljene informacije će biti poslane razvojnom timu kako bi poboljšali "
 "program. Ovo može potrajati par minuta."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "Šaljem informaciju o problemu"

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2023-03-30 12:04+0000\n"
 "Last-Translator: Walter Garcia-Fontes <walter.garcia@upf.edu>\n"
 "Language-Team: Ubuntu Catalan Translators list <Ubuntu-l10n-ca@lists.ubuntu."
@@ -41,11 +41,11 @@ msgstr ""
 "Introduïu la vostra contrasenya per accedir als informes d'error dels "
 "programes del sistema"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "Sembla ser que aquest paquet no s'ha instal·lat correctament"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -56,7 +56,7 @@ msgstr ""
 "d'actualitzar els índexs dels paquets disponibles, si això no funciona, "
 "elimineu els paquets de tercers relacionats i torneu-ho a provar."
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -69,21 +69,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "programa desconegut"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "El programa «%s» s'ha tancat de manera inesperada"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Problema a %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -91,64 +86,69 @@ msgstr ""
 "El vostre sistema no té prou memòria disponible per a analitzar el problema "
 "de manera automàtica i enviar un informe d'error als desenvolupadors."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Problema a %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Informe d'error no vàlid"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "No teniu permís per a accedir a aquest informe d'error."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Error"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "No hi ha prou espai disponible per a processar aquest informe."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr "No s'ha especificat cap PID"
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr "Cal especificar un PID. Consulteu --help per obtenir més informació."
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "PID no vàlid"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr "L'ID de procés especificat no existeix."
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr "No és el vostre PID"
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr "L'ID del procés especificat no us pertany."
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "No s'ha especificat cap paquet"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Cal que especifiqueu un paquet o un PID. Consulteu --help per a obtenir més "
 "informació."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Se us ha denegat el permís"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -156,30 +156,30 @@ msgstr ""
 "El procés especificat no us pertany. Hauríeu d'executar aquest programa com "
 "a propietari del procés o bé com a superusuari."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "L'identificador de procés especificat no pertany a cap programa."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "L'script de símptomes %s no ha determinat cap paquet afectat"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "El paquet %s no existeix"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "No es pot crear l'informe"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "S'està actualitzant l'informe del problema"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -191,7 +191,7 @@ msgstr ""
 "\n"
 "Creeu un informe nou utilitzant l'«apport-bug»."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -212,24 +212,24 @@ msgstr ""
 "\n"
 "Segur que voleu continuar?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "No s'ha recollit informació addicional."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "Sobre quin tipus de problema voleu informar?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Símptoma desconegut"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Es desconeix el símptoma «%s»."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -248,7 +248,7 @@ msgstr ""
 "la pestanya Processos, desplaceu-vos fins a trobar l'aplicació correcta. "
 "L'ID del procés és el nombre llistat a la columna ID."
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -256,34 +256,34 @@ msgstr ""
 "Després de tancar aquest missatge feu clic a una finestra de l'aplicació per "
 "informar d'un problema sobre aquesta."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 "L'xprop ha fallat en determinat l'identificador de procés de la finestra"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr "%(prog)s <report number>"
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "Especifiqueu el nom del paquet."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Afegeix una etiqueta addicional a l'informe. Es pot especificar diverses "
 "vegades."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -293,15 +293,15 @@ msgstr ""
 "opcional o només un --pid. Si no se'n proporciona cap, es mostrarà una "
 "llista de símptomes coneguts. (Implícit si només es proporciona un argument)"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "Feu clic a una finestra per associar-la a l'informe d'error."
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "Inicieu en mode d'actualització d'errors. Admet un --package opcional."
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -309,7 +309,7 @@ msgstr ""
 "Ompliu un informe d'error sobre un símptoma. (Implícit si només es "
 "proporciona el nom del símptoma com a argument)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -318,7 +318,7 @@ msgstr ""
 "s'ha especificat un --pid. (Implícit si només es proporciona el nom del "
 "paquet com a argument)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -328,11 +328,11 @@ msgstr ""
 "l'informe d'error contindrà més informació (en cas que el pid es doni com a "
 "únic argument)."
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "El PID proporcionat és una aplicació que es penja."
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -341,7 +341,7 @@ msgstr ""
 "Informeu de la fallada a partir d'un fitxer .apport o .crash en lloc dels "
 "pendents a %s. (Implícit si només es proporciona el fitxer com a argument)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -351,49 +351,49 @@ msgstr ""
 "en lloc d'enviar l'informe. Aquest fitxer es pot enviar més tard des d'una "
 "màquina diferent."
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Mostra el número de versió de l'Apport."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Això executarà l'Apport-retrace en un terminal per examinar la fallada."
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "Executa una sessió del Gdb"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Executa una sessió del Gdb sense descarregar els símbols de depuració"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Actualitza el fitxer %s amb la traça simbòlica completa de la pila."
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr "No es pot recordar la configuració de l'enviament d'informes"
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 "Ha fallat el desament de l'estat d'informes de fallada. No es pot establir "
 "el mode automàtic o no informar mai."
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr "No es pot recordar la configuració de l'enviament d'informes"
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 "Aquest informe de problema fa referència a un programa que ja no està "
 "instal·lat."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
@@ -402,19 +402,21 @@ msgstr ""
 "El problema ha passat amb el programa %s, el qual ha canviat des que es "
 "produí la fallada."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Aquest informe d'error està malmès i no es pot processar."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr "Aquest informe és sobre un paquest que no està instal·lat."
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "S'ha produït un error mentre s'intentava processar l'informe d'error:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
@@ -422,24 +424,24 @@ msgstr ""
 "Teniu instal·lades dues versions d'aquesta aplicació, de quina voleu "
 "informar d'un error?"
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr "Snap de %s"
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr "Paquet .deb de %s"
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s és proporcionat com un snap publicat per %s. Contacteu-los a través de %s "
 "per obtenir ajuda."
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -449,43 +451,43 @@ msgstr ""
 "adreça de contacte; visiteu el fòrum a https://forum.snapcraft.io/ per "
 "obtenir ajuda."
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr ""
 "No s'ha pogut determinar el nom del paquet del programa o del paquet del "
 "codi font."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "No s'ha pogut iniciar el navegador web"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "No s'ha pogut iniciar el navegador web per a obrir %s."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Problema de la xarxa"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "No es pot connectar a la base de dades de fallades, comproveu la vostra "
 "connexió a Internet."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Problema de la xarxa"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Exhauriment de la memòria"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "El vostre sistema no té prou memòria disponible per a processar aquest "
 "informe de fallada."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -496,11 +498,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "El problema ja és conegut"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -510,40 +512,39 @@ msgstr ""
 "al navegador web. Comproveu si podeu afegir cap informació addicional que "
 "pugui ser d'ajuda per als desenvolupadors."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 "Aquest problema ja fou enviat als desenvolupadors anteriorment. Us agraïm la "
 "vostra ajuda."
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Premeu qualsevol tecla per a continuar…"
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "Què voleu fer? Teniu les opcions següents:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Trieu (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i bytes)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(dades binàries)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Voleu enviar l'informe del problema als desenvolupadors?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -551,53 +552,53 @@ msgstr ""
 "Després d'haver enviat l'informe, ompliu el formulari que veureu en el\n"
 "navegador web que s'iniciarà de manera automàtica."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "En&via l'informe (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "&Examina localment"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "&Visualitza l'informe"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 "&Desa el fitxer de l'informe per a enviar-lo més tard o bé copiar-lo a algun "
 "altre lloc"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr ""
 "Cancel·la i &ignora les fallades d'aquesta versió del programa en el futur"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Cancel·la"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Fitxer de l'informe d'error:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&Confirma"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Error: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "S'està recollint informació sobre el problema"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -605,11 +606,11 @@ msgstr ""
 "La informació recollida es pot enviar als desenvolupadors per a millorar\n"
 "l'aplicació. Això pot trigar uns quants minuts."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "S'està pujant la informació del problema"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -617,40 +618,40 @@ msgstr ""
 "La informació recollida s'està enviant al sistema de seguiment d'errors.\n"
 "Això pot trigar uns quants minuts."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Fet"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "cap"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "S'ha seleccionat: %s. Opcions múltiples:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Opcions:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "Camí al fitxer (premeu Retorn per a cancel·lar):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "El fitxer no existeix."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "Això és un directori."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "Per a continuar, heu d'anar a l'URL següent:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -658,17 +659,17 @@ msgstr ""
 "Podeu iniciar un navegador o copiar aquest URL a un navegador d'un altre "
 "ordinador."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Inicia un navegador"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 "No hi ha cap informe d'error pendent. Proveu amb --help per a obtenir més "
 "informació."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 "En lloc de posar les traces noves a l'informe escriviu-les a la sortida "
@@ -689,29 +690,29 @@ msgstr ""
 "Escriviu l'informe modificat en el fitxer proporcionat en lloc de canviar "
 "l'informe original"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 "Suprimiu el bolcat de memòria de l'informe després de la regeneració de la "
 "traça de la pila"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "Sobreescriu el CoreFile de l'informe"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "Sobreescriu l'ExecutablePath de l'informe"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "Sobreescriu el ProcMaps de l'informe"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "Torna a construir la informació del paquet de l'informe"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -728,7 +729,7 @@ msgstr ""
 "configuració del sistema però només es podran seguir les fallades que hagin "
 "passat a la versió actualment en execució."
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
@@ -738,29 +739,29 @@ msgstr ""
 "seves dependències usant la mateixa versió que l'informe en comptes de la "
 "versió del gdb que tingueu instal·lada."
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 "Informa del progrés de la baixada/instal·lació quan s'instal·lin paquets a "
 "l'entorn de proves"
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr ""
 "Afegeix marques horàries als missatges del registre per poder-los processar "
 "en lot"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 "Crea i usa repositoris de tercers a partir de fonts especificades a informes"
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr "Directori temporal per als paquets baixats a l'entorn de proves"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -769,14 +770,14 @@ msgstr ""
 "assumiran que qualsevol paquet que s'hagi baixat també s'ha extret en aquest "
 "entorn de proves."
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 "Instal·la un paquet addicional a l'entorn de proves (es pot especificar "
 "diverses vegades)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -786,7 +787,7 @@ msgstr ""
 "fallades. S'utilitza quan s'especifica un identificador d'error per a pujar "
 "les traces de pila tornades a traçar (només si no s'especifiquen -g, -o o -s)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -794,32 +795,32 @@ msgstr ""
 "Mostra les traces de pila tornades a traçar i demana confirmació abans "
 "d'enviar-les a la base de dades de fallades."
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 "Camí a la base de dades sqlite de duplicats (per defecte: sense comprovació "
 "de duplicat)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr "No afegegis StacktraceSource a l'informe."
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "No podeu utilitzar l'opció -C sense l'opció -S. S'interromprà."
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "Esteu d'acord en enviar-los com a adjuncions? [y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr "%(prog)s <report> <target directory>"
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr "Fitxer d'informe a desempaquetar"
 
@@ -827,26 +828,26 @@ msgstr "Fitxer d'informe a desempaquetar"
 msgid "directory to unpack report to"
 msgstr "directori on s'ha de desempaquetar l'informe"
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "El directori de destinació existeix i no està buit."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "Vegeu la pàgina de manual (ordre «man») per consultar-ne els detalls."
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "Especifiqueu el nom del fitxer de registre que produeix el Valgrind"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
 msgstr ""
 "Reutilitza una carpeta de proves (SDIR) existent o bé crea'n una de nova"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -854,20 +855,20 @@ msgstr ""
 "No creïs o reutilitzis una carpeta de proves per als símbols de depuració "
 "addicionals. Utilitza només els símbols de depuració instal·lats."
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
 msgstr ""
 "Reutilitza una carpeta de memòria cau (CDIR) existent o bé crea'n una de nova"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 "Mostra un informe del progrés de les baixades i instal·lacions en instal·lar "
 "paquets dins de la carpeta de proves"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
@@ -875,12 +876,12 @@ msgstr ""
 "l'executable que s'executa amb l'eina valgrind's memcheck per a detecció de "
 "fuites de memòria"
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "S'ha produït un error: %s no és un fitxer executable. S'aturarà."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -888,7 +889,7 @@ msgstr ""
 "Això va passar durant una aturada temporal prèvia, i va prevenir el sistema "
 "de continuar correctament."
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -896,7 +897,7 @@ msgstr ""
 "Això va passar durant una hibernació prèvia, i va prevenir el sistema de "
 "continuar correctament."
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -904,7 +905,7 @@ msgstr ""
 "El procés de represa es va penjar molt a prop del final i per això semblarà "
 "que s'hagi completat correctament."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 "Pot ser que el vostre sistema esdevingui ara inestable i que l'hàgiu de "
@@ -920,76 +921,76 @@ msgstr "Informeu d'un problema..."
 msgid "Report a malfunction to the developers"
 msgstr "Informeu els desenvolupadors sobre un funcionament erroni"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "L'aplicació %s s'ha aturat inesperadament."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "%s s'ha tancat inesperadament."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "%s ha experimentat un error intern."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Envia"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Mostra els detalls"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Continua"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "L'aplicació %s ha deixat de respondre."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "El programa «%s» ha deixat de respondre."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Paquet: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "S'ha produït un problema mentre s'instal·lava el programa."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "L'aplicació %s ha experimentat un error intern."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "L'aplicació %s s'ha tancat inesperadament."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr "Si observeu altres problemes, intenteu reiniciar l'ordinador."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "En el futur ignora problemes d'aquest tipus"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Oculta els detalls"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -1045,7 +1046,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>S'està pujant informació sobre el problema</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -1057,27 +1058,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Fitxer de fallada de l'Apport"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "Mantén-la tancada"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Torna-la a executar"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Nom d'usuari:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Contrasenya:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "S'està recollint informació sobre el problema"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1085,6 +1086,6 @@ msgstr ""
 "La informació recollida es pot enviar als desenvolupadors per a millorar "
 "l'aplicació. Això pot trigar uns quants minuts."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "S'està pujant la informació del problema"

--- a/po/ca@valencia.po
+++ b/po/ca@valencia.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2014-04-13 00:15+0000\n"
 "Last-Translator: David Planella <david.planella@gmail.com>\n"
 "Language-Team: Ubuntu Catalan Translators list <Ubuntu-l10n-ca@lists.ubuntu."
@@ -41,11 +41,11 @@ msgstr ""
 "Introduïu la vostra contrasenya per accedir als informes d'error dels "
 "programes del sistema"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "Pareix ser que este paquet no s'ha instal·lat correctament"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -53,7 +53,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -66,21 +66,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "programa desconegut"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "El programa «%s» s'ha tancat de manera inesperada"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Problema a %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -88,64 +83,69 @@ msgstr ""
 "El vostre sistema no té prou memòria disponible per a analitzar el problema "
 "de manera automàtica i enviar un informe d'error als desenvolupadors."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Problema a %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Informe d'error no vàlid"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "No teniu permís per a accedir a este informe d'error."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Error"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "No hi ha prou espai disponible per a processar este informe."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "PID no vàlid"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "No s'ha especificat cap paquet"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Cal que especifiqueu un paquet o un PID. Consulteu --help per a obtindre més "
 "informació."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Se vos ha denegat el permís"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -153,30 +153,30 @@ msgstr ""
 "El procés especificat no vos pertany. Hauríeu d'executar este programa com a "
 "propietari del procés o bé com a superusuari."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "L'identificador de procés especificat no pertany a cap programa."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "L'script de símptomes %s no ha determinat cap paquet afectat"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "El paquet %s no existeix"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "No es pot crear l'informe"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "S'està actualitzant l'informe del problema"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -188,7 +188,7 @@ msgstr ""
 "\n"
 "Creeu un informe nou utilitzant l'«apport-bug»."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -208,24 +208,24 @@ msgstr ""
 "\n"
 "Segur que voleu continuar?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "No s'ha recollit informació addicional."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "Sobre quin tipus de problema voleu informar?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Símptoma desconegut"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Es desconeix el símptoma «%s»."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -236,7 +236,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -244,33 +244,33 @@ msgstr ""
 "Després de tancar este missatge feu clic a una finestra de l'aplicació per "
 "informar d'un problema sobre esta."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 "L'xprop ha fallat en determinat l'identificador de procés de la finestra"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "Especifiqueu el nom del paquet."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Afig una etiqueta addicional a l'informe. Es pot especificar diverses "
 "vegades."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -280,15 +280,15 @@ msgstr ""
 "opcional o només un --pid. Si no se'n proporciona cap, es mostrarà una "
 "llista de símptomes coneguts. (Implícit si només es proporciona un argument)"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "Feu clic a una finestra per associar-la a l'informe d'error."
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "Inicieu en mode d'actualització d'errors. Admet un --package opcional."
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -296,7 +296,7 @@ msgstr ""
 "Ompliu un informe d'error sobre un símptoma. (Implícit si només es "
 "proporciona el nom del símptoma com a argument)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -305,7 +305,7 @@ msgstr ""
 "s'ha especificat un --pid. (Implícit si només es proporciona el nom del "
 "paquet com a argument)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -315,11 +315,11 @@ msgstr ""
 "l'informe d'error contindrà més informació (en cas que el pid es doni com a "
 "únic argument)."
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "El PID proporcionat és una aplicació que es penja."
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -328,7 +328,7 @@ msgstr ""
 "Informeu de la fallada a partir d'un fitxer .apport o .crash en lloc dels "
 "pendents a %s. (Implícit si només es proporciona el fitxer com a argument)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -338,47 +338,47 @@ msgstr ""
 "en lloc d'enviar l'informe. Este fitxer es pot enviar més tard des d'una "
 "màquina diferent."
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Mostra el número de versió de l'Apport."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Això executarà l'Apport-retrace en un terminal per examinar la fallada."
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "Executa una sessió del Gdb"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Executa una sessió del Gdb sense descarregar els símbols de depuració"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Actualitza el fitxer %s amb la traça simbòlica completa de la pila."
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 "Este informe de problema fa referència a un programa que ja no està "
 "instal·lat."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
@@ -387,83 +387,85 @@ msgstr ""
 "El problema ha passat amb el programa %s, el qual ha canviat des que es "
 "produí la fallada."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Este informe d'error està malmés i no es pot processar."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr ""
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "S'ha produït un error mentre s'intentava processar l'informe d'error:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr ""
 "No s'ha pogut determinar el nom del paquet del programa o del paquet del "
 "codi font."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "No s'ha pogut iniciar el navegador web"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "No s'ha pogut iniciar el navegador web per a obrir %s."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Problema de la xarxa"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "No es pot connectar a la base de dades de fallades, comproveu la vostra "
 "connexió a Internet."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Problema de la xarxa"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Exhauriment de la memòria"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "El vostre sistema no té prou memòria disponible per a processar este informe "
 "de fallada."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -474,11 +476,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "El problema ja és conegut"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -488,40 +490,39 @@ msgstr ""
 "al navegador web. Comproveu si podeu afegir cap informació addicional que "
 "puga ser d'ajuda per als desenvolupadors."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 "Este problema ja fou enviat als desenvolupadors anteriorment. Vos agraïm la "
 "vostra ajuda."
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Premeu qualsevol tecla per a continuar…"
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "Què voleu fer? Teniu les opcions següents:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Trieu (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i bytes)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(dades binàries)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Voleu enviar l'informe del problema als desenvolupadors?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -529,53 +530,53 @@ msgstr ""
 "Després d'haver enviat l'informe, ompliu el formulari que veureu en el\n"
 "navegador web que s'iniciarà de manera automàtica."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "En&via l'informe (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "&Examina localment"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "&Visualitza l'informe"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 "Al&ça el fitxer de l'informe per a enviar-lo més tard o bé copiar-lo a algun "
 "altre lloc"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr ""
 "Cancel·la i &ignora les fallades d'esta versió del programa en el futur"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Cancel·la"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Fitxer de l'informe d'error:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&Confirma"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Error: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "S'està recollint informació sobre el problema"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -583,11 +584,11 @@ msgstr ""
 "La informació recollida es pot enviar als desenvolupadors per a millorar\n"
 "l'aplicació. Això pot trigar uns quants minuts."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "S'està pujant la informació del problema"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -595,40 +596,40 @@ msgstr ""
 "La informació recollida s'està enviant al sistema de seguiment d'errors.\n"
 "Això pot trigar uns quants minuts."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Fet"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "cap"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "S'ha seleccionat: %s. Opcions múltiples:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Opcions:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "Camí al fitxer (premeu Retorn per a cancel·lar):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "El fitxer no existeix."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "Això és un directori."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "Per a continuar, heu d'anar a l'URL següent:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -636,17 +637,17 @@ msgstr ""
 "Podeu iniciar un navegador o copiar este URL a un navegador d'un altre "
 "ordinador."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Inicia un navegador"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 "No hi ha cap informe d'error pendent. Proveu amb --help per a obtindre més "
 "informació."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 "En lloc de posar les traces noves a l'informe escriviu-les a l'eixida "
@@ -667,29 +668,29 @@ msgstr ""
 "Escriviu l'informe modificat en el fitxer proporcionat en lloc de canviar "
 "l'informe original"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 "Suprimiu el bolcat de memòria de l'informe després de la regeneració de la "
 "traça de la pila"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "Sobreescriu el CoreFile de l'informe"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "Sobreescriu l'ExecutablePath de l'informe"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "Sobreescriu el ProcMaps de l'informe"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "Torna a construir la informació del paquet de l'informe"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -706,35 +707,35 @@ msgstr ""
 "configuració del sistema però només es podran seguir les fallades que hagen "
 "passat a la versió actualment en execució."
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
 "have installed."
 msgstr ""
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 "Informa del progrés de la baixada/instal·lació quan s'instal·len paquets a "
 "l'entorn de proves"
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr ""
 "Afig marques horàries als missatges del registre per poder-los processar en "
 "lot"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr "Directori temporal per als paquets baixats a l'entorn de proves"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -743,14 +744,14 @@ msgstr ""
 "assumiran que qualsevol paquet que s'haja baixat també s'ha extret en este "
 "entorn de proves."
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 "Instal·la un paquet addicional a l'entorn de proves (es pot especificar "
 "diverses vegades)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -760,7 +761,7 @@ msgstr ""
 "fallades. S'utilitza quan s'especifica un identificador d'error per a pujar "
 "les traces de pila tornades a traçar (només si no s'especifiquen -g, -o o -s)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -768,32 +769,32 @@ msgstr ""
 "Mostra les traces de pila tornades a traçar i demana confirmació abans "
 "d'enviar-les a la base de dades de fallades."
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 "Camí a la base de dades sqlite de duplicats (per defecte: sense comprovació "
 "de duplicat)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr ""
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "No podeu utilitzar l'opció -C sense l'opció -S. S'interromprà."
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "Esteu d'acord en enviar-los com a adjuncions? [y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -801,26 +802,26 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "El directori de destinació existeix i no està buit."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "Vegeu la pàgina de manual (orde «man») per consultar-ne els detalls."
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "Especifiqueu el nom del fitxer de registre que produeix el Valgrind"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
 msgstr ""
 "Reutilitza una carpeta de proves (SDIR) existent o bé crea'n una de nova"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -828,43 +829,43 @@ msgstr ""
 "No crees o reutilitzis una carpeta de proves per als símbols de depuració "
 "addicionals. Utilitza només els símbols de depuració instal·lats."
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
 msgstr ""
 "Reutilitza una carpeta de memòria cau (CDIR) existent o bé crea'n una de nova"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 "Mostra un informe del progrés de les baixades i instal·lacions en instal·lar "
 "paquets dins de la carpeta de proves"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "S'ha produït un error: %s no és un fitxer executable. S'aturarà."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -872,7 +873,7 @@ msgstr ""
 "El procés de represa es va penjar molt a prop del final i per això semblarà "
 "que s'haja completat correctament."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 "Pot ser que el vostre sistema esdevingui ara inestable i que l'hàgeu de "
@@ -888,76 +889,76 @@ msgstr "Informeu d'un problema..."
 msgid "Report a malfunction to the developers"
 msgstr "Informeu els desenvolupadors sobre un funcionament erroni"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "L'aplicació %s s'ha aturat inesperadament."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "%s s'ha tancat inesperadament."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "%s ha experimentat un error intern."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Envia"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Mostra els detalls"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Continua"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "L'aplicació %s ha deixat de respondre."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "El programa «%s» ha deixat de respondre."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Paquet: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "S'ha produït un problema mentre s'instal·lava el programa."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "L'aplicació %s ha experimentat un error intern."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "L'aplicació %s s'ha tancat inesperadament."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr "Si observeu altres problemes, intenteu reiniciar l'ordinador."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "En el futur ignora problemes d'este tipus"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Oculta els detalls"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -1013,7 +1014,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>S'està pujant informació sobre el problema</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -1025,27 +1026,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Fitxer de fallada de l'Apport"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "Mantén-la tancada"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Torna-la a executar"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Nom d'usuari:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Contrasenya:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "S'està recollint informació sobre el problema"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1053,6 +1054,6 @@ msgstr ""
 "La informació recollida es pot enviar als desenvolupadors per a millorar "
 "l'aplicació. Això pot trigar uns quants minuts."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "S'està pujant la informació del problema"

--- a/po/ceb.po
+++ b/po/ceb.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2018-08-22 11:00+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Cebuano <ceb@li.org>\n"
@@ -36,11 +36,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr ""
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -57,111 +57,111 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr ""
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr ""
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr ""
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
 msgstr ""
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr ""
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr ""
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr ""
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr ""
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr ""
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr ""
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr ""
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 msgstr ""
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr ""
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr ""
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr ""
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr ""
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -169,7 +169,7 @@ msgid ""
 "Please create a new report using \"apport-bug\"."
 msgstr ""
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -181,24 +181,24 @@ msgid ""
 "Do you really want to proceed?"
 msgstr ""
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr ""
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr ""
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr ""
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr ""
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -209,202 +209,204 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr ""
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr ""
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr ""
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr ""
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr ""
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr ""
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr ""
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr ""
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr ""
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr ""
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr ""
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr ""
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -412,161 +414,160 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr ""
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 msgstr ""
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr ""
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr ""
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Palihug pamili (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr ""
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(binary data)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr ""
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
 msgstr ""
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr ""
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr ""
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr ""
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr ""
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Kanselahon"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr ""
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr ""
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Sayup: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr ""
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
 msgstr ""
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr ""
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
 msgstr ""
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Humana"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "wala"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr ""
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Pili-anan:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr ""
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr ""
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr ""
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr ""
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
 msgstr ""
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr ""
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 
@@ -581,27 +582,27 @@ msgid ""
 "Write modified report to given file instead of changing the original report"
 msgstr ""
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr ""
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr ""
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr ""
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr ""
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -611,78 +612,78 @@ msgid ""
 "be able to retrace crashes that happened on the currently running release."
 msgstr ""
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
 "have installed."
 msgstr ""
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr ""
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
 msgstr ""
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
 "neither -g, -o, nor -s are specified)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
 msgstr ""
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr ""
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr ""
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr ""
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -690,70 +691,70 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr ""
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
 msgstr ""
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 
@@ -767,76 +768,76 @@ msgstr ""
 msgid "Report a malfunction to the developers"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Ipadala"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Ipakita ang mga detalye"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Padayon"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Pakete: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Itago ang mga Detalye"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr ""
 
@@ -890,7 +891,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr ""
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -900,32 +901,32 @@ msgstr ""
 msgid "Apport crash file"
 msgstr ""
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr ""
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr ""
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr ""
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr ""
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr ""
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
 msgstr ""
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr ""

--- a/po/ckb.po
+++ b/po/ckb.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2020-02-26 15:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Kurdish (Sorani) <ckb@li.org>\n"
@@ -36,11 +36,11 @@ msgstr "تۆماری کێشەکانی سیستم"
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr ""
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -57,111 +57,111 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr ""
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr ""
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr ""
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
 msgstr ""
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr ""
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr ""
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr ""
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "هەڵە"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr ""
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr ""
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "ڕێ پێدان ڕەتکرایەوە"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 msgstr ""
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr ""
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr ""
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr ""
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr ""
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -169,7 +169,7 @@ msgid ""
 "Please create a new report using \"apport-bug\"."
 msgstr ""
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -181,24 +181,24 @@ msgid ""
 "Do you really want to proceed?"
 msgstr ""
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr ""
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr ""
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr ""
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr ""
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -209,202 +209,204 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr ""
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr ""
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr ""
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr ""
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr ""
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr ""
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr ""
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr ""
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr ""
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr ""
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr ""
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr ""
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -412,161 +414,160 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr ""
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 msgstr ""
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr ""
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr ""
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr ""
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i bytes)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr ""
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr ""
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
 msgstr ""
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr ""
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr ""
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "&ڕاپۆرت ببینە"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr ""
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&پاشگه‌زبوونه‌وه‌"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr ""
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr ""
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "هه‌ڵه‌ : %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr ""
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
 msgstr ""
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr ""
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
 msgstr ""
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr ""
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "هیچ"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr ""
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "بژاردەکان:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr ""
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "پەڕگەکە بردەست نیە."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "ئەمە بوخچەیە"
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "تاکو بەردەوام بیت، دەبێت تەماشای ئەم بەستەکە بکەیت:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
 msgstr ""
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "وێبگەڕەکە بکەرەوە"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 
@@ -581,27 +582,27 @@ msgid ""
 "Write modified report to given file instead of changing the original report"
 msgstr ""
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr ""
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr ""
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr ""
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr ""
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -611,78 +612,78 @@ msgid ""
 "be able to retrace crashes that happened on the currently running release."
 msgstr ""
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
 "have installed."
 msgstr ""
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr ""
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
 msgstr ""
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
 "neither -g, -o, nor -s are specified)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
 msgstr ""
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr ""
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr ""
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr ""
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -690,70 +691,70 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "تەماشای پەڕەی هاوکاری بکە بۆ زۆرتر"
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "هەڵە: %s شیاوی جێبەجێبوون نیە. دەوەستێت.."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
 msgstr ""
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 
@@ -767,76 +768,76 @@ msgstr "ڕاپۆڕتی هەڵە بنێرە"
 msgid "Report a malfunction to the developers"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "ناردن"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "پیشاندانی وردەکارییەکان"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "بەردەوام بە"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "شاردنه‌وه‌ی وردەکارییەکان"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr ""
 
@@ -890,7 +891,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr ""
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -900,32 +901,32 @@ msgstr ""
 msgid "Apport crash file"
 msgstr ""
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "بەداخراوی جێی بهێڵە"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr ""
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "ناوی به‌كارهێنه‌ر:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "تێپەڕەوشە:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr ""
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
 msgstr ""
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr ""

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2022-10-05 19:59+0000\n"
 "Last-Translator: Tomáš Marný <tomik.marny@gmail.com>\n"
 "Language-Team: Czech <cs@li.org>\n"
@@ -39,11 +39,11 @@ msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 "Zadejte prosím své heslo, aby mohl být problém systémového programu oznámen."
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "Tento balíček zřejmě není nainstalován správně"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -54,7 +54,7 @@ msgstr ""
 "aktualizaci indexů dostupných balíčků, pokud to nebude fungovat, odeberte "
 "související balíčky třetích stran a zkuste to znovu."
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -67,21 +67,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "neznámý program"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Omlouváme se, program \"%s\" byl neočekávaně uzavřen"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Problém v %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -89,65 +84,70 @@ msgstr ""
 "Váš počítač nemá dostatek volné paměti pro automatickou analýzu problému a "
 "odeslání hlášení vývojářům."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Problém v %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Neplatné hlášení o problému"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "Nemáte oprávnění k přístupu k tomuto hlášení problému."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Chyba"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "Pro zpracování tohoto hlášení není na disku dost místa."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr "Žádné PID nebylo specifikováno"
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 "Musíte specifikovat PID. Více informací naleznete pomocí příkazu --help"
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "Neplatný PID"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr "Proces s daným identifikátorem neexistuje."
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr "Není vaše PID"
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr "Proces s daným identifikátorem vám nepatří."
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "Nebyl specifikován žádný balík"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Musíte určit, o který balík nebo PID se jedná. Pro více informací použijte "
 "přepínač --help."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Přístup odepřen"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -155,30 +155,30 @@ msgstr ""
 "Nejste vlastníkem vybraného procesu. Prosím, spusťte tuto aplikaci jako "
 "vlastník onoho procesu nebo jako root."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "Zadané ID procesu neodpovídá žádnému programu."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Skript %s neurčuje problematický balík"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Balík %s neexistuje"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "Nelze vytvořit hlášení"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "Probíhá aktualizace chybového hlášení"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -190,7 +190,7 @@ msgstr ""
 "\n"
 "Vytvořte prosím nové hlášení pomocí \"apport-bug\"."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -210,24 +210,24 @@ msgstr ""
 "\n"
 "Opravdu chcete pokračovat?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "Nebyly shromážděny žádné další informace."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "Jaký druh problému si přejete nahlásit?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Neznámý příznak"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Příznak \"%s\" je neznámý."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -245,36 +245,36 @@ msgstr ""
 "Procesy posouvejte, dokud nenajdete správnou aplikaci. ID procesu je číslo "
 "uvedené ve sloupci ID."
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr "Po uzavření této zprávy klikněte na okno s nahlášením problému."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop selhal při rozeznávávání ID procesu okna"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr "%(prog)s <číslo hlášení>"
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "Upřesněte název balíku."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "Přidejte do hlášení další tagy - může jich být více."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -284,15 +284,15 @@ msgstr ""
 "pid, nebo pouze --pid. Pokud není zadán ani jeden, zobrazí se seznam známých "
 "příznaků. (Použito, pokud je zadán jediný argument.)"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "Kliknutím vyberte okno pro vytvoření hlášení o chybě."
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "Spustit režim aktualizace chyb.  Může mít volbu --packages"
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -300,7 +300,7 @@ msgstr ""
 "Podat hlášení o chybě o příznaku. (Použito, pokud je zadán název příznaku "
 "jako jediný argument.)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -308,7 +308,7 @@ msgstr ""
 "Určit název balíku v režimu --file-bug. Toto je volitelné, pokud je určeno --"
 "pid. (Použito, pokud je zadán název balíku jako jediný argument.)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -318,11 +318,11 @@ msgstr ""
 "hlášení obsahovat více informací. (Je-li číslo procesu uvedeno jako jediný "
 "argument.)"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "Poskytnuté pid je zamrzlá aplikace."
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -332,7 +332,7 @@ msgstr ""
 "některých nevyřízených z %s. (Použito, pokud je zadán soubor jako jediný "
 "argument.)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -341,65 +341,67 @@ msgstr ""
 "Uložte hlášení do souboru namísto přímého oznámení. Tento soubor může být "
 "nahlášen později nebo z jiného počítače."
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Vypsat číslo verze Apport."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr "Tímto spustíte apport-retrace v terminálovém okně."
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "Spustit gdb"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Spustit gdb bez stahování debugovacích symbolů"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Aktualizovat %s pomocí úplného symbolického trasování zásobníku"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr "Nenalezeno nastavení stavu odeslání hlášení"
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 "Ukládání stavu hlášení o chybě selhalo. Nelze nastavit mód hlášení na "
 "automaticky nebo nikdy."
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr "Nenalezeno nastavení stavu odeslání hlášení"
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr "Toto hlášení o problému se týká programu, který již není nainstalován."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 msgstr "Problém byl zaznamenán v programu %s, který byl od pádu změněn."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Toto hlášení o problému je poškozené a nemůže být zpracováno."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr "Toto hlášení je o balíku, který není nainstalován."
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "Při zpracování chybového hlášení došlo k chybě:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
@@ -407,23 +409,23 @@ msgstr ""
 "Máte nainstalovány dvě verze této aplikace, pro kterou z nich chcete "
 "nahlásit chybu?"
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr "%s snap"
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr "%s deb balíček"
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s je poskytován skrze snap vydaný %s. Pro pomoc je kontaktujte přes %s."
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -432,40 +434,40 @@ msgstr ""
 "%s je poskytován skrze snap vydaný %s. Nejsou poskytnuty žádné kontaktní "
 "údaje; pro pomoc navštivte fórum na adrese https://forum.snapcraft.io/."
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "Nelze určit název balíku nebo zdrojového balíku."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "Nelze spustit webový prohlížeč"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Nelze spustit webový prohlížeč a otevřít %s."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Problém se sítí"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Nelze se připojit k databází havárií, prosím zkontrolujte své internetové "
 "připojení."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Problém se sítí"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Vyčerpání paměti"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Váš systém nemá dostatek paměti pro zpracování tohoto hlášení o havárii."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -476,11 +478,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "Problém je již znám"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -490,38 +492,37 @@ msgstr ""
 "prohlížeči. Prosím zkontrolujte, zda můžete přidat další informace, které by "
 "mohly být vývojářům nápomocné."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Tato chyba byla vývojářům již ohlášena. Děkujeme!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Pro pokračování stiskněte libovolnou klávesu..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "Co chcete udělat? Máte tyto možnosti:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Prosím vyberte (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i bajtů)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(binární data)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Odeslat hlášení o problému vývojářům?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -529,51 +530,51 @@ msgstr ""
 "Po odeslání hlášení o problému vyplňte prosím formulář v nově\n"
 "otevřeném okně prohlížeče."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "&Odeslat hlášení (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "&Prozkoumat místně"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "Zobrazi&t hlášení"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 "&Ponechat soubor s hlášením pro pozdější odeslání nebo kopírování někam jinam"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "Zrušit a &ignorovat budoucí havárie této verze programu"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Zrušit"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Soubor s hlášením o problému:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&Potvrdit"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Chyba: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "Shromažďování informací o problému"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -581,11 +582,11 @@ msgstr ""
 "Sesbírané informace mohou být odeslány vývojářům za účelem zlepšení\n"
 "aplikace. To může trvat i několik minut."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "Odesílání informací o problému"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -593,40 +594,40 @@ msgstr ""
 "Sesbírané informace se odesílají do systému pro sledování chyb.\n"
 "To může trvat i několik minut."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Hotovo"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "nic"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "Vybráno: %s. Více možností:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Volby"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "Cesta k souboru (Enter pro zrušení):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "Soubor neexistuje."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "Toto je adresář."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "Pro pokračování musíte navštívit následující adresu:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -634,17 +635,17 @@ msgstr ""
 "Nyní můžete spustit prohlížeč nebo zkopírovat tuto adresu do prohlížeče nebo "
 "jiného počítače."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Spustit prohlížeč nyní"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 "Žádná nevyřízená hlášení o haváriích. Pro více informací použijte přepínač --"
 "help."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 "Nepřidávejte do hlášení další sledování, přesměrujte je na standardní výstup."
@@ -663,29 +664,29 @@ msgid ""
 msgstr ""
 "Zapsat upravené hlášení do daného souboru místo změny původního hlášení"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 "Odstraňte core dump z hlášení potom, co bude výstupní hlášení znovu "
 "vygenerováno"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "Potlačit zprávy CoreFile"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "Potlačit zprávy ExecutablePath"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "Potlačit zprávy ProcMaps"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "Obnovit zprávy o informacích o balíčcích"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -701,7 +702,7 @@ msgstr ""
 "\"system\", tak budou použity systémové konfigurační soubory, ale pak bude "
 "možné retrasovat havárie pouze u právě spuštěné verze."
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
@@ -710,24 +711,24 @@ msgstr ""
 "Vytvořit další dočasný sandbox pro instalaci gdb a závislostí za použití "
 "stejného vydání jako v hlášení namísto verze gdb, která je nainstalována."
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr "Hlásit postup stahování/instalace při instalaci balíčků do sandboxu"
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr "Pro dávkové zpracování vložit časové razítko před zpávu do logu"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr "Vytvořit a použít repozitáře třetích stran pocházející z hlášení"
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr "Kešovací adresář pro stažené balíčky do sandboxu"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -735,12 +736,12 @@ msgstr ""
 "Adresář pro rozbalené soubory. V budoucnu by tam měly být k dispozici "
 "všechny stažené a rozbalené balíky."
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr "Nainstalovat do sandboxu extra balík (může být vybráno vícekrát)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -750,7 +751,7 @@ msgstr ""
 "použit k nahrání retrasovaných trasování zásobníku (pouze pokud není použit "
 "parametr -g, -o nebo -s)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -758,30 +759,30 @@ msgstr ""
 "Zobrazit retasované trasování zásobníku a poptat na potvrzení před jejich "
 "odesláním do databáze havárií."
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr "Cesta k duplikátu databáze sqlite (výchozí: žádná kontrola duplicit)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr "Nepřidávejte do hlášení StacktraceSource."
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "Nelze užít -C bez -S. Zastavuji proces."
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "Souhlasíte s odesláním těchto jako příloh? [y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr "%(prog)s <hlášení> <cílový adresář>"
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr "Soubor s hlášením k rozbalení"
 
@@ -789,19 +790,19 @@ msgstr "Soubor s hlášením k rozbalení"
 msgid "directory to unpack report to"
 msgstr "adresář, do kterého se má hlášení rozbalit"
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "Cílový adresář existuje a není prázdný."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "Více informací je na manuálové stránce"
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "specifikujte jméno log souboru valgrindu"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
@@ -809,7 +810,7 @@ msgstr ""
 "použít dříve vytvořený adresář sandbox (SDIR) nebo, pokud neexistuje, jej "
 "vytvořit"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -817,7 +818,7 @@ msgstr ""
 "nevytvářet nebo znovu nepoužívat adresář sandbox pro dodatečné debugovací "
 "symboly, ale pouze pro instalované debugovací symboly."
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
@@ -825,11 +826,11 @@ msgstr ""
 "použít dříve vytvořený cache adresář (CDIR) nebo, pokud neexistuje, jej "
 "vytvořit"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr "hlásit postup stahování/instalace během instalování balíku do sandboxu"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
@@ -837,12 +838,12 @@ msgstr ""
 "spustitelný soubor, který spouští nástroj memcheck programu valgrind k "
 "detekci úniků paměti"
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Chyba: %soubor není spustitelný. Ukončuji proces."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -850,7 +851,7 @@ msgstr ""
 "Toto se stalo v průběhu minulého uspání do paměti a zabránilo systému v "
 "probuzení."
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -858,7 +859,7 @@ msgstr ""
 "Toto se stalo v průběhu minulého uspání na disk a zabránilo systému v "
 "probuzení."
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -866,7 +867,7 @@ msgstr ""
 "Proces probouzení byl porušen téměř u konce a vypadá tedy jako řádně "
 "ukončený."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 "Váš systém může být nyní nestabilní a bude jej možná nutné restartovat."
@@ -881,76 +882,76 @@ msgstr "Nahlásit problém…"
 msgid "Report a malfunction to the developers"
 msgstr "Oznámit problém vývojářům"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "Omlouváme se, aplikace %s byla neočekávaně ukončena."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "Omlouváme se, %s byl neočekávaně ukončen."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "Omlouváme se, %s zaznamenal vnitřní chybu."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Odeslat"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Zobrazit podrobnosti"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Pokračovat"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "Aplikace %s neodpovídá."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "Program %s neodpovídá."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Balíček: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "Omlouváme se, při instalaci softwaru nastala chyba."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "V aplikaci %s došlo k chybě."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "Aplikace %s byla neočekávaně ukončena."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr "Pokud problémy neustanou, zkuste restartovat počítač."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "Ignorovat budoucí problémy tohoto typu"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Skrýt podrobnosti"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -1006,7 +1007,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>Odesílání informací o problému</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -1018,27 +1019,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Soubor apport crash"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "Ponechat uzavřené"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Restartovat"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Uživatelské jméno:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Heslo:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "Shromažďování informací o problému"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1046,6 +1047,6 @@ msgstr ""
 "Shromážděné informace mohou být zaslány vývojářům za účelem případného "
 "vylepšení aplikace. Odesílání může trvat několik minut."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "Odesílání informací o problému"

--- a/po/cv.po
+++ b/po/cv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2011-10-07 06:10+0000\n"
 "Last-Translator: Ali Savatar <Unknown>\n"
 "Language-Team: Chuvash <cv@li.org>\n"
@@ -36,11 +36,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr ""
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -57,111 +57,111 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr ""
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr ""
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr ""
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
 msgstr ""
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr ""
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr ""
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr ""
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Jănăš"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "\"PID\" tĕrĕs mar"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr ""
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr ""
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 msgstr ""
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr ""
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr ""
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr ""
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr ""
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -169,7 +169,7 @@ msgid ""
 "Please create a new report using \"apport-bug\"."
 msgstr ""
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -181,24 +181,24 @@ msgid ""
 "Do you really want to proceed?"
 msgstr ""
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr ""
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr ""
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr ""
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr ""
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -209,202 +209,204 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr ""
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr ""
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr ""
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr ""
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr ""
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr ""
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr ""
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr ""
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr ""
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Tetel jănăšĕ"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Tetel jănăšĕ"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr ""
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -412,161 +414,160 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr ""
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 msgstr ""
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr ""
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr ""
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr ""
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr ""
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr ""
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr ""
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
 msgstr ""
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr ""
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr ""
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr ""
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr ""
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Părahăşla"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr ""
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr ""
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Jănăš: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr ""
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
 msgstr ""
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr ""
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
 msgstr ""
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Hatĕr"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "şuk"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr ""
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr ""
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr ""
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "Fajl tupănmarĕ"
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr ""
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr ""
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
 msgstr ""
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr ""
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 
@@ -581,27 +582,27 @@ msgid ""
 "Write modified report to given file instead of changing the original report"
 msgstr ""
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr ""
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr ""
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr ""
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr ""
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -611,78 +612,78 @@ msgid ""
 "be able to retrace crashes that happened on the currently running release."
 msgstr ""
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
 "have installed."
 msgstr ""
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr ""
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
 msgstr ""
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
 "neither -g, -o, nor -s are specified)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
 msgstr ""
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr ""
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr ""
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr ""
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -690,70 +691,70 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr ""
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
 msgstr ""
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 
@@ -767,76 +768,76 @@ msgstr ""
 msgid "Report a malfunction to the developers"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr ""
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr ""
 
@@ -890,7 +891,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr ""
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -900,32 +901,32 @@ msgstr ""
 msgid "Apport crash file"
 msgstr ""
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr ""
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr ""
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr ""
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr ""
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr ""
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
 msgstr ""
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr ""

--- a/po/cy.po
+++ b/po/cy.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2022-09-29 14:03+0000\n"
 "Last-Translator: Rhoslyn Prys <Unknown>\n"
 "Language-Team: Welsh <cy@li.org>\n"
@@ -40,11 +40,11 @@ msgstr ""
 "Rhowch eich cyfrinair i gael mynediad at adroddiadau problemau rhaglenni "
 "system"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "Nid yw'n ymddangos bod y pecyn hwn wedi'i osod yn gywir"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -55,7 +55,7 @@ msgstr ""
 "ar ôl diweddaru mynegeion y pecynnau sydd ar gael, os nad yw hynny'n "
 "gweithio yna tynnwch becynnau trydydd parti cysylltiedig a cheisiwch eto."
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -68,21 +68,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "rhaglen anhysbys"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Mae'n ddrwg gennym, caeodd y rhaglen \"%s\" yn annisgwyl"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Problem yn %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -90,63 +85,68 @@ msgstr ""
 "Nid oes gan eich cyfrifiadur ddigon o gof am ddim i ddadansoddi'r broblem yn "
 "awtomatig ac anfon adroddiad at y datblygwyr."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Problem yn %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Adroddiad problem annilys"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "Ni chaniateir i chi gael mynediad at yr adroddiad problem hwn."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Gwall"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "Nid oes digon o le ar ddisg ar gael i brosesu'r adroddiad hwn."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr "Dim PID wedi'i nodi"
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr "Mae angen i chi nodi PID. Gweler --help am ragor o wybodaeth."
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "PID annilys"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr "Nid yw'r ID proses penodedig yn bodoli."
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr "Nid eich PID"
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr "Nid yw'r ID proses penodedig yn perthyn i chi."
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "Dim pecyn wedi'i nodi"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Mae angen i chi nodi pecyn neu PID. Gweler --help am ragor o wybodaeth."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Gwrthodwyd caniatâd"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -154,30 +154,30 @@ msgstr ""
 "Nid yw'r broses benodedig yn perthyn i chi. Rhedwch y rhaglen hon fel "
 "perchennog y broses neu fel gwraidd."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "Nid yw'r ID proses penodedig yn perthyn i raglen."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Nid yw sgript symptom  wedi canfod y pecyn %s effeithiwyd arno"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Nid yw pecyn %s yn bodoli"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "Methu creu adroddiad"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "Wrthi'n diweddaru adroddiad problem"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -189,7 +189,7 @@ msgstr ""
 "\n"
 "Crëwch adroddiad newydd gan ddefnyddio \"apport-bug\"."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -209,24 +209,24 @@ msgstr ""
 "\n"
 "Ydych chi wir eisiau bwrw ymlaen?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "Dim gwybodaeth ychwanegol wedi'i chasglu."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "Pa fath o broblem ydych chi am roi gwybod amdani?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Symptom anhysbys"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Nid yw'r symptom \"%s\" yn hysbys."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -245,7 +245,7 @@ msgstr ""
 "tab Prosesau, sgroliwch nes i chi ddod o hyd i'r rhaglen gywir. ID y broses "
 "yw'r rhif sy'n cael ei restri yn y golofn ID."
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -253,32 +253,32 @@ msgstr ""
 "Ar ôl cau'r neges hon, cliciwch ar ffenestr y raglen i roi gwybod am broblem "
 "amdani."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop wedi methu pennu ID proses y ffenestr"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr "%(prog)s<report number>"
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "Nodwch enw'r pecyn."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Ychwanegwch dag ychwanegol at yr adroddiad. Mae modd ei nodi sawl gwaith."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -288,15 +288,15 @@ msgstr ""
 "neu dim ond --pid. Os na roddir y naill na'r llall, dangoswch restr o "
 "symptomau hysbys. (Goblygiad os oes ymresymiad sengl yn cael ei gynnig.)"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "Cliciwch ffenestr fel targed ar gyfer ffeilio adroddiad problem."
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "Dechreuwch yn y modd diweddaru gwall. Gall gymryd --package dewisol."
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -304,7 +304,7 @@ msgstr ""
 "Ffeiliwch adroddiad gwall am symptom. (Goblygir os rhoddir enw'r symptom fel "
 "dadl yn unig.)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -312,7 +312,7 @@ msgstr ""
 "Nodwch enw'r pecyn yn y modd --file-bug. Mae hyn yn ddewisol os nodir --pid. "
 "(Goblygiad os oes ymresymiad sengl yn cael ei gynnig.)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -322,11 +322,11 @@ msgstr ""
 "nam yn cynnwys mwy o wybodaeth. (Goblygiad os pid yw'r unig ymresymiad sy'n "
 "cael ei gynnig.)"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "Mae'r pid a ddarperir yn raglen sy'n oedi."
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -336,7 +336,7 @@ msgstr ""
 "rhai sydd ar y gweill yn %s. (Goblygiad os taw ffeil sy'n cael ei chynnig "
 "fel yr unig ymresymiad.)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -346,50 +346,50 @@ msgstr ""
 "hytrach na'i hadrodd. Yna bydd modd adrodd ar y ffeil hon yn ddiweddarach o "
 "beiriant gwahanol."
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Argraffwch y rhif fersiwn Apport."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Bydd hyn yn lansio appport-retrace mewn ffenestr derfynell i archwilio'r "
 "chwaliad."
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "Rhedeg sesiwn gdb"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Rhedeg sesiwn gdb heb lwytho I lawr symbolau dadfygio"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Diweddaru %s gydag olrhain stac symbolaidd llawn"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr "Methu cofio anfon gosodiadau statws adroddiad"
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 "Methodd cadw cyflwr adrodd y chwalfa. Methu â gosod modd adrodd awtomatig "
 "neu byth."
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr "Methu cofio anfon gosodiadau statws adroddiad"
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 "Mae'r adroddiad problem hwn yn berthnasol i raglen nad yw wedi'i gosod "
 "mwyach."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
@@ -397,20 +397,22 @@ msgid ""
 msgstr ""
 "Digwyddodd y broblem gyda'r rhaglen %s a newidiodd ers i'r chwaliad ddigwydd."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr ""
 "Mae'r adroddiad problem hwn wedi'i ddifrodi ac nid oes modd ei brosesu."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr "Mae'r adroddiad hwn yn ymwneud â phecyn nad yw wedi'i osod."
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "Digwyddodd gwall wrth geisio prosesu'r adroddiad problem hwn:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
@@ -418,24 +420,24 @@ msgstr ""
 "Mae gennych chi ddau fersiwn o'r rhaglen hon wedi'u gosod, pa un ydych chi "
 "am adrodd gwall yn ei erbyn?"
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr "%s snap"
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr "Pecyn deb %s"
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "Mae %s yn cael ei ddarparu gan snap a gyhoeddwyd gan %s. Cysylltwch â nhw "
 "trwy %s am gymorth."
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -445,39 +447,39 @@ msgstr ""
 "cyswllt wedi'i ddarparu; ewch i'r fforwm yn https://forum.snapcraft.io/ am "
 "help."
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "Methu pennu enw'r pecyn neu ffynhonnell y pecyn."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "Methu cychwyn porwr gwe"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Methu cychwyn porwr gwe i agor %s."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Problem rhwydwaith"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Methu cysylltu â chronfa ddata chwalfa, gwiriwch eich cysylltiad rhyngrwyd."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Problem rhwydwaith"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Cof wedi dod i ben"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Nid oes gan eich system ddigon o gof i brosesu'r adroddiad chwalfa hwn."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -488,11 +490,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "Problem eisoes yn hysbys"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -502,38 +504,37 @@ msgstr ""
 "yn y porwr gwe. Gwiriwch a allwch ychwanegu unrhyw wybodaeth bellach a allai "
 "fod o gymorth i'r datblygwyr."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Rhoddwyd gwybod i ddatblygwyr am y broblem hon eisoes. Diolch!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Pwyswch unrhyw fysell i barhau..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "Beth hoffech chi ei wneud? Eich opsiynau yw:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Dewiswch (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i beit)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(data deuaidd)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Anfon adroddiad problem i'r datblygwyr?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -541,51 +542,51 @@ msgstr ""
 "Ar ôl i'r adroddiad problem gael ei anfon, llenwch y ffurflen yn y\n"
 "porwr gwe agorwyd yn awtomatig."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "A&nfon adroddiad (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "A&rchwiliwch yn lleol"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "&Gweld yr adroddiad"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 "&Cadw ffeil adroddiad i'w hanfon yn hwyrach neu ei chopïo i rywle arall"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "D&iddymu ac anwybyddu chwaliadau o'r fersiwn rhaglen hon yn y dyfodol"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Diddymu"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Ffeil adroddiad problem:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&Cadarnhau"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Gwall: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "Casglu gwybodaeth am broblemau"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -593,11 +594,11 @@ msgstr ""
 "Mae modd anfon y wybodaeth a gasglwyd at y datblygwyr i wella'r\n"
 "rhaglen. Gall hyn gymryd ychydig funudau."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "Wrthi'n llwytho gwybodaeth problem"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -605,40 +606,40 @@ msgstr ""
 "Mae'r wybodaeth a gasglwyd yn cael ei hanfon i'r system olrhain bygiau.\n"
 "Gall hyn gymryd ychydig o funudau."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Wedi gorffen!"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "dim"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "Wedi'i ddewis: %s. Dewisiadau lluosog:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Dewisiadau:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "Llwybr i'r ffeil (Enter i ddiddymu):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "Nid yw'r ffeil yn bodoli"
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "Cyfeiriadur yw hwn."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "I barhau, rhaid i chi ymweld â'r URL canlynol:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -646,17 +647,17 @@ msgstr ""
 "Gallwch chi lansio porwr nawr, neu gopïo'r URL hwn i mewn i borwr ar "
 "gyfrifiadur arall."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Lansio porwr nawr"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 "Dim adroddiadau chwalu yn yr arfaeth. Rhowch gynnig ar --help am fwy o "
 "wybodaeth."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 "Peidiwch â rhoi'r olion newydd yn yr adroddiad, ond eu hanfon nhw i stdout."
@@ -676,27 +677,27 @@ msgstr ""
 "Ysgrifennwch adroddiad wedi'i addasu i ffeil a roddwyd yn lle newid yr "
 "adroddiad gwreiddiol"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr "Tynnwch y dymp craidd o'r adroddiad ar ôl adfywio olrhain pentwr"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "Diystyru CoreFile yr adroddiad"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "Diystyru Llwybr Gweithredadwy'r adroddiad"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "Diystyru ProcMaps yr adroddiad"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "Ailadeiladwch wybodaeth Pecyn yr adroddiad"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -713,7 +714,7 @@ msgstr ""
 "defnyddio'r ffeiliau ffurfweddiad system, ond dim ond wedyn bydd yn gallu "
 "olrhain damweiniau a ddigwyddodd ar y ryddhad sy'n rhedeg ar hyn o bryd."
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
@@ -723,28 +724,28 @@ msgstr ""
 "gan ddefnyddio'r un datganiad â'r adroddiad yn hytrach na pha fersiwn bynnag "
 "o gdb rydych chi wedi'i osod."
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 "Adroddwch gynnydd llwytho i lawr/gosod wrth osod pecynnau yn y blwch tywod"
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr "Paratowch stampiau amser i gofnodi negeseuon, ar gyfer gweithredu swp"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 "Creu a defnyddio storfeydd trydydd parti o wreiddiau sy'n cael eu nodi nodir "
 "mewn adroddiadau"
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr ""
 "Cyfeiriadur storfa ar gyfer pecynnau wedi'u llwytho i lawr yn y blwch tywod"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -753,12 +754,12 @@ msgstr ""
 "tybio bod unrhyw becyn sydd eisoes wedi'i lwytho I lawr hefyd yn cael ei "
 "echdynnu i'r blwch tywod hwn."
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr "Gosod pecyn ychwanegol yn y blwch tywod (mae modd ei nodi sawl gwaith)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -768,7 +769,7 @@ msgstr ""
 "ei ddefnyddio wrth nodi ID chwalfa i lwytho I fyny'r olion pentwr ôl-olrhain "
 "(dim ond os na nodir -g, -o, nac -s)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -776,31 +777,31 @@ msgstr ""
 "Yn dangos olion stac wedi'u hôl a gofyn am gadarnhad cyn eu hanfon i'r "
 "gronfa ddata damweiniau."
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 "Llwybr i'r gronfa ddata sqlite ddyblyg (rhagosodedig: dim gwirio dyblyg)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr "Peidiwch ag ychwanegu StacktraceSource at yr adroddiad."
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "Methu defnyddio -C heb -S. Stopio."
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "Iawn I anfon y rhain fel atodiadau? [y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr "%(prog)s <report> <target directory>"
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr "Ffeil adrodd i'w dadbacio"
 
@@ -808,19 +809,19 @@ msgstr "Ffeil adrodd i'w dadbacio"
 msgid "directory to unpack report to"
 msgstr "cyfeiriadur i ddadbacio adroddiad iddo"
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "Mae'r cyfeiriadur cyrchfan yn bodoli ac nid yw'n wag."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "Gweler tudalen man am fanylion."
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "nodwch enw'r ffeil log a gynhyrchwyd gan valgrind"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
@@ -828,7 +829,7 @@ msgstr ""
 "ailddefnyddio cyfeiriad blwch tywod a grëwyd yn flaenorol (SDIR) neu, os nad "
 "yw'n bodoli, ei greu"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -837,7 +838,7 @@ msgstr ""
 "symbolau dadfygio ychwanegol ond dibynnu ar symbolau dadfygio wedi'u gosod "
 "yn unig."
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
@@ -845,12 +846,12 @@ msgstr ""
 "ailddefnyddio cache dir (CDIR) a grëwyd yn flaenorol neu, os nad yw'n "
 "bodoli, ei greu"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 "adrodd cynnydd llwytho i lawr/gosod wrth osod pecynnau yn y blwch tywod"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
@@ -858,12 +859,12 @@ msgstr ""
 "y gweithredadwy sy'n cael ei redeg o dan offeryn memcheck valgrind ar gyfer "
 "canfod gollyngiadau cof"
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Gwall: Nid yw %s yn weithredadwy. Yn stopio."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -871,7 +872,7 @@ msgstr ""
 "Digwyddodd hyn yn ystod ataliad blaenorol, ac ataliodd y system rhag "
 "ailddechrau'n iawn."
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -879,7 +880,7 @@ msgstr ""
 "Digwyddodd hyn yn ystod cysgu trwm blaenorol, ac ataliodd y system rhag "
 "ailddechrau'n iawn."
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -887,7 +888,7 @@ msgstr ""
 "Roedd y prosesu ailddechrau yn hongian yn agos iawn at y diwedd a bydd yn "
 "ymddangos ei fod wedi'i gwblhau fel arfer."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 "Mae'n bosibl y bydd eich system yn mynd yn ansefydlog nawr ac efallai y bydd "
@@ -903,77 +904,77 @@ msgstr "Adrodd am broblem..."
 msgid "Report a malfunction to the developers"
 msgstr "Rhoi gwybod am gamweithio i'r datblygwyr"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "Mae'n ddrwg gennym, mae'r rhaglen %s wedi dod i ben yn annisgwyl."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "Mae'n ddrwg gennym, mae %s wedi cau'n annisgwyl."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "Mae'n ddrwg gennym, mae %s wedi profi gwall mewnol."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Anfon"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Dangos Manylion"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Parhau"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "Mae'r rhaglen %s wedi peidio ag ymateb."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "Mae'r rhaglen \"%s\" wedi peidio ag ymateb."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Pecyn: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "Ymddiheuriadau, cafwyd problem wrth osod meddalwedd."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "Mae'r rhaglen %s wedi profi gwall mewnol."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "Mae'r rhaglen %s wedi cau'n annisgwyl."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr ""
 "Os byddwch yn sylwi ar broblemau pellach, ceisiwch ailgychwyn y cyfrifiadur."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "Anwybyddwch broblemau o'r math hwn yn y dyfodol"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Cuddio Manylion"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -1029,7 +1030,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>Wrthi'n llwytho manylion problem</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -1041,27 +1042,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Ffeil chwalfa Apport"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "Gadael ar Gau"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Ail gychwyn"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Enw defnyddiwr:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Cyfrinair:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "Yn Casglu Manylion Problem"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1069,6 +1070,6 @@ msgstr ""
 "Mae modd anfon y wybodaeth a gasglwyd at y datblygwyr i wella'r\n"
 "rhaglen. Gall hyn gymryd ychydig funudau."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "Wrthi'n llwytho manylion problem"

--- a/po/da.po
+++ b/po/da.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2022-10-08 21:37+0000\n"
 "Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Language-Team: Danish <dansk@dansk-gruppen.dk>\n"
@@ -40,11 +40,11 @@ msgstr ""
 "Angiv venligst din adgangskode for at se rapporter over problemer med "
 "systemprogrammer"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "Denne pakke synes ikke at være korrekt installeret"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -55,7 +55,7 @@ msgstr ""
 "tilgængelige pakker og prøv igen. Virker det ikke, så fjern relaterede "
 "tredjepartspakker og prøv igen."
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -67,21 +67,16 @@ msgstr ""
 "følgende pakker og se om problemet stadig opstår:\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "ukendt program"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Undskyld, programmet \"%s\" lukkede uventet"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Problem i %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -89,62 +84,67 @@ msgstr ""
 "Din computer har ikke nok ledig hukommelse til en automatisk analyse af "
 "problemet og afsendelse af en rapport til udviklerne."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Problem i %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Ugyldig problemrapport"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "Du har ikke tilladelse til at tilgå denne problemrapport."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Fejl"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "Der er ikke nok diskplads til rådighed til at behandle denne rapport."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr "Ingen PID angivet"
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr "Du skal angive en PID. Se --help for flere oplysninger."
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "Ugyldigt PID"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr "Det angivne proces-ID findes ikke."
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr "Ikke dit PID"
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr "Det angivne proces-ID tilhører ikke dig."
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "Ingen pakke angivet"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr "Du skal angive en pakke eller en PID. Se --help for mere information."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Tilladelse nægtet"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -152,30 +152,30 @@ msgstr ""
 "Den angivne proces tilhører ikke dig. Kør venligst dette program som ejer af "
 "processen eller som administrator."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "Det angivne proces-ID tilhører ikke et program."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Symptomskript %s udpegede ikke en berørt pakke"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Pakke %s eksisterer ikke"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "Kan ikke oprette rapport"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "Opdaterer problemrapport"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -187,7 +187,7 @@ msgstr ""
 "\n"
 "Opret venligst en ny rapport ved at bruge \"apport-bug\"."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -208,24 +208,24 @@ msgstr ""
 "\n"
 "Ønsker du at fortsætte?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "Ingen yderligere oplysninger indsamlet."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "Hvilken slags problem ønsker du at rapportere?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Ukendt symptom"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Symptomet \"%s\" er ikke kendt."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -243,7 +243,7 @@ msgstr ""
 "fanebladet Processer ruller du ned, indtil du finder det rigtige program. "
 "Proces-id'et er nummeret vist i id-kolonnen."
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -251,30 +251,30 @@ msgstr ""
 "Tryk venligst på et programvindue - efter du lukker denne besked - for at "
 "rapportere et problem med det."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop kunne ikke bestemme proces-id for vinduet"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr "%(prog)s <rapportnummer>"
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "Angiv pakkenavn."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "Tilføj et ekstra mærke til rapporten. Kan gives flere gange."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr "%(prog)s [tilvalg] [symptom|pid|pakke|programsti|.apport/.crash-fil]"
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -284,15 +284,15 @@ msgstr ""
 "eller blot et --pid. Fremvis en liste over kendte symptomer, hvis ingen af "
 "delene er angivet. (Underforstået hvis et enkelt argument er angivet.)"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "Klik på et vindue som et mål for indsendelse af en fejlrapport."
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "Start i fejlopdateringstilstand. Kan have et valgfrit --package."
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -300,7 +300,7 @@ msgstr ""
 "Opret en fejlrapport om et symptom. (Underforstået hvis symptomnavn er "
 "angivet som eneste argument.)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -308,7 +308,7 @@ msgstr ""
 "Angiv pakkenavn i --file-bug-tilstand. Dette er valgfrit hvis et --pid er "
 "angivet. (Underforstået hvis pakkenavn er angivet som eneste argument.)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -318,11 +318,11 @@ msgstr ""
 "fejlrapporten indeholde mere information. (Underforstået, hvis pid gives som "
 "eneste argument.)"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "Det angivne pid er et program som hænger."
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -332,7 +332,7 @@ msgstr ""
 "igangværende filer i %s. (Underforstået hvis fil er angivet som eneste "
 "argument.)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -342,48 +342,48 @@ msgstr ""
 "stedet for at rapportere den. Denne fil kan så rapporteres fra en anden "
 "maskine på et senere tidspunkt."
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Skriv Apport-versionnummer."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Dette vil køre apport-retrace i et terminalvindue for at undersøge "
 "nedbruddet."
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "Kør gdb-session"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Kør gdb-session uden at hente fejlsøgningssymboler"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Opdatér %s med fuldt symbolsk stakspor"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr "Kan ikke huske indstillinger for status for send-rapport"
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 "Det lykkedes ikke at gemme tilstanden for rapportering af nedbrud. Kan ikke "
 "angive rapporteringstilstandene auto eller aldrig."
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr "Kan ikke huske indstillinger for status for send-rapport"
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr "Problemrapporten vedrører et program, som ikke længere er installeret."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
@@ -391,19 +391,21 @@ msgid ""
 msgstr ""
 "Problemet opstod med programmet %s, som har ændret sig siden sidste nedbrud."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Denne problemrapport er beskadiget og kan ikke behandles."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr "Denne rapport handler om en pakke, som ikke er installeret."
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "Der opstod en fejl ved forsøg på at behandle denne problemrapport:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
@@ -411,23 +413,23 @@ msgstr ""
 "Du har to versioner af programmet installeret. Hvilken en vil du rapportere "
 "en fejl i?"
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr "%s snap"
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr "%s deb-pakke"
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s leveres af en snap som er udgivet af %s. Kontakt dem via %s for hjælp."
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -436,40 +438,40 @@ msgstr ""
 "%s leveres af en snap som er udgivet af %s. Der er ikke leveret nogen "
 "kontaktadresse. Besøg forummet på https://forum.snapcraft.io/ for hjælp."
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "Kunne ikke bestemme pakken eller kildepakkenavn."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "Kan ikke starte internetbrowser"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Kan ikke starte internetbrowser for at åbne %s."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Netværksproblem"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Kan ikke forbinde til nedbrudsdatabase. Kontrollér venligst din "
 "internetforbindelse."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Netværksproblem"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Overbelastning af hukommelse"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Dit system har ikke hukommelse nok til at behandle denne nedbrudsrapport."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -480,11 +482,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "Problemet er allerede kendt"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -494,39 +496,38 @@ msgstr ""
 "din internetbrowser. Kontrollér venligst om du kan tilføje yderligere "
 "information, som kan være til hjælp for udviklerne."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 "Dette problem er allerede blevet rapporteret til udviklerne. Mange tak!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Tryk på en tast for at fortsætte..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "Hvad ønsker du at foretage dig? Dine valg er:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Vælg venligst (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i bytes)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(binære data)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Send problemrapport til udviklerne?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -534,51 +535,51 @@ msgstr ""
 "Efter problemrapporten er afsendt, bedes du udfylde formularen i den\n"
 "internetbrowser, som åbner automatisk."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "&Send rapport (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "&Undersøg lokalt"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "&Læs rapport"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 "&Behold rapportfil til senere afsendelse eller kopiér den til et andet sted"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "Annullér og &ignorér nedbrud med denne programversion fremover"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Annullér"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Problemrapportfil:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&Bekræft"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Fejl: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "Indsamler information om problem"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -586,11 +587,11 @@ msgstr ""
 "De indsamlede informationer kan sendes til udviklerne med henblik på\n"
 " at forbedre programmet. Dette kan tage nogle få minutter."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "Sender probleminformation"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -598,40 +599,40 @@ msgstr ""
 "De indsamlede informationer sendes til fejlregistreringssystemet.\n"
 "Dette kan tage et par minutter."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Færdig"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "intet"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "Valgt: %s. Flere valg:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Valg:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "Sti til fil (Enter for at annullere):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "Fil eksisterer ikke."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "Dette er et katalog."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "Du skal beøge følgende internetadresse for at fortsætte:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -639,15 +640,15 @@ msgstr ""
 "Du kan åbne en browser nu eller kopiere adressen til en browser på en anden "
 "computer."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Åbn en browser nu"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr "Ingen ventende nedbrudsrapporter. Prøv --help for mere information."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr "Føj ikke nye spor ind i rapporten, men skriv dem til stdout."
 
@@ -666,27 +667,27 @@ msgstr ""
 "Skriv tilpasset rapport til en angivet fil i stedet for at ændre den "
 "oprindelige rapport"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr "Fjern kernedump fra rapporten efter genoprettelsen af stakspor"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "Tilsidesæt rapports kernefil (CoreFile)"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "Tilsidesæt rapports ExecutablePath"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "Tilsidesæt rapports ProcMaps"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "Genopbyg rapports pakkeinformation"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -702,7 +703,7 @@ msgstr ""
 "\"system\", vi den bruge systemkonfigurationsfilen, men vil så kun kunne "
 "følge nedbrud, der skete på den aktuelt kørende udgivelse."
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
@@ -712,27 +713,27 @@ msgstr ""
 "afhængigheder med den samme udgivelse som rapporteret, fremfor hvilken "
 "version af gdb du har installeret."
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 "Rapporter hentning/installeringsfremskridt når pakker installeres i "
 "sandkassen"
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr "Foranstil tidsstempler i logbeskeder til batch-operation"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 "Opret og benyt tredjepartsarkiver fra kilder som er angivet i rapporter"
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr "Mellemlagermappe for pakker som er hentet til sandkassen"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -740,12 +741,12 @@ msgstr ""
 "Katalog for udpakkede pakker. Fremtidige kørsler vil antage at enhver pakke "
 "som allerede er hentet, også udpakkes til denne sandkasse."
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr "Installér en ekstra pakke til sandkassen (kan angives flere gange)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -755,7 +756,7 @@ msgstr ""
 "bruges, når et nedbruds-id angives til at sende de gensporerede stakspor "
 "(kun hvis hverken -g, -o, eller -s er angivet)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -763,30 +764,30 @@ msgstr ""
 "Vis gensporerede stakspor og spørg om bekræftelse før de afsendes til "
 "nedbrudsdatabasen."
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr "Sti til sqlite-duplikatdatabasen (standard: ingen duplikeret kontrol)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr "Tilføj ikke StacktraceSource til rapporten."
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "Du kan ikke benytte -C uden -S. Afbryder."
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "O.k. at sende disse som bilag [y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr "%(prog)s <rapport> <målmappe>"
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr "Rapportfil som skal udpakkes"
 
@@ -794,19 +795,19 @@ msgstr "Rapportfil som skal udpakkes"
 msgid "directory to unpack report to"
 msgstr "mappe som rapport skal udpakkes i"
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "Destinationskatalog eksisterer og er ikke tomt."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "Se manualsiden for detaljer."
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "angiv navnet på logfilen som blev fremstillet af valgrind"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
@@ -814,7 +815,7 @@ msgstr ""
 "genbrug en tidligere oprettet sandkassemappe (SDIR) eller, hvis denne ikke "
 "findes, opret den"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -822,7 +823,7 @@ msgstr ""
 "undlad at oprette eller genbruge en sandkassemappe for yderligere "
 "fejlsøgningssymboler, og gør kun brug af installerede fejlsøgningssymboler."
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
@@ -830,13 +831,13 @@ msgstr ""
 "genbrug en tidligere oprettet cachemappe (CDIR) eller, hvis denne ikke "
 "findes, opret den"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 "rapportér hentning/installationsforløb, når der installeres pakker i "
 "sandkassen"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
@@ -844,12 +845,12 @@ msgstr ""
 "programmet som køres under valgrinds hukommelsestjekværktøj til registrering "
 "af hukommelseslæk"
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Fejl: %s er ikke en eksekvérbar fil. Afbryder."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -857,7 +858,7 @@ msgstr ""
 "Dette skete under en tidligere hviletilstand, og forhindrede systemet i at "
 "vågne op korrekt."
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -865,7 +866,7 @@ msgstr ""
 "Dette skete under en tidligere dvaletilstand, og forhindrede systemet i at "
 "vågne op korrekt."
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -873,7 +874,7 @@ msgstr ""
 "Opvågningsprocessen gik i stå meget tæt på slutningen, og den har set ud, "
 "som om den er blevet fuldført på normal vis."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 "Dit system kan blive ustabilt nu og kan få brug for at blive genstartet."
@@ -888,77 +889,77 @@ msgstr "Rapportér et problem..."
 msgid "Report a malfunction to the developers"
 msgstr "Rapportér en funktionsfejl til udviklerne"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "Beklager, men programmet %s er stoppet uventet."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "Beklager, men %s lukkede ned uventet."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "Beklager, men der opstod en intern fejl i %s."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Send"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Vis detaljer"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Fortsæt"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "Programmet %s er holdt op med at svare."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "Programmet \"%s\" er holdt op med at svare."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Pakke: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "Beklager, men der opstod et problem under installation af software."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "Programmet %s er stødt på en intern fejl."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "Programmet %s lukkede ned uventet."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr ""
 "Hvis du bemærker yderligere problemer, så prøv at genstarte computeren."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "Ignorér denne type problemer fremover"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Skjul detaljer"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -1014,7 +1015,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>Sender probleminformation</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -1026,27 +1027,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Apport-nedbrudsfil"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "Lad være lukket"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Genstart"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Brugernavn:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Adgangskode:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "Indsamler information om problemet"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1054,6 +1055,6 @@ msgstr ""
 "Den indsamlede information kan sendes til udviklerne for at forbedre "
 "programmet. Dette kan tage nogle få minutter."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "Afsender probleminformation"

--- a/po/de.po
+++ b/po/de.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport 0.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2015-09-10 15:08+0000\n"
 "Last-Translator: Martin Pitt <martin@piware.de>\n"
 "Language-Team: German <de@li.org>\n"
@@ -39,11 +39,11 @@ msgstr ""
 "Bitte geben Sie Ihr Passwort ein, um zu den Problemberichten von "
 "Systemprogrammen zu gelangen"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "Dieses Paket scheint nicht richtig installiert zu sein"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -55,7 +55,7 @@ msgstr ""
 "funktioniert, entfernen Sie die entsprechenden Pakete von Drittanbietern und "
 "versuchen Sie es erneut."
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -69,21 +69,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "unbekanntes Programm"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Entschuldigung, das Programm »%s« wurde unerwartet beendet"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Problem in %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -91,66 +86,71 @@ msgstr ""
 "Ihr System besitzt nicht genug Speicher, um den Absturzbericht zu "
 "verarbeiten und einen Bericht an die Entwickler zu senden."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Problem in %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Ungültiger Problembericht"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "Sie haben keine Berechtigung für diesen Problembericht."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Fehler"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 "Ihr System besitzt nicht genug Festplattenplatz, um den Absturzbericht zu "
 "verarbeiten."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr "Keine PID angegeben"
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr "Sie müssen eine PID angeben. Siehe --help für weitere Informationen"
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "Ungültige Prozesskennung"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr "Die angegebene Prozesskennung existiert nicht."
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr "Nicht Ihre Prozesskennung (PID)"
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr "Die angegebene Prozesskennung gehört nicht Ihnen."
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "Kein Paket angegeben"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Sie müssen ein Paketnamen oder eine PID angeben. Versuchen Sie --help für "
 "weitere Informationen."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Zugriff verweigert"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -158,30 +158,30 @@ msgstr ""
 "Der angegebene Prozess gehört nicht Ihnen. Bitte starten Sie dieses Programm "
 "als den Prozesseigentümer oder als root."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "Die angegebene Prozesskennung gehört zu keinem Programm."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Symptom-Skript %s konnte kein betroffenes Paket finden"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Paket %s existiert nicht"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "Bericht kann nicht erstellt werden"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "Problembericht wird aktualisiert"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -194,7 +194,7 @@ msgstr ""
 "\n"
 "Bitte erstellen Sie mit »apport-bug« einen neuen Problembericht."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -215,24 +215,24 @@ msgstr ""
 "\n"
 "Möchten Sie wirklich fortfahren?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "Keine zusätzlichen Informationen gesammelt."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "Welche Art von Problem möchten Sie melden?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Unbekanntes Symptom"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Das Symptom »%s« ist nicht bekannt."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -252,7 +252,7 @@ msgstr ""
 "Anwendung finden. Die Prozess-ID ist die Nummer, die in der Spalte »Kennung« "
 "aufgeführt ist."
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -260,33 +260,33 @@ msgstr ""
 "Nachdem Sie diese Meldung geschlossen haben, klicken Sie bitte auf das "
 "Fenster der Anwendung, zu der Sie ein Problem melden möchten."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "Xprop konnte die Prozesskennung des Fensters nicht ermitteln"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr "%(prog)s <Berichtsnummer>"
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "Paketnamen angeben."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Eine zusätzliches Schlagwort zu dem Bericht hinzufügen. Kann mehrfach "
 "angegeben werden."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 "%(prog)s [Optionen] [Symptom|pid|Paket|Programmpfad|.apport/.crash-Datei]"
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -296,19 +296,19 @@ msgstr ""
 "nur --pid. Wenn keines angegeben wird, eine Liste bekannter Symptome "
 "anzeigen. (Implizit, wenn nur ein einzelnes Argument angegeben wird.)"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 "Klicken Sie bitte auf das Fenster der Anwendung, die im Bericht vorkommen "
 "soll."
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "Im Fehleraktualisierungsmodus starten. Option --package kann zusätzlich "
 "angegeben werden."
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -316,7 +316,7 @@ msgstr ""
 "Fehler als einen Bericht über ein Symptom melden. (Implizit, wenn der "
 "Symptom-Name als einziges Argument angegeben wird.)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -325,7 +325,7 @@ msgstr ""
 "optional, wenn --pid angegeben wird. (Implizit, wenn der Paketname als "
 "einziges Argument angegeben wurde.)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -335,11 +335,11 @@ msgstr ""
 "Fehlerbericht mehr Informationen enthalten. (Standard, wenn das einzige "
 "Argument eine PID ist.)"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "Die angegebene pid ist eine nicht reagierende Anwendung."
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -349,7 +349,7 @@ msgstr ""
 "anstatt aus einer der in %s wartenden. (Implizit, wenn ein Dateiname als "
 "einziges Argument angegeben wurde.)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -359,50 +359,50 @@ msgstr ""
 "Datei, anstatt sie direkt zu melden. Diese Datei kann später von einem "
 "anderen Rechner aus gesendet werden, um den Fehler zu melden."
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Die Versionsnummer von Apport ausgeben."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Hierdurch wird apport-retrace in einem Terminal ausgeführt, um die "
 "Absturzursache zu untersuchen."
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "Eine gdb-Sitzung ausführen"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Eine gdb-Sitzung ausführen ohne Fehlerdiagnosesymbole herunterzuladen"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "%s mit vollständig symbolischen Stapelspeicher aktualisieren"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-"Die Einstellungen des Sendereportstatus konnten nicht gespeichert werden"
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 "Speichern der Fehlerberichterstattungs-Einstellungen fehlgeschlagen. Die "
 "Option, Fehler automatisch oder nie zu melden konnte nicht gesetzt werden."
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+"Die Einstellungen des Sendereportstatus konnten nicht gespeichert werden"
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 "Der Bericht gehört zu einem Programm welches nicht mehr installiert ist."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
@@ -411,21 +411,23 @@ msgstr ""
 "Das Problem trat in der Anwendung %s auf, die seit dem Absturz verändert "
 "wurde."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr ""
 "Dieser Problembericht ist beschädigt und kann nicht verarbeitet werden."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr "In diesem Bericht geht es um ein Paket, welches nicht installiert ist."
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr ""
 "Bei der Verarbeitung dieses Fehlerberichts ist ein Problem aufgetreten:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
@@ -433,24 +435,24 @@ msgstr ""
 "Sie haben zwei Versionen dieser Anwendung installiert. Gegen welche wollen "
 "Sie einen Fehler melden?"
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr "%s Snap"
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr "%s deb Paket"
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s wird durch einen von %s veröffentlichten Snap bereitgestellt. Für Hilfe "
 "gehen Sie über %s."
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -460,41 +462,41 @@ msgstr ""
 "keine Kontaktadresse angegeben; besuchen Sie das Forum unter https://forum."
 "snapcraft.io/, um Hilfe zu erhalten."
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "Paket- oder Quellpaketname konnten nicht bestimmt werden."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "Konnte Webbrowser nicht starten"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Konnte Webbrowser nicht starten um %s zu öffnen."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Netzwerkproblem"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Es konnte keine Verbindung zur Fehlerdatenbank aufgebaut werden. Bitte "
 "prüfen Sie Ihre Internetverbindung."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Netzwerkproblem"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Kein Speicher mehr verfügbar"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Ihr System besitzt nicht genug Speicher, um den Absturzbericht zu "
 "verarbeiten."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -505,11 +507,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "Dieses Problem ist bereits bekannt"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -520,38 +522,37 @@ msgstr ""
 "weiteren Informationen, welche für die Entwickler hilfreich sein könnten, "
 "hinzufügen können."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Dieses Problem wurde den Entwicklern bereits gemeldet. Vielen Dank!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Bitte eine Taste drücken, um fortzufahren …"
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "Was möchten Sie tun? Ihre Möglichkeiten sind:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Bitte auswählen (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i Bytes)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(binäre Daten)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Problembericht an die Entwickler senden?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -560,52 +561,52 @@ msgstr ""
 "aus, \n"
 "welches sich automatisch in Ihrem Webbrowser öffnen wird."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "Bericht &senden (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "&Lokal analysieren"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "Bericht an&zeigen"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 "Berichtsdatei &behalten, für spätere Meldung oder um sie an einen anderen "
 "Ort zu kopieren."
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "Abbrechen und zukünftige Abstürze dieser Programmversion &ignorieren"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Abbruch"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Datei mit Problembericht:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&Bestätigen"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Fehler: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "Probleminformationen werden gesammelt"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -613,11 +614,11 @@ msgstr ""
 "Die gesammelten Informationen können an die Entwickler gesendet werden,\n"
 "um die Anwendung zu verbessern. Das kann einige Minuten dauern."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "Probleminformationen werden übermittelt"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -625,40 +626,40 @@ msgstr ""
 "Die gesammelten Informationen werden zum Fehlerverfolgungssystem gesendet.\n"
 "Das kann einige Minuten dauern."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Fertig"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "keine"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "Gewählt: %s. Mehrfache Auswahl:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Auswahl:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "Pfad zur Datei (Eingabetaste um abzubrechen):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "Datei existiert nicht."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "Das ist ein Verzeichnis."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "Um fortzufahren, müssen Sie die folgende Adresse aufrufen:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -666,17 +667,17 @@ msgstr ""
 "Sie können jetzt einen Browser starten oder diese Adresse, in einen Browser "
 "auf einem anderen Rechner, kopieren."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Browser starten"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 "Keine aktuellen Absturzberichte. Versuchen Sie --help für weitere "
 "Informationen."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 "Die neuen Stapelspeicher nicht in die Berichtsdatei, sondern auf die "
@@ -697,29 +698,29 @@ msgstr ""
 "Den aktualisierten Bericht in die angegebene Datei schreiben anstatt den "
 "Originalbericht zu ändern"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 "Den Kernspeicherauszug vom Bericht entfernen, nachdem der Stapelspeicher neu "
 "generiert wurde"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "CoreFile des Berichts überschreiben"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "ExecutablePath des Berichts überschreiben"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "ProcMaps des Berichts überschreiben"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "Die Paketinformation des Berichts erneuern"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -737,7 +738,7 @@ msgstr ""
 "Sie dann nur in der Lage Abstürze in der aktuell laufenden Veröffentlichung "
 "zurück zu verfolgen."
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
@@ -747,30 +748,30 @@ msgstr ""
 "der Abhängigkeiten mit der gleichen Version aus dem Bericht statt der "
 "bereits von Ihnen installierten Version."
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 "Übertragungs-/Installationsfortschritt anzeigen, wenn Pakete in einer "
 "Sandbox installiert werden"
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr ""
 "Protokolleinträgen einen Zeitstempel voranstellen, für Stapelverarbeitung"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 "Verwende Paketquellen von Drittanbietern die in Berichten angegeben sind"
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr ""
 "Ordner zum Zwischenspeichern von Paketen, die in der Sandbox heruntergeladen "
 "wurden"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -779,14 +780,14 @@ msgstr ""
 "ausgegangen, dass alle bereits heruntergeladenen Pakete in diese Sandbox "
 "entpackt worden sind."
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 "Ein zusätzliches Paket in die Sandbox installieren (kann mehrfach angegeben "
 "werden)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -797,7 +798,7 @@ msgstr ""
 "der Absturzdaten angegeben wird (nur wenn weder »-g«, »-o« oder »-s« "
 "angegeben werden)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -805,32 +806,32 @@ msgstr ""
 "Zurückverfolgte Stapelspeicher anzeigen und auf Bestätigung warten, bevor "
 "sie zur Fehlerdatenbank gesendet werden."
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 "Pfad zur sqlite-Datenbank mit den Duplikaten (Voreinstellung: Keine Prüfung "
 "auf Duplikate)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr "Fügen Sie dem Bericht keine StackTraceSource hinzu."
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "Sie dürfen -C nicht ohne -S verwenden. Abbruch."
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "Dürfen diese als Anlage mitgeschickt werden? [y = Ja / n = Nein]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr "%(prog)s <Bericht> <Zielverzeichnis>"
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr "Zu entpackende Datei melden"
 
@@ -838,20 +839,20 @@ msgstr "Zu entpackende Datei melden"
 msgid "directory to unpack report to"
 msgstr "Verzeichnis, in welches der Bericht entpackt werden soll"
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "Zielordner existiert und ist nicht leer."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "Weitere Informationen finden Sie in der Handbuchseite."
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr ""
 "Den Namen der Protokolldatei festlegen, die von valgrind erstellt wurde"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
@@ -859,7 +860,7 @@ msgstr ""
 "Einen zuvor erzeugten Sandbox-Ordner (SDIR) verwenden oder einen neuen "
 "erzeugen, falls er noch nicht existiert"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -868,7 +869,7 @@ msgstr ""
 "Fehlerdiagnosesymbole, sondern auf installierte Fehlerdiagnosesymbole "
 "verlassen."
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
@@ -876,13 +877,13 @@ msgstr ""
 "Einen zuvor erzeugten Zwischenspeicherordner (CDIR) verwenden, oder einen "
 "neuen erstellen, falls er noch nicht existiert"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 "Übertragungs-/Installationsfortschritt anzeigen, wenn Pakete in einer "
 "Sandbox installiert werden"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
@@ -890,12 +891,12 @@ msgstr ""
 "Die ausführbare Datei, die unter valgrind's Speicherdiagnose-Tool zur "
 "Erkennung von Speicherlecks ausgeführt wird"
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Fehler: %s ist keine ausführbare Datei. Abbruch."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -903,7 +904,7 @@ msgstr ""
 "Das geschah während eines vorhergehenden Bereitschaftsmodus und verhinderte "
 "ein ordnungsgemäßes Fortsetzen."
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -911,7 +912,7 @@ msgstr ""
 "Das geschah während eines vorhergehenden Ruhezustandes und verhinderte ein "
 "ordnungsgemäßes Fortsetzen."
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -919,7 +920,7 @@ msgstr ""
 "Das Fortsetzen blieb nahe dem Ende des Vorgangs hängen und wird ausgesehen "
 "haben, also ob es ordnungsgemäß abgeschlossen wurde."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 "Ihr System könnte nun instabil werden, und muss eventuell neu gestartet "
@@ -935,79 +936,79 @@ msgstr "Einen Fehler melden …"
 msgid "Report a malfunction to the developers"
 msgstr "Den Entwicklern eine Fehlfunktion melden"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "Entschuldigung, die Anwendung »%s« wurde unerwartet beendet."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "Entschuldigung, »%s« wurde unerwartet beendet."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "Entschuldigung, »%s« hat einen internen Fehler festgestellt."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Senden"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Einzelheiten anzeigen"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Fortfahren"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "Die Anwendung %s reagiert nicht mehr."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "Das Programm »%s« reagiert nicht mehr."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Paket: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr ""
 "Entschuldigung, beim Installieren der Anwendung ist ein Problem aufgetreten."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "Die Anwendung %s hat einen internen Fehler festgestellt."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "Entschuldigung, %s wurde unerwartet beendet."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr ""
 "Falls Sie weitere Probleme bemerken, versuchen Sie Ihren Rechner neu zu "
 "starten."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "Zukünftige Abstürze dieser Art ignorieren"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Einzelheiten ausblenden"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -1064,7 +1065,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>Probleminformationen werden übermittelt</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -1076,27 +1077,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Apport-Absturzberichtsdatei"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "Geschlossen lassen"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Neu starten"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Benutzername:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Passwort:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "Probleminformationen werden gesammelt"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1104,6 +1105,6 @@ msgstr ""
 "Die gesammelten Informationen können an die Entwickler gesendet werden um "
 "die Anwendung zu verbessern. Das kann einige Minuten dauern."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "Probleminformationen werden übermittelt"

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2015-04-27 21:47+0000\n"
 "Last-Translator: Nick Andrik <nick.andrik@gmail.com>\n"
 "Language-Team: Greek, Modern (1453-) <el@li.org>\n"
@@ -40,11 +40,11 @@ msgstr ""
 "Παρακαλώ εισάγετε το συνθηματικό σας για να αποκτήσετε πρόσβαση στις "
 "αναφορές προβλημάτων των προγραμμάτων συστήματος"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "Αυτό το πακέτο δεν φαίνεται να έχει εγκατασταθεί σωστά"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -52,7 +52,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -66,21 +66,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "άγνωστο πρόγραμμα"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Συγνώμη, το πρόγραμμα \"%s\" τερματίστηκε απροσδόκητα"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Πρόβλημα στο %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -88,66 +83,71 @@ msgstr ""
 "Ο υπολογιστής σας δεν έχει αρκετή ελεύθερη μνήμη για να αναλύσει αυτόματα το "
 "πρόβλημα και να στείλει μια αναφορά στους προγραμματιστές."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Πρόβλημα στο %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Μη έγκυρη αναφορά προβλήματος"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr ""
 "Δεν σας επιτρέπεται να αποκτήσετε πρόσβαση σε αυτή την αναφορά προβλήματος."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Σφάλμα"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 "Δεν υπάρχει αρκετός χώρος στον δίσκο για την επεξεργασία αυτής της αναφοράς."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "Άκυρος αριθμός αναγνώρισης της διεργασίας (PID)"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr "Το καθορισμένο αναγνωριστικό διαδικασίας δεν υπάρχει."
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr "Δεν είναι η ταυτότητα της διεργασίας σας"
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr "Το καθορισμένο αναγνωριστικό διεργασίας δεν ανήκει σε εσάς."
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "Δεν ορίστηκε πακέτο"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Χρειάζεται να ορίσετε ένα πακέτο ή ένα PID. Δείτε την --help για "
 "περισσότερες πληροφορίες."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Δεν επιτρέπεται η πρόσβαση"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -155,32 +155,32 @@ msgstr ""
 "Η συγκεκριμένη διεργασία δεν ανήκει σε εσάς. Παρακαλούμε τρέξτε το πρόγραμμα "
 "ως ιδιοκτήτης της διεργασίας ή ως root."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr ""
 "Αυτός ο αριθμός αναγνώρισης της διεργασίας (PID) δεν ανήκει σε κάποιο "
 "πρόγραμμα"
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Το σενάριο συμπτώματος %s δεν προσδιόρισε κανένα επηρεασμένο πακέτο"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Το πακέτο %s δεν υπάρχει"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "Αδυναμία δημιουργίας αναφοράς"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "Ενημέρωση αναφοράς προβλήματος"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -192,7 +192,7 @@ msgstr ""
 "\n"
 "Παρακαλούμε δημιουργήστε μια νέα αναφορά με τη χρήση του \"apport-bug\"."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -213,24 +213,24 @@ msgstr ""
 "\n"
 "Θέλετε σίγουρα να προχωρήσετε;"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "Δεν έχουν συλλεχθεί επιπλέον πληροφορίες."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "Τι είδους πρόβλημα θέλετε να αναφέρετε;"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Άγνωστο σύμπτωμα"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Το σύμπτωμα \"%s\" είναι άγνωστο."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -241,7 +241,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -249,31 +249,31 @@ msgstr ""
 "Αφού κλείσετε αυτό το μήνυμα παρακαλούμε κάντε κλικ στο παράθυρο μιας "
 "εφαρμογής για να αναφέρετε ένα πρόβλημα σχετικό με αυτήν."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "Το xprop απέτυχε να προσδιορίσει την ταυτότητα (PID) του παραθύρου."
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "Καθορίστε ένα όνομα πακέτου."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Προσθέστε μια επιπλέον ετικέτα στην αναφορά. Μπορεί να οριστεί πολλές φορές."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -284,19 +284,19 @@ msgstr ""
 "εμφανίστε έναν κατάλογο γνωστών συμπτωμάτων. ( Η εξ ορισμού επιλογή εάν "
 "δίνεται ένα και μοναδικό όρισμα.)"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 "Επιλέξτε ένα παράθυρο πατώντας το, για να συμπληρώσετε μια αναφορά "
 "προβλήματος."
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "Εκκίνηση σε λειτουργία ενημέρωσης σφάλματος. Δέχεται προαιρετικά την "
 "παράμετρο --package."
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -304,7 +304,7 @@ msgstr ""
 "Υποβάλετε αναφορά σφάλματος για ένα σύμπτωμα. (Στην περίπτωση που η ονομασία "
 "του συμπτώματος δίνεται ως μοναδικό όρισμα.)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -313,7 +313,7 @@ msgstr ""
 "έχει ήδη καθοριστεί ένα --pid. (Στην περίπτωση που το όνομα πακέτου δίνεται "
 "ως μοναδικό όρισμα.)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -323,13 +323,13 @@ msgstr ""
 "προσδιοριστεί, η αναφορά θα περιέχει περισσότερες πληροφορίες. (Όταν η "
 "ταυτότητα διεργασίας (PID) δίνεται ως η μόνη παράμετρος.)"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr ""
 "Το παρεχόμενο αναγνωριστικό διεργασίας (PID) είναι για μια εφαρμογή που έχει "
 "κολλήσει."
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -338,7 +338,7 @@ msgstr ""
 "Αναφέρετε την κατάρρευση από το δεδομένο αρχείο .apport ή .crash αντί αυτών "
 "στο %s. (Στην περίπτωση που το αρχείο δίδεται ως το μοναδικό όρισμα.)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -348,49 +348,49 @@ msgstr ""
 "πληροφορίες σε ένα αρχείο αντί να τις αναφέρετε. Το αρχείο αυτό μπορεί να "
 "αποσταλεί για αναφορά αργότερα από έναν διαφορετικό υπολογιστή."
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Τυπώστε τον αριθμό έκδοσης της εφαρμογής Apport."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Αυτό θα εκκινήσει το apport-retrace σε ένα παράθυρο τερματικού για να "
 "διερευνηθεί η σύγκρουση."
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "Εκτέλεση συνεδρίας gdb"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Εκτέλεση συνεδρίας gdb χωρίς λήψη συμβόλων εκφαλμάτωσης"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Ενημέρωση %s με πλήρως συμβολική παρακολούθηση στίβας"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-"Δεν μπορεί να αποθηκευθεί η ρύθμιση να μην στέλνονται αναφορές κατάστασης"
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 "Αποτυχία αποθήκευσης κατάστασης αναφορών των καταρρεύσεων. Δεν είναι δυνατή "
 "η ρύθμιση της λειτουργίας αυτόματης ή μη αναφοράς."
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+"Δεν μπορεί να αποθηκευθεί η ρύθμιση να μην στέλνονται αναφορές κατάστασης"
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr "Αυτή η αναφορά αφορά πρόγραμμα το οποίο έχει πλέον απεγκατασταθεί."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
@@ -399,86 +399,88 @@ msgstr ""
 "Το πρόβλημα παρουσιάστηκε με το πρόγραμμα %s το οποίο έχει αλλάξει από τη "
 "στιγμή που συνέβη η κατάρρευση."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr ""
 "Αυτή η αναφορά προβλήματος έχει καταστραφεί και είναι αδύνατη η επεξεργασία "
 "της."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr "Αυτή η αναφορά είναι για ένα πακέτο που δεν έχει εγκατασταθεί."
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr ""
 "Παρουσιάστηκε ένα σφάλμα κατά την προσπάθεια επεξεργασίας αυτής της αναφοράς "
 "προβλήματος:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr "%s snap"
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr "%s πακέτο deb"
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr ""
 "Αδύνατος ο καθορισμός του πακέτου ή του ονόματος του πακέτου πηγαίου κώδικα."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "Αδύνατη η εκκίνηση του περιηγητή"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Αδύνατη η εκκίνηση του περιηγητή για το άνοιγμα του %s."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Πρόβλημα δικτύου"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Αδυναμία σύνδεσης στη βάση δεδομένων καταρρεύσεων, παρακαλώ ελέγξτε τη "
 "σύνδεσή σας στο διαδίκτυο."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Πρόβλημα δικτύου"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Εξάντληση μνήμης"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Το σύστημα δεν έχει αρκετή ελεύθερη μνήμη για τη διαδικασία αναφοράς "
 "κατάρρευσης."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -489,11 +491,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "Πρόβλημα ήδη γνωστό"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -503,40 +505,39 @@ msgstr ""
 "που βλέπετε. Παρακαλώ εξετάστε, αν μπορείτε να προσθέσετε κάποιες επιπλέον "
 "πληροφορίες, που να είναι χρήσιμες στους προγραμματιστές."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 "Αυτό το πρόβλημα έχει ήδη αναφερθεί στους συντελεστές της εφαρμογής. Σας "
 "ευχαριστούμε!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Πατήστε ένα πλήκτρο για να συνεχίσετε..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "Τι θα θέλατε να κάνετε; Οι επιλογές σας είναι:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Παρακαλώ επιλέξτε (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i bytes)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(δυαδικά δεδομένα)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Αποστολή αναφοράς προβλήματος στους προγραμματιστές;"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -544,53 +545,53 @@ msgstr ""
 "Μετά την αποστολή της αναφοράς προβλήματος, παρακαλώ\n"
 "συμπληρώστε την φόρμα στον περιηγητή ιστού που θα ανοίξει αυτόματα."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "Απο&στολή αναφοράς (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "&Διερεύνηση τοπικά"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "&Εμφάνιση αναφοράς"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 "&Κράτηση της αναφοράς για μετέπειτα αποστολή ή αντιγραφή της κάπου αλλού"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr ""
 "Ακύρωση και αγνόηση μελλοντ&ικών καταρρεύσεων αυτής της έκδοσης του "
 "προγράμματος"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Ακύρωση"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Αρχείο αναφοράς προβλήματος:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&Επιβεβαίωση"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Σφάλμα: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "Συλλογή πληροφοριών προβλήματος"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -599,11 +600,11 @@ msgstr ""
 "ανάπτυξης για την περαιτέρω βελτίωση της\n"
 "εφαρμογής. Η αποστολή μπορεί να διαρκέσει μερικά λεπτά."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "Αποστολή πληροφοριών προβλήματος"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -612,41 +613,41 @@ msgstr ""
 "σφαλμάτων.\n"
 "Αυτό μπορεί να διαρκέσει μερικά λεπτά."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Ολοκληρώθηκε"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "κανένα"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "Επιλέχθηκε: %s. Πολλαπλές επιλογές:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Επιλογές:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "Διαδρομή προς το αρχείο (πατήστε Enter για ακύρωση):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "Το αρχείο δεν υπάρχει."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "Αυτό είναι κατάλογος αρχείων."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr ""
 "Για να συνεχίσετε πρέπει να επισκεφθείτε αυτή τη διεύθυνση διαδικτύου (URL):"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -654,17 +655,17 @@ msgstr ""
 "Μπορείτε να εκκινήσετε τώρα ένα περιηγητή ιστοσελίδων ή να αντιγράψετε αυτή "
 "τη διεύθυνση σε έναν περιηγητή σε άλλον υπολογιστή."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Εκκινήστε έναν περιηγητή ιστοσελίδων τώρα"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 "Δεν εκκρεμούν αναφορές καταρρεύσεων. Δοκιμάστε την --help για περισσότερες "
 "πληροφορίες."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 "Να μην γίνει προσθήκη νέων στοιχείων στην αναφορά, αλλά να γραφτούν στο "
@@ -685,29 +686,29 @@ msgstr ""
 "Εγγραφή της τροποποιημένης αναφοράς στο επιλεγμένο αρχείο αντί για αλλαγή "
 "της αρχικής αναφοράς"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 "Αφαίρεση του αρχείου εικόνας μνήμης (core dump) από την αναφορά μετά την "
 "επαναδημιουργία της ακολουθίας κλήσεων στοίβας"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "Παράκαμψη του CoreFile της αναφοράς"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "Παράκαμψη του ExecutablePath της αναφοράς"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "Παράκαμψη των ProcMaps της αναφοράς"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "Επανοικοδόμηση των πληροφοριών πακέτου της αναφοράς"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -725,7 +726,7 @@ msgstr ""
 "εντοπίζει τα σπασμένα αρχεία που συνέβησαν όταν ήταν σε εκτέλεση η "
 "αποδέσμευση."
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
@@ -735,32 +736,32 @@ msgstr ""
 "gdb και των εξαρτήσεών του στην ίδια έκδοση όπως και η αναφορά, αντί να "
 "χρησιμοποιηθεί η όποια έκδοση του gdb έχετε ήδη εγκατεστημένη."
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 "Αναφορά προόδου λήψης/εγκατάστασης όταν εγκαθίστανται πακέτα στο δοκιμαστικό "
 "χώρο"
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr ""
 "Βάζουμε μπροστά χρονικές ενδείξεις για να συνδεθούν μηνύματα, για τη "
 "λειτουργία παρτίδας"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 "Δημιουργία και χρήση αποθετηρίων τρίτων από πηγές που καθορίζονται στις "
 "αναφορές"
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr ""
 "Προσωρινός κατάλογος για πακέτα που τοποθετούνται στο δοκιμαστικό χώρο "
 "(sandbox)"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -768,14 +769,14 @@ msgstr ""
 "Κατάλογος για χύμα πακέτα.Οι μελλοντικές διαδρομές ας υποθέσουμε πως ήδη τα "
 "πακέτα έχουν κατεβεί και εξάγονται στο sandbox."
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 "Εγκαταστήστε ένα επιπλέον πακέτο στο περιβάλλον δοκιμών (μπορεί να "
 "προσδιοριστεί πολλές φορές)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -786,7 +787,7 @@ msgstr ""
 "αποστολή των επαναπροσδιορισμένων στοιχείων του stack (μόνο αν κανένα από τα "
 "-g, -o και -s δεν ορίζονται)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -794,32 +795,32 @@ msgstr ""
 "Προβολή των επαναπροσδιορισμένων στοιχείων του stack και ερώτηση για "
 "επιβεβαίωση πριν την αποστολή τους στη βάση δεδομένων κατάρρευσης."
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 "Διαδρομή προς τη διπλότυπη βάση δεδομένων sqlite (προεπιλογή: μη έλεγχος "
 "διπλότυπου)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr "Να μην προστεθούν στην αναφορά οι πληροφορίες StacktraceSource."
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "Δεν μπορείτε να χρησιμοποιήσετε το -C χωρίς το -S. Διακοπή."
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "Συμφωνείτε με την αποστολή αυτών ως συνημμένων; [y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -827,19 +828,19 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "Ο κατάλογος προορισμού υπάρχει ήδη και δεν είναι κενός."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "Δείτε τη σελίδα τεκμηρίωσης για λεπτομέρειες."
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "ορίστε το όνομα αρχείου καταγραφών που θα παράγεται από το valgrind"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
@@ -847,7 +848,7 @@ msgstr ""
 "επαναχρησιμοποίηση ενός καταλόγου απομόνωσης (SDIR) που δημιουργήθηκε την "
 "προηγούμενη φορά, ή αν δεν υπάρχει, δημιούργησε το"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -856,7 +857,7 @@ msgstr ""
 "αποσφαλμάτωσης, αλλά να χρησιμοποιηθούν μόνο εγκαταστημένα σύμβολα "
 "αποσφαλμάτωσης."
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
@@ -864,24 +865,24 @@ msgstr ""
 "επαναχρησιμοποίηση ενός καταλόγου προσωρινής μνήμης (CDIR) που δημιουργήθηκε "
 "προηγούμενη φορά, ή αν δεν υπάρχει, δημιούργησε το"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 "να αναφέρεται η πρόοδος λήψης/εγκατάστασης όταν γίνεται εγκατάσταση πακέτων "
 "σε περιβάλλον απομόνωσης"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Σφάλμα: το %s δεν είναι εκτελέσιμο. Διακοπή."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -889,7 +890,7 @@ msgstr ""
 "Αυτό προκλήθηκε από προηγούμενη αναστολή και απέτρεψε το σύστημα από το να "
 "συνεχίσει σωστά."
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -897,7 +898,7 @@ msgstr ""
 "Αυτό προκλήθηκε από προηγούμενη αδρανοποίηση και απέτρεψε το σύστημα από το "
 "να συνεχίσει σωστά."
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -905,7 +906,7 @@ msgstr ""
 "Η διαδικασία επαναφοράς σταμάτησε λίγο πριν την ολοκλήρωσή της και φαίνεται "
 "σαν να ολοκληρώθηκε κανονικά."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 "Το σύστημά σας πιθανώς να καταστεί ασταθές και ίσως  απαιτηθεί η "
@@ -921,79 +922,79 @@ msgstr "Αναφορά προβλήματος..."
 msgid "Report a malfunction to the developers"
 msgstr "Αναφορά δυσλειτουργίας στους προγραμματιστές"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "Λυπούμαστε, η εφαρμογή %s σταμάτησε απροσδόκητα."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "Συγνώμη,το %s τερματίστηκε απροδόκητα."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "Συγνώμη, το %s παρουσίασε εσωτερικό σφάλμα."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Αποστολή"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Προβολή λεπτομερειών"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Συνέχεια"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "Η εφαρμογή %s σταμάτησε να ανταποκρίνεται."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "Το πρόγραμμα \"%s\" σταμάτησε να ανταποκρίνεται."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Πακέτο: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr ""
 "Συγνώμη , κάποιο πρόβλημα παρουσιάστηκε κατά την εγκατάσταση του λογισμικού."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "Η εφαρμογή %s παρουσίασε ένα εσωτερικό σφάλμα."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "Η εφαρμογή %s τερματίστηκε απροσδόκητα."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr ""
 "Εάν συναντήσετε περαιτέρω προβλήματα, παρακαλούμε επανεκκινήστε  τον "
 "υπολογιστή σας."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "Στο μέλλον να αγνοούνται προβλήματα αυτού του τύπου"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Απόκρυψη λεπτομεριών"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -1049,7 +1050,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>Αποστολή πληροφοριών του προβλήματος</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -1061,27 +1062,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Αρχείο κατάρρευσης Apport"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "Να παραμείνει κλεισμένο"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Επανεκκίνηση"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Όνομα χρήστη:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Κωδικός πρόσβασης:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "Συλλογή πληροφοριών προβλήματος"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1090,6 +1091,6 @@ msgstr ""
 "ανάπτυξης ώστε να βελτιώσουν την εφαρμογή. Αυτό μπορεί να διαρκέσει λίγα "
 "λεπτά."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "Αποστολή πληροφοριών προβλήματος"

--- a/po/en_AU.po
+++ b/po/en_AU.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2015-04-27 21:46+0000\n"
 "Last-Translator: Anthony Harrington <Unknown>\n"
 "Language-Team: English (Australia) <en_AU@li.org>\n"
@@ -39,11 +39,11 @@ msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 "Please enter your password to access problem reports of system programs"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "This package does not seem to be installed correctly"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -54,7 +54,7 @@ msgstr ""
 "the indexes of available packages, if that does not work then remove related "
 "third party packages and try again."
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -67,21 +67,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "unknown program"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Sorry, the program \"%s\" closed unexpectedly"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Problem in %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -89,63 +84,68 @@ msgstr ""
 "Your computer does not have enough free memory to automatically analyse the "
 "problem and send a report to the developers."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Problem in %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Invalid problem report"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "You are not allowed to access this problem report."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Error"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "There is not enough disk space available to process this report."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr "No PID specified"
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr "You need to specify a PID. See --help for more information."
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "Invalid PID"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr "The specified process ID does not exist."
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr "Not your PID"
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr "The specified process ID does not belong to you."
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "No package specified"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "You need to specify a package or a PID. See --help for more information."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Permission denied"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -153,43 +153,43 @@ msgstr ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "The specified process ID does not belong to a program."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Symptom script %s did not determine an affected package"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Package %s does not exist"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "Cannot create report"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "Updating problem report"
 
+#: ../apport/ui.py:772
+msgid ""
+"You are not the reporter or subscriber of this problem report, or the report "
+"is a duplicate or already closed.\n"
+"\n"
+"Please create a new report using \"apport-bug\"."
+msgstr ""
+"You are not the reporter or subscriber of this problem report, or the report "
+"is a duplicate or already closed.\n"
+"\n"
+"Please create a new report using \"apport-bug\"."
+
 #: ../apport/ui.py:784
 msgid ""
-"You are not the reporter or subscriber of this problem report, or the report "
-"is a duplicate or already closed.\n"
-"\n"
-"Please create a new report using \"apport-bug\"."
-msgstr ""
-"You are not the reporter or subscriber of this problem report, or the report "
-"is a duplicate or already closed.\n"
-"\n"
-"Please create a new report using \"apport-bug\"."
-
-#: ../apport/ui.py:796
-msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
 "a new bug.\n"
@@ -208,24 +208,24 @@ msgstr ""
 "\n"
 "Do you really want to proceed?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "No additional information collected."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "What kind of problem do you want to report?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Unknown symptom"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "The symptom \"%s\" is not known."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -236,7 +236,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -244,30 +244,30 @@ msgstr ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop failed to determine process ID of the window"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "Specify package name."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "Add an extra tag to the report. Can be specified multiple times."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -277,15 +277,15 @@ msgstr ""
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "Click a window as a target for filing a problem report."
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "Start in bug updating mode. Can take an optional --package."
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -293,7 +293,7 @@ msgstr ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -301,7 +301,7 @@ msgstr ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -311,11 +311,11 @@ msgstr ""
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "The provided pid is a hanging application."
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -324,7 +324,7 @@ msgstr ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -334,47 +334,47 @@ msgstr ""
 "reporting it. This file can then be reported later on from a different "
 "machine."
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Print the Apport version number."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "Run gdb session"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Run gdb session without downloading debug symbols"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Update %s with fully symbolic stack trace"
 
-#: ../apport/ui.py:1418
+#: ../apport/ui.py:1386
+msgid ""
+"Saving crash reporting state failed. Can't set auto or never reporting mode."
+msgstr ""
+"Saving crash reporting state failed. Can't set auto or never reporting mode."
+
+#: ../apport/ui.py:1390
 msgid "Can't remember send report status settings"
 msgstr "Can't remember send report status settings"
 
-#: ../apport/ui.py:1422
-msgid ""
-"Saving crash reporting state failed. Can't set auto or never reporting mode."
-msgstr ""
-"Saving crash reporting state failed. Can't set auto or never reporting mode."
-
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 "This problem report applies to a program which is not installed any more."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
@@ -383,19 +383,21 @@ msgstr ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "This problem report is damaged and cannot be processed."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr "This report is about a package that is not installed."
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "An error occurred while attempting to process this problem report:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
@@ -403,23 +405,23 @@ msgstr ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr "%s snap"
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr "%s deb package"
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s is provided by a snap published by %s. Contact them via %s for help."
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -428,38 +430,38 @@ msgstr ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "Could not determine the package or source package name."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "Unable to start web browser"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Unable to start web browser to open %s."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Network problem"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Cannot connect to crash database, please check your Internet connection."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Network problem"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Memory exhaustion"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "Your system does not have enough memory to process this crash report."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -470,11 +472,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "Problem already known"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -484,38 +486,37 @@ msgstr ""
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "This problem was already reported to developers. Thank you!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Press any key to continue..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "What would you like to do? Your options are:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Please choose (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i bytes)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(binary data)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Send problem report to the developers?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -523,50 +524,50 @@ msgstr ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "&Send report (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "&Examine locally"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "&View report"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr "&Keep report file for sending later or copying to somewhere else"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "Cancel and &ignore future crashes of this program version"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Cancel"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Problem report file:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&Confirm"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Error: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "Collecting problem information"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -574,11 +575,11 @@ msgstr ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "Uploading problem information"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -586,40 +587,40 @@ msgstr ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Done"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "none"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "Selected: %s. Multiple choices:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Choices:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "Path to file (Enter to cancel):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "File does not exist."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "This is a directory."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "To continue, you must visit the following URL:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -627,15 +628,15 @@ msgstr ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Launch a browser now"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr "No pending crash reports. Try --help for more information."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr "Do not put the new traces into the report, but write them to stdout."
 
@@ -653,27 +654,27 @@ msgid ""
 msgstr ""
 "Write modified report to given file instead of changing the original report"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr "Remove the core dump from the report after stack trace regeneration"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "Override report's CoreFile"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "Override report's ExecutablePath"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "Override report's ProcMaps"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "Rebuild report's Package information"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -689,7 +690,7 @@ msgstr ""
 "\"system\", it will use the system configuration files, but will then only "
 "be able to retrace crashes that happened on the currently running release."
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
@@ -699,25 +700,25 @@ msgstr ""
 "using the same release as the report rather than whatever version of gdb you "
 "have installed."
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr "Report download/install progress when installing packages into sandbox"
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr "Prepend timestamps to log messages, for batch operation"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 "Create and use third-party repositories from origins specified in reports"
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr "Cache directory for packages downloaded in the sandbox"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -725,13 +726,13 @@ msgstr ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -741,7 +742,7 @@ msgstr ""
 "used when specifying a crash ID to upload the retraced stack traces (only if "
 "neither -g, -o, nor -s are specified)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -749,30 +750,30 @@ msgstr ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr "Path to the duplicate sqlite database (default: no duplicate checking)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr "Do not add StacktraceSource to the report."
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "You cannot use -C without -S. Stopping."
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "OK to send these as attachments? [y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -780,19 +781,19 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "Destination directory exists and is not empty."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "See man page for details."
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "specify the log file name produced by valgrind"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
@@ -800,7 +801,7 @@ msgstr ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -808,7 +809,7 @@ msgstr ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
@@ -816,46 +817,46 @@ msgstr ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr "report download/install progress when installing packages into sandbox"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Error: %s is not an executable. Stopping."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 "This occurred during a previous suspend, and prevented the system from "
-"resuming properly."
-
-#: ../data/apportcheckresume.py:72
-msgid ""
-"This occurred during a previous hibernation, and prevented the system from "
-"resuming properly."
-msgstr ""
-"This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 
 #: ../data/apportcheckresume.py:80
 msgid ""
+"This occurred during a previous hibernation, and prevented the system from "
+"resuming properly."
+msgstr ""
+"This occurred during a previous hibernation, and prevented the system from "
+"resuming properly."
+
+#: ../data/apportcheckresume.py:88
+msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
 msgstr ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr "Your system might become unstable now and might need to be restarted."
 
@@ -869,76 +870,76 @@ msgstr "Report a problem..."
 msgid "Report a malfunction to the developers"
 msgstr "Report a malfunction to the developers"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "Sorry, the application %s has stopped unexpectedly."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "Sorry, %s has closed unexpectedly."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "Sorry, %s has experienced an internal error."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Send"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Show Details"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Continue"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "The application %s has stopped responding."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "The program \"%s\" has stopped responding."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Package: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "Sorry, a problem occurred while installing software."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "The application %s has experienced an internal error."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "The application %s has closed unexpectedly."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr "If you notice further problems, try restarting the computer."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "Ignore future problems of this type"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Hide Details"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -994,7 +995,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>Uploading problem information</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -1006,27 +1007,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Apport crash file"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "Leave Closed"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Relaunch"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Username:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Password:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "Collecting Problem Information"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1034,6 +1035,6 @@ msgstr ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "Uploading Problem Information"

--- a/po/en_CA.po
+++ b/po/en_CA.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2020-07-10 14:15+0000\n"
 "Last-Translator: Marc Deslauriers <marc.deslauriers@canonical.com>\n"
 "Language-Team: English (Canada) <en_CA@li.org>\n"
@@ -39,11 +39,11 @@ msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 "Please enter your password to access problem reports of system programs"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "This package does not seem to be installed correctly"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -54,7 +54,7 @@ msgstr ""
 "the indexes of available packages, if that does not work then remove related "
 "third party packages and try again."
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -67,85 +67,85 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "unknown program"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Sorry, the program \"%s\" closed unexpectedly"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
+#: ../apport/ui.py:475
+msgid ""
+"Your computer does not have enough free memory to automatically analyze the "
+"problem and send a report to the developers."
+msgstr ""
+"Your computer does not have enough free memory to automatically analyze the "
+"problem and send a report to the developers."
+
+#: ../apport/ui.py:480 ../apport/ui.py:1909
 #, python-format
 msgid "Problem in %s"
 msgstr "Problem in %s"
 
-#: ../apport/ui.py:477
-msgid ""
-"Your computer does not have enough free memory to automatically analyze the "
-"problem and send a report to the developers."
-msgstr ""
-"Your computer does not have enough free memory to automatically analyze the "
-"problem and send a report to the developers."
-
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Invalid problem report"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "You are not allowed to access this problem report."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Error"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "There is not enough disk space available to process this report."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr "No PID specified"
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr "You need to specify a PID. See --help for more information."
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "Invalid PID"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr "The specified process ID does not exist."
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr "Not your PID"
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr "The specified process ID does not belong to you."
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "No package specified"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "You need to specify a package or a PID. See --help for more information."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Permission denied"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -153,43 +153,43 @@ msgstr ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "The specified process ID does not belong to a program."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Symptom script %s did not determine an affected package"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Package %s does not exist"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "Cannot create report"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "Updating problem report"
 
+#: ../apport/ui.py:772
+msgid ""
+"You are not the reporter or subscriber of this problem report, or the report "
+"is a duplicate or already closed.\n"
+"\n"
+"Please create a new report using \"apport-bug\"."
+msgstr ""
+"You are not the reporter or subscriber of this problem report, or the report "
+"is a duplicate or already closed.\n"
+"\n"
+"Please create a new report using \"apport-bug\"."
+
 #: ../apport/ui.py:784
 msgid ""
-"You are not the reporter or subscriber of this problem report, or the report "
-"is a duplicate or already closed.\n"
-"\n"
-"Please create a new report using \"apport-bug\"."
-msgstr ""
-"You are not the reporter or subscriber of this problem report, or the report "
-"is a duplicate or already closed.\n"
-"\n"
-"Please create a new report using \"apport-bug\"."
-
-#: ../apport/ui.py:796
-msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
 "a new bug.\n"
@@ -208,24 +208,24 @@ msgstr ""
 "\n"
 "Do you really want to proceed?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "No additional information collected."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "What kind of problem do you want to report?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Unknown symptom"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "The symptom \"%s\" is not known."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -243,7 +243,7 @@ msgstr ""
 "the Processes tab, scroll until you find the correct application. The "
 "process ID is the number listed in the ID column."
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -251,30 +251,30 @@ msgstr ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop failed to determine process ID of the window"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "Specify package name."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "Add an extra tag to the report. Can be specified multiple times."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -284,15 +284,15 @@ msgstr ""
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "Click a window as a target for filing a problem report."
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "Start in bug updating mode. Can take an optional --package."
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -300,7 +300,7 @@ msgstr ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -308,7 +308,7 @@ msgstr ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -318,11 +318,11 @@ msgstr ""
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "The provided pid is a hanging application."
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -331,7 +331,7 @@ msgstr ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -341,47 +341,47 @@ msgstr ""
 "reporting it. This file can then be reported later on from a different "
 "machine."
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Print the Apport version number."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "Run gdb session"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Run gdb session without downloading debug symbols"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Update %s with fully symbolic stack trace"
 
-#: ../apport/ui.py:1418
+#: ../apport/ui.py:1386
+msgid ""
+"Saving crash reporting state failed. Can't set auto or never reporting mode."
+msgstr ""
+"Saving crash reporting state failed. Can't set auto or never reporting mode."
+
+#: ../apport/ui.py:1390
 msgid "Can't remember send report status settings"
 msgstr "Can't remember send report status settings"
 
-#: ../apport/ui.py:1422
-msgid ""
-"Saving crash reporting state failed. Can't set auto or never reporting mode."
-msgstr ""
-"Saving crash reporting state failed. Can't set auto or never reporting mode."
-
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 "This problem report applies to a program which is not installed any more."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
@@ -390,19 +390,21 @@ msgstr ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "This problem report is damaged and cannot be processed."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr "This report is about a package that is not installed."
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "An error occurred while attempting to process this problem report:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
@@ -410,23 +412,23 @@ msgstr ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr "%s snap"
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr "%s deb package"
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s is provided by a snap published by %s. Contact them via %s for help."
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -435,38 +437,38 @@ msgstr ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "Could not determine the package or source package name."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "Unable to start web browser"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Unable to start web browser to open %s."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Network problem"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Cannot connect to crash database, please check your Internet connection."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Network problem"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Memory exhaustion"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "Your system does not have enough memory to process this crash report."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -477,11 +479,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "Problem already known"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -491,38 +493,37 @@ msgstr ""
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "This problem was already reported to developers. Thank you!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Press any key to continue..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "What would you like to do? Your options are:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Please choose (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i bytes)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(binary data)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Send problem report to the developers?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -530,50 +531,50 @@ msgstr ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "&Send report (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "&Examine locally"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "&View report"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr "&Keep report file for sending later or copying to somewhere else"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "Cancel and &ignore future crashes of this program version"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Cancel"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Problem report file:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&Confirm"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Error: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "Collecting problem information"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -581,11 +582,11 @@ msgstr ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "Uploading problem information"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -593,40 +594,40 @@ msgstr ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Done"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "none"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "Selected: %s. Multiple choices:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Choices:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "Path to file (Enter to cancel):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "File does not exist."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "This is a directory."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "To continue, you must visit the following URL:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -634,15 +635,15 @@ msgstr ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Launch a browser now"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr "No pending crash reports. Try --help for more information."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr "Do not put the new traces into the report, but write them to stdout."
 
@@ -660,27 +661,27 @@ msgid ""
 msgstr ""
 "Write modified report to given file instead of changing the original report"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr "Remove the core dump from the report after stack trace regeneration"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "Override report's CoreFile"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "Override report's ExecutablePath"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "Override report's ProcMaps"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "Rebuild report's Package information"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -696,7 +697,7 @@ msgstr ""
 "\"system\", it will use the system configuration files, but will then only "
 "be able to retrace crashes that happened on the currently running release."
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
@@ -706,25 +707,25 @@ msgstr ""
 "using the same release as the report rather than whatever version of gdb you "
 "have installed."
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr "Report download/install progress when installing packages into sandbox"
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr "Prepend timestamps to log messages, for batch operation"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 "Create and use third-party repositories from origins specified in reports"
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr "Cache directory for packages downloaded in the sandbox"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -732,13 +733,13 @@ msgstr ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -748,7 +749,7 @@ msgstr ""
 "used when specifying a crash ID to upload the retraced stack traces (only if "
 "neither -g, -o, nor -s are specified)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -756,30 +757,30 @@ msgstr ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr "Path to the duplicate sqlite database (default: no duplicate checking)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr "Do not add StacktraceSource to the report."
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "You cannot use -C without -S. Stopping."
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "OK to send these as attachments? [y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -787,19 +788,19 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "Destination directory exists and is not empty."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "See man page for details."
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "specify the log file name produced by valgrind"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
@@ -807,7 +808,7 @@ msgstr ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -815,7 +816,7 @@ msgstr ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
@@ -823,11 +824,11 @@ msgstr ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr "report download/install progress when installing packages into sandbox"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
@@ -835,36 +836,36 @@ msgstr ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Error: %s is not an executable. Stopping."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 "This occurred during a previous suspend, and prevented the system from "
-"resuming properly."
-
-#: ../data/apportcheckresume.py:72
-msgid ""
-"This occurred during a previous hibernation, and prevented the system from "
-"resuming properly."
-msgstr ""
-"This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 
 #: ../data/apportcheckresume.py:80
 msgid ""
+"This occurred during a previous hibernation, and prevented the system from "
+"resuming properly."
+msgstr ""
+"This occurred during a previous hibernation, and prevented the system from "
+"resuming properly."
+
+#: ../data/apportcheckresume.py:88
+msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
 msgstr ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr "Your system might become unstable now and might need to be restarted."
 
@@ -878,76 +879,76 @@ msgstr "Report a problem..."
 msgid "Report a malfunction to the developers"
 msgstr "Report a malfunction to the developers"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "Sorry, the application %s has stopped unexpectedly."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "Sorry, %s has closed unexpectedly."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "Sorry, %s has experienced an internal error."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Send"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Show Details"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Continue"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "The application %s has stopped responding."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "The program \"%s\" has stopped responding."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Package: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "Sorry, a problem occurred while installing software."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "The application %s has experienced an internal error."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "The application %s has closed unexpectedly."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr "If you notice further problems, try restarting the computer."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "Ignore future problems of this type"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Hide Details"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -1003,7 +1004,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>Uploading problem information</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -1015,27 +1016,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Apport crash file"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "Leave Closed"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Relaunch"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Username:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Password:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "Collecting Problem Information"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1043,6 +1044,6 @@ msgstr ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "Uploading Problem Information"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2022-10-05 00:36+0000\n"
 "Last-Translator: Stephan Woidowski <swoidowski@t-online.de>\n"
 "Language-Team: English (United Kingdom) <en_GB@li.org>\n"
@@ -39,11 +39,11 @@ msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 "Please enter your password to access problem reports of system programs"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "This package does not seem to be installed correctly"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -54,7 +54,7 @@ msgstr ""
 "the indexes of available packages. If that does not work, then remove "
 "related third party packages and try again."
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -67,21 +67,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "unknown program"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Sorry, the program \"%s\" closed unexpectedly"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Problem in %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -89,63 +84,68 @@ msgstr ""
 "Your computer does not have enough free memory to automatically analyse the "
 "problem and send a report to the developers."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Problem in %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Invalid problem report"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "You are not allowed to access this problem report."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Error"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "There is not enough disk space available to process this report."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr "No PID specified"
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr "You need to specify a PID. See --help for more information."
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "Invalid PID"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr "The specified process ID does not exist."
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr "Not your PID"
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr "The specified process ID does not belong to you."
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "No package specified"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "You need to specify a package or a PID. See --help for more information."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Permission denied"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -153,43 +153,43 @@ msgstr ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "The specified process ID does not belong to a program."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Symptom script %s did not determine an affected package"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Package %s does not exist"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "Cannot create report"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "Updating problem report"
 
+#: ../apport/ui.py:772
+msgid ""
+"You are not the reporter or subscriber of this problem report, or the report "
+"is a duplicate or already closed.\n"
+"\n"
+"Please create a new report using \"apport-bug\"."
+msgstr ""
+"You are not the reporter or subscriber of this problem report, or the report "
+"is a duplicate or already closed.\n"
+"\n"
+"Please create a new report using \"apport-bug\"."
+
 #: ../apport/ui.py:784
 msgid ""
-"You are not the reporter or subscriber of this problem report, or the report "
-"is a duplicate or already closed.\n"
-"\n"
-"Please create a new report using \"apport-bug\"."
-msgstr ""
-"You are not the reporter or subscriber of this problem report, or the report "
-"is a duplicate or already closed.\n"
-"\n"
-"Please create a new report using \"apport-bug\"."
-
-#: ../apport/ui.py:796
-msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
 "a new bug.\n"
@@ -208,24 +208,24 @@ msgstr ""
 "\n"
 "Do you really want to proceed?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "No additional information collected."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "What kind of problem do you want to report?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Unknown symptom"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "The symptom \"%s\" is not known."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -243,7 +243,7 @@ msgstr ""
 "the Processes tab, scroll until you find the correct application. The "
 "process ID is the number listed in the ID column."
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -251,31 +251,31 @@ msgstr ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop failed to determine process ID of the window"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr "%(prog)s <report number>"
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "Specify package name."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "Add an extra tag to the report. Can be specified multiple times."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -285,15 +285,15 @@ msgstr ""
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "Click a window as a target for filing a problem report."
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "Start in bug updating mode. Can take an optional --package."
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -301,7 +301,7 @@ msgstr ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -309,7 +309,7 @@ msgstr ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -319,11 +319,11 @@ msgstr ""
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "The provided pid is a hanging application."
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -332,7 +332,7 @@ msgstr ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -342,47 +342,47 @@ msgstr ""
 "reporting it. This file can then be reported later on from a different "
 "machine."
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Print the Apport version number."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "Run gdb session"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Run gdb session without downloading debug symbols"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Update %s with fully symbolic stack trace"
 
-#: ../apport/ui.py:1418
+#: ../apport/ui.py:1386
+msgid ""
+"Saving crash reporting state failed. Can't set auto or never reporting mode."
+msgstr ""
+"Saving crash reporting state failed. Can't set auto or never reporting mode."
+
+#: ../apport/ui.py:1390
 msgid "Can't remember send report status settings"
 msgstr "Can't remember send report status settings"
 
-#: ../apport/ui.py:1422
-msgid ""
-"Saving crash reporting state failed. Can't set auto or never reporting mode."
-msgstr ""
-"Saving crash reporting state failed. Can't set auto or never reporting mode."
-
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 "This problem report applies to a program which is not installed any more."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
@@ -391,19 +391,21 @@ msgstr ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "This problem report is damaged and cannot be processed."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr "This report is about a package that is not installed."
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "An error occurred while attempting to process this problem report:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
@@ -411,23 +413,23 @@ msgstr ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr "%s snap"
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr "%s deb package"
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s is provided by a snap published by %s. Contact them via %s for help."
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -436,38 +438,38 @@ msgstr ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "Could not determine the package or source package name."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "Unable to start web browser"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Unable to start web browser to open %s."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Network problem"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Cannot connect to crash database, please check your Internet connection."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Network problem"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Memory exhaustion"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "Your system does not have enough memory to process this crash report."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -478,11 +480,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "Problem already known"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -492,38 +494,37 @@ msgstr ""
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "This problem has already been reported to developers. Thank you!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Press any key to continue..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "What would you like to do? Your options are:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Please choose (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i bytes)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(binary data)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Send problem report to the developers?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -531,50 +532,50 @@ msgstr ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "&Send report (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "&Examine locally"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "&View report"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr "&Keep report file for sending later or copying to somewhere else"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "Cancel and &ignore future crashes of this program version"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Cancel"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Problem report file:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&Confirm"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Error: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "Collecting problem information"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -582,11 +583,11 @@ msgstr ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "Uploading problem information"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -594,40 +595,40 @@ msgstr ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Done"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "none"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "Selected: %s. Multiple choices:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Choices:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "Path to file (Enter to cancel):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "File does not exist."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "This is a directory."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "To continue, you must visit the following URL:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -635,15 +636,15 @@ msgstr ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Launch a browser now"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr "No pending crash reports. Try --help for more information."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr "Do not put the new traces into the report, but write them to stdout."
 
@@ -661,27 +662,27 @@ msgid ""
 msgstr ""
 "Write modified report to given file instead of changing the original report"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr "Remove the core dump from the report after stack trace regeneration"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "Override report's CoreFile"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "Override report's ExecutablePath"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "Override report's ProcMaps"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "Rebuild report's Package information"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -697,7 +698,7 @@ msgstr ""
 "\"system\", it will use the system configuration files, but will then only "
 "be able to retrace crashes that happened on the currently running release."
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
@@ -707,25 +708,25 @@ msgstr ""
 "using the same release as the report, rather than whatever version of gdb "
 "you have installed."
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr "Report download/install progress when installing packages into sandbox"
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr "Prepend timestamps to log messages, for batch operation"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 "Create and use third-party repositories from origins specified in reports"
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr "Cache directory for packages downloaded in the sandbox"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -733,13 +734,13 @@ msgstr ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -749,7 +750,7 @@ msgstr ""
 "used when specifying a crash ID to upload the retraced stack traces (only if "
 "neither -g, -o, nor -s are specified)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -757,30 +758,30 @@ msgstr ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr "Path to the duplicate sqlite database (default: no duplicate checking)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr "Do not add StacktraceSource to the report."
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "You cannot use -C without -S. Stopping."
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "OK to send these as attachments? [y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr "%(prog)s <report> <target directory>"
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr "Report file to unpack"
 
@@ -788,19 +789,19 @@ msgstr "Report file to unpack"
 msgid "directory to unpack report to"
 msgstr "directory to unpack report to"
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "Destination directory exists and is not empty."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "See man page for details."
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "specify the log file name produced by Valgrind"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
@@ -808,7 +809,7 @@ msgstr ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -816,7 +817,7 @@ msgstr ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
@@ -824,11 +825,11 @@ msgstr ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr "report download/install progress when installing packages into sandbox"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
@@ -836,28 +837,28 @@ msgstr ""
 "the executable that is run under Valgrind's memcheck tool for memory leak "
 "detection"
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Error: %s is not an executable. Stopping."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 "This occurred during a previous suspend, and prevented the system from "
-"resuming properly."
-
-#: ../data/apportcheckresume.py:72
-msgid ""
-"This occurred during a previous hibernation, and prevented the system from "
-"resuming properly."
-msgstr ""
-"This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 
 #: ../data/apportcheckresume.py:80
+msgid ""
+"This occurred during a previous hibernation, and prevented the system from "
+"resuming properly."
+msgstr ""
+"This occurred during a previous hibernation, and prevented the system from "
+"resuming properly."
+
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -865,7 +866,7 @@ msgstr ""
 "The resume processing hung very near the end and appears to have completed "
 "normally."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr "Your system might become unstable now and might need to be restarted."
 
@@ -879,76 +880,76 @@ msgstr "Report a problem..."
 msgid "Report a malfunction to the developers"
 msgstr "Report a malfunction to the developers"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "Sorry, the application %s has stopped unexpectedly."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "Sorry, %s has closed unexpectedly."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "Sorry, %s has experienced an internal error."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Send"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Show Details"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Continue"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "The application %s has stopped responding."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "The program \"%s\" has stopped responding."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Package: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "Sorry, a problem occurred while installing software."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "The application %s has experienced an internal error."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "The application %s has closed unexpectedly."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr "If you notice further problems, try restarting the computer."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "Ignore future problems of this type"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Hide Details"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -1004,7 +1005,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>Uploading problem information</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -1016,27 +1017,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Apport crash file"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "Leave Closed"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Relaunch"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Username:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Password"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "Collecting Problem Information"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1044,6 +1045,6 @@ msgstr ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "Uploading Problem Information"

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2015-04-27 21:47+0000\n"
 "Last-Translator: Michael Moroni <michaelmoroni@disroot.org>\n"
 "Language-Team: Esperanto <eo@li.org>\n"
@@ -36,11 +36,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "Ŝajnas, ke ĉi tiu pakaĵo ne estas korekte instalita"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -61,21 +61,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "nekonata programaro"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Bedaŭrinde la programaro \"%s\" fermiĝis neatendite"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Problemo en %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -83,62 +78,67 @@ msgstr ""
 "Via komputilo ne havas sufiĉe da libera memoro por analizi la problemon kaj "
 "sendi raporton al la evoluigantoj."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Problemo en %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Nevalida problemraporto"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "Vi ne rajtas aliri ĉi tiun problemraporton."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Eraro"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "Spaco en disko ne sufiĉas por trakti ĉi tiun raporton."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "Nevalida PID"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "Neniu pakaĵo indikita."
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr "Vi devas indiki pakaĵon aŭ PID. Vidu --help por pliaj informoj."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Permeso malaprobita"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -146,30 +146,30 @@ msgstr ""
 "La indikita procezo ne apartenas al vi. Bonvole rulu ĉi tiun programaron "
 "kiel posedanto de la procezo aŭ kiel ĉefuzanto."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "La indikita procesa identigilo ne apartenas al iu programaro."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "La skripto por analizi problemon %s ne trovis koncernatan pakaĵon"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Pakaĵo %s ne ekzistas"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "La raporto ne kreeblas"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "Ĝisdatiganta problemraporton"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -181,7 +181,7 @@ msgstr ""
 "\n"
 "Bonvole kreu novan raporton per \"apport-bug\"."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -201,24 +201,24 @@ msgstr ""
 "\n"
 "Ĉu vi vere volas daŭrigi?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "Neniu aldonaj informoj estis kolektitaj."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "Kiuspecan problemon vi volas raporti?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "nekonata simptomo"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "La simptomo \"%s\" ne estas konata."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -229,7 +229,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -237,30 +237,30 @@ msgstr ""
 "Ferminte ĉi tiun mesaĝon, bonvole alklaku aplikaĵfenestron por raporti "
 "problemon pri ĝi."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop fiaskis en determinado de procesidentigilo de la fenestro"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "Specifi pakaĵnomon."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "Aldoni plian markon al la raporto. Tio plurfoje specifeblas."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -271,15 +271,15 @@ msgstr ""
 "simptomoj aperas. (Ĉi tiu reĝimo validas aŭtomate, se nur unu argumento "
 "estas specifita.)"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "Alklaku sur fenestro kiel celo, por sendi problemraporton."
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "Startigi en redakta reĝimo. La opcio --package aldoneblas."
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -287,7 +287,7 @@ msgstr ""
 "Sendu problemraporton pri simptomoj. (Ĉi tiu regimo validas aŭtomate, se la "
 "nomo de la simptomo estas donita kiel sola argumento.)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -296,7 +296,7 @@ msgstr ""
 "specifita. (Ĉi tiu regimo validas aŭtomate, se la nomo de la pakaĵo estas "
 "donita kiel sola argumento.)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -306,11 +306,11 @@ msgstr ""
 "cimraporto enhavos pli da informoj.  (Ĉi tiu regimo validas aŭtomate, se pid "
 "estas donita kiel sola argumento.)"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -320,7 +320,7 @@ msgstr ""
 "okazantaj en %s.  (Ĉi tiu regimo validas aŭtomate, se la dosiero estas "
 "donita kiel sola argumento.)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -329,45 +329,45 @@ msgstr ""
 "En cimpleniga reĝimo, konservi la kolektitajn informojn en dosieron anstataŭ "
 "ol raporti ĝin. Ĉi tiu dosiero povas poste esti raportata per alia maŝino."
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Eligi la numeron de versio de Aporto."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Tio rulos apport-retrace en fenestro de terminalo por testi la kolapson."
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "Ruli seancon de gdb"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Ruli seancon de gdb sen elŝuti sencimigsimbolojn"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Ĝisdatigi %s kun tute simbolika staka spuro"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr "Ĉi tiu raporto apartenas al ne plu instalita programaro."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
@@ -375,79 +375,81 @@ msgid ""
 msgstr ""
 "La problemo okazis kun la programaro %s, kiu ŝanĝis ekde la kolapso okazis."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "La raporto estas damaĝita kaj ne povas esti traktata."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr ""
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "Eraro okazis dum klopodado por procezi ĉi tiun raporton de problemo:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "Ne eblis eltrovi la nomon de la pakaĵo aŭ de la fonta pakaĵo."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "Ne eblis startigi retfoliumilon."
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Ne eblis starti retfoliumilo por malfermi %s."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Reta problemo"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Ne eblas konekti al la datumbazo pri kolapsoj. Bonvole kontrolu vian "
 "retkonekton."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Reta problemo"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Memoro elĉerpita"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "Via sistemo ne havas sufiĉe da memoro por trakti la kolapsraporton."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -458,11 +460,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "Jam konata problemo."
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -472,38 +474,37 @@ msgstr ""
 "retfoliumilo. Bonvole kontrolu, ĉu vi povas aldoni pliajn eble utilajn "
 "informojn por la evoluigantoj."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Ĉi tiu problemo estas jam raportita al programistoj. Dankon!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Premu klavon por daŭrigi..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "Kion vi ŝatus fari? Viaj ebloj estas:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Bonvole ekektu (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i bajtoj)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(duumaj datumoj)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Ĉu sendi problem-raporton al la evoluigantoj?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -511,50 +512,50 @@ msgstr ""
 "Post sendo de la problem-raporto, bonvole plenigu la formularon en la\n"
 "fenestro de la retfoliumilo, kiu aŭtomate malfermiĝos."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "&Sendi raporton (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "Lok&e testi"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "&Montri raporton"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr "&Konservi raportdosieron por poste sendi ĝin aŭ kopii aliloken."
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "Nuligi kaj &ignori ontajn kolapsojn de ĉi tiu programarversio."
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Nuligi"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Problemraporta dosiero:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&Konfirmi"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Eraro: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "Kolektado de informoj pri la problemo"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -562,11 +563,11 @@ msgstr ""
 "La kolektitaj informoj povas esti senditaj al la evoluigantoj por\n"
 "plibonigi la aplikaĵon. Tio povas daŭri kelkajn minutojn."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "Alŝutado de informoj pri la problemo"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -574,40 +575,40 @@ msgstr ""
 "La kolektitaj informoj estas sendataj al la sistemo de cimspurado.\n"
 "Tio povas daŭri kelkajn minutojn."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Farite"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "nenio"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "Elektita: %s. Pluraj ebloj:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Ebloj:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "Pado al la dosiero (presi \"enigu\" por nuligi):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "Dosiero ne ekzistas."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "Ĉi tio estas dosierujo."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "Por daŭrigi vi devas viziti la sekvan URL:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -615,16 +616,16 @@ msgstr ""
 "Vi povas nun lanĉi retfoliumilon aŭ kopii la URL en retfoliumilo en alia "
 "komputilo."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Nun lanĉi retfoliumilon"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 "Ne restas netrakitaj kolapsraportoj. Indiku --help por vidi pliajn informojn."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr "Ne meti la novajn spurojn en la raporto sed sendi ilin al 'stdout'."
 
@@ -643,27 +644,27 @@ msgstr ""
 "Konservi la modifitan raporton al la indikita dosiero anstataŭ ol ŝanĝi la "
 "originalan raporton."
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr "Forigi la nekropsion de la raporto por regenero de la stak-spurado"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "Transpasi CoreFile de raporto"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "Transpasi ExecutablePath de raporto"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "Transpasi ProcMaps de raporto"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "Refari pakaĵinformojn de raporto"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -679,44 +680,44 @@ msgstr ""
 "\"system\", ĝi uzos la sistemagordajn dosierojn, sed tiam ĝi havos nur la "
 "eblon por retrovi kolapsojn okazitajn sur la nune funkcianta sistemo."
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
 "have installed."
 msgstr ""
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 "Raporti progreson de elŝutado/instalado dum instalado de pakaĵoj en la "
 "provejon."
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr "Antaŭmeti tempindikojn al protokolmesaĝoj. Por komandoj"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr "Kaŝmemora dosierujo por pakaĵoj elŝutitaj en la provejo"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
 msgstr ""
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr "Instali kroman pakaĵon en la provejon (plurfoje specifeblas)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -726,7 +727,7 @@ msgstr ""
 "estas uzata dum specifigo de kolaps-identigilo por alŝuti la respuritajn "
 "stakspurojn (nur se nek -g, nek -o, nek -s estas specifitaj)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -734,32 +735,32 @@ msgstr ""
 "Montri respuritajn stakspurojn kaj peti konfirmon antaŭ ol sendi ilin al la "
 "kolapsdatumbazo."
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 "Pado al la duobligita sqlite-datumbazo (apriore: neniu kontrolo por "
 "duobligoj)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr ""
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr ""
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "Ĉu sendi ĉi tiujn kiel kunsendaĵoj? [y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -767,64 +768,64 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "La celdosierujo ekzistas kaj ne estas malplena."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr ""
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -832,7 +833,7 @@ msgstr ""
 "La vekiĝprocezo paraliziĝis tuj antaŭ la fino. Aspektis kiel ĝi normale "
 "kompletiĝis."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr "Via sistemo povas nun nestabiliĝi kaj eble ĝi devas esti restartigata"
 
@@ -846,76 +847,76 @@ msgstr "Raporti problemon..."
 msgid "Report a malfunction to the developers"
 msgstr "Raporti misfunkcion al la programistoj"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "Pardonu, %s fermiĝis neatendite."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "Pardonu, interna eraro okazis en %s."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Sendi"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Montri detalojn"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Daŭrigi"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Pakaĵo: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "Pardonu, problemo okazis dum instalado de la programaro."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "La aplikaĵo %s fermiĝis neatendite."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr "Se vi renkontiĝas pliajn problemojn, klopodu restartigi la komputilon."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "Ignori onte tian problemon"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Kaŝi detalojn"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Aporto"
 
@@ -971,7 +972,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>Alŝutado de informoj pri la problemo</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -983,27 +984,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Kolapsdosiero de Aporto"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "Lasi fermitan"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Relanĉi"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Uzantnomo:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Pasvorto:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "Kolektanta probleminformojn"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1011,6 +1012,6 @@ msgstr ""
 "La kolektitaj informoj povas esti senditaj al la programistoj por plibonigi "
 "la aplikaĵon. Tio povas daŭri kelkajn minutojn."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "Alŝutanta probleminformojn"

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2015-04-27 21:46+0000\n"
 "Last-Translator: Adolfo Jayme Barrientos <fitoschido@gmail.com>\n"
 "Language-Team: Spanish <es@li.org>\n"
@@ -40,11 +40,11 @@ msgstr ""
 "Escriba su contraseña para acceder a los informes de problemas de programas "
 "del sistema"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "Este paquete no parece haberse instalado correctamente"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -55,7 +55,7 @@ msgstr ""
 "actualizar los índices de paquetes disponibles; si eso no funciona, "
 "desinstale los paquetes de terceros relacionados y reintente."
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -68,21 +68,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "programa desconocido"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "El programa «%s» se cerró inesperadamente"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Problema en %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -90,65 +85,70 @@ msgstr ""
 "Su equipo no tiene memoria libre suficiente para analizar el problema "
 "automáticamente y enviar un informe a los desarrolladores."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Problema en %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Informe de problema no válido"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "No tiene permitido acceder a este informe de problema."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Error"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 "No hay suficiente espacio de disco disponible para procesar este informe."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr "No se ha especificado ningún PID"
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr "Debe especificar un PID. Vea --help para obtener más información."
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "PID no válido"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr "El ID de proceso especificado no existe."
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr "No es su PID"
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr "El ID de proceso especificado no le pertenece."
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "No se especificó ningún paquete"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Necesita especificar un paquete o un PID. Consulte --help para más "
 "información."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Permiso denegado"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -156,30 +156,30 @@ msgstr ""
 "El proceso especificado no le pertenece. Ejecute este programa como "
 "propietario del proceso o como superusuario."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "El ID de proceso especificado no pertenece a ningún programa."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "El script de síntomas %s no determinó ningún paquete afectado"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "El paquete %s no existe"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "No se puede crear el informe"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "Informe de problema con actualización"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -191,7 +191,7 @@ msgstr ""
 "\n"
 "Cree un informe nuevo usando «apport-bug»."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -212,24 +212,24 @@ msgstr ""
 "\n"
 "¿Está seguro de que quiere continuar?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "No se ha recopilado información adicional."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "¿De qué tipo de problema quiere informar?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Síntoma desconocido"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "El síntoma «%s» es desconocido."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -248,7 +248,7 @@ msgstr ""
 "En la pestaña Procesos, desplácese por la lista hasta hallar la aplicación "
 "correcta. El identificador es el número que se muestra en la columna Id."
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -256,25 +256,25 @@ msgstr ""
 "Después de cerrar este mensaje pulse en una ventana de aplicación para "
 "informar acerca de un problema con ella."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop falló al determinar la ID de proceso de la ventana"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr "%(prog)s <número de informe>"
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "Especifique el nombre del paquete."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Añade una etiqueta adicional al informe. Se puede especificar varias veces."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
@@ -282,7 +282,7 @@ msgstr ""
 "%(prog)s [opciones] [síntoma|pid|paquete|ruta del programa|archivo .apport/."
 "crash]"
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -293,17 +293,17 @@ msgstr ""
 "lista de síntomas conocidos. (Implícito si se proporciona un único "
 "argumento.)"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "Pulse una ventana como objetivo para rellenar un informe de problema."
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "Iniciar en modo de actualización de errores. Admite un parámetro --package "
 "opcional."
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -311,7 +311,7 @@ msgstr ""
 "Rellenar un informe de error acerca de un síntoma. (Implícito si se "
 "proporciona un nombre de síntoma como único argumento)."
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -320,7 +320,7 @@ msgstr ""
 "un --pid es especificado. (Implícito si se ha dado un nombre de paquete como "
 "un único argumento)."
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -330,11 +330,11 @@ msgstr ""
 "el informe de error contendrá más información. (Implica si pid se da como un "
 "argumento solo.)"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "El pid proporcionado es una aplicación colgada."
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -344,7 +344,7 @@ msgstr ""
 "lugar de los pendientes en %s. (Implícito si se indica el archivo como único "
 "argumento.)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -354,47 +354,47 @@ msgstr ""
 "archivo en vez de enviarla. Este archivo se puede enviar más tarde desde un "
 "equipo diferente."
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Mostrar el número de versión de Apport"
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr "Esto ejecutará apport-retrace en una terminal para examinar la falla."
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "Ejecutar una sesión gdb"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Ejecutar una sesión gdb sin descargar símbolos de depuración"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Actualizar %s con una pila de seguimiento completamente simbólica"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr "No se puede recordar la preferencia sobre enviar estados de informes"
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 "No se pudo guardar el estado del informe de error. No se puede establecer el "
 "modo de informe «auto» o «nunca»."
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr "No se puede recordar la preferencia sobre enviar estados de informes"
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 "Este informe de problema aplica a un programa que ya no está instalado."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
@@ -402,19 +402,21 @@ msgid ""
 msgstr ""
 "El problema ocurrió con el programa %s, que ha sido modificado desde esa vez."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "El informe del problema está dañado y no puede procesarse."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr "Este informe es sobre un paquete que no se encuentra instalado."
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "Ocurrió un error al intentar procesar este informe de problema:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
@@ -422,24 +424,24 @@ msgstr ""
 "Ha instalado dos versiones de esta aplicación. ¿A cuál se refiere el informe "
 "de error que creará?"
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr "«Snap» de %s"
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr "Paquete .deb de %s"
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s se ofrece como «snap», el cual publica %s. Póngase en contacto con ellos "
 "a través de %s (en inglés) para obtener ayuda."
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -449,41 +451,41 @@ msgstr ""
 "dirección de contacto; visite el foro en https://forum.snapcraft.io (en "
 "inglés) para obtener ayuda."
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "No se pudo determinar el nombre del paquete binario o fuente."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "No se puede arrancar el navegador web"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "No se puede arrancar el navegador web para abrir %s."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Problemas con la red"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "No es posible la conexión con la base de datos de errores, por favor, "
 "verifique su conexión a Internet."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Problemas con la red"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Memoria agotada"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Su sistema no tiene la memoria suficiente para procesar este informe de "
 "fallo."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -494,11 +496,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "Problema ya conocido"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -508,38 +510,37 @@ msgstr ""
 "mostrado en el navegador web. Por favor, compruebe si puede añadir cualquier "
 "información adicional que pudiera resultar de utilidad a los desarrolladores."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Ya se ha informado de este problema a los desarrolladores. ¡Gracias!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Pulse una tecla para continuar..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "¿Qué desea hacer? Sus opciones son:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Por favor elija (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i bytes)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(datos binarios)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "¿Quiere enviar un informe del problema a los desarrolladores?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -547,51 +548,51 @@ msgstr ""
 "Después de que se haya enviado el informe del problema, por favor,\n"
 "complete el formulario que se abrirá automáticamente en su navegador."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "&Enviar informe (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "&Examinar localmente"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "&Ver informe"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 "&Guardar el informe para enviarlo luego, o para copiarlo a algún otro lugar."
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "Cancelar e &ignorar errores futuros de esta versión del programa"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Cancelar"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Archivo del informe del problema:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&Confirmar"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Error: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "Recopilando información del problema"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -600,11 +601,11 @@ msgstr ""
 "la\n"
 "aplicación. Esto puede tardar unos minutos."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "Enviando la información del problema"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -613,40 +614,40 @@ msgstr ""
 "errores.\n"
 "Esto puede tardar unos minutos."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Hecho"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "ninguno"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "Seleccionado: %s. Varias opciones:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Opciones:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "Ruta al archivo (Intro para cancelar):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "El archivo no existe."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "Esto es un directorio."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "Para continuar, visite la siguiente URL:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -654,16 +655,16 @@ msgstr ""
 "Puede lanzar un navegador ahora, o copiar esta URL a un navegador en otro "
 "equipo."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Lanzar un navegador ahora"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 "No hay informes de errores pendientes. Intente --help para más información."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 "No añadir los rastros nuevos en el informe, sino escribirlos en la salida "
@@ -684,29 +685,29 @@ msgstr ""
 "Escribir el informe modificado en el archivo dado, en vez de cambiar el "
 "informe original"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 "Eliminar del informe el volcado de memoria tras la regeneración de la traza "
 "de la pila"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "Sobrescribir los informes de CoreFile"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "Sobrescribir los informes de ExecutablePath"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "Sobrescribir los informes de ProcMaps"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "Reconstruir la información de paquetes del informe"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -723,7 +724,7 @@ msgstr ""
 "configuración del sistema, pero solo será capaz de volver sobre los errores "
 "que ocurrieron en la ejecución actual."
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
@@ -733,29 +734,29 @@ msgstr ""
 "utilizando la misma versión que el informe en lugar de cualquier versión de "
 "gdb que haya instalado."
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 "Informar del progreso de la descarga/instalación de paquetes en la caja de "
 "arena"
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr ""
 "Anteponer cronomarcadores para registrar mensajes, para su operación en lote"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 "Crear y usar repositorios de terceros de orígenes especificados en los "
 "informes"
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr "Almacenar directorios para paquetes descargados en la caja de arena"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -763,14 +764,14 @@ msgstr ""
 "Directorio para paquetes desempacados. Las ejecuciones futuras asumirán que "
 "cualquier paquete ya descargado se extrae también a esta caja de arena."
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 "Instalar un paquete adicional en la caja de arena (puede especificarse "
 "varias veces)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -780,7 +781,7 @@ msgstr ""
 "errores. Esto se usa cuando especifica un ID de error para cargar una pila "
 "de rastros reconstituidos (solo si no se especifican ni -g, ni -o ni -s"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -788,32 +789,32 @@ msgstr ""
 "Mostrar la pila de rastros reconstituidos y pedir confirmación antes de "
 "enviarlos a la base de datos de errores"
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 "Ruta a la base de datos sqlite duplicada (por omisión: sin comprobación de "
 "duplicado)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr "No añadir StacktraceSource al reporte."
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "No se puede usar -C sin -S. Parando."
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "¿Está de acuerdo en enviar esto como adjuntos? [y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr "%(prog)s <informe> <carpeta objetivo>"
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr "Archivo de informe que desempaquetar"
 
@@ -821,19 +822,19 @@ msgstr "Archivo de informe que desempaquetar"
 msgid "directory to unpack report to"
 msgstr "carpeta en la que desempaquetar el informe"
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "El directorio de destino existe y no está vacío."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "Consulte la página de man para más detalles."
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "especifica el nombre del archivo de registro generado por valgrind"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
@@ -841,7 +842,7 @@ msgstr ""
 "reusar un directorio de pruebas (SDIR) creado anteriormente o, si no existe, "
 "crearlo"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -849,7 +850,7 @@ msgstr ""
 "no crear ni reusar un directorio de pruebas para símbolos de depuración "
 "adicional, sino depender únicamente de los símbolos de depuración instalados."
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
@@ -857,13 +858,13 @@ msgstr ""
 "reutilizar un directorio caché (REDC) creado previamente, si no existe, "
 "crearlo"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 "informar del el avance en la descarga/instalación al instalar paquetes en el "
 "sistema de pruebas"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
@@ -871,12 +872,12 @@ msgstr ""
 "el ejecutable que se abre con la herramienta «memcheck» de Valgrind para "
 "detectar fugas de memoria"
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Error: %s no es un ejecutable. Parando."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -884,7 +885,7 @@ msgstr ""
 "El evento se produjo durante una suspensión anterior y evitó que el sistema "
 "se reanudara adecuadamente."
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -892,7 +893,7 @@ msgstr ""
 "El evento se produjo durante una hibernación anterior y evitó que el sistema "
 "se reanudara adecuadamente."
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -900,7 +901,7 @@ msgstr ""
 "El proceso de reanudación se colgó muy cerca del final y parecerá que se "
 "completó normalmente."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr "Su sistema puede volverse inestable y puede que necesite reiniciarlo."
 
@@ -914,76 +915,76 @@ msgstr "Informar de un problema..."
 msgid "Report a malfunction to the developers"
 msgstr "Notificar un mal funcionamiento a los desarrolladores"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "Lo sentimos, la aplicación %s se detuvo inesperadamente."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "%s se cerró inesperadamente."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "Lo sentimos, %s ha experimentado un error interno."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Enviar"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Mostrar detalles"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Continuar"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "La aplicación %s ha dejado de responder."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "El programa «%s» ha dejado de responder."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Paquete: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "Lo sentimos, ha ocurrido un problema al instalar el software."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "La aplicación %s ha experimentado un error interno."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "La aplicación %s se cerró inesperadamente."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr "Si sigue teniendo problemas, intente reiniciar el equipo."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "Ignorar problemas futuros de este tipo"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Ocultar detalles"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -1039,7 +1040,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>Enviando información del problema</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -1051,27 +1052,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Archivo de fallo de Apport"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "Dejar cerrada"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Reabrir"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Nombre de usuario:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Contraseña:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "Recopilando información del problema"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1079,6 +1080,6 @@ msgstr ""
 "La información recopilada se puede enviar a los desarrolladores para mejorar "
 "la aplicación. Esto puede tardar algunos minutos."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "Enviando información del problema"

--- a/po/et.po
+++ b/po/et.po
@@ -8,37 +8,39 @@ msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2023-07-21 16:31+0200\n"
-"PO-Revision-Date: 2013-08-28 23:23+0000\n"
-"Last-Translator: olavi tohver <Unknown>\n"
+"PO-Revision-Date: 2023-04-28 09:24+0000\n"
+"Last-Translator: vaba <Unknown>\n"
 "Language-Team: Estonian <et@li.org>\n"
 "Language: et\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2022-12-07 14:36+0000\n"
-"X-Generator: Launchpad (build 41e7553f8097ce3a683f90e835708cbe7bf0006c)\n"
+"X-Launchpad-Export-Date: 2023-07-21 14:36+0000\n"
+"X-Generator: Launchpad (build 2bfac4503c7b6a57e9a8acd782035a16f97e2ddb)\n"
 
 #: ../apport/com.ubuntu.apport.policy.in.h:1
 msgid "Collect system information"
-msgstr "Süsteemiinfo kogumine"
+msgstr "Koguge süsteemiteavet"
 
 #: ../apport/com.ubuntu.apport.policy.in.h:2
 msgid ""
 "Authentication is required to collect system information for this problem "
 "report"
 msgstr ""
+"Selle probleemiaruande jaoks süsteemiteabe kogumiseks on vaja autentimist"
 
 #: ../apport/com.ubuntu.apport.policy.in.h:3
 msgid "System problem reports"
-msgstr ""
+msgstr "Süsteemiprobleemide aruanded"
 
 #: ../apport/com.ubuntu.apport.policy.in.h:4
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
+"Süsteemiprogrammide probleemiaruannetele juurdepääsuks sisestage oma parool"
 
 #: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
-msgstr ""
+msgstr "Tundub, et see pakett ei ole õigesti installitud"
 
 #: ../apport/ui.py:269
 #, python-format
@@ -47,6 +49,9 @@ msgid ""
 "the indexes of available packages, if that does not work then remove related "
 "third party packages and try again."
 msgstr ""
+"See ei tundu olevat ametlik %s pakett. Proovige pärast saadaolevate "
+"pakettide indeksite värskendamist uuesti, kui see ei tööta, eemaldage seotud "
+"kolmanda osapoole paketid ja proovige uuesti."
 
 #: ../apport/ui.py:299
 #, python-format
@@ -103,11 +108,11 @@ msgstr "Vearaporti käsitsemiseks pole piisavalt vaba kettaruumi."
 
 #: ../apport/ui.py:583
 msgid "No PID specified"
-msgstr ""
+msgstr "PID-d pole määratud"
 
 #: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
-msgstr ""
+msgstr "Pead määrama PID-i. Lisateabe saamiseks vaadake --help."
 
 #: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
@@ -115,15 +120,15 @@ msgstr "Vigane PID"
 
 #: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
-msgstr ""
+msgstr "Määratud protsessi ID-d pole olemas."
 
 #: ../apport/ui.py:598
 msgid "Not your PID"
-msgstr ""
+msgstr "Mitte sinu PID"
 
 #: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
-msgstr ""
+msgstr "Määratud protsessi ID ei kuulu sulle."
 
 #: ../apport/ui.py:656
 msgid "No package specified"
@@ -192,6 +197,14 @@ msgid ""
 "\n"
 "Do you really want to proceed?"
 msgstr ""
+"Te ei ole selle probleemiaruande reporter. Palju lihtsam on märkida viga "
+"teise vea duplikaadiks, kui teisaldada oma kommentaarid ja manused uude "
+"veasse.\n"
+"\n"
+"Seejärel soovitame teil esitada uus veaaruanne, kasutades \"apport-bug\" ja "
+"kommenteerida selle vea kohta esitatud viga.\n"
+"\n"
+"Kas soovite tõesti jätkata?"
 
 #: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
@@ -220,6 +233,14 @@ msgid ""
 "the Processes tab, scroll until you find the correct application. The "
 "process ID is the number listed in the ID column."
 msgstr ""
+"Akna valikut ei saa Waylandis kasutada.\n"
+"\n"
+"Leidke akna protsessi ID ja seejärel käivitage \"ubuntu-bug <protsessi "
+"ID>\".\n"
+"\n"
+"Protsessi ID leiate, käivitades süsteemimonitori rakenduse. Kerige "
+"vahekaardil Protsessid, kuni leiate õige rakenduse. Protsessi ID on ID "
+"veerus loetletud number."
 
 #: ../apport/ui.py:978
 msgid ""
@@ -244,7 +265,7 @@ msgstr "Täpsusta paketi nimi."
 
 #: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
-msgstr ""
+msgstr "Lisa aruandele täiendav silt. Võib määrata mitu korda."
 
 #: ../apport/ui.py:1061
 #, python-format
@@ -272,6 +293,8 @@ msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
+"Esita sümptomi kohta veaaruanne. (See tähendab, kui sümptomi nimi on toodud "
+"ainsa argumendina.)"
 
 #: ../apport/ui.py:1106
 msgid ""
@@ -288,7 +311,7 @@ msgstr ""
 
 #: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
-msgstr ""
+msgstr "Pakutud pid on rippuv rakendus."
 
 #: ../apport/ui.py:1133
 #, python-format
@@ -306,7 +329,7 @@ msgstr ""
 
 #: ../apport/ui.py:1159
 msgid "Print the Apport version number."
-msgstr ""
+msgstr "Printige välja Apport versiooninumber."
 
 #: ../apport/ui.py:1321
 msgid ""
@@ -331,10 +354,12 @@ msgstr ""
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
+"Krahhi aruandluse oleku salvestamine ebaõnnestus. Ei saa seadistada "
+"automaatset või mitte kunagi aruandlusrežiimi."
 
 #: ../apport/ui.py:1390
 msgid "Can't remember send report status settings"
-msgstr ""
+msgstr "Aruande olekuseadeid ei mäleta"
 
 #: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
@@ -356,27 +381,29 @@ msgstr "See vearaport on rikutud ja seetõttu ei ole võimalik seda käsitseda."
 
 #: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
-msgstr ""
+msgstr "See aruanne käsitleb paketti, mis pole installitud."
 
 #: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
-msgstr ""
+msgstr "Selle probleemiaruande töötlemisel ilmnes viga:"
 
 #: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
+"Teil on installitud selle rakenduse kaks versiooni, mille kohta soovite "
+"veast teatada?"
 
 #: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
-msgstr ""
+msgstr "%s snap"
 
 #: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
-msgstr ""
+msgstr "%s deb pakett"
 
 #: ../apport/ui.py:1633
 #, python-format
@@ -401,7 +428,7 @@ msgstr "Veebisirvija käivitamine ebaõnnestus"
 #: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
-msgstr ""
+msgstr "%s avamiseks ei saa veebibrauserit käivitada."
 
 #: ../apport/ui.py:1839
 msgid ""
@@ -447,7 +474,7 @@ msgstr ""
 
 #: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
-msgstr ""
+msgstr "Sellest probleemist teatati juba arendajatele. Aitäh!"
 
 #: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
@@ -557,7 +584,7 @@ msgstr "puudub"
 #: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
-msgstr ""
+msgstr "Valitud: %s. Mitu valikut:"
 
 #: ../bin/apport-cli.py:380
 msgid "Choices:"
@@ -597,7 +624,7 @@ msgstr "Ootel vearaporteid pole. Proovi --help võtit lisainfo jaoks."
 
 #: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
-msgstr ""
+msgstr "Ärge pange uusi jälgi aruandesse, vaid kirjutage need stdouti."
 
 #: ../bin/apport-retrace.py:53
 msgid ""
@@ -608,7 +635,7 @@ msgstr ""
 #: ../bin/apport-retrace.py:62
 msgid ""
 "Write modified report to given file instead of changing the original report"
-msgstr ""
+msgstr "Algse aruande muutmise asemel kirjutage antud faili muudetud aruanne"
 
 #: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
@@ -628,7 +655,7 @@ msgstr ""
 
 #: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
-msgstr ""
+msgstr "Uuenda aruande paketi teave"
 
 #: ../bin/apport-retrace.py:93
 msgid ""
@@ -713,7 +740,7 @@ msgstr ""
 
 #: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
-msgstr ""
+msgstr "Teata lahtipakkitavast failist"
 
 #: ../bin/apport-unpack.py:33
 msgid "directory to unpack report to"
@@ -725,7 +752,7 @@ msgstr "Sihtkataloog on olemas ja ei ole tühi."
 
 #: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
-msgstr ""
+msgstr "Vaata üksikasju man-lehelt."
 
 #: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
@@ -805,12 +832,12 @@ msgstr "Vabandust, rakendus %s peatus ootamatult."
 #: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
-msgstr ""
+msgstr "Vabandust, %s sulgus ootamatult."
 
 #: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
-msgstr ""
+msgstr "Vabandust, %s ilmnes sisemine viga."
 
 #: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
@@ -828,7 +855,7 @@ msgstr "Jätka"
 #: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
-msgstr ""
+msgstr "Rakendus %s on lakanud reageerimast."
 
 #: ../gtk/apport-gtk.py:281
 #, python-format
@@ -847,20 +874,20 @@ msgstr "Vabandust, tarkvara paigaldamisel tekkis viga."
 #: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
-msgstr ""
+msgstr "Rakenduses %s ilmnes sisemine viga."
 
 #: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
-msgstr ""
+msgstr "Rakendus %s suleti ootamatult."
 
 #: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
-msgstr ""
+msgstr "Kui märkad täiendavaid probleeme, proovi arvuti taaskäivitada."
 
 #: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
-msgstr ""
+msgstr "Ignoreeri seda tüüpi tulevasi probleeme"
 
 #: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
@@ -872,15 +899,15 @@ msgstr "Apport"
 
 #: ../gtk/apport-gtk.ui.h:2
 msgid "Cancel"
-msgstr ""
+msgstr "Loobu"
 
 #: ../gtk/apport-gtk.ui.h:3
 msgid "OK"
-msgstr ""
+msgstr "OK"
 
 #: ../gtk/apport-gtk.ui.h:4
 msgid "Crash report"
-msgstr ""
+msgstr "Krahhiaruanne"
 
 #: ../gtk/apport-gtk.ui.h:5
 msgid "<big><b>Sorry, an internal error happened.</b></big>"
@@ -888,23 +915,23 @@ msgstr "<big><b>Vabandust, ilmnes sisemine viga .</b></big>"
 
 #: ../gtk/apport-gtk.ui.h:8
 msgid "Remember this in future"
-msgstr ""
+msgstr "Pidage seda tulevikus meeles"
 
 #: ../gtk/apport-gtk.ui.h:9
 msgid "Ignore future problems of this program version"
-msgstr ""
+msgstr "Ignoreeri selle programmiversiooni tulevasi probleeme"
 
 #: ../gtk/apport-gtk.ui.h:10
 msgid "Relaunch this application"
-msgstr ""
+msgstr "Taaskäivita see rakendus"
 
 #: ../gtk/apport-gtk.ui.h:12
 msgid "_Examine locally"
-msgstr ""
+msgstr "_Uuri olukorda"
 
 #: ../gtk/apport-gtk.ui.h:13
 msgid "Don't send"
-msgstr ""
+msgstr "Ära saada"
 
 #: ../gtk/apport-gtk.ui.h:15
 msgid "<big><b>Collecting problem information</b></big>"
@@ -931,11 +958,11 @@ msgstr ""
 
 #: ../kde/apport-kde-mimelnk.desktop.in.h:1
 msgid "Apport crash file"
-msgstr ""
+msgstr "Apport krahhifail"
 
 #: ../kde/apport-kde.py:255
 msgid "Leave Closed"
-msgstr ""
+msgstr "Jätke suletuks"
 
 #: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"

--- a/po/et.po
+++ b/po/et.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2013-08-28 23:23+0000\n"
 "Last-Translator: olavi tohver <Unknown>\n"
 "Language-Team: Estonian <et@li.org>\n"
@@ -36,11 +36,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr ""
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -61,21 +61,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "tundmatu programm"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Vabandust, programm \"%s\" sulgus ootamatult"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Probleem %s ga"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -83,62 +78,67 @@ msgstr ""
 "Sinu arvutil ei ole piisavalt vaba mälu probleemi automaatse analüüsi ja "
 "arendajate teavitamise jaoks."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Probleem %s ga"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Ebasobiv vearaport"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "Sul puudub ligipääs sellele vearaportile."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Viga"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "Vearaporti käsitsemiseks pole piisavalt vaba kettaruumi."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "Vigane PID"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "Pakett määramata"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr "Sa pead määrama paketi või PID-i. Vaata --help lisainfo jaoks."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Ligipääs keelatud"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -146,30 +146,30 @@ msgstr ""
 "Valitud protsess ei kuulu sulle. Palun käivita see programm protsessi "
 "omaniku või administraatorina."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "Protsessi ID ei kuulu ühelegi programmile."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Sümptomiskript %s ei tuvastanud seotud paketti"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Paketti %s ei leitud"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "Raportit ei õnnestu luua"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "Probleemiraporti uuendamine"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -181,7 +181,7 @@ msgstr ""
 "\n"
 "Palun luua uus raport kasutades \"apport-bug\" käsku."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -193,24 +193,24 @@ msgid ""
 "Do you really want to proceed?"
 msgstr ""
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "Täiendavaid andmeid ei kogutud."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "Mis liiki veast sa tahad raporteerida?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Tundmatu sümptom"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Sümptom \"%s\" pole teada."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -221,7 +221,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -229,197 +229,199 @@ msgstr ""
 "Probleemist teatamiseks vajuta peale selle sõnumi sulgemist probleemse "
 "rakenduse aknal."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "Täpsusta paketi nimi."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr ""
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "Käivita gdb sessioon"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr "See veateade on programmi kohta, mida ei ole enam paigaldatud."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "See vearaport on rikutud ja seetõttu ei ole võimalik seda käsitseda."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr ""
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr ""
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "Paketi või lähtekoodi paketi nime ei suudetud tuvastada."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "Veebisirvija käivitamine ebaõnnestus"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr ""
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Probleem võrguühendusega"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Ei saa ühendust krahhide andmebaasiga, palun kontrolli oma internetiühendust."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Probleem võrguühendusega"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Mälu ammendatud"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "Sinu arvutil pole piisavalt mälu selle krahhirapordi käsitlemiseks."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -430,11 +432,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "Probleem on varasemast teada"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -443,38 +445,37 @@ msgstr ""
 "Sellest probleemist teavitati juba veebisirvijas nähaolevas vearaportis. "
 "Palun vaata, kas sul on arendajate jaoks olulist informatsiooni, mida lisada."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Jätkamiseks vajutage mõnd klahvi..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "Mida sa tahad teha? Sinu võimalused on järgnevad:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Palun vali (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i baiti)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(binaarandmed)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Kas saata arendajatele vearaport?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -482,50 +483,50 @@ msgstr ""
 "Pärast vearaporti saatmist täida palun vorm automaatselt avanevas "
 "veebibrauseri aknas."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "&Saada raport (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr ""
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "&Näita raportit"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr "&Hoia raportifail alles, et see saata hiljem või kopeerida mujale"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "Katkesta ja &ignoreeri edaspidi selle programmi versiooni krahhe"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Loobu"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Vearaporti fail:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "K&innita"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Viga: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "Probleemi kirjeldavate andmete kogumine"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -533,11 +534,11 @@ msgstr ""
 "Kogutud teabe võib saata arendajatele, et rakendust parandada.\n"
 "See võib võtta mõne minuti."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "Probleemi kirjeldava teabe üleslaadimine"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -545,40 +546,40 @@ msgstr ""
 "Kogutud teave saadetakse veahaldussüsteemi.\n"
 "See võib võtta mõne minuti."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Valmis"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "puudub"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr ""
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Valikud:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr ""
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "Faili ei ole."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "See on kataloog."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "Jätkamiseks pead külastama järgmist URLi:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -586,15 +587,15 @@ msgstr ""
 "Võite nüüd veebilehitseja käivitada, või kopeerida selle URLi mõne teise "
 "arvuti brauserisse."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Käivitada veebilehitseja nüüd"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr "Ootel vearaporteid pole. Proovi --help võtit lisainfo jaoks."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 
@@ -609,27 +610,27 @@ msgid ""
 "Write modified report to given file instead of changing the original report"
 msgstr ""
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr ""
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr ""
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr ""
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr ""
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -639,78 +640,78 @@ msgid ""
 "be able to retrace crashes that happened on the currently running release."
 msgstr ""
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
 "have installed."
 msgstr ""
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr ""
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
 msgstr ""
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
 "neither -g, -o, nor -s are specified)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
 msgstr ""
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr ""
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr ""
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "Kas saata need nagu manuseid? [jah: y /ei: n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -718,70 +719,70 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "Sihtkataloog on olemas ja ei ole tühi."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Viga: %s ei ole käivitusfail. Katkestan."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
 msgstr ""
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 "Teie süsteem võib nüüd muutuda ebastabiilseks ja võib vajada taaskäivitust."
@@ -796,76 +797,76 @@ msgstr "Probleemist teatamine..."
 msgid "Report a malfunction to the developers"
 msgstr "Arendajate teavitamine tõrkest"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "Vabandust, rakendus %s peatus ootamatult."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Saada"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Näita üksikasju"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Jätka"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "Programm \"%s\" ei vasta enam."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Pakett: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "Vabandust, tarkvara paigaldamisel tekkis viga."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Peida üksikasjad"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -920,7 +921,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>Probleemi kirjeldava teabe üleslaadimine</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -932,27 +933,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr ""
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr ""
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Taaskäivita"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Kasutajanimi:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Parool:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "Probleemi kirjeldavate andmete kogumine"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -960,6 +961,6 @@ msgstr ""
 "Kogutud andmed võib saata arendajatele, et rakenduse saaks parandada. "
 "Saatmine võib võtta mõned minutid."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "Probleemi kirjeldava teabe üleslaadimine"

--- a/po/eu.po
+++ b/po/eu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2020-03-25 16:37+0000\n"
 "Last-Translator: Ibai Oihanguren Sala <Unknown>\n"
 "Language-Team: Basque <eu@li.org>\n"
@@ -38,11 +38,11 @@ msgstr "Sistemako arazoaren jakinarazpena"
 msgid "Please enter your password to access problem reports of system programs"
 msgstr "Sartu pasahitza sistemako programen arazoen txostenak atzitzeko"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "Paketea ez dela behar bezala instalatu dirudi"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -50,7 +50,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -63,21 +63,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "programa ezezaguna"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Lastima, ustekabean itxi da \"%s\" programa"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Arazoa %s-n"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -85,63 +80,68 @@ msgstr ""
 "Zure ordenagailuak ez dauka memoria aske nahikorik arazoa automatikoki "
 "aztertu eta garatzaileei txosten bat bidaltzeko."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Arazoa %s-n"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Arazoaren txosten baliogabea"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "Ez daukazu errore-txosten hau eskuratzeko baimenik."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Errorea"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "Diskoan ez dago txostena prozesatzeko leku libre nahikorik."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "PID baliogabea"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr "Zehazturiko prozesu-IDa ez da existitzen."
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr "Ez da zure PIDa"
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr "Ez zara zehazturiko prozesu-IDaren jabea."
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "Ez da paketerik zehaztu"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Pakete edo PID bat zehaztu behar duzu. Informazio gehiagorako, ikusi --help."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Baimena ukatuta"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -149,30 +149,30 @@ msgstr ""
 "Zehaztutako prozesua ez da zurea. Exekutatu programa hau  jabe moduan edo "
 "erro moduan."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "Zehaztutako prozesu-IDa ez dagokio inongo programari."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "%s script sintomak ez du determinatzen eraginda dagoen pakete bat"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "%s paketea ez da existitzen"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "Ezin da txostena sortu"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "Arazoaren txostena eguneratzen"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -184,7 +184,7 @@ msgstr ""
 "\n"
 "Sortu txosten berri bat \"apport-bug\" erabiliz."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -205,24 +205,24 @@ msgstr ""
 "\n"
 "Ziur aurrera jarraitu nahi duzula?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "Ez dago bilduta informazio gehiago."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "Zein arazo-motaren berri eman nahi duzu?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Sintoma ezezaguna"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "\"%s\" sintoma ezezaguna da."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -233,7 +233,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -241,31 +241,31 @@ msgstr ""
 "Mezu hau itxi ondoren egin klik aplikazioaren leiho baten gainean eta eman "
 "arazoaren berri."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop-ek ezin izan du leihoaren prozesu-IDa ebatzi"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "Zehaztu pakete-izena."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Gehitu etiketa gehigarri bat txostenari. Hainbat alditan zehaztu daiteke."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -275,18 +275,18 @@ msgstr ""
 "edo --pid bakarrik. Ezer ez zehaztuz gero, sintoma ezagunen zerrenda bat "
 "bistaratzen da. (Inplizitua argumentu bakarra zehaztuz gero.)"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 "Egin klik leiho baten gainean, leiho hori helburu gisa jartzeko arazoaren "
 "berri ematean."
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "Hasi erroreak eguneratzeko moduan. Aukerazko --package bat hartu dezake."
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -294,7 +294,7 @@ msgstr ""
 "Sintoma baten berri emateko txostena bete. (Inplizitua sintomaren izena "
 "zehaztuz gero argumentu bakar bezala.)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -303,18 +303,18 @@ msgstr ""
 "zehaztu bada. (Inplizitua pakete-izen bakarra zehaztuz gero argumentu bakar "
 "bezala.)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -324,131 +324,133 @@ msgstr ""
 "%s(e)koen ordez. (Inplizitua fitxategi bat zehaztuz gero argumentu bakar "
 "bezala.)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Apport bertsio-zenbakia erakutsi."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "Exekutatu gdb saioa"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Exekutatu gdb saioa arazte-sinboloak deskargatu gabe"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Eguneratu %s stack trace erabat sinbolikoarekin"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 "Jadanik instalatuta ez dagoen programa bati dagokio errore-txosten honek."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Txosten hau kalteturik dago eta ezin da prozesatua izan."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr ""
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "Errore bat gertatu da arazo honen txostena prozesatzean:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "Ezin izan da paketearen edo jatorrizko paketearen izena zehaztu."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "Ezin izan da web-arakatzailea abiarazi"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Ezin izan da web-arakatzailea abiarazi %s irekitzeko."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Sarearen arazoa"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Ezin kraskatze-datubasera konektatu, zure Internet-konexioa egiaztatu ezazu."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Sarearen arazoa"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Memoriaren agortzea"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Zure sistemak ez dauka kraskatzearen txostena prozesatzeko memoria nahiko."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -459,11 +461,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "Arazoa ezaguna da jadanik"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -473,38 +475,37 @@ msgstr ""
 "garatzaileentzat lagungarria izan daitekeen informazio gehiago eman "
 "dezakezun egiaztatu ezazu."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Dagoeneko eman zaie arazoaren berri garatzaileei. Eskerrik asko!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Edozein tekla sakatu ezazu jarraitzeko..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "Zer nahi duzu egin? Aukera hauek dituzu:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Mesedez, hautatu (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i byte)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(datu bitarrak)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Arazoaren txosten bat bidali garatzaileei?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -512,50 +513,50 @@ msgstr ""
 "Arazoaren txostena bidali ondoren, mesedez, web-arakatzailean\n"
 "automatikoki irekitako formularioa bete ezazu."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "&Txostena bidali (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "&Lokalki aztertu"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "Txostena &ikusi"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr "Txostena &gorde geroago bidaltzeko edo beste leku batera kopiatzeko"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "Utzi eta baztertu programa bertsio honen kraskatzeak hemendik aurrera"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Utzi"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Errore-txostenaren fitxategia:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&Berretsi"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Errorea: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "Errorearen inguruko informazioa biltzen"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -563,11 +564,11 @@ msgstr ""
 "Bildutako informazioa garatzaileei bidali diezaiekezu, aplikazioa\n"
 "hobetzen laguntzeko. Minutu batzuk behar ditzake honek."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "Errorearen inguruko informazioa bidaltzen"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -575,40 +576,40 @@ msgstr ""
 "Errore-segimendu sistemara bidaltzen ari da bildutako informazioa.\n"
 "Minutu batzuk behar ditzake honek."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Eginda"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "batere ez"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "Hautatuta: %s. Aukera ugari:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Aukerak:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "Fitxategira bidea (\"Entrar\" uzteko):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "Fitxategia ez da existitzen."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "Direktorioa da hau."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "Jarraitzeko, URL hau bisitatu ezazu:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -616,16 +617,16 @@ msgstr ""
 "Oraintxe abiarazi dezakezu nabigatzailea, edo URLa kopiatu ezazu beste "
 "ordenagailu bateko nabigatzailean erabiltzeko."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Oraintxe abiarazi nabigatzailea"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 "Ez dago txostenik bidaltzeke. Informazio gehiagorako, --help probatu ezazu."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr "Ez traza berririk gehitu txostenera, horren ordez, stdout-en idatzi."
 
@@ -644,27 +645,27 @@ msgstr ""
 "Fitxategi zehatz batean gorde txosten aldatua, jatorrizko txostena aldatu "
 "ordez."
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "Txostenaren CoreFile-a ezikusi"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "Txostenaren ExecutablePath-a ezikusi"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "Txostenaren ProcMaps-a ezikusi"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "Berreraiki txostenaren pakete-informazioa"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -674,45 +675,45 @@ msgid ""
 "be able to retrace crashes that happened on the currently running release."
 msgstr ""
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
 "have installed."
 msgstr ""
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 "Eman deskarga/instalazioaren aurrerapenaren berri sandboxean paketeak "
 "instalatzean"
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr ""
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
 msgstr ""
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 "Instalatu pakete gehigarri bat sandboxean (hainbat alditan zehatz daiteke)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -723,7 +724,7 @@ msgstr ""
 "hutsegitearen IDa zehazten denean (soilik -g, -o, eta -s zehazten ez "
 "direnean)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -731,32 +732,32 @@ msgstr ""
 "Erakutsi berriro igarotako stack trace-ak eta eskatu berrestea hutsegiteen "
 "datu-basera bidali aurretik."
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 "Bikoiztuta dagoen sqlite datu-basera ailegatzeko bidea (lehenetsia: frogatze "
 "bikoizturik ez)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr ""
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr ""
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "Ondo dago eranskin hauek bidaltzea? (y, bai; n, ez) [y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -764,19 +765,19 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "Jada existitzen da helburu direktorioa, eta ez dago hutsik."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "Ikusi man orria xehetasunetarako."
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "zehaztu valgrind bidez sortutako egunkariaren fitxategi-izena"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
@@ -784,7 +785,7 @@ msgstr ""
 "berrerabili aurrez sortutako sandbox direktorioa (SDIR) edo, ez bada "
 "existitzen, sor ezazu"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -792,7 +793,7 @@ msgstr ""
 "ez sortu edo berrerabili sandbox direktoriorik arazte-sinbolo "
 "gehigarrientzat, instalatutako arazte-sinboloetaz soilik fidatu."
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
@@ -800,36 +801,36 @@ msgstr ""
 "berrerabili aurrez sortutako cache direktorioa (CDIR) edo, ez bada "
 "existitzen, sor ezazu"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 "eman deskarga/instalazioaren aurrerapenaren berri sandboxean paketean "
 "instalatzean"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Errorea: %s ez da exekutagarria. Gelditzen."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -837,7 +838,7 @@ msgstr ""
 "Amaieratik oso gertu hutsegin du jarraitze-prozesuak, eta egokiro burutu den "
 "itxura eman ahal izan du."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 "Ezegonkor bilakatu daiteke zure sistema orain eta berrabiarazi beharko "
@@ -853,76 +854,76 @@ msgstr "Arazo baten berri eman..."
 msgid "Report a malfunction to the developers"
 msgstr "Eman garatzaileei funtzionamendu oker baten berri"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "Barkatu, %s aplikazioa ustekabean gelditu da."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "Barkatu, %s ustekabean itxi da."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "Barkatu, %s(e)k barne-errore bat izan du."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Bidali"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Erakutsi xehetasunak"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Jarraitu"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "%s aplikazioak ez du erantzuten."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "\"%s\" programak ez du erantzuten."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Paketea: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "Barkatu, arazo bat egon da softwarea instalatzean."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "%s aplikazioak barne-errore bat izan du."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "%s aplikazioa ustekabean itxi da."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr "Arazo gehiago aurkitzen badituzu, probatu ordenagailua berrabiaraziz."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "Egin ezikusi aurrerantzean mota honetako arazoei"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Ezkutatu xehetasunak"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -978,7 +979,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>Arazoari buruzko informazioa bidaltzen</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -990,27 +991,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Apport kraskatze-fitxategia"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "Mantendu itxita"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Berrabiarazi"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Erabiltzaile-izena:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Pasahitza:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "Arazoari Buruzko Informazioa Biltzen"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1018,6 +1019,6 @@ msgstr ""
 "Bildutako informazioa garatzaileei bidali daiteke, hauek aplikazioa "
 "hobetzeko. Bidaltzeak agian minutu batzuk beharko lituzke."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "Arazoari Buruzko Informazioa Bidaltzen"

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2022-03-11 13:14+0000\n"
 "Last-Translator: Tuomas Lähteenmäki <Unknown>\n"
 "Language-Team: Finnish <fi@li.org>\n"
@@ -38,11 +38,11 @@ msgstr "Järjestelmän ongelmaraportit"
 msgid "Please enter your password to access problem reports of system programs"
 msgstr "Anna salasanasi nähdäksesi järjestelmäohjelmien ongelmaraportteja"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "Tätä pakettia ei ole asennettu oikein"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -53,7 +53,7 @@ msgstr ""
 "olevan pakettiluettelon päivittämisen jälkeen. Jos se ei auta, poista asiaan "
 "liittyvät kolmannen osapuolen paketit ja yritä uudelleen."
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -66,21 +66,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "tuntematon sovellus"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Ikävä kyllä ohjelma \"%s\" sulkeutui yllättäen"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Ongelma osan %s kanssa"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -88,64 +83,69 @@ msgstr ""
 "Muistia ei ole vapaana tarpeeksi ongelman automaattiseen analysointiin ja "
 "virheraportin lähettämiseen."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Ongelma osan %s kanssa"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Virheellinen ongelmaraportti"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "Sinulla ei ole lukuoikeuksia tähän ongelmaraporttiin."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Virhe"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "Levyllä ei ole tarpeeksi tilaa raportin käsittelyyn."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr "PID:iä ei määritetty"
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr "Sinun tulee määrittää PID. Katso --help saadaksesi lisätietoja."
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "PID-numero ei kelpaa"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr "Määriteltyä prosessitunnistetta ei ole."
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr "Ei sinun PID"
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr "Määritelty prosessitunniste ei kuulu sinulle."
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "Pakettia ei ole määritelty"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Paketti tai PID-tunniste on annettava. Katso lisätietoja käyttämällä "
 "valitsinta --help."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Lupa evätty"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -153,30 +153,30 @@ msgstr ""
 "Kyseinen prosessi ei kuulu sinulle. Aja tämä ohjelma prosessin omistajana "
 "tai pääkäyttäjänä."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "Määritetty prosessin ID-numero ei kuulu kyseiselle ohjelmalle."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Oirekomentosarja %s ei määritellyt vaikuttanutta pakettia"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Pakettia %s ei ole olemassa"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "Raporttia ei voida luoda"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "Päivitetään ongelmaraporttia"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -188,7 +188,7 @@ msgstr ""
 "\n"
 "Ole hyvä, ja luo uusi raportti käyttäen \"apport-bug\" määrittelyä."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -209,24 +209,24 @@ msgstr ""
 "\n"
 "Haluatko todella jatkaa?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "Lisätietoja ei kerätty."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "Millainen ongelma raportoidaan?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Tuntematon ongelma"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Ongelmaa \"%s\" ei tunnistettu."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -245,7 +245,7 @@ msgstr ""
 "Prosessit-välilehteä, kunnes löydät oikean sovelluksen. Prosessin tunnus on "
 "ID-sarakkeessa oleva numero."
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -253,31 +253,31 @@ msgstr ""
 "Kun olet sulkenut tämän viestin napsauta sen sovelluksen ikkunaa, johon "
 "liittyvän virheraportin haluat tehdä."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop ei onnistunut selvittämään ikkunaan ID-tunnistenumeroa"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "Määritä paketin nimi."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Lisää raporttiin liittyvä tunniste. Tämä voidaan tehdä useampia kertoja."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -287,17 +287,17 @@ msgstr ""
 "pid:n, tai vain --pid:n. Jos kumpaakaan ei anneta, näytä lista tunnetuista "
 "oireista. (Epäsuora jos yksi argumentti on annettu.)"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "Napsauta ikkunaa, johon liittyvän virheraportin haluat tehdä."
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "Aloita ohjelmavirheiden päivitystilassa. Voi ottaa valinnaisen valitsimen --"
 "package."
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -305,7 +305,7 @@ msgstr ""
 "Arkistoi ohjelmavirheen raportti oireena. (Epäsuorasti jos oireen nimi on "
 "annettu vain argumenttina.)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -313,7 +313,7 @@ msgstr ""
 "Määritä paketin nimi --file-bug-tilassa. Tämä on valinnainen jos --pid on "
 "määritetty. (Epäsuorasti jos paketin nimi on annettu vain argumenttina.)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -323,11 +323,11 @@ msgstr ""
 "virheraportti sisältää enemmän tietoa.  (Epäsuorasti, jos pid on annettu "
 "ainoana argumenttina.)"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "Annettu pid on ohjelma, joka ei vastaa."
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -336,7 +336,7 @@ msgstr ""
 "Raportoi kaatuminen annetusta .apport tai .crash-tiedostosta odottavien "
 "sijaan kohdassa %s. (Epäsuora jos tiedosta on annettu vain argumenttina.)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -346,65 +346,67 @@ msgstr ""
 "raportoimisen sijaan. Tämä tiedosto voidaan raportoida myöhemmin toiselta "
 "koneelta."
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Tulosta Apport-versionumero."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr "Tämä käynnistää apport-retracen pääteikkunnassa ongelman tutkimiseksi."
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "Käynnistä gdb sessiossa"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Suorita gdb-istunto ilman virheenjäljityssymbolien lataamista"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Päivitä %s täysin symbolisella pinolistauksella"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr "Ei muisteta raportin lähetystilan asetuksia"
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 "Kaatumisilmoitusraportin tilan tallennus epäonnistui. Ei voida asettaa "
 "automaattista tai ei ikinä raportointitiloja."
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr "Ei muisteta raportin lähetystilan asetuksia"
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr "Tämä ongelmaraportti kytkeytyy ohjelmaan, joka ei ole enää asennettu."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 msgstr "Ongelma koskee ohjelmaa %s, joka on muuttunut kaatumisen jälkeen."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Tämä ongelman raportti on vahingoittunut, eikä sitä voida käsitellä."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr "Tämä raportti koskee pakettia, jota ei ole asennettu."
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "Virhe käsiteltäessä ongelmaraporttia:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
@@ -412,24 +414,24 @@ msgstr ""
 "Sinulla on tästä sovelluksesta kaksi versiota asennettuna. Kummasta haluat "
 "tehdä vikailmoituksen?"
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr "%s snap"
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr "%s deb paketti"
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s tarjotaan snap-muodossa, ja sen julkaisija on %s. Ole yhteydessä käyttäen "
 "%s saadaksesi apua."
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -439,39 +441,39 @@ msgstr ""
 "ei ole määritetty; käy keskustelualueella osoitteessa https://forum."
 "snapcraft.io/ saadaksesi apua."
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "Paketin tai lähdekoodipaketin nimeä ei voi määrittää."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "Selaimen käynnistäminen epäonnistui"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Verkkoselainta ei saatu käynnistettyä avattaessa sivua %s."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Verkko-ongelma"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Kaatumistietokantaan ei voi yhdistää. Tarkista Internet-yhteyden toimivuus."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Verkko-ongelma"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Muisti ei riitä"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Järjestelmässäsi ei ole tarpeeksi muistia tämän kaatumisraportin käsittelyyn."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -482,11 +484,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "Ongelma on jo tiedossa"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -495,40 +497,39 @@ msgstr ""
 "Tämä ongelma raportoitiin jo virheraportissa, joka on näkyvissä selaimessa. "
 "Tarkista, voisitko lisätä joitakin kehittäjiä auttavaa tietoa."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 "Tästä ongelmasta on jo ilmoitettu kehittäjille. Kiitos kuitenkin "
 "auttamishalustasi!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Paina mitä tahansa näppäintä jatkaaksesi..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "Kuinka haluat edetä? Vaihtoehdot ovat:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Ole hyvä ja valitse (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i tavua)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(binääritiedot)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Lähetetäänkö raportti ongelmasta kehittäjille?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -536,51 +537,51 @@ msgstr ""
 "Kun raportti ongelmasta on lähetetty, ole ystävällinen ja täytä selaimeesi\n"
 "automaattisesti aukeava lomake."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "&Lähetä raportti (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "&Tutki paikallisesti"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "Tarkastele &raporttia"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 "&Säilytä raporttitiedosto myöhemmin lähetettäväksi tai muualle kopioitavaksi"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "Peru ja &jätä jatkossa huomiotta tämän ohjelmaversion kaatumiset"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Peruuta"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Ongelmaraporttitiedosto:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&Vahvista"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Virhe: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "Kerätään tietoja ongelmasta"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -588,11 +589,11 @@ msgstr ""
 "Kerätyt tiedot voidaan lähettää kehittäjille ohjelman parantamiseksi.\n"
 "Tähän voi mennä muutama minuutti."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "Lähetetään tiedot ongelmasta"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -600,40 +601,40 @@ msgstr ""
 "Kerätyt tiedot lähetetään virheseurantajärjestelmään.\n"
 "Tähän voi mennä muutama minuutti."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Valmis"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "ei mitään"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "Valittu: %s. Useita valintoja:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Valinnat:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "Polku tiedostoon (Enter peruu):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "Tiedostoa ei ole olemassa."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "Tämä on hakemisto."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "Jatkaaksesi sinun tulee käydä seuraavassa URL-osoitteessa:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -641,16 +642,16 @@ msgstr ""
 "Voit nyt käynnistää selaimen tai kopioida tämän URL-osoitteen selaimeen "
 "toisella tietokoneella."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Käynnistä selain nyt"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 "Ei odottavia kaatumisraportteja. Kokeile --help saadaksesi lisäinformaatiota."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr "Älä laita uusia jäljityksiä raporttiin, mutta kirjoita ne stdout:iin."
 
@@ -669,27 +670,27 @@ msgstr ""
 "Kirjoita muokattu raportti annetulle tiedostolle alkuperäisen raportin "
 "muuttamisen sijaan"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr "Poista muistivedos raportista pinojäljityksen elvyttämisen jälkeen"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "Korvaa raportin CoreFile"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "Korvaa raportin ExecutablePath"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "Korvaa raportin ProcMaps"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "Rakenna raportin Paketti-informaatio uudelleen"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -706,7 +707,7 @@ msgstr ""
 "järjestelmän asetustiedostoja, mutta voi silloin ainoastaan jäljittää "
 "kaatumisia, jotka tapahtuivat tällä hetkellä ajettavassa julkaisuversiossa."
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
@@ -716,28 +717,28 @@ msgstr ""
 "asentamista varten käyttäen samaa julkaisuversiota kuin raportissa, "
 "mieluummin kuin mitä tahansa versiota gdb:stä joka sinulla on asennettuna."
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 "Raportoi latauksen/asentamisen eteneminen asennettaessa paketteja "
 "hiekkalaatikkoon"
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr "Liitä aikaleimat lokitiedostojen alkuun, eräoperaatiota varten"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 "Luo ja käytä kolmannen osapuolen pakettivarastoja raporteissa määritellyistä "
 "lähteistä"
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr "Välimuistin hakemisto hiekkalaatikkoon ladattaville paketeille"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -745,12 +746,12 @@ msgstr ""
 "Hakemisto purettaville paketeille. Tulevat suorituskerrat olettavat jokaisen "
 "jo ladatun paketin tulevan puretuksi tähän hiekkalaatikkoon."
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr "Lataa ekstrapakkaukset hiekkalaatikkoon (voi kestää pitkään)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -760,7 +761,7 @@ msgstr ""
 "käytetään määritettäessä kaatumistunnistetta ladattaessa jäljitettyä "
 "pinojälkiä. (vain jos yhtäkään seuraavista ei ole määritetty: -g, -o ja -s)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -768,31 +769,31 @@ msgstr ""
 "Näytä seuratut pinojäljet ja pyydä vahvistusta ennen niiden lähettämistä "
 "kaatumistietokantaan."
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 "Polku jäljennös-sqlite-tietokantaan (oletus: ei jäljennöksen tarkistusta)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr "Älä lisää pinolistauslähteitä raporttiin."
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "Et voi käyttää valitsinta -C ilman valitsinta -S. Pysäytetään."
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "Sopiiko näiden lähettäminen liitteinä? [y/n] (y=kyllä, n=ei)"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -800,19 +801,19 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "Kohdehakemisto on jo olemassa, eikä ole tyhjä."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "Katso lisätietoja man-sivulta."
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "syötä valgrindin tuottaman lokitiedoston nimi"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
@@ -820,7 +821,7 @@ msgstr ""
 "käytä uudelleen jo aikaisemmin luotua hiekkalaatikkokansiota (SDIR), tai jos "
 "sitä ei ole, luo sellainen"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -829,7 +830,7 @@ msgstr ""
 "virheenkorjaussymboleja varten, vaan luota vain asennettuihin "
 "virheenkorjaussymboleihin."
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
@@ -837,24 +838,24 @@ msgstr ""
 "uudelleenkäytä aiemmin luotua välimuistin hakemistoa  (CDIR) tai, jos sitä "
 "ei ole, luo se"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 "raportoi latauksen/asennuksen eteneminen  asennettaessa paketteja "
 "hiekkalaatikkoon"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Virhe: %s ei ole suoritettava tiedosto. Lopetetaan."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -862,7 +863,7 @@ msgstr ""
 "Tämä tapahtui edellisen valmiustilan aikana ja esti järjestelmää "
 "palautumasta oikein."
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -870,7 +871,7 @@ msgstr ""
 "Tämä tapahtui edellisen lepotilan aikana ja esti järjestelmää palautumasta "
 "oikein."
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -878,7 +879,7 @@ msgstr ""
 "Aloitettu ajo jumiutui erittäin lähellä loppua ja tulee ilmestymään "
 "suorittuakseen loppuun normaalisti."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 "Järjestelmästäsi saattaa tulla epävakaa ja se saattaa tarvita "
@@ -894,76 +895,76 @@ msgstr "Raportoi ongelma..."
 msgid "Report a malfunction to the developers"
 msgstr "Raportoi toimintahäiriöstä sovelluksen kehittäjille"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "Valitettavasti sovellus %s pysähtyi odottamatta."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "Valitettavasti %s sulkeutui odottamatta."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "Valitettavasti %s kohtasi sisäisen virheen."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Lähetä"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Näytä tiedot"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Jatka"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "Sovellus \"%s\" ei vastaa."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "Ohjelma \"%s\" ei vastaa."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Paketti: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "Valitettavasti ohjelmistoja asennettaessa ilmeni ongelma."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "Sovellus %s kohtasi sisäisen virheen."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "Sovellus %s sulkeutui yllättäen."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr "Jos ongelmat jatkuvat, käynnistä tietokone uudelleen."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "Jätä huomiotta tulevat vastaavanlaiset ongelmat"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Piilota tiedot"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -1017,7 +1018,7 @@ msgstr "Kerätään tietoja ongelman korjaamisen helpottamiseksi."
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>Lähetetään tietoja ongelmasta</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -1029,27 +1030,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Apport-kaatumistiedosto"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "Sulje sovellus"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Käynnistä uudelleen"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Käyttäjätunnus:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Salasana:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "Kerätään tietoja ongelmasta"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1057,6 +1058,6 @@ msgstr ""
 "Kerätty tieto voidaan lähettää kehittäjille ohjelmiston parantamiseksi. Tämä "
 "voi kestää muutamia minuutteja."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "Lähetetään tiedot ongelmasta"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2015-12-23 11:09+0000\n"
 "Last-Translator: Anne017 <Unknown>\n"
 "Language-Team: French <fr@li.org>\n"
@@ -40,11 +40,11 @@ msgstr ""
 "Veuillez saisir votre mot de passe pour accéder à des rapports de problèmes "
 "de programmes système"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "Ce paquet ne semble pas installé correctement."
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -55,7 +55,7 @@ msgstr ""
 "à jour des index de paquets proposés. Si cela ne fonctionne pas, supprimez "
 "alors les paquets tiers associés et réessayez."
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -69,21 +69,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "programme inconnu"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Désolé, le programme « %s » a quitté de façon inattendue"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Problème dans %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -91,64 +86,69 @@ msgstr ""
 "Votre ordinateur ne possède pas suffisamment de mémoire libre pour analyser "
 "automatiquement le problème et envoyer un rapport aux développeurs."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Problème dans %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Rapport d'anomalie non valide"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "Vous n'êtes pas autorisé à accéder à ce rapport d'anomalie."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Erreur"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "Il n'y a pas assez d'espace disque disponible pour traiter ce rapport."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr "Aucun PID n’est indiqué"
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr "Vous devez indiquer un PID. Voir --help pour plus de précisions"
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "PID non valide"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr "L'ID de processus indiqué n'existe pas."
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr "Pas votre PID"
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr "L’identifiant de processus indiqué ne vous appartient pas."
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "Aucun paquet spécifié"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Vous devez préciser un paquet ou un PID. Utilisez --help pour plus "
 "d'informations."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Autorisation refusée"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -157,30 +157,30 @@ msgstr ""
 "en tant que propriétaire du processus ou en tant que super-utilisateur "
 "(root)."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "L'ID de processus spécifié n'appartient à aucun programme."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Le script  %s n'a pas pu déterminer un paquet affecté"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Le paquet %s n'existe pas"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "Impossible de créer le rapport"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "Mise à jour du rapport d'anomalie"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -192,7 +192,7 @@ msgstr ""
 "\n"
 "Veuillez créer un nouveau rapport en utilisant « apport-bug »."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -213,24 +213,24 @@ msgstr ""
 "\n"
 "Voulez-vous vraiment continuer ?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "Aucune information supplémentaire n'a été collectée."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "Quel type de problème voulez-vous signaler ?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Symptôme inconnu"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Le symptôme « %s » est inconnu."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -241,7 +241,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -249,32 +249,32 @@ msgstr ""
 "Après avoir fermé ce message, veuillez cliquer sur la fenêtre de "
 "l'application pour laquelle vous voulez signaler un problème."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop n'a pas pu déterminer l'ID du processus de la fenêtre"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "Veuillez indiquer le nom du paquet."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Ajouter un marqueur supplémentaire pour le rapport. Peut être spécifié "
 "plusieurs fois."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -284,15 +284,15 @@ msgstr ""
 "pid en option, ou simplement --pid. Si aucun n'est fournit, affiche une "
 "liste de symptômes connus. (Implicite si un seul argument est fournit.)"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "Cliquez sur la fenêtre pour laquelle vous voulez signaler un problème."
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "Démarrer en mode de mise à jour de bogue. Accepte l’option --package."
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -300,7 +300,7 @@ msgstr ""
 "Rédiger un rapport de bogue concernant un symptôme. (Implicite si le nom du "
 "symptôme est donné comme unique argument.)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -309,7 +309,7 @@ msgstr ""
 "--pid est spécifié. (Implicite si le nom du paquet est donné comme unique "
 "argument.)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -319,11 +319,11 @@ msgstr ""
 "spécifié, le rapport de bogue contiendra davantage d'informations. "
 "(implicite si l’identifiant du processus est passé comme unique argument)"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "Le pid fourni est une application qui ne répond pas."
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -333,7 +333,7 @@ msgstr ""
 "qu'à partir de ceux en attente dans %s. (Implicite si le fichier est donné "
 "comme unique argument.)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -343,68 +343,70 @@ msgstr ""
 "un fichier au lieu de générer un rapport. Ce fichier pourra être utilisé "
 "plus tard à partir d'une autre machine pour envoyer un rapport."
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Afficher le numéro de version d'Apport."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Cela va lancer apport-retrace dans une fenêtre de terminal pour examiner le "
 "plantage."
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "Lancer une session gdb"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Exécuter la session gdb sans télécharger les symboles de débogage"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Mettre %s à jour avec une trace de pile entièrement symbolique"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr "Impossible de se souvenir des paramètres d'état du rapport d'envoi"
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 "L'enregistrement de l'état des rapports de plantage a échoué. Impossible de "
 "définir le mode de signalement automatique ou jamais."
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr "Impossible de se souvenir des paramètres d'état du rapport d'envoi"
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 "Ce rapport d'anomalie fait référence à un logiciel qui n'est plus installé."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 msgstr "Le problème concerne le programme %s qui a changé depuis le plantage."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Ce rapport d'anomalie est endommagé et ne peut pas être traité."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr "Ce rapport concerne un paquet qui n'est pas installé."
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "Une erreur est survenue lors du traitement de ce rapport d'anomalie :"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
@@ -412,24 +414,24 @@ msgstr ""
 "Deux versions de cette application sont installées. Pour laquelle voulez-"
 "vous signaler un bogue ?"
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr "Snap %s"
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr "Paquet deb %s"
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s est fourni par un snap publié par %s. Contactez-les via %s pour obtenir "
 "de l'aide."
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -439,40 +441,40 @@ msgstr ""
 "indiquée ; visitez le forum à l’adresse https://forum.snapcraft.io/ pour "
 "obtenir de l’aide."
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "Impossible de déterminer le nom du paquet ou du paquet source."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "Impossible de lancer le navigateur Web"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Impossible de lancer le navigateur Web pour ouvrir %s."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Problème de réseau"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Impossible de se connecter à la base de données des plantages. Veuillez "
 "vérifier votre connexion Internet."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Problème de réseau"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Mémoire saturée"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Votre système n'a pas assez de mémoire pour traiter ce rapport de plantage."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -483,11 +485,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "Problème déjà connu"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -497,38 +499,37 @@ msgstr ""
 "navigateur Web. Veuillez vérifier si vous pouvez ajouter des informations "
 "complémentaires susceptibles d'aider les développeurs."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Ce problème a déjà été signalé aux développeurs. Merci !"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Appuyer sur une touche pour continuer…"
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "Que voulez-vous faire ? Les choix possibles sont :"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Faites un choix (%s) :"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i octets)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(données binaires)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Envoyer un rapport d'anomalie aux développeurs ?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -536,52 +537,52 @@ msgstr ""
 "Après l'envoi du rapport d'anomalie, veuillez compléter le formulaire\n"
 "dans le navigateur Web ouvert automatiquement."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "&Envoyer le rapport (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "E&xaminer en local"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "&Voir le rapport"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 "&Conserver le fichier du rapport pour l'envoyer ultérieurement ou le copier "
 "quelque part"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "Annuler et &ignorer les plantages futurs de cette version du programme"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Annuler"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Fichier du rapport d'anomalie :"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&Confirmer"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Erreur : %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "Collecte des informations liées au problème"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -589,11 +590,11 @@ msgstr ""
 "Les informations collectées peuvent être envoyées aux développeurs pour\n"
 "améliorer l'application. Cela peut prendre quelques minutes."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "Téléversement des informations liées au problème"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -601,40 +602,40 @@ msgstr ""
 "Les informations collectées sont envoyées au système de suivi de bogues.\n"
 "Cela peut prendre quelques minutes."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Terminé"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "aucun"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "Sélectionné : %s. Choix multiples :"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Choix :"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "Chemin du fichier (Entrée pour annuler) :"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "Le fichier n'existe pas."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "Ceci est un répertoire."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "Pour continuer, vous devez visiter l'adresse suivante :"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -642,17 +643,17 @@ msgstr ""
 "Vous pouvez lancer un navigateur maintenant, ou copier cette adresse dans un "
 "navigateur sur un autre ordinateur."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Lancer un navigateur Web maintenant"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 "Aucun rapport de plantage en attente. Essayer --help pour plus "
 "d'informations."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 "Ne pas placer les nouvelles « traces » dans le rapport, mais les écrire sur "
@@ -673,29 +674,29 @@ msgstr ""
 "Écrire le rapport modifié dans le fichier donné au lieu de changer le "
 "rapport original."
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 "Supprimer l'image système du rapport après régénération de la trace de la "
 "pile"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "Écraser le fichier core du rapport"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "Écraser le chemin de l'exécutable du rapport"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "Écraser la mappe des processus du rapport"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "Reconstruire les informations sur les paquets du rapport"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -712,7 +713,7 @@ msgstr ""
 "les fichiers de configuration du système seront utilisés, mais seuls les "
 "plantages de la version en cours d'exécution pourront être tracés."
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
@@ -722,29 +723,29 @@ msgstr ""
 "ses dépendances en utilisant la même version que celle du rapport plutôt que "
 "la version de GDB que vous avez installée."
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 "Signaler l'avancement du téléchargement/de l'installation lors de "
 "l'installation de paquets dans le bac à sable."
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr ""
 "Préfixer un horodatage aux messages de journal, pour un traitement par lots"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 "Créer et utiliser les dépôts tiers à partir des origines spécifiées dans les "
 "rapports"
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr "Répertoire de cache pour les paquets téléchargés dans le bac à sable"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -752,14 +753,14 @@ msgstr ""
 "Répertoire pour les paquets décompressés. Les exécutions futures présumeront "
 "qu'un paquet déjà téléchargé sera aussi extrait dans ce bac à sable."
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 "Installer un paquet supplémentaire dans le bac à sable (peut être spécifié "
 "plusieurs fois)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -770,7 +771,7 @@ msgstr ""
 "plantage pour téléverser les traces de la pile retracées (seulement si -g, -"
 "o ou -s ne sont pas spécifiés)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -778,32 +779,32 @@ msgstr ""
 "Afficher les traces de la pile retracées et demander une confirmation avant "
 "de les envoyer à la base de données des plantages."
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 "Chemin de la copie de la base de données sqlite (par défaut : pas de "
 "vérification de la copie)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr "Ne pas ajouter StacktraceSource au rapport."
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "Vous ne pouvez pas utiliser -C sans -S. Arrêt."
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "D'accord pour envoyer ceci comme pièces jointes ? [y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr "Fichier de rapport à décompresser"
 
@@ -811,19 +812,19 @@ msgstr "Fichier de rapport à décompresser"
 msgid "directory to unpack report to"
 msgstr "répertoire dans lequel décompresser le rapport"
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "Le dossier de destination existe déjà et n'est pas vide."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "Voir la page de manuel pour plus de détails."
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "spécifier le nom du fichier journal produit par valgrind"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
@@ -831,7 +832,7 @@ msgstr ""
 "réutiliser un répertoire de bac à sable (« sandbox ») (SDIR) créé "
 "précédemment ou, s'il n'existe pas, le créer"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -840,7 +841,7 @@ msgstr ""
 "additionnels de débogage, mais s'appuyer seulement sur les symboles de "
 "débogage installés."
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
@@ -848,24 +849,24 @@ msgstr ""
 "réutiliser un répertoire de cache (CDIR) précédemment créé ou, s'il n'existe "
 "pas, le créer"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 "afficher la progression du téléchargement et de l'installation lors de "
 "l'installation de paquets dans le bac à sable (« sandbox »)"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Erreur : %s n'est pas un exécutable. Arrêt."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -873,7 +874,7 @@ msgstr ""
 "Cela s'est produit lors d'une mise en veille précédente et a empêché la "
 "bonne reprise du système."
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -881,7 +882,7 @@ msgstr ""
 "Cela s'est produit lors d'une mise en veille prolongée précédente et a "
 "empêché la bonne reprise du système."
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -889,7 +890,7 @@ msgstr ""
 "Le processus de sortie de veille a bloqué juste avant la fin et apparaîtra "
 "comme ayant terminé normalement."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 "Votre système peut maintenant devenir instable et nécessiter un redémarrage."
@@ -904,76 +905,76 @@ msgstr "Signaler un problème..."
 msgid "Report a malfunction to the developers"
 msgstr "Signaler un dysfonctionnement aux développeurs"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "Désolé, l'application %s s'est arrêtée de façon inattendue."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "Désolé, %s a quitté de façon inattendue."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "Désolé, %s a rencontré une erreur interne."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Envoyer"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Afficher les détails"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Continuer"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "L'application %s a cessé de répondre."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "Le programme « %s » a cessé de répondre."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Paquet : %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "Désolé, une erreur est survenue lors de l'installation du logiciel."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "L'application %s a subi une erreur interne."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "L'application %s a quitté de façon inattendue."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr "En cas de nouveaux problèmes, essayez de redémarrer votre ordinateur."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "Ignorer les prochains problèmes de ce genre"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Masquer les détails"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -1029,7 +1030,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>Téléversement des informations liées au problème</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -1041,27 +1042,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Fichier de plantage Apport"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "Laisser fermé"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Relancer"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Nom d'utilisateur :"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Mot de passe :"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "Collecte des informations liées au problème"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1069,6 +1070,6 @@ msgstr ""
 "Les informations collectées peuvent être envoyées aux développeurs pour "
 "améliorer l'application. Cela peut prendre quelques minutes."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "Téléversement des informations liées au problème"

--- a/po/fr_CA.po
+++ b/po/fr_CA.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2015-04-27 21:45+0000\n"
 "Last-Translator: Martin Pitt <martin@piware.de>\n"
 "Language-Team: French (Canada) <fr_CA@li.org>\n"
@@ -40,11 +40,11 @@ msgstr ""
 "Veuillez saisir votre mot de passe pour accéder aux relevés de problèmes des "
 "programmes système"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "Ce paquet ne semble pas être installé correctement."
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -55,7 +55,7 @@ msgstr ""
 "à jour des index de paquets proposés. Ssi cela ne fonctionne pas, supprimez "
 "alors les paquets tiers associés et réessayez."
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -69,21 +69,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "programme inconnu"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Désolé, le programme « %s » s'est fermé de façon inattendue"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Problème dans %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -91,64 +86,69 @@ msgstr ""
 "Votre ordinateur n’a pas assez de mémoire libre pour analyser "
 "automatiquement le problème et envoyer un relevé aux développeurs."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Problème dans %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Le relevé de problème est invalide"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "Vous n’êtes pas autorisé à accéder à ce relever de problème."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Erreur"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "Il n’y a pas assez d’espace disque libre pour traiter ce relevé."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr "Aucun PID n’est indiqué"
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr "Vous devez indiquer un PID. Voir --help pour plus de précisions"
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "PID invalide"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr "L’ID de processus indiqué n’existe pas."
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr "N’est pas votre PID"
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr "L’ID de processus indiqué ne vous appartient pas."
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "Aucun paquet n’est indiqué"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Vous devez préciser un paquet ou un PID. Voir --help pour plus "
 "d'informations."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Permission refusée"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -156,30 +156,30 @@ msgstr ""
 "Le processus indiqué ne vous appartient pas. Veuillez exécuter ce programme "
 "en tant que propriétaire du processus ou en tant que root."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "L'ID de processus indiqué n’appartient à aucun programme."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Le script symptome %s n'a pas déterminé un paquet affecté"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Le paquet %s n'existe pas"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "Impossible de créer le relevé"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "Mise à jour du relevé de problème"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -191,7 +191,7 @@ msgstr ""
 "\n"
 "Veuillez créer un nouveau relevé en utilisant « apport-bug »."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -212,24 +212,24 @@ msgstr ""
 "\n"
 "Voulez-vous vraiment continuer ?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "Aucune autre information n'a été recueillie."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "Quel sorte de problème voulez-vous signaler?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Symptôme inconnu"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Le symptôme « %s » est inconnu."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -240,7 +240,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -248,32 +248,32 @@ msgstr ""
 "Après avoir fermé ce message, veuillez cliquer sur la fenêtre de "
 "l’application pour laquelle vous voulez signaler un problème."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop n'a pas pu déterminer l'ID du processus de la fenêtre"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "Indiquer le nom du paquet."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Ajouter une balise supplémentaire au relevé. Peut être indiquée plusieurs "
 "fois."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -283,15 +283,15 @@ msgstr ""
 "option, ou juste --pid. Si aucun n'est donné, afficher une liste de "
 "symptômes connus. (Implicite si un seul argument est donné.)"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "Cliquer sur une fenêtre qui sera la cible du relevé de problème."
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "Démarrer en mode de mise à jour de bogue. Accepte l’option --package."
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -299,7 +299,7 @@ msgstr ""
 "Rédiger un relevé de bogue relatif à un symptôme. (Implicite si le nom du "
 "symptôme est donné comme seul argument.)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -308,7 +308,7 @@ msgstr ""
 "--pid est indiqué. (Implicite si le nom du paquet est donné comme seul "
 "argument.)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -318,11 +318,11 @@ msgstr ""
 "relevé de bogue contiendra plus d’informations. (implicite si le pid est "
 "donné comme seul argument)"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "Le pid fourni est une application bloquée."
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -332,7 +332,7 @@ msgstr ""
 "qu’à partir de ceux en attente dans %s. (Implicite si le fichier est donné "
 "comme seul argument.)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -342,48 +342,48 @@ msgstr ""
 "un fichier au lieu de les signaler. Ce fichier pourra ensuite être signalé "
 "plus tard à partir d'une machine différente."
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Imprimer le numéro de version d'Apport."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "apport-retrace sera lancé dans une fenêtre de terminal pour examiner le "
 "plantage."
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "Exécuter une session gdb"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Exécuter une session gdb sans télécharger les symboles de débogage"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Mettre %s à jour avec une trace de pile entièrement symbolique"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr "Impossible de se souvenir des paramètres d'état du relevé d'envoi"
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 "Échec de sauvegarde de l’état de signalement du plantage. Impossible de "
 "définir le mode de signalement automatique ou jamais."
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr "Impossible de se souvenir des paramètres d'état du relevé d'envoi"
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr "Ce relevé de problème concerne un logiciel qui n’est plus installé."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
@@ -391,19 +391,21 @@ msgid ""
 msgstr ""
 "Le problème est survenu avec le programme %s qui a changé depuis le plantage."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Ce relevé de problème est endommagé et ne peut pas être traité."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr "Ce relevé concerne un paquet qui n’est pas installé."
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "Une erreur est survenue lors du traitement de ce relevé de problème :"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
@@ -411,24 +413,24 @@ msgstr ""
 "Deux versions de cette application sont installées. Pour laquelle voulez-"
 "vous signaler un bogue ?"
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr "Snap %s"
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr "Paquet deb %s"
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s est fourni par un snap publié par %s. Contactez-les par %s pour obtenir "
 "de l’aide."
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -438,40 +440,40 @@ msgstr ""
 "indiquée ; visitez le forum à l’adresse https://forum.snapcraft.io/ pour "
 "obtenir de l’aide."
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "Impossible de déterminer le nom du paquet ou du paquet source."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "Impossible de démarrer le navigateur Web"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Impossible de démarrer le navigateur Web pour ouvrir %s."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Problème de réseau"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Impossible de se connecter à la base de données des plantages. Veuillez "
 "vérifier votre connexion Internet."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Problème de réseau"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Mémoire pleine"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Votre système n’a pas assez de mémoire pour traiter ce relevé de plantage."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -482,11 +484,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "Problème déjà connu"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -496,38 +498,37 @@ msgstr ""
 "navigateur Web. Veuillez vérifier si vous pouvez ajouter des renseignements "
 "complémentaires susceptibles d’aider les développeurs."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Ce problème a déjà été signalé aux développeurs. Merci!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Peser sur une touche pour continuer…"
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "Que voudriez-vous faire? Les options sont :"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Veuiilez choisir (%s) :"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i octets)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(données binaires)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Envoyer un relevé de problème aux développeurs?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -535,52 +536,52 @@ msgstr ""
 "Après envoi du relevé de problème, veuillez compléter le formulaire\n"
 "dans le navigateur Web ouvert automatiquement."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "&Envoyer le relevé (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "&Examiner localement"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "&Visualiser le relevé"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 "&Garder le fichier du relevé pour un envoi ultérieur ou pour le copier "
 "ailleurs"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "Annuler et &ignorer les plantages futurs de cette version du programme"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Annuler"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Fichier du relevé de problème :"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&Confirmer"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Erreur : %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "Collecte des informations du problème"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -588,11 +589,11 @@ msgstr ""
 "Les informations recueillies peuvent être envoyées aux développeurs pour\n"
 "améliorer l’application. Cela pourrait prendre quelques minutes."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "Téléversement des informations du problème"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -600,40 +601,40 @@ msgstr ""
 "Les informations recueillies sont envoyées au gestionnaire de bogues.\n"
 "Cela pourrait prendre quelques minutes."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Effectué"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "aucun"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "Choisinbsp]: %s. Choix multiples :"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Choix :"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "Chemin du fichier (Entrée pour annuler) :"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "Le fichier n'existe pas."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "Ceci est un répertoire."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "Pour continuer, vous devez visiter l'URL suivante :"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -641,16 +642,16 @@ msgstr ""
 "Vous pouvez lancer un navigateur maintenant, ou copier cette URL dans un "
 "navigateur sur un autre ordinateur."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Lancer un navigateur maintenant"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 "Aucun relevé de plantage en attente. Essayer --help pour plus d’informations."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 "Ne pas placer les nouvelles « traces » dans le relevé, mais les écrire sur "
@@ -671,29 +672,29 @@ msgstr ""
 "Écrire le relevé modifié dans le fichier donné au lieu de changer le relevé "
 "original."
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 "Supprimer le vidage du système du rapport après régénération de la trace de "
 "la pile"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "Remplacer le fichier CoreFile du relevé"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "Remplacer le chemin ExecutablePath du relevé"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "Remplacer la mappe des processus ProcMaps du relevé"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "Reconstruire les informations sur les paquets du relevé"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -710,7 +711,7 @@ msgstr ""
 "configuration du système seront utilisés, mais seuls les plantages de la "
 "version en cours d'exécution pourront être retracés."
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
@@ -720,30 +721,30 @@ msgstr ""
 "dépendances en utilisant la même version que celle du relevé plutôt que la "
 "version de gdb que vous avez installée."
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 "Signaler l'avancement du téléchargement/de l'installation lors de "
 "l'installation de paquets dans le bac à sable."
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr ""
 "Ajouter un horodatage au début des messages de journal, pour un traitement "
 "par lots"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 "Créer et utiliser les dépôts tiers à partir des origines indiquées dans les "
 "relevés"
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr "Répertoire de cache pour les paquets téléchargés dans le bac à sable"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -751,14 +752,14 @@ msgstr ""
 "Répertoire pour les paquets décompressés. Les exécutions futures supposeront "
 "qu'un paquet déjà téléchargé est aussi extrait dans ce bac à sable."
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 "Installer un paquet supplémentaire dans le bac à sable (peut être indiqué "
 "plusieurs fois)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -769,7 +770,7 @@ msgstr ""
 "pour téléverser les traces de la pile retracées (seulement si -g, -o ou -s "
 "ne sont pas indiqués)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -777,32 +778,32 @@ msgstr ""
 "Afficher les traces de la pile retracées et demander une confirmation avant "
 "de les envoyer à la base de données des plantages."
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 "Chemin de la copie de la base de données sqlite (par défaut : pas de "
 "vérification de la copie)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr "Ne pas ajouter StacktraceSource au relevé."
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "Vous ne pouvez pas utiliser -C sans -S. Arrêt."
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "Envoyer cela comme fichiers joints? [y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -810,19 +811,19 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "Le répertoire de destination existe et n'est pas vide."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "Voir la page man pour plus de détails."
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "indiquer le nom du fichier journal produit par valgrind"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
@@ -830,7 +831,7 @@ msgstr ""
 "réutiliser un répertoire de bac à sable (SDIR) créé précédemment ou, s'il "
 "n'existe pas, le créer"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -839,7 +840,7 @@ msgstr ""
 "additionnels de débogage, mais s'appuyer seulement sur les symboles de "
 "débogage installés."
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
@@ -847,24 +848,24 @@ msgstr ""
 "réutiliser un répertoire de cache (CDIR) précédemment créé ou, s'il n'existe "
 "pas, le créer"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 "signaler la progression du téléchargement/installation lors de "
 "l’installation de paquets dans le bac à sable"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Erreur : %s n'est pas un exécutable. Arrêt."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -872,7 +873,7 @@ msgstr ""
 "Cela s'est produit lors d'une mise en veille précédente et a empêché la "
 "reprise correcte du système."
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -880,7 +881,7 @@ msgstr ""
 "Cela s'est produit lors d'une mise en veille prolongée précédente et a "
 "empêché la reprise correcte du système."
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -888,7 +889,7 @@ msgstr ""
 "Le processus de sortie de veille a bloqué juste avant la fin et apparaîtra "
 "comme ayant terminé normalement."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 "Votre système pourrait maintenant devenir instable et nécessiter un "
@@ -904,78 +905,78 @@ msgstr "Signaler un problème…"
 msgid "Report a malfunction to the developers"
 msgstr "Signaler un dysfonctionnement aux développeurs"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "Désolé, l'application %s s'est arrêtée de manière inattendue."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "Désolé, %s s'est fermé de manière inattendue."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "Désolé, %s a rencontré une erreur interne."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Envoyer"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Montrer les détails"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Continuer"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "L'application %s a cessé de répondre."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "Le programme « %s » a cessé de répondre."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Paquet : %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "Désolé, une erreur est survenue durant l'installation d'un logiciel."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "L'application %s a rencontré une erreur interne."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "L'application %s a quitté de façon inattendue."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr ""
 "Si vous continuez à remarquer des problèmes, essayez de redémarrer "
 "l'ordinateur."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "Ignorer les problèmes futurs de ce type"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Masquer les détails"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -1031,7 +1032,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>Téléversement des informations sur le problème</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -1043,27 +1044,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Fichier de plantage Apport"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "Laisser fermé"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Relancer"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Nom d'utilisateur :"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Mot de passe :"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "Collecte des informations du problème"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1071,6 +1072,6 @@ msgstr ""
 "Les informations recueillies peuvent être envoyées aux développeurs pour "
 "améliorer l’application. Cela peut prendre quelques minutes."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "Téléversement des informations du problème"

--- a/po/gd.po
+++ b/po/gd.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2016-01-29 01:13+0000\n"
 "Last-Translator: Akerbeltz <fios@akerbeltz.org>\n"
 "Language-Team: Gaelic; Scottish <gd@li.org>\n"
@@ -40,11 +40,11 @@ msgstr ""
 "Cuir a-steach am facal-faire agad gus cothrom fhaighinn air aithrisean mu "
 "dhèidhinn duilgheadas a bha aig prògraman a t-siostaim"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "Tha coltas nach deach a' phacaid seo a stàladh mar bu chòir"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -52,7 +52,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -65,21 +65,16 @@ msgstr ""
 "\n"
 " %s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "prògram neo-aithnichte"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Tha sinn duilich ach dhùin am prògram \"%s\" gu h-obann."
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Duilgheadas ann an %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -88,64 +83,69 @@ msgstr ""
 "dha an duilgheadas a sgrùdadh gu fèin-obrachail is aithris a chur dhan luchd-"
 "leasachaidh."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Duilgheadas ann an %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Aithris duilgheadais mhì-dhligheach"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "Chan eil cead-inntrigidh agad dhan aithris duilgheadais seo."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Mearachd"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "Chan eil àite gu leòr air an diosg gus an aithris seo a làimhseachadh."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "PID mì-dhligheach"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "Cha deach pacaid a shònrachadh"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Feumaidh tu pacaid no PID a shònrachadh. Faic --help airson barrachd "
 "fiosrachaidh."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Chaidh cead a dhiùltadh"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -153,30 +153,30 @@ msgstr ""
 "Chan eil am pròiseas a shònraich thu a' buntainn riut. Ruith am prògram seo "
 "mar shealbhadair a' phròiseis no mar root."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "Chan eil ID a' phròiseis a shònraich thu a' buntainn do phrògram."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Cha do lorg an sgriobt %s pacaid air a bheil buaidh"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Chan eil a' phacaid %s ann"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "Cha ghabh an aithris a chruthachadh"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "Ag ùrachadh aithris an duilgheadais"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -189,7 +189,7 @@ msgstr ""
 "\n"
 "Cruthaich aithris ùr le \"apport-bug\"."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -209,24 +209,24 @@ msgstr ""
 "\n"
 "A bheil thu cinnteach gu bheil thu airson leantainn air adhart?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "Cha deach fiosrachadh a bharrachd a chruinneachadh."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "Dè seòrsa duilgheadas tha thu airson aithris a dhèanamh air?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Buaidh nach aithne dhuinn"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Chan aithne dhuinn a' bhuaidh \"%s\"."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -237,7 +237,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -245,32 +245,32 @@ msgstr ""
 "An dèidh dhut an teachdaireachd seo a dhùnadh. briog air uinneag aplacaid "
 "gus aithris a dhèanamh air duilgheadas leis."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "Cha b' urrainn dha xprop ID pròiseas na h-uinneige a dhearbhadh"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "Sònraich ainm na pacaid."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Cuir taga a bharrachd ris an aithris. 'S urrainn dhut a shònrachadh iomadh "
 "turas."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -281,17 +281,17 @@ msgstr ""
 "de bhuaidhean air a bheil eòlas. (Tuigear dheth seo ma tha argamaid "
 "shingilte air a chur ann)."
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "Briog air uinneag mar thargaid gus aithris a dhèanamh air duilgheadas."
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "Tòisich sa mhodh ùrachadh bhugaichean. Gabhaidh seo ri --package ma tha feum "
 "air."
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -299,7 +299,7 @@ msgstr ""
 "Clàraich buga mu dhèidhinn buaidh. (Tuigear dheth seo mas e ainm na buaidhe "
 "an aon argamaid.)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -307,7 +307,7 @@ msgstr ""
 "Sònraich ainm na pacaid sa mhodh --file-bug. Tha seo roghainneil ma chaidh --"
 "pid a shònrachadh. (Tuigear dheth seo mas e ainm na pacaid an aon argamaid.)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -317,11 +317,11 @@ msgstr ""
 "shònrachadh, bidh barrachd fiosrachaidh san aithris. (Tuigear dheth seo mas "
 "e pid an aon argamaid.)"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "Tha am pid a shònraich thu 'na aplacaid chrochte."
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -331,7 +331,7 @@ msgstr ""
 "an fheadhainn a tha ri dhèiligeadh ann an %s. (Tuigear dheth seo mas e am "
 "faidhle an aon argamaid.)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -342,50 +342,50 @@ msgstr ""
 "urrainn dhut aithris a dhèanamh leis an fhaidhle às a dhèidh sin no o "
 "choimpiutair eile."
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Clò-bhuail àireamh an tionndaidh aig Apport."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Cuireadh seo air bhog apport-retrace ann an uinneag tèirmineil gus sgrùdadh "
 "a dhèanamh air an tuisleadh."
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "Ruith seisean gdb"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 "Ruith seisean gdb as aonais gun a bhith a' luchdadh a-nuas nan samhlaidhean "
 "dì-bhugachaidh"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Ùraich %s le Stack Trace a tha gu tur samhlach"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 "Tha aithris an duilgheadais seo a' buntainn ri prògram nach eil stàlaichte "
 "tuilleadh."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
@@ -394,84 +394,86 @@ msgstr ""
 "Thachair an duilgheadas leis a' phrògram %s ach chaidh atharrachadh on a "
 "thachair an tuisleadh."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Chaidh an aithris seo a dhochann is cha ghabh a làimhseachadh."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr ""
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr ""
 "Thachair mearachd fhad 's a bha sinn a' feuchainn ri aithris na mearachd seo "
 "a làimhseachadh:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr ""
 "Cha b' urrainn dhuinn a' phacaid no ainm na pacaid thùsail a dhearbhadh."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "Chan urrainn dhuinn brabhsair-lìn a thòiseachadh"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Chan urrainn dhuinn brabhsair-lìn a thòiseachadh gus %s fhosgladh."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Duilgheadas leis an lìonra"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Chan urrainn dhuinn ceangal ri stòr-dàta nan tuisleadh, thoir sùil air a' "
 "cheangal agad ris an eadar-lìon."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Duilgheadas leis an lìonra"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Gainnead cuimhne"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Chan eil cuimhne gu leòr air an t-siostam agad is chan urrainn dha aithris "
 "an tuislidh seo a làimhseachadh."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -482,11 +484,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "Tha sinn eòlach air an duilgheadas seo mu thràth"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -496,41 +498,40 @@ msgstr ""
 "aithris a' bhuga sa bhrabhsair-lìn agad. Thoir sùil ach a bheil fiosrachadh "
 "ùr sam bith agad a dh'fhaodadh a bhith feumail dhan luchd-leasachaidh."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 "Fhuair an luchd-leasachaidh aithris air an duilgheadas seo mu thràth. Tapadh "
 "leat!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Brùth putan sam bith airson leantainn air adhart..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "Dè bu chaomh leat dèanamh? Seo na roghainnean agad:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Dèan taghadh (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i bytes)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(dàta bìnearaidh)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr ""
 "A bheil thu airson aithris mun duilgheadas a chur gun luchd-leasachaidh?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -538,54 +539,54 @@ msgstr ""
 "An dèidh dhut an aithris air an duilgheadas a chur, nach lìon thu am foirm\n"
 "ann an uinneag a' bhrabhsair a thèid fhosgladh gu fèin-obrachail?"
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "&Cuir an aithris (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "&Sgrùd gu h-ionadail"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "&Faic an aithris"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 "&Glèidh faidhle na h-aithrise gus a chur uaireigin eile no airson lethbhreac "
 "dheth a chur am badeigin eile"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr ""
 "Sguir dheth agus le&ig seachad tuislidhean de thionndadh seo a' phrògraim "
 "seo san àm ri teachd"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Sguir dheth"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Faidhle aithris an duilgheadais:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&Dearbhaich"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Mearachd: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "A' cruinneachadh fiosrachadh mun duilgheadas"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -595,11 +596,11 @@ msgstr ""
 "an urrainn dhaibh an aplacaid a leasachadh. Faodaidh gun doir seo beagan "
 "mhionaidean."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "A' luchdadh suas fiosrachadh mun duilgheadas"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -608,42 +609,42 @@ msgstr ""
 "bugaichean.\n"
 "Dh'fhaoidte gun doir seo beagan mhionaidean."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Deiseil"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "chan eil gin"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "Thagh thu: %s. Iomadh roghainn:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Roghainnean:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr ""
 "An t-slighe a dh'ionnsaigh an fhaidhle (Brùth Enter airson sgur dheth):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "Chan eil am faidhle ann."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "'S e pasgan a tha seo."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr ""
 "Feumaidh tu tadhal air an URL a leanas mus urrainn dhut leantainn air adhart:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -651,17 +652,17 @@ msgstr ""
 "'S urrainn dhut brabhsair a chur gu dol an-dràsta no lethbhreac dhen URL seo "
 "a chur ann am brabhsair no coimpiutair eile."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Cuir brabhsair gu dol an-dràsta"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 "Chan eil aithris sam bith air tuisleadh ri dhèiligeadh. Feuch --help airson "
 "barrachd fiosrachaidh."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr "Na cuir na traces ùra dhan aithris ach sgrìobh iad ann an stdout."
 
@@ -680,29 +681,29 @@ msgstr ""
 "Sgrìobh an aithris atharraichte san fhaidhle a tha ann 's na atharraich an "
 "aithris thùsail"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 "Thoir air falbh an core dump às an aithris às dèidh ath-ghintinn an stack "
 "trace"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "Tar-àithn CoreFile na h-aithrise"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "Tar-àithn ExecutablePath na h-aithrise"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "Tar-àithn ProcMaps na h-aithrise"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "Ath-thog fiosrachadh pacaid na h-aithrise"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -720,39 +721,39 @@ msgstr ""
 "siostaim ach ma nì thu sin, chan urrainn dha retrace a dhèanamh air "
 "tuislidhean ach feadhainn san sgaoileadh a tha a' ruith an-dràsta fhèin."
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
 "have installed."
 msgstr ""
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 "Seall adhartas an luchdaidh a-nuas/an stàlaidh nuair a stàlaichear pacaidean "
 "sa bhogsa-ghainmhich"
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr ""
 "Cuir stampa-ama air beulaibh teachdaireachdan an loga, airson gnìomhachadh "
 "batch"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 "Cruthaich is cleachd ionadan-tasgaidh le treas-phàrtaidhean o thùsan a "
 "chaidh a shònrachadh ann an aithrisean"
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr ""
 "Pasgan an tasgadain airson pacaidean a chaidh a luchdadh a-nuas dhan bhogsa-"
 "ghainmhich"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -761,14 +762,14 @@ msgstr ""
 "sam bith o seo a-mach gun dèid pacaid sam bith a chaidh a luchdadh a-nuas "
 "fhosgladh 's a chur dhan bhogsa-ghainmhich seo mu thràth."
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 "Stàlaich pacaid a bharrachd san bhogsa-ghainmhich (gabhaidh seo a "
 "shònrachadh iomadh turas)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -779,7 +780,7 @@ msgstr ""
 "retraced stack traces a luchdadh suas (dìreach mur an deach -g, -o no -s a "
 "shònrachadh)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -787,32 +788,32 @@ msgstr ""
 "Seall na retraced stack traces is faighnich dhìom mus dèid an cur gu stòr-"
 "dàta nan tuislidhean."
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 "An t-slighe gun stòr-dàta sqlite dùblaichte (bun-roghainn: cha doirear sùil "
 "a bheil iad dùblaichte)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr ""
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "Chan urrainn dhut -C a chleachdadh às aonais -S. A' stad."
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "A bheil e ceart gu leòr an cur mar cheanglachain? [y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -820,19 +821,19 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "Tha am pasgan sin sa cheann-uidhe mu thràth 's chan eil e falamh."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "Faic duilleag na treòire airson mion-fhiosrachadh."
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "sònraich ainm faidhle an loga a rinn valgrind"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
@@ -840,7 +841,7 @@ msgstr ""
 "Cleachd Sandbox Dir (SDIR) a-rithist a chaidh a chruthachadh roimhe no, mur "
 "eil e ann, cruthaich e"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -848,7 +849,7 @@ msgstr ""
 "na cruthaich 's na cleachd Sandbox Directory a-rithist airson samhlaidhean "
 "dì-bhugachaidh a bharrachd is cleachd dìreach an fheadhainn a tha stàlaichte."
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
@@ -856,24 +857,24 @@ msgstr ""
 "Cleachd Cache Dir (CDIR) a-rithist a chaidh a chruthachadh roimhe no, mur "
 "eil e ann, cruthaich e"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 "seall adhartas an luchdaidh a-nuas/an stàlaidh nuair a stàlaichear pacaidean "
 "sa bhogsa-ghainmhich"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Mearachd: Chan eil %s 'na rud so-ghnìomhaichte. A' sgur dheth."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -881,7 +882,7 @@ msgstr ""
 "Thachair seo nuair a chaidh a chur ’na dhàil roimhe agus cha b’ urrainn dhan "
 "t-siostam leantainn air adhart mar bu chòir ri linn."
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -889,7 +890,7 @@ msgstr ""
 "Thachair seo nuair a chaidh a chur ’na chadal-geamhraidh roimhe agus cha b’ "
 "urrainn dhan t-siostam leantainn air adhart mar bu chòir ri linn."
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -897,7 +898,7 @@ msgstr ""
 "Lean sinn air ach thuislich e aig an fhìor-dheireadh agus bidh coltas gun "
 "deach a choileanadh mar bu chòir."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 "Dh'fhaoidte gum fàs an siostam agad neo-sheasmhach a-nis is gum b' fheairrde "
@@ -913,80 +914,80 @@ msgstr "Dèan aithris air duilgheadas..."
 msgid "Report a malfunction to the developers"
 msgstr "Dèan aithris air mearachd dhan luchd-leasachaidh"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "Tha sinn duilich ach stad an aplacaid %s gu h-obann."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "Tha sinn duilich ach dhùin %s  gu h-obann."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "Tha sinn duilich, thachair mearachd inntearnail ann an %s."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Cuir"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Seall am mion-fhiosrachadh"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Lean air adhart"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "Chan eil an aplacaid \"%s\" a' freagairt tuilleadh."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "Chan eil am prògram \"%s\" a' freagairt tuilleadh."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Pacaid: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr ""
 "Tha sinn duilich, dh'èirich duilgheadas nuair a bha sinn a' stàladh a' "
 "bhathair-bhog."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "Thachair an aplacaid %s ri mearachd inntearnail."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "Dhùin an aplacaid %s gu h-obann."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr ""
 "Ma mhothaicheas tu do dhuilgheadasan eile, feuch is ath-thòisich an "
 "coimpiutair."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "Leig seachad duilgheadasan dhen t-seòrsa seo san àm ri teachd"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Falaich am mion-fhiosrachadh"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -1043,7 +1044,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>A' luchdadh suas fiosrachadh mun duilgheadas</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -1055,27 +1056,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Faidhle tuislidh  Apport"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "Fàg dùinte e"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Cuir air bhog a-rithist"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Ainm-cleachdaiche:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Facal-faire:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "A' cruinneachadh fiosrachadh mun duilgheadas"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1084,6 +1085,6 @@ msgstr ""
 "leasachaidh airson 's gun urrainn dhaibh an aplacaid a leasachadh. "
 "Dh'fhaoidte gum feum seo beagan mhionaidean."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "A' luchdadh suas fiosrachadh mun duilgheadas"

--- a/po/gl.po
+++ b/po/gl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2017-03-15 22:17+0000\n"
 "Last-Translator: Xosé <Unknown>\n"
 "Language-Team: Galician <gl@li.org>\n"
@@ -40,11 +40,11 @@ msgstr ""
 "Introduza o seu contrasinal para acceder aos informes de problemas dos "
 "programas do sistema"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "Este paquete semella que non está instalado correctamente"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -55,7 +55,7 @@ msgstr ""
 "actualizar os índices dos paquetes dispoñibles; se isto non funciona, "
 "elimine os paquetes relacionados de terceiros e tente de novo."
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -68,21 +68,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "programa descoñecido"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Desculpe, o programa «%s» pechouse inesperadamente"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Problema en %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -90,64 +85,69 @@ msgstr ""
 "O seu computador non dispón de memoria libre abondo para analizar "
 "automaticamente o problema e enviarlle un informe aos desenvolvedores."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Problema en %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "O informe de problema non é válido"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "Non ten permiso para acceder a este informe de problema."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Erro"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "Non hai espazo abondo no disco para procesar este informe."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr "Non se indicou ningún PID"
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr "Hai que indicar un PID. Vexa --axuda para máis información."
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "O PID non é válido"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr "O identificador de proceso indicado non existe."
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr "Non é o seu PID"
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr "O identificador de proceso indicado non lle pertence a vostede."
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "Non se especificou ningún paquete"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Ten que especificar un paquete ou un PID. Vexa --axuda para obter máis "
 "información."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Permiso denegado"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -155,30 +155,30 @@ msgstr ""
 "O proceso especificado non lle pertence. Execute este programa como "
 "propietario do proceso ou como root."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "O ID de proceso especificado non pertence a ningún programa."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "O script «symptom» %s non determinou ningún paquete afectado"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "O paquete %s non existe"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "Non se pode crear o informe"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "Actualización de informe de problemas"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -190,7 +190,7 @@ msgstr ""
 "\n"
 "Por favor, cree un novo informe con «apport-bug»."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -210,24 +210,24 @@ msgstr ""
 "\n"
 "Desexa continuar?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "Non se recolleu información adicional."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "De que tipo de problema quere informar?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Síntoma descoñecida"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Non se coñece a síntoma «%s»."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -246,7 +246,7 @@ msgstr ""
 "Sistema. Na lapela Procesos, baixe até atopar a aplicación correcta. O "
 "identificador do proceso é o número que aparece na lista Identificador."
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -254,25 +254,25 @@ msgstr ""
 "Despois de pechar esta mensaxe, prema nunha xanela do aplicativo para "
 "informar sobre este problema."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "Produciuse un fallo en «xprop» ao determinar o ID de proceso da xanela"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr "%(prog)s <número de informe>"
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "Especifique o nome do paquete."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Engade unha etiqueta extra ao informe. Pódese especificar varias veces."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
@@ -280,7 +280,7 @@ msgstr ""
 "%(prog)s [opcións] [síntoma|pid|paquete|ruta ao programa| ficheiro .apport/."
 "crash]"
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -290,17 +290,17 @@ msgstr ""
 "opcional, ou só un --pid. Se non se fornece ningún, mostra unha lista de "
 "síntomas coñecidas. (Implícito se se fornece un único argumento.)"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "Prema nunha xanela como un obxectivo para informar do problema."
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "Iniciar en modo de actualización de erros. Pode aceptar un --package "
 "opcional."
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -308,7 +308,7 @@ msgstr ""
 "Ficheiro dun informe de erro dunha síntoma. (Implícito se se deu como único "
 "argumento o nome da síntoma)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -316,7 +316,7 @@ msgstr ""
 "Especificar un nome de paquete no modo --file-bug. Isto é opcional se se "
 "especifica un --pid. (Tamén se o nome do paquete foi dado só como argumento)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -326,11 +326,11 @@ msgstr ""
 "informe de erro conterá máis información.  (Implica se o PID se fornece só "
 "como un argumento.)"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "O pid fornecido é un aplicativo bloqueado."
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -339,7 +339,7 @@ msgstr ""
 "Informe sobre a falla no ficheiro dado .apport ou .crash en lugar de facelo "
 "nos pendentes en %s. (Tamén se o ficheiro foi dado só como argumento) ."
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -349,50 +349,50 @@ msgstr ""
 "no canto de enviala. Este ficheiro pódese enviar máis adiante desde unha "
 "máquina diferente."
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Imprimir o número da versión do Apport."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Isto iniciará apport-retrace nunha xanela de terminal para examinar o peche "
 "inesperado."
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "Executar sesión de gdb"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Executar sesión de gdb sen descargar os símbolos de depuración"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Actualizar %s coa pila de chamadas simbólicas completas"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-"Non é posíbel lembrar a preferencia sobre o envío do estado dos informes"
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 "Produciuse un fallo ao gardar o estado do informe de fallos. Non é posíbel "
 "estabelecer o modo de informe automático nin o de non informar nunca."
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+"Non é posíbel lembrar a preferencia sobre o envío do estado dos informes"
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 "Este informe de problema aplícase a un programa que xa non está instalado.."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
@@ -400,19 +400,21 @@ msgid ""
 msgstr ""
 "O problema aconteceu co programa %s, que mudou desde que se produciu o fallo."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "O informe de erro está danado e non pode ser procesado."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr "Este informe é sobre un paquete que non está instalado."
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "Produciuse un erro ao tentar procesar este informe de problema:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
@@ -420,24 +422,24 @@ msgstr ""
 "Hai instaladas dúas versións desta aplicación; sobre cal delas quere "
 "informar dun erro?"
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr "%s snap"
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr "%s paquete deb"
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s foi fornecido cun snap publicado por %s. Contacte con eles a través de %s "
 "se precisa axuda."
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -446,39 +448,39 @@ msgstr ""
 "%s foi fornecido cun snap publicado por %s. Non se forneceu ningún enderezo "
 "de contacto; visite o foro en https://forum.snapcraft.io/ se precisa axuda."
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "Non se puido determinar o paquete ou o nome do paquete fonte."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "Non é posíbel iniciar o navegador web"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Non é posíbel iniciar o navegador para abrir %s."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Erro de conexión"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "É imposíbel conectar coa base de datos de fallos. Verifique a conexión á "
 "Internet."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Erro de conexión"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Memoria esgotada"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "O sistema non posúe memoria abondo para procesar este informe de erro,"
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -489,11 +491,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "Problema coñecido"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -503,38 +505,37 @@ msgstr ""
 "web. Comprobe se pode engadir información adicional que lle poida resultar "
 "de utilidade aos desenvolvedores."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Este problema xa foi informado ao desenvolvedores. Grazas!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Prema calquera tecla para seguir..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "Que quere facer? As opcións que ten son:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Escolla (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i bytes)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(datos binarios)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Enviarlle un informe do problema aos desenvolvedores?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -542,52 +543,52 @@ msgstr ""
 "Unha vez enviado o informe do problema, encha o formulario no navegador web "
 "que se abrirá automaticamente."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "E&nviar informe (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "&Examinar localmente"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "&Ver o informe"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 "&Gardar o ficheiro co informe para envialo máis tarde ou para copialo noutro "
 "sitio"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "Cancelar e &ignorar fallos futuros desta versión do programa"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Cancelar"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Ficheiro co informe do problema:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&Confirmar"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Erro: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "Recopilando información do erro"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -595,11 +596,11 @@ msgstr ""
 "Pódeselles enviar a información recollida aos desenvolvedores para que\n"
 "melloren o aplicativo. Isto pode levar uns minutos."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "Enviando a información do problema"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -607,40 +608,40 @@ msgstr ""
 "Estase a enviar a información recollida ao sistema de seguimento de erros.\n"
 "Isto pode levar uns minutos."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Feito"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "ningún"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "Seleccionado: %s. Varias opcións:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Opcións"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "Ruta ao ficheiro (Intro para cancelar):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "O ficheiro non existe."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "Isto é un directorio"
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "Para continuar ten que visitar o URL seguinte:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -648,16 +649,16 @@ msgstr ""
 "Pode executar un navegador agora, ou copiar este URL a un navegador en outro "
 "equipo."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Executar un navegador agora"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 "Non hai informes de fallos pendentes. Tente --help para máis información."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 "Non poñer as trazas novas no informe senón escribilas na saída estándar "
@@ -678,29 +679,29 @@ msgstr ""
 "Escribir o informe modificado no ficheiro dado no canto de modificar o "
 "informe orixinal"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 "Eliminar a saída do núcleo do informe despois da rexeneración da traza da "
 "pila"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "Sobreescribir o CoreFile do informe"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "Sobreescribir o ExecutablePath do informe"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "Sobreescribir ProcMaps do informe"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "Reconstruír a información do informe de paquete"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -717,7 +718,7 @@ msgstr ""
 "sistema, mais só poderá analizar problemas serios que acontezan na versión "
 "en execución actualmente."
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
@@ -727,30 +728,30 @@ msgstr ""
 "dependencias usando a mesma versión que hai no informe antes que calquera "
 "outra versión de gdb que teña instalada."
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 "Informar do progreso da descarga/instalación mentres se instalan paquetes na "
 "área de probas"
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr ""
 "Engadir ao inicio a marca de tempo nas mensaxes do rexistro, para operacións "
 "en lote"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 "Crear e empregar repositorios de terceiros a partir de orixes indicadas en "
 "informes"
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr "Cartafol de caché para os paquetes descargados na área de probas"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -758,14 +759,14 @@ msgstr ""
 "Directorio para os paquetes non empaquetados. As execucións futuras asumirán "
 "que calquera paquete xa descargado tamén está extraído nesta caixa de area."
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 "Instalar un paquete adicional na área de probas (pode especificarse "
 "múltiples veces)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -775,7 +776,7 @@ msgstr ""
 "datos. Isto úsase ao especificar un ID de falla para actualizar as trazas da "
 "pila retrazada (só no caso de que se especifique -g, -o ou -s)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -783,32 +784,32 @@ msgstr ""
 "Mostrar a pila retrazada e pedir confirmación antes de enviala á base de "
 "datos de falla."
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 "Ruta á base de datos de duplicados de sqlite (por omisión: non se verifica "
 "se hai duplicados)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr "Non engadir StacktraceSource ao informe."
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "Non é posíbel empregar -C sen -S. Paramos."
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "Acepta enviar estes como anexos? [y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr "%(prog)s <informe> <directorio de destino>"
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr "Ficheiro de informe para desempaquetar"
 
@@ -816,19 +817,19 @@ msgstr "Ficheiro de informe para desempaquetar"
 msgid "directory to unpack report to"
 msgstr "Directorio no que desempaquetar o informe"
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "O directorio de destino existe e non está baleiro."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "Vexa a páxina de man para máis detalles."
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "indique o nome do ficheiro de rexistro producido por valgrind"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
@@ -836,7 +837,7 @@ msgstr ""
 "reutilizar o cartafol de «sandbox» creado anteriormente (SDIR) ou, se non "
 "existe, crealo"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -844,7 +845,7 @@ msgstr ""
 "non crear ou reutilizar o cartafol «sandbox» para os símbolos de depuración "
 "adicionais nese caso basearse só nos símbolos de depuración instalados"
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
@@ -852,13 +853,13 @@ msgstr ""
 "reutilizar o cartafol de cache creado anteriormente (CDIR) ou, se non "
 "existe, crealo"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 "informar do progreso da descarga/instalación ao instalar paquetes na "
 "«sandbox»"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
@@ -866,12 +867,12 @@ msgstr ""
 "o executábel que se executa baixo a ferramenta valgrind de memcheck para a "
 "detección de fugas de memoria"
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Erro: %s no né un executábel. Paramos."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -879,7 +880,7 @@ msgstr ""
 "Isto produciuse durante unha suspensión anterior do sistema e impediu que se "
 "retomase adecuadamente."
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -887,7 +888,7 @@ msgstr ""
 "Isto produciuse durante unha hibernación anterior do sistema e impediu que "
 "se retomase adecuadamente."
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -895,7 +896,7 @@ msgstr ""
 "O proceso de recuperación colgouse moi cerca do final e debeu parecer como "
 "que se remataba normalmente."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 "O sistema poderíase volver inestábel agora e podería haber que reinicialo."
@@ -910,76 +911,76 @@ msgstr "Informar dun problema..."
 msgid "Report a malfunction to the developers"
 msgstr "Informar dun fallo aos desenvolvedores"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "O aplicativo %s detívose de forma inesperada."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "Sentímolo, %s pechouse de maneira inesperada."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "Sentímolo, %s sufriu un erro interno."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Enviar"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Mostrar detalles"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Continuar"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "O aplicativo %s non responde."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "O programa «%s» non responde."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Paquete: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "Sentímolo, produciuse un problema ao instalar o software."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "O aplicativo %s sufriu un erro interno."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "O aplicativo %s pechouse de maneira inesperada."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr "Se segue tendo problemas, tente reiniciar o equipo."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "Ignorar os futuros problemas deste tipo"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Agochar os detalles"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -1035,7 +1036,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>Enviando información do erro</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -1047,27 +1048,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Ficheiro de ruptura de Apport"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "Manter pechado"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Volver a iniciar"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Nome de usuario:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Contrasinal:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "Recompilando información do erro"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1075,6 +1076,6 @@ msgstr ""
 "A información recollida pódeselle enviar aos desenvolvedores para que "
 "melloren o aplicativo. Isto podería levar uns minutos."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "Enviando a información do erro"

--- a/po/gu.po
+++ b/po/gu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2011-10-07 06:10+0000\n"
 "Last-Translator: raj <Unknown>\n"
 "Language-Team: Gujarati <gu@li.org>\n"
@@ -36,11 +36,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr ""
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -61,21 +61,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "અજાણયો પ્રોગ્રામ"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "માફ કરશો, પ્રોગ્રામ %s એકાએક બંધ થયો છે"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "%s માં તકલીફ છે"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -83,62 +78,67 @@ msgstr ""
 "તમારા કૉમ્પ્યૂટર માં મુશ્કેલીનુ આપોઆપ વિશ્લેષણ કરવા માટે અને ડેવલોપરોને રિપૉર્ટ (હકીકત) "
 "મોકલાવવા માટે પુરતા પ્રમાણ માં મુકત મેમરી નથી."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "%s માં તકલીફ છે"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "અપ્રમાણ મુશ્કેલી રિપૉર્ટ"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "આપને મુશ્કેલી રિપૉર્ટ જોવાની પરવાનગી નથી."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr ""
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "આ રિપૉર્ટ ને આગળ વધારવા માટે પુરતી માત્રામાં ડિસ્ક સ્પેઇસ મોજુદ નથી."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "અમાન્ય પીઆઈડી"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "કોઈ પેકેજ જણાવેલ નથી"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr "તમારે ચોક્કસ પેકેજ અથવા પીઆઈડી નો ઉલ્લેખ કરવાની જરૂર છે. વધુ વિઞત માટે --મદદ જુઓ."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr ""
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -146,30 +146,30 @@ msgstr ""
 "જણાવેલ પ્રોસેસ તમારી સાથે જોડાયેલી નથી. મહેરબાની કરીને આ પ્રોગ્રામ તમે પ્રોસેસ ના માલિક "
 "અથવા રૂટ તરીકે ચલાવો."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "જણાવેલ પ્રોસેસ આઈડી પ્રોગ્રામ સાથે જોડાયેલું નથી."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "પેકેજ %s નુ અસ્તિત્વ નથી"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr ""
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr ""
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -177,7 +177,7 @@ msgid ""
 "Please create a new report using \"apport-bug\"."
 msgstr ""
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -189,24 +189,24 @@ msgid ""
 "Do you really want to proceed?"
 msgstr ""
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr ""
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "કયા પ્રકારનો પ્રશ્ન આપ રજૂ કરવા માગો છો?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "અજાણયુ ચિહ્ન"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "ચિહ્ન %s જાણીતુ નથી."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -217,57 +217,57 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr ""
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -275,18 +275,18 @@ msgstr ""
 "પેકેજ ના નામનો  --ફાઇલ-બગ મોડ માં ઉલ્લેખ કરો. આ વૈકલ્પિક છે જો --પીઆઈડી નો ઉલ્લેખ હોય. "
 "(સૂચિત જો ચિહ્ન નુ નામ ફકત આર્ગ્યૂમેન્ટ તરીકે આપેલ હોય.)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -295,129 +295,131 @@ msgstr ""
 "પતન વિશે ની રજુઆત નિકાલ ન થયેલા %s ના બદલે આપેલી .અપોર્ટ અથવા .ક્રૅશ ફાઈલ માંથી કરો. "
 "(સૂચિત જો એક આર્ગ્યૂમેન્ટ આપેલ હોય.)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "અપોર્ટ વર્ઝન નંબર ની નકલ કાઢો."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr ""
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr "આ મુશ્કેલી અહેવાલ પ્રોગ્રામને લાગુ પડે છે જે હવે વધુ કાંઇ સ્થાપીત નથી."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "આ સમસ્યા રિપૉર્ટ નુકસાન પામેલ છે અને આગળ વધી નહી શકાય."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr ""
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr ""
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "પેકેજ અથવા સૉર્સ પેકેજ નુ નામ શોધી નથી શકાયુ."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "વેબ બ્રાઊઝર શરુ કરવામાં સમર્થ નથી."
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "%s ને ખોલવા માટે વેબ બ્રાઊઝર શરુ કરવામાં સમર્થ નથી."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "નેટવર્ક માં સમસ્યા"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "ક્રૅશ ડેટાબેઞ સાથે જોડાણ થઈ શકે તેમ નથી. મહેરબાની કરીને તમારા ઈનટરનેટનુ જોડાણ તપાશો."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "નેટવર્ક માં સમસ્યા"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "મેમરીની થકાવટ"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "આ ક્રૅશ રિપૉર્ટ ને પ્રોસેસ કરવા માટે તમારી સિસ્ટમમાં પૂરતી મેમરી નથી."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -428,11 +430,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "મુશ્કેલી પહેલાંથી જાણીતી છે."
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -441,150 +443,149 @@ msgstr ""
 "આ સમસ્યા વેબ બ્રાઊઝરમાં દેખાતા બગ રિપૉટમાં પહેલાંથી રજુ કરેલ છે. મહેરબાની કરીને ચકાસો કે "
 "તમે વધુ માહીતી ઊમેરી શકો છો કે જે ડેવલોપરો માટે ઊપયોગી થઈ શકે."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "ચાલુ રાખવું માટે કોઈપણ કી દબાવો..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "તમે શુ કરવાનુ પસંદ કરશો? તમારા વિકલ્પો છે:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "મહેરબાની કરીને પસંદ કરો (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr ""
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr ""
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr ""
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
 msgstr ""
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr ""
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr ""
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr ""
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "આ પ્રોગ્રામ વર્ઝનના ભવિષ્યના ક્રૅશો ની અવગણના કરો અને રદ કરો."
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&રદ કરો"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr ""
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr ""
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr ""
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr ""
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
 msgstr ""
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr ""
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
 msgstr ""
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr ""
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr ""
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr ""
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr ""
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr ""
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr ""
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr ""
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr ""
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
 msgstr ""
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr ""
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 
@@ -599,27 +600,27 @@ msgid ""
 "Write modified report to given file instead of changing the original report"
 msgstr ""
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr ""
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr ""
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr ""
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr ""
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -629,78 +630,78 @@ msgid ""
 "be able to retrace crashes that happened on the currently running release."
 msgstr ""
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
 "have installed."
 msgstr ""
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr ""
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
 msgstr ""
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
 "neither -g, -o, nor -s are specified)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
 msgstr ""
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr ""
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr ""
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr ""
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -708,70 +709,70 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr ""
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
 msgstr ""
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 
@@ -785,76 +786,76 @@ msgstr ""
 msgid "Report a malfunction to the developers"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr ""
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr ""
 
@@ -908,7 +909,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr ""
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -918,32 +919,32 @@ msgstr ""
 msgid "Apport crash file"
 msgstr ""
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr ""
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr ""
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr ""
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr ""
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr ""
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
 msgstr ""
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr ""

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2022-08-19 14:26+0000\n"
 "Last-Translator: Yaron <sh.yaron@gmail.com>\n"
 "Language-Team: Hebrew <he@li.org>\n"
@@ -36,11 +36,11 @@ msgstr "דיווחי תקלות במערכת"
 msgid "Please enter your password to access problem reports of system programs"
 msgstr "נא להזין את הססמה שלך כדי לגשת לדיווחים על תקלות שנמצאו בתכניות המערכת"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "מסתבר כי חבילה זו אינה מותקנת כראוי"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -51,7 +51,7 @@ msgstr ""
 "החבילות הזמינות, אם זה לא עובד אז יש להסיר את החבילות מגורמי צד־שלישי ולנסות "
 "שוב."
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -64,113 +64,113 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "תכנית בלתי מוכרת"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "התכנה „%s“  נסגרה במפתיע, עמך הסליחה"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "תקלה ב־%s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
 msgstr ""
 "למחשבך אין די זכרון פנוי כדי לנתח את התקלה אוטומטית ולשלוח דוח למפתחים."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "תקלה ב־%s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "דוח תקלה שגוי"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "אין לך הרשאה לגשת לדוח תקלה זה."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "שגיאה"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "אין די שטח פנוי בכונן כדי לעבד דוח זה."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr "לא צוין מזהה תהליך"
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr "עליך לציין מזהה תהליך. פרטים נוספים עם ‎--help."
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "מזהה התהליך שגוי"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr "מזהה התהליך שצוין לא נמצא."
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr "לא מזהה התהליך שלך"
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr "מזהה התהליך שצוין לא שייך לך."
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "לא צוינה חבילה כלשהי"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr "עליך לציין חבילה או מזהה תהליך. ניתן לעיין ב־‎--help לקבלת מידע נוסף."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "הגישה נדחתה"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 msgstr ""
 "התהליך שצוין אינו שייך לך. נא להריץ תכנה זו כבעל התהליך או כמשתמש על (root)."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "מזהה התהליך שצוין אינו שייך לאף תכנית."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "סקריפט התסמינים %s לא איתר חבילות שנפגעו"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "החבילה %s אינה קיימת"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "לא ניתן ליצור דוח"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "דוח הבעיה מתעדכן"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -182,7 +182,7 @@ msgstr ""
 "\n"
 "יש ליצור דיווח חדש באמצעות \"apport-bug\"."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -201,24 +201,24 @@ msgstr ""
 "\n"
 "האם ברצונך להמשיך?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "לא נאסף מידע נוסף."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "מהי הבעיה עליה ברצונך לדווח?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "תסמין לא מוכר"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "התסמין „%s“ אינו מוכר."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -229,37 +229,37 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 "לאחר סגירת הודעה זו יש ללחוץ על חלון היישום כדי לדווח על בעיות בהפעלתו."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop לא הצליח לזהות את מזהה התהליך של החלון"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "נא לציין את שם החבילה."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "הוספת תגית נוספת לדיווח. ניתן לציין מספר פעמים."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -269,21 +269,21 @@ msgstr ""
 "אף אחד מאלה לא הוזן, תוצג רשימה של סימפטומים ידועים. (מרומז במקרה שצוין "
 "ארגומנט יחיד.)"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "יש ללחוץ על חלון כיעד לדיווח על תקלה."
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "הפעלה במצב עדכון. ניתן להוסיף ‎--package במידת הצורך."
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr "הגשת דיווח על תסמין. (מרומז אם שם התסמין ניתן רק כארגומנט.)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -291,7 +291,7 @@ msgstr ""
 "יש לציין את שם החבילה במצב ‎--file-bug. אין חובה לעשות כך אם צוין ה־‎--pid. "
 "(מרומז אם שם החבילה הוא הארגומנט היחיד שצוין.)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -300,11 +300,11 @@ msgstr ""
 "יש לציין תכנית פעילה במצב ‎--file-bug. אם פרמטר זה יתווסף דיווח הבאג יכיל "
 "מידע נוסף.  (כלומר שהמזהה התהליך, ה־pid, ניתן כארגומנט בלבד.)"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "ה־pid (מזהה היישום) שסופק מצביע על יישום תקוע."
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -313,7 +313,7 @@ msgstr ""
 "דיווח על התקלה מקובץ ‎.apport או ‎.crash נתון במקום אלו שממתינים ב־%s. (מרומז "
 "אם ניתן קובץ כארגומנט יחיד.)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -322,87 +322,89 @@ msgstr ""
 "במצב דיווח על באגים, יש לשמור את המידע שנאסף לקובץ במקום לדווח עליו. ניתן "
 "לדווח באמצעות קובץ זה בשלב מאוחר יותר דרך מחשב אחר."
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "הצגת מספר הגרסה של Apport."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr "פעולה זו תפעיל את apport-retrace בחלון מסוף כדי לנתח את הקריסה."
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "הפעלת gdb"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "הפעלת gdb מבלי להוריד סימני ניפוי שגיאות"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "עדכון %s במעקב ערימה בסמליות מלאה"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr "לא ניתן לשמור הגדרות מצב שליחת דיווח"
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 "שמירת מצב דיווח הקריסה נכשלה. לא ניתן להגדיר מצב דיווח אוטומטי או לעולם לא."
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr "לא ניתן לשמור הגדרות מצב שליחת דיווח"
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr "דיווח תקלה זה חל על תכנית שאינה מותקנת עוד."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 msgstr "התקלה אירעה בתכנית %s שהשתנתה מאז קריסתה האחרונה."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "דוח תקלה זה פגום ולכן לא ניתן לעבד אותו."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr "דיווח זה מתייחס לחבילה שאינה מותקנת."
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "אירעה שגיאה במהלך ניסיון עיבוד דוח תקלה זה:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 "מותקנות אצלך שתי גרסאות של היישום הזה, מול איזו מהן ברצונך לדווח על תקלה?"
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr "%s snap"
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr "חבילת deb %s"
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s מסופק על ידי snap שהופץ על ידי %s. יש ליצור אתם קשר דרך %s לקלבת עזרה."
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -411,37 +413,37 @@ msgstr ""
 "%s מסופק על ידי snap שהופץ על ידי %s. לא סופקה דרך ליצירת קשר, יש לבקר "
 "בפורום https://forum.snapcraft.io/‎ לקבלת עזרה."
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "לא ניתן לאתר את החבילה או את שם חבילת המקור."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "לא ניתן להפעיל את דפדפן האינטרנט."
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "לא ניתן להפעיל את דפדפן האינטרנט כדי לפתוח את %s."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "תקלת רשת"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr "לא ניתן להתחבר אל מסד נתוני הקריסות, יש לבדוק את החיבור לאינטרנט."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "תקלת רשת"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "תשישות הזכרון"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "למערכת שלך אין די זכרון פנוי כדי לעבד דוח תקלה זה."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -452,11 +454,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "התקלה כבר מוכרת"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -465,38 +467,37 @@ msgstr ""
 "תקלה זו כבר דווחה בדוח התקלה המוצג בדפדפן האינטרנט. נא לבדוק האם ניתן להוסיף "
 "מידע נוסף שעלול לעזור למפתחים בפתרון התקלה."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "תקלה זו כבר דווחה למתכנתים. תודה רבה!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "נא ללחוץ על מקש כלשהו להמשך..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "מה ברצונך לעשות? אפשרויותיך הן:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "נא לבחור (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i בתים)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(נתונים בינריים)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "האם לשלוח דוח תקלה למפתחים?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -504,50 +505,50 @@ msgstr ""
 "לאחר שהדיווח על התקלה נשלח, נא למלא את הטופס\n"
 "שנפתח אוטומטית בדפדפן האינטרנט."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "&שליחת דוח (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "&ניתוח מקומי"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "&צפייה בדוח"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr "יש ל&שמור על קובץ הדוח לשליחה במועד מאוחר יותר או להעתיק למיקום אחר"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "יש לבטל ולהת&עלם מקריסות עתידיות של גרסה זו של התכנה"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&ביטול"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "קובץ דיווח התקלה:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&אישור"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "שגיאה: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "נאסף מידע על התקלה"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -555,11 +556,11 @@ msgstr ""
 "ניתן לשלוח את המידע שנאסף למפתחים כדי לשפר את היישום.\n"
 "פעולה זו עלולה להמשך מספר דקות."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "פרטי התקלה נשלחים"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -567,54 +568,54 @@ msgstr ""
 "המידע שנאסף נשלח כעת אל מערכת המעקב אחר התקלות.\n"
 "פעולה זו עלולה להמשך מספר דקות."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&סיום"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "ללא"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "נבחרו %s. ריבוי בחירות:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "בחירות:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "נתיב אל הקובץ (Enter לביטול):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "הקובץ אינו קיים."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "זוהי תיקייה."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "כדי להמשיך, עליך לבקר בכתובת הבאה:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
 msgstr "ניתן לטעון את הדפדפן כעת, או להעתיק כתובת זאת לדפדפן במחשב אחר."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "טעינת הדפדפן כעת"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr "אין דיווחי קריסות בהמתנה. ניתן לנסות את ‎--help לקבלת מידע נוסף."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr "אין להוסיף את העקבות החדשים אל הדוח, אך יש לכתוב אותם אל stdout."
 
@@ -631,27 +632,27 @@ msgid ""
 "Write modified report to given file instead of changing the original report"
 msgstr "כתיבת דוח ערוך לקובץ הנתון במקום לשנות את הדוח המקורי"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr "הסרת איסוף הליבה מהדוח לאחר יצירה מחדש של מעקב אחר המחסנית"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "שכתוב על קובץ הליבה של הדוח (CoreFile)"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "שכתוב על נתיב ההפעלה של הדוח (ExecutablePath)"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "שכתוב על מפות התהליכים של הדוח (ProcMaps)"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "בנייה מחדש חבילת מידע של דוח"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -666,31 +667,31 @@ msgstr ""
 "הארגומנט יהיה „system“, ייעשה שימוש בקובצי התצורה של המערכת אך במצב כזה ניתן "
 "יהיה רק לעקוב מחדש אחר הקריסות שהתחרשו בהפצה הפעילה הנוכחית."
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
 "have installed."
 msgstr ""
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr "דיווח על תהליך של הורדה/התקנה בעת התקנת חבילות בתוך ארגז החול"
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr "הוספת קידומת חותמת זמן להודעות ביומן, לצורך פעולות אצווה"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr "תיקיית המטמון לחבילות שהורדו בארגז החול"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -698,12 +699,12 @@ msgstr ""
 "ספרייה של חבילות בלתי ארוזות. הפעלות עתידיות יניחו שכל חבילה שכבר הורדת "
 "תחולץ גם כן לארגז חול זה."
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr "התקנת חבילה נוספת לתוך ארגז החול (ניתן לציין מספר פעמים)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -712,37 +713,37 @@ msgstr ""
 "נתיב לקובץ עם פרטי האימות מול מסד נתוני הקריסות. בקובץ ייעשה שימוש בעת ציון "
 "מזהה קריסה כדי לעלות מעקבי מחסניות מחודשים (רק אם לא צוינו ‎-g, -o, או ‎-s)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
 msgstr "הצגת מעקבי מחסניות מחודשים ובקשת אישור בטרם שליחה למסד נתוני הקריסות."
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 "נתיב אל מסד הנתונים של הכפילויות מסוג sqlite (בררת מחדל: ללא בדיקות כפילויות)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr "לא להוסיף StacktraceSource (מקור השתלשלות התקלה) לדיווח."
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "לא ניתן להשתמש ב־‎-C בלי ‎-S. נעצר."
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "האם זה בסדר לשלוח קבצים מצורפים אלה? [y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -750,71 +751,71 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "ספריית היעד קיימת ואינה ריקה."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "יש לעיין בדף ה־man לקבלת פרטים נוספים."
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "נא לציין את שם קובץ הרישום שנוצר על ידי valgrind"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "שגיאה: %s זה לא קובץ שניתן להריץ. נעצר."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr "תקלה זו קרתה במהלך השהיה קודמת ומנעה מהמשך פעילות המערכת באופן תקין."
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr "זה קרה במהלך תרדמת קודמת ומנע מהמערכת להמשיך בפעילות כראוי."
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
 msgstr ""
 "תהליך חזרת המחשב לפעולה נתקע ממש לקראת הסוף ונראה כאילו הוא הסתיים כרגיל."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 "המערכת שלך עלולה להפוך לבלתי יציבה כעת ויתכן שיהיה צורך בהפעלת המחשב מחדש."
@@ -829,76 +830,76 @@ msgstr "דיווח על תקלה..."
 msgid "Report a malfunction to the developers"
 msgstr "דיווח על תפקוד לקוי למתכנתים"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "היישום %s הפסיק לפעול במפתיע, עמך הסליחה."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "היישום %s נסגר במפתיע, עמך סליחה."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "היישום %s סבל משגיאה פנימית, עמך הסליחה."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "שליחה"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "הצגת פרטים"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "להמשיך"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "היישום %s הפסיק להגיב."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "התכנית \"%s\" הפסיקה להגיב."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "חבילה: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "אירעה תקלה בעת התקנת תוכנות, עמך הסליחה."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "היישום %s נתקל בתקלה פנימית."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "היישום %s  נסגר במפתיע"
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr "אם הבחנת בבעיות נוספות, כדאי לנסות להפעיל את המחשב מחדש."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "התעלמות מתקלות חוזרות ונשנות מסוג זה"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "הסתרת הפרטים"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -952,7 +953,7 @@ msgstr "המידע נאסף כדי לעזור למפתחים לתקן את הב�
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>נתוני הבעיה נשלחים</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -963,27 +964,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "קובץ קריסה של Apport"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "להשאיר סגור"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "הפעלה מחדש"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "שם המשתמש:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "ססמה:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "נאספים נתונים על התקלה"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -991,6 +992,6 @@ msgstr ""
 "ניתן לשלוח את המידע שנאסף למפתחים כדי לשפר את התכנה. פעולה זו עלולה להמשך "
 "מספר דקות."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "נתוני התקלה נשלחים"

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2011-12-27 13:13+0000\n"
 "Last-Translator: Vibhav Pant <vibhavp@gmail.com>\n"
 "Language-Team: Hindi <hi@li.org>\n"
@@ -36,11 +36,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "ऐसा लगता है कि इस पैकेज को सही ढंग से स्थापित नहीं करा गया है"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -61,21 +61,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "अज्ञात प्रोग्राम"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "क्षमा करें, %s प्रोग्राम अनपेक्षित ढंग से बंद हो गया।"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "%s में समस्या"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -83,63 +78,68 @@ msgstr ""
 "आपके कंप्युटर में समस्या का स्वतः विश्लेषण करने और विकासकर्ताओं को सूचित करने के लिये पर्याप्त "
 "रिक्त स्मृति नहीं है।"
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "%s में समस्या"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "अमान्य समस्या सूचना"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "इस समस्या रिपोर्ट में आपके पहुँच की अनुमति नहीं है."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "त्रुटी"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "इस रिपोर्ट को प्रक्रिया करने हेतु डिस्क में प्रर्याप्त जगह उपलब्ध नहीं है."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "अवैध पीआईडी"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "पैकेज का विशिष्ट निर्देश नहीं है"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "आपको पैकेज या PID का विशिष्ट निर्देश देना होगा. अधिक जानकारी के लिए  --help देखें."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "अनुमति निषेधित"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -147,30 +147,30 @@ msgstr ""
 "यह आपका विशिष्ट निर्देश नहीं है. कृपया इस प्रोग्राम को प्रक्रिया उत्तराधिकारी के रुप में या "
 "रुट में चलाएं."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "विशिष्ट निर्देश आईडी प्रोग्राम का हिस्सा नहीं है."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "सिनेप्टिक स्क्रिप्ट %s प्रभावित पैकेज का निर्धारण नहीं कर पा रहा है"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "पैकेज %s मोजूद नहीं है"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "रिपोर्ट बनाई नहीं जा सकती"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "समस्या रिपोर्ट को अद्यतन कर रहा है"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -182,7 +182,7 @@ msgstr ""
 "\n"
 "कृपया \"apport-bug\" का उपयोग कर एक नया रिपोर्ट बनाएं."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -201,24 +201,24 @@ msgstr ""
 "\n"
 "क्या आप आगे की प्रक्रिया करेंगें?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "अतरिक्त सूचना संगृहित नहीं की जाएगी."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "किस तरह की समस्या का आप रिपोर्ट करना चाहते हैं?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "अज्ञात लक्षण"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "यह लक्षण \"%s\" ज्ञात नहीं है."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -229,37 +229,37 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 "इस संदेश के बंद होने के पश्चात कृपया अनुप्रयोग विंडो पर क्लिक कर समस्या के बारे में रिपोर्ट करें."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop विंडो की प्रक्रिया आईडी को निर्धारित करने में असफल हो गया"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "संकुल नाम निर्दिष्ट करें."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "रिपोर्ट में एक अतरिक्त टैग जोड़े जिससे एकाधिक बार का उल्लेख हो सके."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -269,15 +269,15 @@ msgstr ""
 "एक --pid की. यदि कोई भी नहीं दिया हुआ हो, तो ज्ञात लक्षणों की सूची दिखाएं. (यदि एक "
 "ही तर्क दिया हो तो लागु करें.)"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "एक समस्या रपट दर्ज करने हेतु लक्ष्य विंडो पर क्लिक करें."
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "बग अद्यतन पद्धति में चालु करें. एक विकल्प --package ले सकते हैं ."
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -285,7 +285,7 @@ msgstr ""
 "लक्षण के बारे में एक बग रिपोर्ट दाखिल करें. (जब लक्षण के नाम केवल तर्क के रुप में दिया गया "
 "हो तो लागु करें.)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -293,7 +293,7 @@ msgstr ""
 "पैकेज का नाम --file-bug पद्धति में वर्णन करें. यह वैकल्पिक होगा यदि एक --pid का वर्णन "
 "होगा. (जब पैकेज का नाम केवल तर्क के रुप में दिया गया हो तो लागु करें.)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -302,11 +302,11 @@ msgstr ""
 "एक चल रहे प्रोग्राम --file-bug पद्धति में का उल्लेख करें. यदि इसका उल्लेख है, तो दोष रपट "
 "अधिक सूचनात्मक हो जाएगा.(यह लागू हो यदि pid में केवल तर्क दिया होगा.)"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -315,7 +315,7 @@ msgstr ""
 "विध्वंस रिपोर्ट को दिए गए .apport या .crash संचिका से करें बजाए %s में जो विचाराधीन "
 "है. (यदि तर्क के रुप में केवल संचिका दिया गया हो.)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -324,121 +324,123 @@ msgstr ""
 "बग भराई पद्धति में, संगृहित सूचना को रपट करने के बजाए एक फ़ाइल में सहेजें. यह फ़ाइल परवर्ति "
 "एक अन्य मशीन से रपट किया जा  सकता है."
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "एपोर्ट(Apport) संस्करण संख्या को छापे."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "जीडीबी सत्र चलाएँ"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "जीडीबी का सत्र बिना डिबग प्रतीकों डाउनलोड करें शुरु करें"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr "यह समस्या रिपोर्ट एक ऐसे कार्यक्रम के संबंधित है जो की अब संस्थापित नहीं है."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "यह समस्या सूचना क्षतिग्रस्त है तथा संसाधित नहीं की जा सकती."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr ""
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr ""
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "पैकेज या स्त्रोत पैकेज नाम को निर्धारित नहीं कर सका."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "वेब खंगालक(ब्राउजर) को शुरु करनें में असमर्थ"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "वेब खंगालक(ब्राउजर) खोलने में असमर्थ %s."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "संजाल समस्या"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr "विध्वंस समंंकआधार से जुड़ नहीं सका, कृपया अपने अंतरजाल संयोजन की जाँच करें."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "संजाल समस्या"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "स्मरण समाप्त हो गया है"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "आपके तंत्र में पर्याप्त स्मरण नहीं है कि इस ध्वंस के रिपोर्ट की प्रक्रिया कर सके."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -449,11 +451,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "समस्या पूर्व से ज्ञात है"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -463,38 +465,37 @@ msgstr ""
 "कृपया जाँच करे कि यदि अन्य को अतिरिक्त सूचना जोड़ सकते है या नहीं जो कि विकासकर्ता को "
 "अधिक मददगार साबित हो."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "यह समस्या पहले से ही डेवलपर्स को  सूचित किया गया था. शुक्रिया!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "आगे बढ़ने के लिए कोई कुंजी दबाएं..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "आप क्या करना चाहते है? आपके विकल्प है:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "कृपया चुनें (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i बाइट)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(द्विचर समंक)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "समस्या रिपोर्ट विकासकर्ता को भेजें?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -502,50 +503,50 @@ msgstr ""
 "समस्या रिपोर्ट भेजने के पश्चात, कृपया इस फार्म को भरें जो\n"
 "स्वचालित रुप से वेब खंगालक(ब्राउजर) में खुलेगा."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "रिपोर्ट (&S)भेजें (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "&स्थानीय स्तर पर जांच"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "रिपोर्ट देखें(&V)"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr "बाद में भेजने हेतु रिपोर्ट संचिका रखें(&K) या किसी अन्य जगह पर इसकी नकल रखे"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "निरस्त करें तथा इस कार्यक्रम संस्करण के आगे से ध्वंस की उपेक्षा(&i)करें"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "निरस्त(&C) करें"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "समस्या रिपोर्ट संचिकाः"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "सुनिश्चित(&C)"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "त्रुटि: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "समस्या सूचना इकठ्ठा कर रहा है"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -553,11 +554,11 @@ msgstr ""
 "संगृहित सूचना के द्वारा कार्यक्रम को उन्नत करने हेतु विकासकर्ता के पास भेजा जा सकता है\n"
 "इसमें कुछ मिनट का समय लग सकता है."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "समस्या सूचना अपलोड कर रहा है"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -565,40 +566,40 @@ msgstr ""
 "संकलित सूचना बग खोज तंत्र को भेजा जाना है.\n"
 "इसमें कुछ मिनट का समय लग सकता है."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "सम्पन्न (&D)"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "कोई नहीं"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "चुने: %s. बहुविकल्प:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "विकल्प:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "संचिका का मार्ग(निरस्त हेतु एंटर करें)"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "संचिका उपलब्ध नहीं है"
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "यह एक निर्देशिका है."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "आगे बढ़ने के लिए, आप निम्न URL पर जाएंः"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -606,15 +607,15 @@ msgstr ""
 "आप अब एक खंगालक(ब्राउजर) खोल सकते है या इस URL की नकल अन्य कंप्यूटर के खंगालक में कर सकते "
 "हैं."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "अब एक खंगालक(ब्राउजर) खोले"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr "विध्वंस रिपोर्ट विचारधीन नहीं है. अधिक जानकारी हेतु --help का उपयोग करें."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr "इस रिपोर्ट में नया खोज नहीं डाले, लेकिन इसे stdout में लिखें."
 
@@ -631,27 +632,27 @@ msgid ""
 "Write modified report to given file instead of changing the original report"
 msgstr "मूल रिपोर्ट में बदलाव के स्थान पर दिए गए संचिका हेतु आशोधन रिपोर्ट लिखें"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr "ढ़ेर खोज पुनःउत्पत्ति के पश्चात रिपोर्ट से कोर ढ़ेर को हटाएं"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "कोरसंचिका रिपोर्ट की अवहेलना करें"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "ExecutablePath रिपोर्ट की अवहेलना करे"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "ProcMaps रिपोर्ट की अवहेलना करे"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "पैकेज सूचना रिपोर्ट को पुनः बनाएं"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -661,42 +662,42 @@ msgid ""
 "be able to retrace crashes that happened on the currently running release."
 msgstr ""
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
 "have installed."
 msgstr ""
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr ""
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
 msgstr ""
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr "सैन्द्बौक्स  में एक अतिरिक्त पैकेज स्थापित (कई बार निर्दिष्ट किया जा सकता है है)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -706,7 +707,7 @@ msgstr ""
 "होगा जब एक विध्वंस आईडी का वर्णन retraced stack traces अपलोड करते समय किया जाएगा."
 "( केवल तब जब न तो -g, -o न ही -s का वर्णन रहेगा)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -714,30 +715,30 @@ msgstr ""
 "retraced stack traces को दिखाएं तथा उसके विध्वंस समंकआधार को भेजने के पूर्व पुष्टिकरण हेतु "
 "कहें."
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr "sqlite समंकआधार के नकल पर ले जाएं (डिफॉल्ट: कोई नकल जाँच नहीं है)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr ""
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr ""
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "इस संलग्नक को भेजने की पुष्टि करें? [हाँy / नn]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -745,64 +746,64 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "गंतव्य निर्देशिका वर्तमान है तथा यह खाली नहीं है."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr ""
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -810,7 +811,7 @@ msgstr ""
 "पुनःप्राप्त करने की प्रक्रिया लगभग समाप्ति पे है तथा आशा है की यह समान्यरुप से पुरा हो "
 "जाएगा."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr "आपका तंत्र संभवतः अब अस्थायी है तथा पुनःशुरु करने की जरुरत है."
 
@@ -824,76 +825,76 @@ msgstr "समस्या को रिपोर्ट करें..."
 msgid "Report a malfunction to the developers"
 msgstr "विकासकर्ता को खराबी के बारे में रिपोर्ट करें"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "भेजें"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "विवरण दिखाएँ"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "जारी रखें"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "विवरण छिपाएँ"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "अप्पोर्ट(Apport)"
 
@@ -949,7 +950,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>समस्या सूचना को अपलोड कर रहा है</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -959,27 +960,27 @@ msgstr "संगृहित सूचना को बग मार्ग त�
 msgid "Apport crash file"
 msgstr "विध्वंस संचिका संविभाजित करें"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr ""
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "पुन: लॉन्‍च करें"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "प्रयोक्तानाम:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "कूटशब्द:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "समस्या सूचना संग्रह करें"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -987,6 +988,6 @@ msgstr ""
 "संगृहीत समस्या को अनुप्रयोग को विकसीत करने हेतु विकासकर्ता को भेजा जाएगा. इसमें कुछ मिनटों "
 "का समय लगेगा."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "समस्या सूचना को अपलोड कर रहा है"

--- a/po/hr.po
+++ b/po/hr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2022-09-03 12:24+0000\n"
 "Last-Translator: gogo <trebelnik2@gmail.com>\n"
 "Language-Team: Croatian <hr@li.org>\n"
@@ -39,11 +39,11 @@ msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 "Upišite svoju lozinku za pristup izvještajima problema programa sustava"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "Izgleda da ovaj paket nije ispravno instaliran"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -54,7 +54,7 @@ msgstr ""
 "sadržaja dostupnih paketa, ako to ne uspije tada uklonite povezane pakete "
 "treće strane i pokušajte ponovno."
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -67,21 +67,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "nepoznati program"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Program \"%s\" se neočekivano zatvorio"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Problem u %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -89,92 +84,97 @@ msgstr ""
 "Vaše računalo nema dovoljno slobodne memorije za automatsku analizu problema "
 "i slanje izvještaja razvijateljima."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Problem u %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Neispravan izvještaj o problemu"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "Niste ovlašteni za pristup ovom izvještaju o problemu."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Greška"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "Nema dovoljno prostora na disku za obradu ovog izvještaja."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr "PID nije naveden"
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr "Morate navesti PID. Pogledajte --help za više informacija."
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "Neispravan PID"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr "Određeni ID procesa ne postoji."
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr "Nije vaš PID"
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr "Određeni ID procesa vam ne pripada."
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "Nema određenih paketa"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr "Morate odrediti paket ili PID. Pogledajte --help za više informacija."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Pristup odbijen"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 msgstr ""
 "Određeni proces vam ne pripada. Pokrenite ovaj program kao root korisnik."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "Određeni ID proces ne pripada programu."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Skripta simptoma %s nije odredila zahvaćeni paket"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Paket %s ne postoji"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "Ne mogu napraviti izvještaj"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "Nadopuna izvještaja problema"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -186,7 +186,7 @@ msgstr ""
 "\n"
 "Napravite novi izvještaj koristeći \"apport-bug\"."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -206,24 +206,24 @@ msgstr ""
 "\n"
 "Želite li stvarno nastaviti?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "Nisu prikupljene dodatne informacije."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "Kakav problem želite prijaviti?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Nepoznat simptom"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Simptom \"%s\" nije poznat."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -241,7 +241,7 @@ msgstr ""
 "Procesi, potražite odgovarajuću aplikaciju. ID procesa je broj prikazan u "
 "stupcu Identifikacija."
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -249,24 +249,24 @@ msgstr ""
 "Nakon zatvaranja ove poruke kliknite na prozor aplikacije za prijavu ovog "
 "problema."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop nije uspio odrediti proces ID prozora"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr "%(prog)s <broj izvještaja>"
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "Odredite naziv paketa."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "Dodajte dodatnu oznaku u izvještaj. Moguće je odrediti više puta."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
@@ -274,7 +274,7 @@ msgstr ""
 "%(prog)s [mogućnosti] [simptom|pid|paket|program putanja|.apport/.crash "
 "datoteka]"
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -284,15 +284,15 @@ msgstr ""
 "ukratko samo --pid. Ako ni jedno nije navedeno, prikaži popis poznatih "
 "simptoma. (Podrazumijeva se ako je jedan argument zadan.)"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "Kliknite na prozor kao cilj za podnošenje izvještaja o problemu."
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "Početak načina nadopune greške. Može se dodati po izboru --package."
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -300,7 +300,7 @@ msgstr ""
 "Prijavi izvještaj greške o simptomu. (Podrazumijeva ako je naziv simptoma "
 "naveden kao jedini argument.)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -308,7 +308,7 @@ msgstr ""
 "Navedite naziv paketa u --file-bug načinu. Ovo nije obavezno ako je --pid "
 "naveden. (Podrazumijeva se ako je naziv paketa naveden kao jedini argument.)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -318,11 +318,11 @@ msgstr ""
 "greške će sadržavati više informacija. (Podrazumijeva se ako je pid naveden "
 "kao jedini argument.)"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "Zadani pid prekida aplikaciju."
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -332,7 +332,7 @@ msgstr ""
 "nezavršenih u %s. (Podrazumijeva se ako je datoteka zadana kao jedini "
 "argument.)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -342,67 +342,69 @@ msgstr ""
 "da je prijavite. Ta datoteka se zatim kasnije može prijaviti s drugog "
 "računala."
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Ispiši broj Apport inačice."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "To će pokrenuti apport-retrace u prozoru terminala zbog ispitivanja rušenja."
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "Pokreni gdb sesiju"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Pokreni gdb sesiju bez preuzimanja simbola otklanjanja greške"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Nadopuni %s s potpunim simboličkim opširnim zapisom"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr "Nemoguće zapamtiti postavke stanja slanja izvještaja"
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 "Neuspješno spremanje stanja izvještaja rušenja. Nemoguće postavljanje "
 "automatskog ili isključenog načina."
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr "Nemoguće zapamtiti postavke stanja slanja izvještaja"
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 "Ovaj izvještaj problema se odnosi na program koji više nije instaliran."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 msgstr "Dogodio se problem s programom %s koji se promijenio otkada se srušio."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Ovaj izvještaj o problemu je oštećen i ne može biti obrađen."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr "Ovaj izvještaj je o paketu koji nije instaliran."
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "Došlo je do greške pri pokušaju obrade izvještaja problema:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
@@ -410,24 +412,24 @@ msgstr ""
 "Imate instalirane dvije inačice ove aplikacije, za koju želite prijaviti "
 "grešku?"
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr "%s snap paket"
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr "%s deb paket"
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s je omogućen putem snap paketa objavljen od strane %s. Kontaktirajte ih "
 "putem %s za pomoć."
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -436,41 +438,41 @@ msgstr ""
 "%s je omogućen putem snap paketa objavljen od strane %s. Nema adrese za "
 "kontakt, posjetite forum https://forum.snapcraft.io/ za pomoć."
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "Ne može se odrediti paket ili naziv izvornog paketa."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "Nemoguće pokretanje Internet preglednika"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Nemoguće pokretanje Internet preglednik za otvaranje %s."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Problem s mrežom"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Nemoguće povezivanje na bazu podataka rušenja. Provjerite vaš pristup "
 "Internetu."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Problem s mrežom"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Nedostatak memorije"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Vaš sustav nema dovoljno memorije za obradu ovog izvještaja o rušenju "
 "sustava."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -481,11 +483,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "Problem je već poznat"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -495,38 +497,37 @@ msgstr ""
 "internet pregledniku. Provjerite možete li dodati neke dodatne informacije "
 "koje mogu pomoći razvijateljima."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Ovaj problem je već prijavljen razvijateljima. Hvala Vam!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Pritisnite bilo koju tipku za nastavak..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "Što želite napraviti? Vaše mogućnosti su:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Molim odaberite (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i bajta)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(binarni podaci)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Pošaljite izvještaj problema razvijateljima?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -534,52 +535,52 @@ msgstr ""
 "Nakon slanja izvještaja problema, ispunite formular u\n"
 "automatski otvorenom internet pregledniku."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "&Pošalji izvještaj (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "&Pregledaj lokalno"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "&Pogledaj izvještaj"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 "&Zadržite datoteku izvještaja za kasnije slanje ili kopiranje na neku drugu "
 "lokaciju"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "Poništi i &zanemari buduća rušenja za ovu inačicu programa"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Odustani"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Datoteka izvještaja problema:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&Potvrdi"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Greška: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "Skupljanje informacija o problemu"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -588,11 +589,11 @@ msgstr ""
 "aplikacija\n"
 "poboljšala. Ovo može potrajati nekoliko minuta."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "Slanje informacija o problemu"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -600,40 +601,40 @@ msgstr ""
 "Prikupljene informacije se šalju sustavu za praćenje grešaka.\n"
 "Ovo može potrajati nekoliko minuta."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Završeno"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "nijedno"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "Odabrano: %s. Višestruki odabiri:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Odabiri:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "Putanja do datoteke (Enter za prekid):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "Datoteka ne postoji."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "Ovo je direktorij."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "Za nastavak, morate posjetiti sljedeći URL:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -641,17 +642,17 @@ msgstr ""
 "Sada možete pokrenuti internet preglednik, ili kopirati ovaj URL u "
 "preglednik na drugom računalu."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Pokreni preglednik odmah"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 "Nema izvještaja o rušenju koji su na čekanju. Pokušajte s --help za više "
 "informacija."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr "Ne spremaj nove podatke u izvještaj, već ih zapiši u stdout."
 
@@ -670,27 +671,27 @@ msgstr ""
 "Zapiši izmijenjen izvještaj za zadanu datoteku umjesto promjene izvornog "
 "izvještaja"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr "Ukloni sadržaj jezgre iz izvještaja nakon regeneracije opširnog zapisa"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "Zaobiđi datoteku jezgre izvještaja"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "Zaobiđi izvršnu putanju izvještaja"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "Zaobiđi ProcMaps izvještaja"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "Obnovi izvještaje o informacijama paketa"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -707,7 +708,7 @@ msgstr ""
 "onda samo biti moguće zapisivati rušenja koja su se dogodila na trenutno "
 "pokrenutom izdanju."
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
@@ -717,26 +718,26 @@ msgstr ""
 "zavisnosti upotrebom istog izdanja kao izvještaja bez obzira koju gdb "
 "inačicu imate instaliranu."
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 "Prijavi napredak preuzimanja/instalacije tijekom instalacije paketa u sandbox"
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr "Dodaj vremenske oznake u poruke zapisa, za skupne radnje"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 "Stvori i koristi repozitorije treće strane iz izvora navedenih u izvješću"
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr "Direktorij predmemorije za pakete preuzete u sandboxu"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -744,12 +745,12 @@ msgstr ""
 "Direktorij za neraspakirane pakete. Buduća pokretanja će pretpostaviti da "
 "svaki preuzeti paket je isto tako raspakiran u sandboxu."
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr "Instaliraj dodatne pakete u sandbox (može se odrediti više puta)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -759,7 +760,7 @@ msgstr ""
 "koristi pri određivanju ID-a rušenja za slanje ponovljenog opširnog "
 "zapisivanja (samo ako su -g, -o, ili -s određeni)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -767,32 +768,32 @@ msgstr ""
 "Prikaži ponovljeno opširno zapisivanje i traži potvrdu prije slanja u bazu "
 "podataka rušenja."
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 "Putanja do kopije sqlite baze podataka (zadano: bez provjere ima li još "
 "kopija)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr "Nemoj dodati opširni zapis u izvješće."
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "Ne možete koristiti -C bez -S. Zaustavljanje."
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "Je li u redu poslati ovo kao privitke? [d/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr "%(prog)s <izvještaj> <odredišni direktorij>"
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr "Datoteka izvještaja za raspakiravanje"
 
@@ -800,19 +801,19 @@ msgstr "Datoteka izvještaja za raspakiravanje"
 msgid "directory to unpack report to"
 msgstr "direktorij za raspakiravanje izvještaja"
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "Direktorji odredišta postoji i nije prazan."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "Pogledajte man stranice za više pojedinosti."
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "odredi naziv datoteke zaspisa koju je stvorio valgrind"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
@@ -820,7 +821,7 @@ msgstr ""
 "ponovno koristi prije stvoreni sandbox direktorij (SDIR) ili, ako ne "
 "postoji, stvori ga"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -829,7 +830,7 @@ msgstr ""
 "otklanjanja greške nego se samo oslanjaj na instalirane simbole otklanjanja "
 "greške."
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
@@ -837,13 +838,13 @@ msgstr ""
 "ponovno koristi prije stvoreni direktorij predmemorije (CDIR) ili, ako ne "
 "postoji, stvori ga"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 "prijavi napredak preuzimanja/instalacije prilikom instalacije paketa u "
 "sandbox"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
@@ -851,12 +852,12 @@ msgstr ""
 "izvršna datoteka koja je pokrenuta valgrindovim alatom provjere memorije za "
 "otkrivanje curenja memorije"
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Greška: %s nije izvršna datoteka. Zaustavljanje."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -864,7 +865,7 @@ msgstr ""
 "Ovo je nastalo tijekom prijašnje suspenzije i spriječilo je ispravno "
 "pokretanje sustava."
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -872,7 +873,7 @@ msgstr ""
 "Ovo je nastalo tijekom prijašnje hibernacije i spriječilo je ispravno "
 "pokretanje sustava."
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -880,7 +881,7 @@ msgstr ""
 "Postupak pokretanja se prekinuo pred sam kraj i završit će se u potpunosti "
 "normalno."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 "Moguće je da vaš sustav postane nestabilan i zatreba ponovno pokretanje."
@@ -895,76 +896,76 @@ msgstr "Prijavite problem..."
 msgid "Report a malfunction to the developers"
 msgstr "Prijavite neispravnost razvojnom timu"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "Aplikacija %s je neočekivano zaustavljena."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "%s se neočekivano zatvorio."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "%s je iskusio unutrašnju grešku."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Pošalji"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Prikaži pojedinosti"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Nastavi"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "Aplikacija %s više ne odgovara."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "Program \"%s\" više ne odgovara."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Paket: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "Problem se dogodio tijekom instalacije softvera."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "Aplikacija %s je iskusila unutrašnju grešku."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "Aplikacija %s se zatvorila neočekivano."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr "Ako primjetite daljne probleme, pokušajte ponovno pokrenuti računalo."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "Zanemari buduće probleme ove vrste"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Sakrij pojedinosti"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -1020,7 +1021,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>Učitavanje informacija o problemu</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -1032,27 +1033,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Apport datoteka o rušenju"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "Ostavi zatvoreno"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Pokreni ponovo"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Korisničko Ime:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Lozinka:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "Prikupljanje Informacija o problemu"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1060,6 +1061,6 @@ msgstr ""
 "Prikupljene informacije mogu biti poslane razvijateljima kako bi se "
 "aplikacija poboljšala. Ovo može potrajati nekoliko minuta."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "Slanje informacija o problemu"

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2020-04-03 16:38+0000\n"
 "Last-Translator: Úr Balázs <balazs@urbalazs.hu>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -38,11 +38,11 @@ msgstr "Rendszerhiba-jelentések"
 msgid "Please enter your password to access problem reports of system programs"
 msgstr "Adja meg jelszavát a rendszerprogramok hibáinak eléréséhez"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "Úgy tűnik, ez a csomag nincs megfelelően telepítve"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -50,7 +50,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -63,21 +63,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "ismeretlen program"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Elnézést, a(z) „%s” program váratlanul összeomlott."
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Probléma a következőben: %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -85,64 +80,69 @@ msgstr ""
 "A számítógépe nem rendelkezik elegendő szabad memóriával a probléma "
 "automatikus elemzéséhez és a jelentés elküldéséhez a fejlesztőknek."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Probléma a következőben: %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Érvénytelen hibajelentés"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "A hibajelentés elérése nem engedélyezett"
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Hiba"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "Nincs elegendő lemezterület a hiba feldolgozásához."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "Érvénytelen PID"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr "A megadott folyamatazonosító nem létezik."
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr "Nem az Ön folyamatazonosítója"
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr "A megadott folyamatazonosító nem Önhöz tartozik."
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "Nincs megadva csomag"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Meg kell adnia egy csomagot vagy PID azonosítót. További információkért "
 "tekintse meg a --help kapcsoló kimenetét."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Hozzáférés megtagadva"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -150,30 +150,30 @@ msgstr ""
 "A megadott folyamat nem Önhöz tartozik. Ezt a programot a folyamat "
 "tulajdonosaként vagy rendszergazdaként futtassa."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "A megadott PID nem programhoz tartozik."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "A(z) %s tünetparancsfájl nem határozott meg érintett csomagot"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "A(z) %s csomag nem létezik"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "Nem készíthető jelentés"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "Hibajelentés frissítése"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -185,7 +185,7 @@ msgstr ""
 "\n"
 "Készítsen új jelentést az „apport-bug” használatával."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -206,24 +206,24 @@ msgstr ""
 "\n"
 "Biztosan folytatja?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "Nem került gyűjtésre további információ."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "Milyen problémát kíván jelenteni?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Ismeretlen tünet"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "A(z) „%s” tünet ismeretlen."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -234,7 +234,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -242,30 +242,30 @@ msgstr ""
 "Ezen üzenet bezárása után kattintson egy alkalmazásablakra az azzal "
 "kapcsolatos hiba jelentéséhez."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "Az xprop nem tudta meghatározni az ablak folyamatazonosítóját"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "Adja meg a csomagnevet."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "Extra címke hozzáadása a jelentéshez. Többször is megadható."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -275,16 +275,16 @@ msgstr ""
 "egy --pid kapcsolót igényel. Ha egyik sincs megadva, az ismert tünetek "
 "listáját jeleníti meg. (Egy paraméter megadása is ezt jelenti.)"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "Kattintson egy ablakra az azzal kapcsolatos hiba jelentéséhez."
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "Indítás hibafrissítés módban. Opcionálisan használható a --package kapcsoló."
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -292,7 +292,7 @@ msgstr ""
 "Hiba bejelentése egy tünetről. (Ha az egyetlen paraméter tünetnév, az is ezt "
 "jelenti.)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -300,7 +300,7 @@ msgstr ""
 "Csomagnév megadása --file-bug módban. Ez elhagyható, ha a --pid meg van "
 "adva. (Ha az egyetlen paraméter egy csomagnév, az is ezt jelenti.)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -309,11 +309,11 @@ msgstr ""
 "Futó program megadása --file-bug módban. Ha ez meg van adva, a hibajelentés "
 "több információt fog tartalmazni."
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "A megadott PID egy nem válaszoló alkalmazásra mutat."
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -323,7 +323,7 @@ msgstr ""
 "függőben lévők helyet. (Ha az egyetlen paraméter egy fájl, az is ezt "
 "jelenti.)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -332,50 +332,50 @@ msgstr ""
 "Hibajelentő módban az összegyűjtött információk mentése fájlba a bejelentés "
 "helyett. Ez a fájl később másik gépről beküldhető."
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Az Apport verziószámának megjelenítése."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Ez meg fogja nyitni az apport-retrace-t egy terminálban, hogy az "
 "megvizsgálja az összeomlást."
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "gdb folyamat futtatása"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "gdb folyamat futtatása a hibakeresési szimbólumok letöltése nélkül"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "%s frissítése teljes szimbolikus veremkiíratással"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr "Nem lehet megjegyezni a jelentés küldése állapot beállításait"
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 "Az összeomlási jelentés állapotának mentése sikertelen. Nem lehet beállítani "
 "az automatikus vagy sohasem jelentési módot."
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr "Nem lehet megjegyezni a jelentés küldése állapot beállításait"
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 "Ez a problémajelentés egy olyan programra vonatkozik, amely már nincs "
 "telepítve."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
@@ -383,81 +383,83 @@ msgid ""
 msgstr ""
 "A hiba a(z) „%s” programmal lépett fel, amely megváltozott az összeomlás óta."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "A hibajelentés megsérült és nem dolgozható fel."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr "Ez a jelentés egy nem telepített csomagról szól."
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "Hiba történt a következő hibabejelentés feldolgozása közben:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "A csomag vagy forrás neve nem állapítható meg."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "A webböngésző nem indítható."
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "A(z) „%s” megnyitásához nem lehet elindítani a webböngészőt."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Hálózati probléma"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Nem lehet kapcsolódni az összeomlás-adatbázishoz, ellenőrizze az "
 "internetkapcsolatát."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Hálózati probléma"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Elfogyott a memória"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "A rendszere nem rendelkezik elegendő memóriával ezen összeomlásjelentés "
 "feldolgozásához."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -468,11 +470,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "A probléma már ismert."
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -482,38 +484,37 @@ msgstr ""
 "hibajelentés. Ellenőrizze, hogy tud-e további információkkal szolgálni, "
 "amelyek hasznosak lehetnek a fejlesztők számára."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Ez a probléma már jelentve volt a fejlesztőknek. Köszönjük!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "A folytatáshoz nyomjon le egy billentyűt…"
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "Mit szeretne tenni? A lehetőségek:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Válasszon (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i bájt)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(bináris adatok)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Elküldi a hibajelentést a feljesztőknek?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -521,51 +522,51 @@ msgstr ""
 "A hibajelentés elküldése után töltse ki a kérdőívet az\n"
 "automatikusan megnyíló webböngészőben."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "&Hibajelentés küldése (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "&Vizsgálat helyileg"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "Hi&bajelentés megtekintése"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr "Hibajelentés megtartása &későbbi küldésre, vagy más helyre másolásra"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr ""
 "Mégse, és ezentúl a programverzió összeomlásainak figyelmen &kívül hagyása"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "Mé&gse"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Hibajelentésfájl:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "Meg&erősítés"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Hiba: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "Információgyűjtés a hibáról"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -574,11 +575,11 @@ msgstr ""
 "javíthassanak\n"
 "az alkalmazáson. A küldés eltarthat pár percig."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "A hibával kapcsolatos információk feltöltése"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -586,40 +587,40 @@ msgstr ""
 "Az összegyűjtött információk elküldése a hibakövető rendszernek.\n"
 "Ez eltarthat pár percig."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Kész"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "nincs"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "Kiválasztva: %s. További lehetőségek:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Lehetőségek:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "Fájl helye (kilépés enterrel):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "A fájl nem létezik."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "Ez egy könyvtár."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "A folytatáshoz meg kell nyitnia a következő URL-címet:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -627,17 +628,17 @@ msgstr ""
 "Elindíthatja most a böngészőt, vagy átmásolhatja ezt az URL-címet egy másik "
 "számítógépen lévő böngészőbe."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Böngésző indítása most"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 "Nincs függőben lévő összeomlás-jelentés. \r\n"
 "További információkért tekintse meg a --help kapcsoló kimenetét."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 "Ne tegye be az új nyomkövetéseket a jelentésbe, hanem írja ki a szabványos "
@@ -658,29 +659,29 @@ msgstr ""
 "Módosított jelentés írása a megadott fájlba az eredeti jelentés módosítása "
 "helyett"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 "A veremkiíratás ismételt előállítása után a memóriakiíratás eltávolítása a "
 "jelentésből"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "A jelentés CoreFile-jának felülbírálása"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "A jelentés ExecutablePath-jának felülbírálása"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "A jelentés ProcMaps-jának felülbírálása"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "A jelentés csomaginformációinak újjáépítése"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -696,7 +697,7 @@ msgstr ""
 "„system” esetén a rendszer konfigurációs fájljait használja, de ekkor csak "
 "az aktuálisan futó kiadás összeomlásait lesz képes nyomon követni."
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
@@ -706,26 +707,26 @@ msgstr ""
 "homokozót a gdb és függőségei telepítéséhez az Ön által telepített "
 "valamilyen gdb verzió helyett."
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 "Homokozóba történő telepítéskor a letöltés/telepítési folyamat kijelzése"
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr "Helyezzen időbélyegeket a naplóüzenetek elé, a kötegelt működéshez"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 "Külső tárolók létrehozása és használata a jelentésekben megadott forrásokból"
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr "Homokozóba letöltött csomagok gyorsítókönyvtára"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -733,12 +734,12 @@ msgstr ""
 "Kicsomagolt csomagok könyvtára. A jövőbeli futások feltételezik, hogy a már "
 "kicsomagolt csomagok ugyanebbe a homokozóba lesznek kicsomagolva."
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr "Extra csomag homokozóba telepítése (többször is megadható)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -749,7 +750,7 @@ msgstr ""
 "követett veremkiíratások feltöltésekor (ha a -g, -o és -s egyike sincs "
 "megadva)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -757,31 +758,31 @@ msgstr ""
 "Ismételten nyomon követett veremkiíratások megjelenítése, és megerősítés "
 "kérése a beküldés előtt az összeomlási adatbázisba."
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 "Útvonal a kettőzött sqlite adatbázishoz (alapértelmezett: nincs ellenőrzés)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr "Ne adja hozzá a veremkövetés forrását a jelentéshez."
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "Nem használhatja a -C kapcsolót az -S kapcsoló nélkül. Leállítás."
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "Elküldhetők ezek mellékletként? [y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -789,19 +790,19 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "A célkönyvtár létezik és nem üres."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "Részletekért lásd a man oldalt."
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "Adja meg a Valgrind naplófájl nevét"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
@@ -809,7 +810,7 @@ msgstr ""
 "Korábban létrehozott sandbox mappa (SDIR) újra felhasználása, vagy ha nem "
 "létezik, létrehozása"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -818,7 +819,7 @@ msgstr ""
 "hibakeresési szimbólumokhoz, csak a telepített hibakeresési szimbólumokat "
 "használja."
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
@@ -826,23 +827,23 @@ msgstr ""
 "Korábban létrehozott gyorsítókönyvtár (CDIR) újra felhasználása, vagy ha nem "
 "létezik, létrehozása"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 "Letöltési/telepítési folyamat jelentése csomagok telepítésekor a homokozóba"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Hiba: a(z) %s nem végrehajtható. Leállítás."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -850,7 +851,7 @@ msgstr ""
 "Ez egy korábbi felfüggesztés közben történt, és ezzel megakadályozta a "
 "rendszer megfelelő indulását."
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -858,7 +859,7 @@ msgstr ""
 "Ez egy korábbi hibernálás közben történt, és ezzel megakadályozta a rendszer "
 "megfelelő indulását."
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -866,7 +867,7 @@ msgstr ""
 "A folytatás feldolgozása a vége felé megszakadt, és úgy fog tűnni, hogy "
 "normálisan befejeződött."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr "A rendszer instabillá válhatott, és szükség lehet az újraindítására."
 
@@ -880,77 +881,77 @@ msgstr "Hiba jelentése…"
 msgid "Report a malfunction to the developers"
 msgstr "Hibás működés jelentése a fejlesztőknek"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "Elnézést, a(z) %s alkalmazás váratlanul leállt."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "Elnézést, a(z) %s váratlanul befejeződött."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "Elnézést, a(z) %s belső hibát észlelt."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Küldés"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Részletek megjelenítése"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Folytatás"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "A(z) %s alkalmazás nem válaszol."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "A(z) „%s” program nem válaszol."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Csomag: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "Elnézést, hiba történt a szoftvertelepítés alatt."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "A(z) %s alkalmazás belső hibát észlelt."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "A(z) %s alkalmazás váratlanul befejeződött."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr ""
 "Ha további problémákat észlel, próbálja meg újraindítani a számítógépet."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "Ilyen típusú problémák figyelmen kívül hagyása a jövőben"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Részletek elrejtése"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -1006,7 +1007,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>Hibainformációk feltöltése</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -1018,27 +1019,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Apport jelentésfájl"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "Bezárva hagyás"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Újraindítás"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Felhasználónév:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Jelszó:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "Információgyűjtés a hibáról"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1046,6 +1047,6 @@ msgstr ""
 "Az összegyűjtött információk elküldhetők a fejlesztőknek az alkalmazás "
 "javítása érdekében. Ez eltarthat néhány percig."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "A hibával kapcsolatos információk feltöltése"

--- a/po/hy.po
+++ b/po/hy.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2011-03-11 22:55+0000\n"
 "Last-Translator: Serj Safarian <serjsafarian@gmail.com>\n"
 "Language-Team: Armenian <hy@li.org>\n"
@@ -36,11 +36,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr ""
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -57,111 +57,111 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "անհայտ ծրագիր"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr ""
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Խնդիր %s֊ում"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
 msgstr ""
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Խնդիր %s֊ում"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr ""
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr ""
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr ""
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr ""
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr ""
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr ""
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 msgstr ""
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr ""
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr ""
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr ""
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr ""
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -169,7 +169,7 @@ msgid ""
 "Please create a new report using \"apport-bug\"."
 msgstr ""
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -181,24 +181,24 @@ msgid ""
 "Do you really want to proceed?"
 msgstr ""
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr ""
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr ""
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr ""
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr ""
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -209,202 +209,204 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr ""
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr ""
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr ""
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr ""
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr ""
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr ""
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr ""
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr ""
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr ""
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr ""
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr ""
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr ""
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -412,161 +414,160 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr ""
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 msgstr ""
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr ""
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr ""
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr ""
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr ""
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr ""
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr ""
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
 msgstr ""
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr ""
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr ""
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr ""
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr ""
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr ""
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr ""
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr ""
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr ""
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr ""
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
 msgstr ""
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr ""
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
 msgstr ""
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr ""
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr ""
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr ""
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr ""
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr ""
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr ""
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr ""
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr ""
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
 msgstr ""
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr ""
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 
@@ -581,27 +582,27 @@ msgid ""
 "Write modified report to given file instead of changing the original report"
 msgstr ""
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr ""
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr ""
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr ""
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr ""
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -611,78 +612,78 @@ msgid ""
 "be able to retrace crashes that happened on the currently running release."
 msgstr ""
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
 "have installed."
 msgstr ""
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr ""
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
 msgstr ""
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
 "neither -g, -o, nor -s are specified)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
 msgstr ""
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr ""
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr ""
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr ""
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -690,70 +691,70 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr ""
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
 msgstr ""
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 
@@ -767,76 +768,76 @@ msgstr ""
 msgid "Report a malfunction to the developers"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr ""
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr ""
 
@@ -890,7 +891,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr ""
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -900,32 +901,32 @@ msgstr ""
 msgid "Apport crash file"
 msgstr ""
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr ""
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr ""
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr ""
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr ""
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr ""
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
 msgstr ""
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr ""

--- a/po/ia.po
+++ b/po/ia.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2018-05-09 23:32+0000\n"
 "Last-Translator: karm <melo@carmu.com>\n"
 "Language-Team: Interlingua <ia@li.org>\n"
@@ -40,11 +40,11 @@ msgstr ""
 "Per favor Inserer le contrasigno pro acceder la reporto de problemas del "
 "programmas del systema"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "Iste pacchetto non pare esser installate correctemente"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -52,7 +52,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -65,21 +65,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "programma incognite"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Displacente, le programma \"%s\" claudeva inexpectatemente"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Problema in %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -87,65 +82,70 @@ msgstr ""
 "Tu computer non ha bastante memoria libere pro analysar automaticamente le "
 "problema e inviar un reporto al disveloppatores."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Problema in %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Reporto de problema invalide"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "Tu es permittite acceder iste reporto de problema."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Error"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 "Il non ha bastante spatio del disco disponibile a processar iste reporto."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "PID invalide"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "Nulle pacchetto specificate"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Tu necessita specificar un pacchetto o un PID. Vider --help pro plus de "
 "informationes."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Permission negate"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -153,30 +153,30 @@ msgstr ""
 "Le processo specificate non pertine a te. Per favor flue iste programma como "
 "le proprietario del processo o como radice."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "Le ID del processo specificate non pertine a un programma."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Le script del symptoma %s non determina un pacchetto affligite"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Le pacchetto %s non existe"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "On non pote crear un reporto"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "Ajornamento del reporto del problema"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -188,7 +188,7 @@ msgstr ""
 "\n"
 "Per favor crear un nove reporto per \"apport-bug\"."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -209,24 +209,24 @@ msgstr ""
 "\n"
 "Desira tu realmente proceder?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "Nulle information additional colligite."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "Qual genere de problema desira tu reportar?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Symptoma incognite"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Le symptoma \"%s\" non es note."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -237,7 +237,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -245,30 +245,30 @@ msgstr ""
 "Post claudite iste message, cliccar per favor su un fenestra de application "
 "pro reportar un problema re illo."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop ha mancate a determinar le ID de processo del fenestra"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "Specificar le nomine del pacchetto."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "Adder un tag extra al reporto. Pote esser specificate multiple vices."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -278,17 +278,17 @@ msgstr ""
 "--pid, o sol un --pid. Si non es date, displicar un lista del symptomas "
 "notori. (Implicite si es date un argumento singule.)"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 "Cliccar un fenestra qual destination pro registrar un reporto del problema."
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "Initiar in modo ajornamento del defecto. Pote prender un --package optional."
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -296,7 +296,7 @@ msgstr ""
 "Registrar un reporto de defecto circa un symptoma. (Implicite si le nomine "
 "del symptoma es date qual argumento unic.)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -305,7 +305,7 @@ msgstr ""
 "es specificate un --pid. (Implicite si le nomine del pacchetto es date qual "
 "argumento unic.)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -315,11 +315,11 @@ msgstr ""
 "le reporto de defecto continera plus de informationes.  (Implicite si le pid "
 "es date qual argumento unic.)"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "Le pid supplite es un application suspendite."
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -328,7 +328,7 @@ msgstr ""
 "Reportar le crash per le file .apport o .crash date in vice de illos "
 "pendente in %s. (Implicite si le file es date qual argumento unic.)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -338,47 +338,47 @@ msgstr ""
 "file in vice de reportar lo. Iste file pote pois esser reportate ex un "
 "machina differente."
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Imprimer le numero de version de Apport."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Isto lanceara apport-retrace in un fenestra de terminal pro examinar le "
 "crash."
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "Facer fluer un session gdb"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Facer fluer un session gdb sin discargar symbolos del correction"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Ajornar %s con le tracia del pila plenmente symbolic"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 "Iste reporto de problema refere se a un programma que non es plus installate."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
@@ -387,81 +387,83 @@ msgstr ""
 "Le problema ha occurrite con le programma %s que ha cambiate depois que le "
 "crash occurreva."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Iste reporto de problema is damnificate e non pote esser processate."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr "Iste reporto es re un pacchetto que non es installate"
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr ""
 "Un error occurreva durante que tentava processar iste reporto de problema:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "Non poterea determinar le pacchetto o le nomine del pacchetto fonte."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "Incapace de lancear le navigator del web"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Incapace de lancear le navigator del web pro aperir %s."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Problema de rete"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "On non pote connecter al base de datos del crash, per favor controlar le "
 "connexion al Rete."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Problema de rete"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Exhaustion del memoria"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Tu systema non ha bastante memoria pro processar iste reporto de crash."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -472,11 +474,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "Problema ja note"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -486,38 +488,37 @@ msgstr ""
 "navigator del Web. Per favor controla si tu pote adder alcun information "
 "additional que pote esser auxilio al disveloppatores."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Iste problema esseva ja reportate al disveloppatores. Gratias!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Pulsar un clave pro continuar..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "Quod amarea tu facer? Tu optiones es:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Per favor optar (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i bytes)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(datos binari)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Mandar le reporto de problema al disveloppatores?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -526,52 +527,52 @@ msgstr ""
 "modulo in le\n"
 "navigator navigator aperite automaticamente."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "&S Mandar le reporto (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "&Examinar localmente"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "&Vider le reporto"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 "&K Tener le file de reporto pro le expedition subsequente o sinon copiar a "
 "alicubi"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "Cancellar e &ignorar futur crashes de iste version de programma"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Cancellar"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "File reporto de problema:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&Confirmar"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Error: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "Collection del informationes del problema"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -579,11 +580,11 @@ msgstr ""
 "Le informationes colligite pote esser expedite al disveloppatores pro "
 "affinar le application. Isto pote prender alicun minutas."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "Cargamento del informationes del problema"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -591,40 +592,40 @@ msgstr ""
 "Le informationes colligite pote esser expedite al systema de revision del "
 "defectos. Isto pote prender alicun minutas."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&D Facite"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "necun"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "Seligite: %s. Selectiones multiple:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Selectiones:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "Percurso al file (Entrar pro cancellar):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "Le file non existe."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "Isto es un directorio."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "Pro continuar, tu debe visitar le adresse URL sequente:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -632,16 +633,16 @@ msgstr ""
 "Tu pote lancear ora un navigator, o copiar iste adresse URL in un navigator "
 "sur un altere computer."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Lancear un navigator ora"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 "Nulle reporto de crash pendente. Probar --help pro plus de informationes."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr "Non poner le nove tracias in le reporto, ma scriber los al stdout."
 
@@ -660,28 +661,28 @@ msgstr ""
 "Scriber on reporto modificate pro le file date in vice de cambiar le reporto "
 "original"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 "Remover le core dump ex le reporto post le regeneration del tracias del pila"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "Superscriber le CoreFile del reporto"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "Superscriber le ExecutablePath del reporto"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "Superscriber le ProcMaps del reporto"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "Reproducer le informationes del pacchetto del reporto"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -698,7 +699,7 @@ msgstr ""
 "configuration del systema, ma alora essera habile sol a retraciar le crashes "
 "que ha occurrite sur le edition fluente actualmente."
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
@@ -708,28 +709,28 @@ msgstr ""
 "per le mesme edition del reporto, plu tosto que ulle version de gdb que tu "
 "ha ja installate."
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 "Referer le progresso del discargamento/installation quando on installa un "
 "pacchetto in le arenario"
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr "Prepend timestamps pro messages de registro, pro le operation de fundo"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 "Crear e usar repositorios de tertie partes ex origines specificate in le "
 "reportos"
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr "Directorio tampon pro le pacchettos discargate in le arenario"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -738,14 +739,14 @@ msgstr ""
 "assumera que omne le pacchettos ja discargate essera extrahite in iste "
 "arenario."
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 "Installar un pacchetto extra in le arenario (pote esser specificate multiple "
 "vices)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -755,7 +756,7 @@ msgstr ""
 "del crash. Isto es usate pro specificar un ID de crash pro cargar le tracias "
 "del pila retraciate (sol si ni -g, -o, ni -s es specificate)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -763,32 +764,32 @@ msgstr ""
 "Monstrar le tracias del pila retraciate e quere pro le confirmation ante que "
 "inviar los al base de datos del crash ."
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 "Percurso al base de datos sqlite duplicate (standard: nulle controlo del "
 "duplicatos)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr "Non adder StacktraceSource al reporto."
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "On non pote usar -C sin -S. Arrestar."
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "OK a inviar istes como attaccamentos? [s/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -796,19 +797,19 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "Le directorio de destination existe e non es vacue."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "Vider pro le detalios le pagina principal."
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "attribuer le nomine del file registro producite per valgrind"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
@@ -816,7 +817,7 @@ msgstr ""
 "reusar un directorio (SDIR) del arenario create anteriormente o, si illo non "
 "existe, crear lo"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -824,7 +825,7 @@ msgstr ""
 "non crear o reusar un directorio del arenario o symbolos additional de "
 "correctiones sed fider sol sur le symbolos de correction ja installate."
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
@@ -832,24 +833,24 @@ msgstr ""
 "directorio (SDIR) del memoria tampon create anteriormente o, si illo non "
 "existe, crear lo"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 "referer le progresso del discargamento/installation quando on installa un "
 "pacchetto in le arenario"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Error: %s non es un  executabile. Arresto."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -857,7 +858,7 @@ msgstr ""
 "Iato occurreva durante un previe suspension e ha prevenite le proprie "
 "reinitio del systema."
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -865,7 +866,7 @@ msgstr ""
 "Iato occurreva durante un previe hibernation e ha prevenite le proprie "
 "reinitio del systema."
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -873,7 +874,7 @@ msgstr ""
 "Le processo de resumer hung multo proxime al fin e essera apparite haber "
 "completate normalmente."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 "Tu systema pote devenir instabile ora e pote necessitar ser reinitiate."
@@ -888,77 +889,77 @@ msgstr "Reportar un problema..."
 msgid "Report a malfunction to the developers"
 msgstr "Reportar un dysfunction al disveloppatores"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "Displacente, le application %s ha stoppate inexpectatemente."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "Displacente, %s ha claudite inexpectatemente."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "Displacente, %s ha experimentate un error interne."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Mandar"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Monstrar le detalios"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Continuar"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "Le application %s ha stoppate de responder."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "Le programma %s ha stoppate de responder."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Pacchetto: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr ""
 "Displacente, un problema occurreva durante le installation del software."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "Le application %s ha experimentate un  error interne."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "Le application %s ha claudite inexpectatemente."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr "Si on nota problemas additional, provar a reinitiar le computer."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "Ignorar le problema futur de iste typo"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Occultar le detalios"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -1014,7 +1015,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>Cargamento del informationes del problema</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -1026,27 +1027,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "File crash de Apport"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "Lassar clause"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Relancear"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Nomine del usator:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Contrasigno:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "Collection del informationes del problema"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1054,6 +1055,6 @@ msgstr ""
 "Le informationes colligite pote esser expedite al disveloppatores pro "
 "affinar le application. Isto pote prender alicun minutas."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "Cargamento del informationes del problema"

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2015-04-27 21:46+0000\n"
 "Last-Translator: Cecep Mahbub <cecep.mahbub@gmail.com>\n"
 "Language-Team: Indonesian <id@li.org>\n"
@@ -38,11 +38,11 @@ msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 "Harap masukkan sandi Anda untuk mengakses laporan masalah dari program sistem"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "Paket ini nampaknya tak terpasang secara benar"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -53,7 +53,7 @@ msgstr ""
 "indeks dari paket yang tersedia, bila itu tidak bekerja maka hapuslah paket "
 "pihak ke tiga dan coba lagi."
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -66,21 +66,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "program tak dikenal"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Maaf, program \"%s\" ditutup tak disangka-sangka"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Masalah di %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -88,65 +83,70 @@ msgstr ""
 "Komputer anda sepertinya tidak memiliki cukup memori bebas untuk secara "
 "otomatis menganalisa masalah dan mengirimkan laporan pada pengembang."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Masalah di %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Laporan masalah tidak valid"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "Anda tak diijinkan untuk mengakses laporan masalah ini."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Galat"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "Tak tersedia ruang cakram yang cukup untuk mengolah laporan ini."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr "Tidak ada PID yang dinyatakan"
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 "Anda perlu menyatakan suatu PID. Lihat --help untuk informasi lebih lanjut."
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "PID tak valid"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr "ID proses yang dinyatakan tidak ada."
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr "Bukan PID Anda"
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr "ID proses yang dinyatakan bukan milik Anda."
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "Tak ada paket yang dinyatakan"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Anda perlu menyatakan suatu paket atau sebuah PID. Lihat --help untuk "
 "informasi lebih."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Tak diijinkan"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -154,30 +154,30 @@ msgstr ""
 "Proses berikut tidak dimiliki oleh Anda. Silakan jalankan program ini dengan "
 "mengunakan root atau pemilik proses."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "ID proses yang dinyatakan bukan milik suatu program."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Skrip gejala %s tak menentukan paket yang terpengaruh"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Paket %s tidak ada"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "Tidak dapat membuat laporan"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "Sedang memperbarui laporan masalah"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -189,7 +189,7 @@ msgstr ""
 "\n"
 "Silakan membuat suatu laporan baru memakai \"apport-bug\"."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -210,24 +210,24 @@ msgstr ""
 "\n"
 "Apakah Anda yakin ingin meneruskan?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "Tidak ada informasi tambahan yang dikumpulkan"
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "Masalah macam apa yang ingin Anda laporkan?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Gejala tak dikenal"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Gejala '%s' tak dikenal."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -245,7 +245,7 @@ msgstr ""
 "tab Proses, gulir sampai Anda menemukan aplikasi yang tepat. ID proses "
 "adalah angka yang dicantumkan dalam kolom ID."
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -253,32 +253,32 @@ msgstr ""
 "Setelah menutup pesan ini silakan klik pada jendela aplikasi untuk "
 "melaporkan masalah tentang hal ini."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop gagal untuk menentukan ID proses dari jendela"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "Tentukan nama paket."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Tambahkan label tambahan untuk laporan. Dapat memasukkan beberapa label "
 "sekaligus."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -288,15 +288,15 @@ msgstr ""
 "atau hanya --pid. Bila keduanya tak diberikan, tampilkan daftar dari gejala "
 "yang telah diketahui. (Otomatis bila argumen tunggal diberikan.)"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "Klik jendela sebagai target untuk mengajukan laporan masalah."
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "Memulai mode memperbarui bug. Dapat mengambil optional --package."
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -304,7 +304,7 @@ msgstr ""
 "Laporkan kutu tentang suatu gejala. (Otomatis bila nama gejala diberikan "
 "sebagai argumen tunggal.)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -312,7 +312,7 @@ msgstr ""
 "Nyatakan nama paket dalam moda --file-bug. Ini opsional bila suatu --pid "
 "dinyatakan.  (Otomatis bila nama paket diberikan sebagai argumen tunggal.)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -322,11 +322,11 @@ msgstr ""
 "dinyatakan, laporan kutu akan memuat lebih banyak informasi. (diasumsikan "
 "bila pid diberikan sebagai satu-satunya argumen.)"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "Pid yang diberikan adalah aplikasi yang hang."
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -335,7 +335,7 @@ msgstr ""
 "Laporkan crash dari berkas .apport atau .crash alih-alih dari yang tertunda "
 "di %s. (Otomatis bila berkas diberikan sebagai argumen tunggal.)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -345,49 +345,49 @@ msgstr ""
 "berkas alih-alih melaporkannya. Berkas ini kemudian dapat dilaporkan nanti "
 "atau dari mesin lain."
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Cetak nomor versi Apport."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Ini akan meluncurkan apport-retrace dalam suatu jendela terminal untuk "
 "memeriksa crash."
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "Memulai sesi gdb"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Memulai sesi gdb tanpa mengunduh simbol debug"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Mutakhirkan %s dengan pelacakan stack simbol lengkap"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr "Tak bisa mengingat pengaturan status kirim laporan"
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 "Menyimpan keadaan pelaporan kres gagal. Tak bisa menata mode pelaporan "
 "otomatis atau tak pernah."
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr "Tak bisa mengingat pengaturan status kirim laporan"
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 "Laporan masalah berlaku bagi suatu program yang telah tak terpasang lagi."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
@@ -395,19 +395,21 @@ msgid ""
 msgstr ""
 "Terjadi masalah dengan program %s yang berubah semenjak terjadinya crash."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Laporan permasalah gagal dan tidak dapat diproses."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr "Laporan ini adalah tentang suatu paket yang tidak terpasang."
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "Terjadi kesalahan ketika mencoba untuk memproses laporan masalah:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
@@ -415,24 +417,24 @@ msgstr ""
 "Anda memiliki dua versi dari aplikasi ini yang terpasang, yang mana yang "
 "Anda ingin laporkan kutunya?"
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr "%s snap"
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr "%s paket deb"
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s disediakan oleh sebuah snap yang dipublikasikan oleh %s. Hubungi mereka "
 "melalui %s untuk bantuan."
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -442,41 +444,41 @@ msgstr ""
 "kontak yang disediakan; kunjungi forum pada https://forum.snapcraft.io/ "
 "untuk bantuan."
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "TIdak dapat menentukan nama paket atau nama paket sumber."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "TIdak dapat menjalankan perambah web"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "TIdak dapat menjalankan perambah web untuk membuka %s."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Masalah di jaringan"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Tak bisa menyambung ke basis data crash, silakan periksa sambungan Internet "
 "Anda."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Masalah di jaringan"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Kehabisan memori"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Sistem Anda tidak memiliki memori yang cukup untuk memproses laporan crash "
 "ini."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -487,11 +489,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "Masalah sudah diketahui"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -501,38 +503,37 @@ msgstr ""
 "web. Silakan periksa apakah Anda dapat menambah informasi lebih lanjut yang "
 "mungkin berguna bagi para pengembang."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Masalah ini sudah dilaporkan ke pengembang. Terima kasih!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Tekan sembarang tombol untuk lanjut..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "Apa yang ingin Anda lakukan? Pilihan Anda adalah:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Silakan pilih (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i bytes)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(data biner)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Kirim laporan masalah ke para pengembang?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -540,51 +541,51 @@ msgstr ""
 "Setelah laporan masalah dikirim, silakan mengisi formulir di peramban\n"
 "web yang otomatis dibuka."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "&Kirim laporan (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "P&eriksa secara lokal"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "&Tilik laporan"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 "Simpan ber&kas laporan untuk pengiriman nanti atau penyalinan ke tempat lain"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "Batalkan dan aba&ikan crash di masa mendatang dari versi program ini"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Batal"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Berkas laporan masalah:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&Konfirmasi"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Galat: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "Mengumpukan informasi masalah"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -592,11 +593,11 @@ msgstr ""
 "Informasi yang dikumpulkan dapat dikirim ke para pengembang untuk\n"
 "memperbaiki aplikasi. Ini mungkin makan waktu beberapa menit."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "Mengunggah informasi masalah"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -604,40 +605,40 @@ msgstr ""
 "Informasi yang dikumpulan sedang dikirim ke sistem pelacak kutu.\n"
 "Ini mungkin makan waktu beberapa menit."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Selesai"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "tak ada"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "Terpilih: %s. Pilihan berganda:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Pilihan:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "Path ke berkas (Enter untuk membatalkan):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "Berkas tidak ada."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "Ini bukan direktori."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "Untuk melanjutkan, Anda mesti mengunjungi URL berikut:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -645,15 +646,15 @@ msgstr ""
 "Anda dapat meluncurkan sebuah peramban sekarang, atau menyalin URL ini ke "
 "dalam peramban pada komputer lain."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Luncurkan sebuah peramban sekarang"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr "Tak ada laporan crash tertunda. Coba --help untuk informasi lebih."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 "Jangan letakkan pelacakan baru ke dalam laporan, tapi tulis mereka ke stdout."
@@ -673,27 +674,27 @@ msgstr ""
 "Tulis laporan yang diubah ke berkas yang diberikan alih-alih mengubah "
 "laporan asli"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr "Buang core dump dari laporan setelah regenerasi stack trace"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "Timpa CoreFile laporan"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "Timpa ExecutablePath laporan"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "Timpa ProcMaps laporan"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "Bangun ulang informasi Package laporan"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -710,7 +711,7 @@ msgstr ""
 "hanya akan dapat melacak ulang crash yang terjadi pada rilis yang kini "
 "sedang berjalan."
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
@@ -720,28 +721,28 @@ msgstr ""
 "memakai rilis yang sama sebagai laporan bukan sebarang versi gdb yang telah "
 "Anda pasang."
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 "Laporkan kemajuan pengunduhan/pemasangan ketika memasang paket ke dalam "
 "kotak pasir"
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr "Awali pesan log dengan penanda waktu, bagi operasi batch"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 "Buat dan pakai repositori pihak ketiga dari sumber yang dinyatakan dalam "
 "laporan"
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr "Direktori singgahan bagi paket yang diunduh dalam kotak pasir"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -750,14 +751,14 @@ msgstr ""
 "akan menganggap bahwa paket yang telah diunduh juga diekstrak ke kotak pasir "
 "ini."
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 "Pasang suatu paket ekstra ke dalam kotak pasir (dapat dinyatakan berkali-"
 "kali)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -767,7 +768,7 @@ msgstr ""
 "ketika menyatakan ID crash untuk mengunggah jejak stack yang dilacak ulang "
 "(hanya bila -g, -o, maupun -s tak dinyatakan)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -775,30 +776,30 @@ msgstr ""
 "Tampilkan jejak stack yang dilacak ulang dan tanyakan persetujuan sebelum "
 "mengirim mereka ke basis data crash."
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr "Path ke basis data sqlite duplikat (baku: tak ada uji duplikasi)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr "Jangan tambahkan StacktraceSource ke laporan."
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "Anda tidak bisa menggunakan -C tanpa -S. Sedang menghentikan."
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "Ok untuk mengirim lampiran-lampiran ini? [y/t]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -806,19 +807,19 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "Direktori tujuan ada dan tak kosong."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "Lihat rincian di laman man"
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "nyatakan nama berkas log yang dihasilkan oleh valgrind"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
@@ -826,7 +827,7 @@ msgstr ""
 "pakai ulang dir kotak pasir yang sebelumnya dibuat (SDIR), atau bila belum "
 "ada, buatlah"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -834,7 +835,7 @@ msgstr ""
 "jangan buat atau pakai ulang direktori kotak pasir untuk simbol awakutu "
 "tambahan tapi hanya bergantung kepada simbol awakutu yang telah dipasang"
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
@@ -842,23 +843,23 @@ msgstr ""
 "pakai ulang dir singgahan yang sebelumnya dibuat (CDIR), atau bila belum "
 "ada, buatlah"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 "laporkan kemajuan unduh/pasang ketika memasang paket ke dalam kotak pasir"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Galat: %s bukan executable. Menghentikan."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -866,7 +867,7 @@ msgstr ""
 "Ini terjadi saat suspensi sebelumnya, dan mencegah sistem melanjutkan secara "
 "benar."
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -874,7 +875,7 @@ msgstr ""
 "Ini terjadi saat hebernasi sebelumnya, dan mencegah sistem melanjutkan "
 "secara benar."
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -882,7 +883,7 @@ msgstr ""
 "Pemrosesan pelanjutan menggantung sangat dekat dengan ujung dan akan nampak "
 "seperti komplit secara normal."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 "Sistem Anda mungkin menjadi tak stabil sekarang dan mungkin perlu distart "
@@ -898,77 +899,77 @@ msgstr "Laporkan masalah..."
 msgid "Report a malfunction to the developers"
 msgstr "Lapor kegagalan kepada pengembang"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "Maaf, aplikasi %s telah berhenti secara tak terduga."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "Maaf, %s telah tertutup secara tak terduga."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "Maaf, %s telah mengalami galat internal."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Kirim"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Tunjukkan Rincian"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Lanjutkan"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "Aplikasi %s telah berhenti merespon."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "Program \"%s\" telah berhenti merespon."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Paket: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "Maaf, terjadi masalah ketika memasang perangkat lunak."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "Aplikasi %s telah mengalami galat internal."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "Aplikasi %s telah tertutup tanpa diharapkan."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr ""
 "Bila Anda menemui masalah lebih lanjut, cobalah memulai ulang komputer."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "Abaikan masalah tipe ini di masa mendatang"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Sembunyikan Rincian"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -1024,7 +1025,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>Unggah informasi masalah</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -1036,27 +1037,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Berkas crash Apport"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "Biarkan Tertutup"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Luncurkan Ulang"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Nama pengguna:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Sandi:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "Mengumpulkan Informasi Masalah"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1064,6 +1065,6 @@ msgstr ""
 "Informasi yang dikumpulkan dapat dikirim ke para pengembang untuk "
 "meningkatkan aplikasi. Ini mungkin perlu waktu beberapa menit."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "Mengunggah Informasi Masalah"

--- a/po/id.po
+++ b/po/id.po
@@ -8,15 +8,15 @@ msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2023-07-21 16:31+0200\n"
-"PO-Revision-Date: 2015-04-27 21:46+0000\n"
-"Last-Translator: Cecep Mahbub <cecep.mahbub@gmail.com>\n"
+"PO-Revision-Date: 2023-06-14 11:27+0000\n"
+"Last-Translator: Ajam Jamaludin <Unknown>\n"
 "Language-Team: Indonesian <id@li.org>\n"
 "Language: id\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2022-12-07 14:36+0000\n"
-"X-Generator: Launchpad (build 41e7553f8097ce3a683f90e835708cbe7bf0006c)\n"
+"X-Launchpad-Export-Date: 2023-07-21 14:36+0000\n"
+"X-Generator: Launchpad (build 2bfac4503c7b6a57e9a8acd782035a16f97e2ddb)\n"
 
 #: ../apport/com.ubuntu.apport.policy.in.h:1
 msgid "Collect system information"
@@ -260,7 +260,7 @@ msgstr "xprop gagal untuk menentukan ID proses dari jendela"
 #: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
-msgstr ""
+msgstr "%(prog)s <nomor laporan>"
 
 #: ../apport/ui.py:1017
 msgid "Specify package name."
@@ -276,7 +276,7 @@ msgstr ""
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
-msgstr ""
+msgstr "%(prog)s [opsi] [symptom|pid|pake|path program|berkas .apport/.crash]"
 
 #: ../apport/ui.py:1072
 msgid ""
@@ -797,15 +797,15 @@ msgstr "Ok untuk mengirim lampiran-lampiran ini? [y/t]"
 #: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
-msgstr ""
+msgstr "%(prog)s <laporan> <direktori tujuan>"
 
 #: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
-msgstr ""
+msgstr "Berkas laporan yang akan dibuka"
 
 #: ../bin/apport-unpack.py:33
 msgid "directory to unpack report to"
-msgstr ""
+msgstr "direktori tempat mengekstrak laporan"
 
 #: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
@@ -853,6 +853,8 @@ msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
+"program yang dapat dijalankan di bawah alat pemeriksa kebocoran memori "
+"valgrind untuk mendeteksi kebocoran memori."
 
 #: ../bin/apport-valgrind.py:130
 #, python-format

--- a/po/is.po
+++ b/po/is.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2021-10-18 22:33+0000\n"
 "Last-Translator: Sveinn í Felli <sv1@fellsnet.is>\n"
 "Language-Team: Icelandic <is@li.org>\n"
@@ -38,11 +38,11 @@ msgstr "Vandamálaskýrslur kerfis"
 msgid "Please enter your password to access problem reports of system programs"
 msgstr "Sláðu inn lykilorð til að fá aðgang að villuskýrslum kerfisforrita"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "Þessi pakki virðist ekki rétt upp settur"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -50,7 +50,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -63,21 +63,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "óþekkt forrit"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Fyrirgefðu, forritið \"%s\" hætti óvænt"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Vandamál í %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -85,63 +80,68 @@ msgstr ""
 "Tölvan þín hefur ekki nóg laust innra minni til að greina sjálfkrafa "
 "vandamálið og senda til forritaranna."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Vandamál í %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Ógild vandamálsskýrsla"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "Þú hefur ekki leyfi til að skoða þessa skýrslu."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Villa"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "Það er ekki nóg diskpláss til að vinna úr skýrslunni."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "Ógilt PID"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "Enginn pakki valinn"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Þú þarft að tilgreina pakka eða PID. Sjá --help fyrir meiri upplýsingar."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Aðgangur bannaður"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -149,30 +149,30 @@ msgstr ""
 "Tiltekið ferli tilheyrir þér ekki. Keyrðu þetta forrit sem eigandi ferlisins "
 "eða sem kerfisstjórnandi"
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "Þetta ID tilheyrir ekki neinu forriti."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Pakki %s er ekki til"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "Get ekki gert skýrslu"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "Uppfæri villuskýrslu"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -184,7 +184,7 @@ msgstr ""
 "\n"
 "Búðu til nýja skýrslu með ‚apport-bug‘."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -204,24 +204,24 @@ msgstr ""
 "\n"
 "Ertu alveg viss þú viljir halda áfram?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "Engum aukaupplýsingum er safnað"
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "Hvers konar forrit viltu senda skýrslu um?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Óþekkt einkenni"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Einkennið „%s“ er ekki þekkt."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -232,7 +232,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -240,119 +240,119 @@ msgstr ""
 "Eftir lokun þessa skilaboða, smelltu á forritsglugga til að skrá villu um "
 "hann."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "Tilgreindu pakkaheiti."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "Gefna PID-ið er forrit sem hangir."
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Gefa Apport útgáfunúmerið."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr ""
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr "Þessi vandamálaskýrsla á við forrit sem er ekki uppsett lengur."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
@@ -360,78 +360,80 @@ msgid ""
 msgstr ""
 "Vandamálið kom fyrir í forritunu %s sem er breytt síðan síðasta hrun varð."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Skýrslan er löskuð og ég get ekki unnið úr henni"
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr ""
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "Villa kom upp þegar reynt var að vinna þessa villuskýrslu:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "Gat ekki ákveðið nafn pakka eða grunnpakka"
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "Gat ekki ræst vefvafra"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Gat ekki ræst vefvafra til að opna %s"
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Vandamál með nettengingu"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr "Get ekki tengst við gagnagrunn, athugaðu nettenginguna."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Vandamál með nettengingu"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Minnisvandamál"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Kerfið þitt hefur ekki nóg vinnsluminni til að vinna úr þessari skýrslu."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -442,11 +444,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "Vandamál þegar þekkt"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -456,39 +458,38 @@ msgstr ""
 "vefvafranum. Athugaðu hvort þú getur bætt við einhverjum gagnlegum "
 "upplýsingum."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 "Þetta vandamál hefur nú þegar verið tilkynnt til þróunarteymis. Takk fyrir!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Ýttu á einhvern lykil til að halda áfram..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "Hvað viltu gera? Þú getur:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Veldu (%s);"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i bæti)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(gögn í tvíundakerfi)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Senda vandamálsskýrslu til forritara?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -497,50 +498,50 @@ msgstr ""
 "formi.\n"
 "Vinsamlegast fylltu það út."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "&Senda skýrslu (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "Skoða &hér"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "&Lesa skýrslu"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr "&Geyma skýrslu til að senda inn seinna eða til að færa á annan stað"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "Hætta við og h&unsa frekari hrun í þessari útgáfu forritsins"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Hætta við"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Skrá með upplýsingar um vandamál:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&Staðfesta"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Villa: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "Safna saman upplýsingum um vandamál"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -548,11 +549,11 @@ msgstr ""
 "Þú getur sent inn skýrslu með þessum upplýsingum til að bæta forritið.\n"
 "Þetta getur tekið nokkra stund."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "Sendi vandamálsskýrslu"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -560,55 +561,55 @@ msgstr ""
 "Verið er að senda upplýsingar sem safnað hefur verið í villukerfi.\n"
 "Það getur tekið nokkrar mínútur."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Lokið"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "ekkert"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "Valið: %s. Margir valkostir:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Valkostir:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "Slóð skráar (Enter til að hætta við):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "Skrá er ekki til."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "Þetta er mappa."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "Þú verður að heimsækja eftirfarandi slóð til að halda áfram:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
 msgstr ""
 "Þú getur ræst vafra núna eða afritað þessa slóð í vafra á annari tölvu."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Ræsa netvafra"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 
@@ -623,27 +624,27 @@ msgid ""
 "Write modified report to given file instead of changing the original report"
 msgstr ""
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr ""
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr ""
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr ""
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr ""
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -653,78 +654,78 @@ msgid ""
 "be able to retrace crashes that happened on the currently running release."
 msgstr ""
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
 "have installed."
 msgstr ""
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr ""
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
 msgstr ""
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
 "neither -g, -o, nor -s are specified)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
 msgstr ""
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr ""
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "Þú getur ekki notað -C án -S. Hætti."
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "Er allt í lagi að senda þetta sem sem viðhengi? [y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -732,19 +733,19 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "Sjá nánar á man-síðu."
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
@@ -752,7 +753,7 @@ msgstr ""
 "endurnýta sandkassamöppu (SDIR) sem þegar hefur verið búin til eða, ef hún "
 "er ekki til, búa hana til"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -760,7 +761,7 @@ msgstr ""
 "ekki búa til né endurnýta sandkassamöppu fyrir auka aflúsunarmerki heldur "
 "aðeins treysta á uppsett aflúsunarmerki."
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
@@ -768,41 +769,41 @@ msgstr ""
 "endurnýta skyndiminnismöppu (CDIR) sem þegar hefur verið búin til eða, ef "
 "hún er ekki til, búa hana til"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Villa: %s er ekki keyranlegt forrit. Hætti."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
 msgstr ""
 "Endurvakningin hékk í blá endann en lítur út fyrir að hafa klárast eðlilega."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 "Kerfið þitt verður kannski óstöðugt núna og þarf hugsanlega að endurræsa það."
@@ -817,76 +818,76 @@ msgstr "Tilkynna vandamál..."
 msgid "Report a malfunction to the developers"
 msgstr "Tilkynna bilun til forritara"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "Því miður, forritið %s hætti óvænt."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "Því miður, forritið %s lokaði óvænt."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "Því miður, %s hefur lent í innri villu."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Senda"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Sýna ítarlegri upplýsingar"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Halda áfram"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "Forritið %s hætti að svara."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "Forritið %s hætti að svara."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Pakki: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "Því miður, vandamál kom upp við upppsetningu hugbúnaðar."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "Forritið %s lenti í innri villu."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "Forritið %s lokaði óvænt."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr "Ef þú verður var við fleiri vandamál, reyndu þá að endurræsa tölvuna."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "Hunsa svona vandamál héðan í frá"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Fela nánari upplýsingar"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -942,7 +943,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>Sendi vandamálsskýrslu</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -953,27 +954,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Apport villuskrá"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "Skilja eftir lokað"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Keyra aftur upp"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Notandanafn:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Lykilorð:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "Safna saman upplýsingum um vandamál"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -981,6 +982,6 @@ msgstr ""
 "Söfnuðum upplýsingum er hægt að koma til forritaranna til að bæta forritið. "
 "Þetta gæti tekið nokkrar mínútur."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "Sendi upplýsingar um vandamálið"

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2015-04-27 21:47+0000\n"
 "Last-Translator: Gianfranco Frisani <gfrisani@libero.it>\n"
 "Language-Team: Italian <it@li.org>\n"
@@ -40,11 +40,11 @@ msgstr ""
 "Inserire la propria password per accedere alle segnalazioni d'errore di "
 "programmi di sistema"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "Questo pacchetto non sembra installato correttamente"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -55,7 +55,7 @@ msgstr ""
 "aggiornato gli indici dei pacchetti disponibili, se non funziona rimuovere i "
 "relativi pacchetti di terze parti e riprovare."
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -69,21 +69,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "programma sconosciuto"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Chiusura inattesa del programma «%s»"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Problema in %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -91,66 +86,71 @@ msgstr ""
 "Nel computer non è presente abbastanza memoria libera per analizzare "
 "automaticamente il problema e inviare una segnalazione agli sviluppatori."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Problema in %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Segnalazione di problema non valida"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "Accesso non consentito alla segnalazione riguardo questo problema."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Errore"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 "Non c'è spazio sufficiente sul disco per elaborare questa segnalazione."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr "Nessun PID specificato"
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 "È necessario specificare un PID. Per maggiori informazioni consultare --help."
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "PID non valido"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr "L'ID di processo specificato non esiste."
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr "Non è un PID dell'utente attuale"
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr "L'ID di processo specificato non appartiene all'utente attuale."
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "Nessun pacchetto specificato"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "È necessario specificare un pacchetto o un PID. Per maggiori informazioni "
 "consultare --help."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Permesso negato"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -158,32 +158,32 @@ msgstr ""
 "Il processo specificato non appartiene all'utente corrente. Eseguire questo "
 "programma come il proprietario del processo o come root."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "L'identificatore di processo specificato non appartiene al programma"
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 "Lo script per l'analisi delle anomalie %s  non ha rilevato alcun pacchetto "
 "alterato"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Il pacchetto %s non esiste"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "Impossibile creare la segnalazione"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "Aggiornamento segnalazione del problema"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -195,7 +195,7 @@ msgstr ""
 "\n"
 "Creare una nuova segnalazione utilizzando «apport-bug»."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -215,24 +215,24 @@ msgstr ""
 "\n"
 "Procedere?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "Non è stata raccolta alcuna informazione aggiuntiva."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "Che tipo di problema segnalare?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Anomalia sconosciuta"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "L'anomalia «%s» è sconosciuta."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -251,7 +251,7 @@ msgstr ""
 "Monitor. Nella scheda Processi, scorri fino a trovare l'applicazione "
 "corretta. L'ID processo è il numero elencato nella colonna ID."
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -259,27 +259,27 @@ msgstr ""
 "Dopo aver chiuso questo messaggio, fare clic sulla finestra di "
 "un'applicazione per segnalarne un problema."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 "Recupero dell'identificativo del processo della finestra da parte di xprop "
 "non riuscito"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr "%(prog)s <numero rapporto>"
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "Specificare il nome del pacchetto."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Aggiunge un'etichetta alla segnalazione, può essere specificata più volte"
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
@@ -287,7 +287,7 @@ msgstr ""
 "%(prog)s [opzioni] [sintomo|pid|pacchetto|percorso programma|.apport/.crash "
 "file]"
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -297,16 +297,16 @@ msgstr ""
 "pid  oppure solo --pid: se non è indicato alcuno dei due, sarà visualizzato "
 "un elenco di anomalie (implicito se è indicato un singolo argomento)."
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "Fare clic su una finestra per completare i campi della segnalazione."
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "Avvia in modalità aggiornamento bug: è possibile usare l'opzione --package"
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -314,7 +314,7 @@ msgstr ""
 "Invia una segnalazione di bug riguardo un'anomalia (implicito se è indicato "
 "il nome di un'anomalia come unico argomento)."
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -323,7 +323,7 @@ msgstr ""
 "stato specificato (implicito se il nome del pacchetto è indicato come unico "
 "argomento)."
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -333,11 +333,11 @@ msgstr ""
 "specificato, la segnalazione conterrà maggiori informazioni (implicito se il "
 "PID è passato come argomento)"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "Il PID fornito è un'applicazione in attesa."
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -346,7 +346,7 @@ msgstr ""
 "Segnala il crash da un file .apport o .crash fornito, piuttosto che da "
 "quelli in attesa in %s (implicito se file è indicato come unico argomento)."
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -356,49 +356,49 @@ msgstr ""
 "invece di inviare la segnalazione; il file può poi essere inviato "
 "successivamente da un computer differente"
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Mostra il numero di versione del programma."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Questo eseguirà apport-retrace in una finestra di terminale per esaminare il "
 "crash."
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "Esegui una sessione gdb"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Esegui una sessione gdb senza scaricare i simboli di debug"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Aggiornare %s con uno stack trace completamente simbolico"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr "Impostazioni di invio rapporto non trovate o non memorizzate"
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 "Salvataggio del rapporto sul crash non riuscito. Impossibile impostare la "
 "modalità di segnalazione."
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr "Impostazioni di invio rapporto non trovate o non memorizzate"
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 "La segnalazione del problema riguarda un programma che non è più installato."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
@@ -407,21 +407,23 @@ msgstr ""
 "Il problema si è verificato con il programma «%s», che risulta essere stato "
 "modificato rispetto al momento in cui si è verificato il crash."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr ""
 "Questa segnalazione di problema è danneggiata e non può essere elaborata."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr "Questa segnalazione riguarda un pacchetto che non è installato."
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr ""
 "Si è verificato un errore nel tentativo di elaborare questa segnalazione:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
@@ -429,24 +431,24 @@ msgstr ""
 "Hai due versioni di questa applicazione installate, quale vuoi segnalare un "
 "bug?"
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr "snap %s"
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr "pacchetto deb %s"
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s è fornito da uno snap pubblicato da %s. Contattali tramite %s per "
 "assistenza."
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -456,42 +458,42 @@ msgstr ""
 "indirizzo di contatto; visita il forum all'indirizzo https://forum.snapcraft."
 "io/ per assistenza."
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr ""
 "Impossibile determinare il nome del pacchetto o del pacchetto sorgente."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "Impossibile avviare il browser web"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Impossibile avviare il browser web per aprire %s."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Problema di rete"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Impossibile connettersi al database dei crash, controllare la connessione "
 "Internet."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Problema di rete"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Memoria esaurita"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Il sistema non ha abbastanza memoria per elaborare questa segnalazione di "
 "crash."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -502,11 +504,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "Problema già noto"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -516,38 +518,37 @@ msgstr ""
 "mostrato nel browser web. Verificare se è possibile aggiungere ulteriori "
 "informazioni che potrebbero essere utili agli sviluppatori."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Il problema è già stato segnalato agli sviluppatori. Grazie."
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Premere un tasto per continuare..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "Cosa fare? Le opzioni sono:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Scegliere (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i byte)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(dati binari)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Inviare la segnalazione del problema agli sviluppatori?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -556,52 +557,52 @@ msgstr ""
 "finestra\n"
 "del browser web che si aprirà automaticamente."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "&Invia segnalazione (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "&Esamina localmente"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "&Visualizza segnalazione"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 "&Tenere il file di segnalazione per un successivo invio o per copiarlo in "
 "un'altra posizione"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "&Annulla e ignora i futuri crash di questa versione del programma"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "A&nnulla"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "File segnalazione problema:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&Conferma"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Errore: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "Raccolta informazioni sul problema"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -610,11 +611,11 @@ msgstr ""
 "migliorare\n"
 "l'applicazione. Potrebbe impiegare alcuni minuti."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "Invio informazioni sul problema"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -623,40 +624,40 @@ msgstr ""
 "tracciamento dei bug.\n"
 "Potrebbe impiegare alcuni minuti."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Fatto"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "nessuno"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "Selezionato: %s. Scelte multiple:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Scelte:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "Percorso del file (Invio per annullare):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "Il file non esiste."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "Questa è una directory."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "Per continuare, è necessario visitare il seguente URL:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -664,17 +665,17 @@ msgstr ""
 "È possibile avviare il browser ora o copiare questo URL in un browser su un "
 "altro computer."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Lanciare un browser ora"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 "Nessuna segnalazione di crash pendente. Provare --help per maggiori "
 "informazioni."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 "Non inserisce i nuovi trace nella segnalazione, ma li scrive sullo stdout"
@@ -694,28 +695,28 @@ msgstr ""
 "Scrive la segnalazione modificata nel file indicato, invece di modificare la "
 "segnalazione originale"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 "Elimina il core dump dalla segnalazione dopo la generazione dello stack trace"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "Sovrascrive il CoreFile della segnalazione"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "Sovrascrive l'ExecutablePath della segnalazione"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "Sovrascrive la ProcMap della segnalazione"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "Rigenera le informazioni sul Package della segnalazione"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -732,7 +733,7 @@ msgstr ""
 "possibile eseguire il retrace dei crash avvenuti all'interno della release "
 "attualmente in esecuzione."
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
@@ -741,27 +742,27 @@ msgstr ""
 "Creare un'altra sandbox temporanea per installare la versione di gdb del "
 "rapporto al posto di quella di sistema."
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 "Segnala avanzamento di scaricamento/installazione durante l'installazione di "
 "pacchetti nella sandbox"
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr "Anteporre gli orari ai messaggi di log nelle operazioni batch"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 "Crea e usa repository di terze parti dalle sorgenti specificate nei rapporti"
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr "Directory cache per i pacchetti scaricati nella sandbox"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -769,14 +770,14 @@ msgstr ""
 "Directory per i pacchetti estratti; una successiva esecuzione assumerà che i "
 "pacchetti già scaricati siano stati estratti in questa sandbox."
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 "Installa un pacchetto extra nella sandbox (può essere specificato molteplici "
 "volte)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -787,7 +788,7 @@ msgstr ""
 "trace a cui è stato eseguito un retrace (solo se non è specificato alcuno di "
 "-g, -o e -s)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -795,32 +796,32 @@ msgstr ""
 "Visualizza gli stack trace a cui è stato eseguito un retrace e chiede "
 "conferma prima di inviarli al database dei crash."
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 "Percorso al duplicato del database sqlite (predefinito: nessun controllo sul "
 "duplicato)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr "Non aggiunge StacktraceSource alla segnalazione"
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "Impossibile usare -C senza -S. Arresto."
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "OK per inviare questi come allegati? [y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr "%(prog)s <report> <directory di destinazione>"
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr "Segnala il file da decomprimere"
 
@@ -828,19 +829,19 @@ msgstr "Segnala il file da decomprimere"
 msgid "directory to unpack report to"
 msgstr "directory in cui decomprimere il rapporto"
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "La directory di destinazione esiste e non è vuota."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "Consultare la pagina man per maggiori dettagli."
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "Specifica il nome del file di registro creato da valgrind"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
@@ -848,7 +849,7 @@ msgstr ""
 "Riutilizza una directory di sandbox (SDIR) creata precedentemente o, se non "
 "esiste, la crea"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -856,7 +857,7 @@ msgstr ""
 "Non crea o riutilizzare la directory di sandbox per i simboli di debug "
 "aggiuntivi , ma utilizza solo quelli installati nel sistema"
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
@@ -864,13 +865,13 @@ msgstr ""
 "Riutilizza una directory di cache (CDIR) creata precedentemente o, se non "
 "esiste, la crea"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 "Indica l'avanzamento di scaricamento/installazione quando installa pacchetti "
 "nella sandbox"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
@@ -878,12 +879,12 @@ msgstr ""
 "l'eseguibile che viene eseguito con lo strumento memcheck di valgrind per il "
 "rilevamento della perdita di memoria"
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Errore: %s non è eseguibile. Arresto."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -891,7 +892,7 @@ msgstr ""
 "Ciò si è verificato durante una precedente sospensione che non ha consentito "
 "il corretto ripristino del sistema."
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -899,7 +900,7 @@ msgstr ""
 "Ciò si è verificato durante una precedente ibernazione che non ha consentito "
 "il corretto ripristino del sistema."
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -907,7 +908,7 @@ msgstr ""
 "Il processo di ripristino si è bloccato verso il termine e sarebbe apparso "
 "come completato normalmente."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 "Il sistema potrebbe diventare instabile e potrebbe essere necessario "
@@ -923,76 +924,76 @@ msgstr "Segnala un problema..."
 msgid "Report a malfunction to the developers"
 msgstr "Segnala un malfunzionamento agli sviluppatori"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "L'applicazione %s si è chiusa inaspettatamente."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "«%s» si è chiuso inaspettatamente."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "«%s» ha riscontrato un errore interno."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Invia"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Mostra dettagli"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Continua"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "L'applicazione %s non risponde più."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "L'applicazione «%s» non risponde più."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Pacchetto: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "Si è verificato un problema durante l'installazione del software."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "L'applicazione %s ha riportato un errore interno."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "L'applicazione «%s» si è chiusa inaspettatamente."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr "Se vengono riscontrati ulteriori problemi, riavviare il computer."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "Ignorare futuri problemi di questo tipo"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Nascondi dettagli"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -1048,7 +1049,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>Invio informazioni sul problema</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -1060,27 +1061,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "File crash di Apport"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "Lascia chiuso"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Rilancia"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Nome utente:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Password:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "Raccolta informazioni sul problema"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1088,6 +1089,6 @@ msgstr ""
 "Le informazioni raccolte possono essere inviate agli sviluppatori per "
 "migliorare l'applicazione. Potrebbe richiedere alcuni minuti."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "Invio informazioni sul problema"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2021-10-19 10:21+0000\n"
 "Last-Translator: id:sicklylife <Unknown>\n"
 "Language-Team: Japanese <ja@li.org>\n"
@@ -38,11 +38,11 @@ msgstr ""
 "システムプログラムの問題レポートにアクセスするにはパスワードを入力してくださ"
 "い"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "このパッケージは恐らく正常にインストールされていません"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -53,7 +53,7 @@ msgstr ""
 "デックスを更新してから再度試してみてください。問題が解決しない場合、関連する"
 "サードパーティーのパッケージの削除も試してみてください。"
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -66,21 +66,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "不明なプログラム"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "残念ながら、プログラム \"%s\" が予期せず終了しました"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "%s に問題があります"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -88,65 +83,70 @@ msgstr ""
 "コンピューターに、問題を自動的に解析して開発者にレポートを送るための十分な空"
 "きメモリーがありません。"
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "%s に問題があります"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "無効な問題のレポートです"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "この問題を報告するための権限がありません。"
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "エラー"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "このレポートを作成するための空きスペースがディスクにありません。"
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr "PIDが指定されていません"
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 "PIDを指定する必要があります。詳細については --help の出力を確認してください。"
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "無効なプロセスID"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr "指定されたプロセスIDは存在しません。"
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr "プロセスIDの所有者ではありません"
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr "あなたは指定されたプロセスIDの所有者ではありません。"
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "パッケージが指定されていません"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "パッケージまたはプロセスIDを指定する必要があります。詳細については --help の"
 "出力を確認してください。"
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "許可がありません"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -154,30 +154,30 @@ msgstr ""
 "このプロセスを操作する権限がありません。プロセスの所有者もしくはrootユーザー"
 "として実行してください。"
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "指定されたプロセスIDはプログラムに属していません。"
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Symptomスクリプト %s は、影響を受けたパッケージを特定していません"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "パッケージ %s は存在しません"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "レポートを作成できません"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "問題点のレポートを更新中"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -189,7 +189,7 @@ msgstr ""
 "\n"
 "\"apport-bug\"を使って新規にレポートを作成してください。"
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -209,24 +209,24 @@ msgstr ""
 "\n"
 "本当に進めますか?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "収集する追加情報はありません。"
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "どのような種類の問題を報告しますか？"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "未知の現象"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "現象 \"%s\" は知られていません。"
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -237,7 +237,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -245,30 +245,30 @@ msgstr ""
 "このメッセージを閉じた後でアプリケーションウィンドウ上でクリックして、その問"
 "題について報告してください。"
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "xpropはウィンドウのプロセスIDを特定できませんでした"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "パッケージ名を指定"
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "レポートに追加タグを追加します。複数回指定できます。"
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -279,16 +279,16 @@ msgstr ""
 "ないときには、既知の現象のリストを表示します（暗黙の一つの引数が与えられた場"
 "合）。"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 "問題レポートを埋めるには、ターゲットとなるウィンドウをクリックしてください。"
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "バグ更新モードを開始します。オプション --package が使用できます。"
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -296,7 +296,7 @@ msgstr ""
 "SYMPTOM（症状）についてのバグを報告します（唯一の引数は症状の名前を意味しま"
 "す）。"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -304,7 +304,7 @@ msgstr ""
 "--file-bug モードで使用するパッケージ名を指定します。--pid が指定されている場"
 "合はオプション扱いになります（唯一の引数はパッケージ名を意味します）。"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -314,11 +314,11 @@ msgstr ""
 "指定した場合、バグ報告にはより多くの情報が含まれます（唯一の引数はプロセスID"
 "を意味します）。"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "指定されたpidはハングアップしたアプリケーションのものです。"
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -327,7 +327,7 @@ msgstr ""
 "クラッシュの報告を %s で保留中のプログラムのかわりに .apport または .crash "
 "ファイルで行う（ファイル名が引数のみで与えられた場合）。"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -336,47 +336,47 @@ msgstr ""
 "バグファイリングモードでは、収集した情報は報告する代わりにファイルに保存され"
 "ます。このファイルは、後で別のコンピューターから報告することができます。"
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Apportのバージョン番号を表示します。"
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr "クラッシュの解析を行うため端末ウィンドウでapport-retraceを起動します。"
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "gdbセッションを実行"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "デバッグシンボルをダウンロードせずgdbセッションを実行"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "%s を完全なシンボリックスタックトレースに更新する"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr "レポートの送信のステータス設定を記憶できません"
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 "クラッシュレポートの状態の保存に失敗しました。報告モードを「自動」または「し"
 "ない」に設定できません。"
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr "レポートの送信のステータス設定を記憶できません"
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 "この問題レポートは、もうインストールされていないプログラムに対するものです。"
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
@@ -385,19 +385,21 @@ msgstr ""
 "この問題はプログラム %s に発生したものですが、このプログラムはクラッシュして"
 "から変更されています。"
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "この問題の報告は破損しており、処理することができません。"
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr "このレポートは、インストールされていないパッケージに対するものです。"
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "この問題の報告の処理中にエラーが発生しました:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
@@ -405,24 +407,24 @@ msgstr ""
 "このアプリケーションは2種類のバージョンがインストールされています。どちらのバ"
 "グを報告しますか？"
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr "snapの %s"
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr "debパッケージの %s"
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s は %s が公開しているsnapです。バグ報告や質問については %s に連絡してくださ"
 "い。"
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -431,41 +433,41 @@ msgstr ""
 "%s は %s が公開しているsnapです。連絡先のアドレスは提供されていないため、バグ"
 "報告や質問については https://forum.snapcraft.io/ にアクセスしてください。"
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "パッケージまたはソースパッケージ名を特定できませんでした。"
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "ウェブブラウザーを起動できません"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "%s を開くためのウェブブラウザーを起動できません"
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "ネットワークの問題"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "クラッシュデータベースに接続できませんでした。インターネット接続を確認してく"
 "ださい。"
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "ネットワークの問題"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "メモリー不足"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "コンピューターには、このクラッシュレポートを処理するのに十分なメモリーがあり"
 "ません。"
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -476,11 +478,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "問題は既知のものです"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -489,38 +491,37 @@ msgstr ""
 "この問題は、ブラウザーに表示されたバグレポートですでに報告されています。開発"
 "者にとって役立つような、より詳しい情報を追加できるかどうか確認してください。"
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "この問題はすでに開発者に報告されています。ありがとうございます！"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "続けるには何かキーを押してください..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "対処方法を選択してください:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "選択してください (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i バイト)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(バイナリデータ)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "問題のレポートを開発者に送信しますか？"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -528,51 +529,51 @@ msgstr ""
 "問題のレポートが送信された後で、フォームに入力してください（入力用ページを"
 "ウェブブラウザーで自動的に開きます）。"
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "レポートの送信(&S) (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "ローカルで解析する(&E)"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "レポートの表示(&V)"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 "後で送信もしくは他の場所にコピーするためにレポートファイルを保持する(&K)"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "中止し、このプログラムバージョンでは今後クラッシュしても無視する(&I)"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "キャンセル(&C)"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "問題報告ファイル:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "確認(&C)"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "エラー: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "問題の情報を集めています"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -580,11 +581,11 @@ msgstr ""
 "収集された情報はアプリケーションを改善するために開発者へ送られます。\n"
 "しばらくお待ちください。"
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "問題の情報をアップロードしています"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -592,40 +593,40 @@ msgstr ""
 "収集された情報はバグトラッキングシステムに送信されます。\n"
 "しばらくお待ちください。"
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "完了(&D)"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "なし"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "現在の設定: %s。複数選択:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "選択肢:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "ファイルへのパス (Enterでキャンセル):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "ファイルが存在しません。"
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "これはディレクトリです。"
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "続行するには、以下のURLを開いてください:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -633,17 +634,17 @@ msgstr ""
 "ブラウザーを今すぐ起動するか、または他のコンピューターのブラウザーにURLをコ"
 "ピーしてください。"
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "今すぐブラウザーを起動する"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 "未解決のクラッシュレポートはありません。詳しくは --help を試してみてくださ"
 "い。"
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 "これ以上レポートに新しいトレースを書き込みませんが、標準出力には表示します。"
@@ -663,27 +664,27 @@ msgstr ""
 "オリジナルのレポートを変更せずに、指定されたファイルに変更後のレポートを書き"
 "込みます"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr "スタックトレースを再生成した後にコアダンプをレポートから取り除きます"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "レポートのコアファイルを上書きします"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "レポートの ExecutablePath を上書きします"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "レポートの ProcMaps を上書きします"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "レポートに含まれるパッケージ情報を再生成します"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -700,7 +701,7 @@ msgstr ""
 "ファイルを利用しますが、その場合には現在実行中のリリースで発生したクラッシュ"
 "しかリトレースできません。"
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
@@ -710,29 +711,29 @@ msgstr ""
 "トールされているgdbのバージョンとは関係なく、レポートにあるのと同じリリースを"
 "利用します"
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 "サンドボックスにパッケージをインストールする際に、ダウンロードおよびインス"
 "トールの進捗状況を表示します"
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr "ログメッセージの先頭にタイムスタンプを挿入します（バッチ処理用）"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 "レポートで指定された提供元から、サードパーティーのリポジトリを作成して使用し"
 "ます。"
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr ""
 "サンドボックスにダウンロードされたパッケージのためのキャッシュディレクトリ"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -740,12 +741,12 @@ msgstr ""
 "展開したパッケージのためのディレクトリ。これ以降はダウンロード済みのパッケー"
 "ジはすべてこのサンドボックスに展開されているものと仮定します。"
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr "サンドボックスに追加のパッケージをインストールします（複数回指定可）"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -755,7 +756,7 @@ msgstr ""
 "クトレースをアップロードする際にクラッシュIDを指定するために使われます（-g, -"
 "o, または -s が指定されていない場合）。"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -763,30 +764,30 @@ msgstr ""
 "スタックトレースのリトレースを表示し、クラッシュデータベースに送る前に確認し"
 "ます。"
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr "sqliteデータベースの複製へのパス（デフォルトは複製のチェックをしない）"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr "レポートにスタックトレースソースを追加しないでください。"
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "-S を指定せずに -C を使用することはできません。中止します。"
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "これらを添付ファイルとして送ってよろしいですか？ [y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -794,19 +795,19 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "目的のディレクトリは存在しますが、空ではありません。"
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "詳細はmanページをご覧ください。"
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "valgrindによって生成されたログファイルの名前を指定"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
@@ -814,7 +815,7 @@ msgstr ""
 "以前作成されたサンドボックスディレクトリ (SDIR) を再利用するか、もし存在しな"
 "い場合には作成する"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -822,7 +823,7 @@ msgstr ""
 "追加のデバッグシンボル用にサンドボックスディレクトリを作成または再利用せず、"
 "インストールされたデバッグシンボルのみを利用する。"
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
@@ -830,24 +831,24 @@ msgstr ""
 "以前作成されたキャッシュディレクトリ (CDIR) を再利用するか、もし存在しない場"
 "合には作成する"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 "サンドボックス内にパッケージをインストールする際、ダウンロードおよびインス"
 "トールの進捗状況を報告する"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "エラー: %s は実行ファイルではありません。中止します。"
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -855,7 +856,7 @@ msgstr ""
 "このことは前のサスペンド中に発生しており、システムが正常に復帰できませんでし"
 "た。"
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -863,7 +864,7 @@ msgstr ""
 "このことは前のハイバネーション中に発生しており、システムが正常に復帰できませ"
 "んでした。"
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -871,7 +872,7 @@ msgstr ""
 "リジューム処理が終わる寸前でハングしましたが、通常通り完了していると思われま"
 "す。"
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 "システムが不安定になる可能性があるので、再起動する必要があるかもしれません。"
@@ -886,76 +887,76 @@ msgstr "問題を報告する..."
 msgid "Report a malfunction to the developers"
 msgstr "開発者に異常動作を報告してください"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "残念ながら、アプリケーション %s が予期せず停止しました。"
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "残念ながら、%s が予期せず終了しました。"
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "残念ながら、%s で内部エラーが発生しました。"
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "送信"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "詳細を表示"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "続行"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "アプリケーション %s は応答していません。"
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "プログラム \"%s\" は応答していません。"
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "パッケージ: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "残念ながら、ソフトウェアのインストール中に問題が発生しました。"
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "アプリケーション %s で内部エラーが発生しました。"
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "アプリケーション %s が予期せず終了しました。"
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr "さらに問題が発生する場合は、コンピューターを再起動してみてください。"
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "今後、この種類の問題は無視する"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "詳細を隠す"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -1011,7 +1012,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>問題の情報をアップロードしています</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -1023,27 +1024,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "クラッシュファイルを Apport する"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "閉じて終了する"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "再起動する"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "ユーザー名:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "パスワード:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "問題の情報を集めています"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1051,6 +1052,6 @@ msgstr ""
 "収集された情報はアプリケーションを改善するために開発者へ送られます。しばらく"
 "お待ちください。"
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "問題の情報をアップロードしています"

--- a/po/kab.po
+++ b/po/kab.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2011-10-07 06:10+0000\n"
 "Last-Translator: yugurten <yugurten1@hotmail.fr>\n"
 "Language-Team: Kabyle <kab@li.org>\n"
@@ -40,11 +40,11 @@ msgstr ""
 "Ttxil sekcem awal-ik uffir akken ad tkecmeḍ ɣer yineqqisen n wuguren n "
 "wahilen n unagraw"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "Akemmus ur d-ittban ara yettwasbedd akken ilaq"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -52,7 +52,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -65,21 +65,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "ahil arussin"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Suref-aɣ, ahil \"%s\" yemdel akka kan"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Agnu deg %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -87,62 +82,67 @@ msgstr ""
 "Aselkim-inek m ur yesɛi ara ddeqs n tkatut tilellit akken ad yesleḍ ugur s "
 "wudem awurman yerna ad yazen aneqqis i yisneflayen."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Agnu deg %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Aneqqis n wuguren mačči d ameɣtu"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "Ur tesɛiḍ ara tasiregt ad tkecmeḍ ɣer uneqqis-a n wuguren."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Tuccḍa"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "Ulac ddeqs n tallunt n uḍebsi iwejden akken ad yekker uneqqis-agi."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr "Ulac PID i d-ittunefken"
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr "Teḥwaǧeḍ ad d-tefkeḍ PID. Ẓer --help i wugar n telɣut."
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "PID mačči d ameɣtu"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr "ID i d-ittunefken ur yelli ara."
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr "Mačči PID inek m"
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr "ID n ukala i d-ittunefken mačči d ayla-k m."
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "Ulac akemmus i d-ittunefken"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr "Teḥwaǧed ad d-tefkeḍ akemmus neɣ ID. Ẓer --help i wugar n telɣut."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Tasiregt ur tettwaqbel ara"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -150,30 +150,30 @@ msgstr ""
 "Akala i d-ittnefken mačči d ayla-k. Ttxil-k m selkem ahil-agi am bab n ukala "
 "neɣ am root."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "ID n ukala i d-ittunefken mačči d ayla n wahil."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Akemmus %s ur yelli ara"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "Timerniwt n uneqqis d tawezɣit"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "Aleqqem n uneqqis n wuguren"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -181,7 +181,7 @@ msgid ""
 "Please create a new report using \"apport-bug\"."
 msgstr ""
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -193,24 +193,24 @@ msgid ""
 "Do you really want to proceed?"
 msgstr ""
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "Ulac tilɣa-nniḍen i d-yettwaleqḍen."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "Anwa anaw n wuguren i tebɣiḍ ad temleḍ?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Ccira ur nettwassen ara"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Ccira-nni %s\" ur tettwassen ara."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -221,7 +221,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -229,140 +229,142 @@ msgstr ""
 "Mi tmedleḍ izen-agi ttxil-k m ssit ɣef usfaylu n usnas akken ad tazneḍ "
 "aneqis fell-as."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop igguma ad d-yaf ID n ukala n usfaylu"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "Sbadu isem n ukemmus."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "Rnu ticreḍt-nniḍen i weneqqis. Tezmer ad d-ttunefk aṭas n tikkal."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "Ssit ɣef usfaylu amzun d anican aken ad yaččar uneqqis n wugur."
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Siggez uḍḍun n lqem n uneqqis."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Ayagi ad iskker apport-retrace deg usfaylu n tdiwent akken ad isekyed "
 "aɣelluy."
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "Senker tiɣimit gdb"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Selkem tiɣimit gdb war asader n yizamulen n useɣti"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr "Ur necfi ara nuzen iɣewwaṛen n waddad n uneqqis"
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr "Ur necfi ara nuzen iɣewwaṛen n waddad n uneqqis"
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr "Aneqqis-agi n wugur yeɛna ahil ur nettwasbedd ara."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 msgstr "Ugur yeḍra-d akked wahil %s i yebeddelen segmi d-yeḍra uɣelluy."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Aneqqis-agi n wugur yerreẓ yerna ulamek ara yettusekker."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr "Aneqqis-a ɣef ukemmus ur nettwasbedd ara."
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "Teḍra-d tuccḍa mi neɛreḍ ad nsekker aneqqis-agi n wugur:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
@@ -370,63 +372,63 @@ msgstr ""
 "Tesɛiḍ sin n yileqman i snas-a yettwasbedden, anwa i tebɣiḍ ad temleḍ abug "
 "fell-as?"
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr "snap %s"
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr "Akemmus deb %s"
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "Ulamek tifin n ukemmus neɣ aɣbalu n yisem n ukemmus."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "Ulamek asekker n yiminig n web"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Ulamek asekker n yiminig n web akken ad yeldi %s."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Ugur n uẓeṭṭa"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Ulamek tuqqna ɣer uzadur n yisefka n yiɣelluyen, ttxil-k m elken tuqqna "
 "internet inek m."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Ugur n uẓeṭṭa"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr ""
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Anagraw-inek m ur yesɛi ara ddeqs n tkatut akken ad isekker aneqqis-agi n "
 "uɣelluy."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -437,49 +439,48 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "Ugur yetwassen yakan"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 msgstr ""
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Ugur-a dayen yettwamla i yineflayen. Tanemmirt!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Sit ɣef tsarut tebɣiḍ akken ad tkemmleḍ..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "D acu i tebɣiḍ ad tgeḍ? Tesɛiḍ ad tferneḍ gar:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Ttxil fren (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i n yibiten)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(isefka imisinen)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Tuzzna n uneqqis n wuguren i yineflayen?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -487,52 +488,52 @@ msgstr ""
 "Mi yettwazen uneqqis n wuguren, ttxil ččar tiferkit deg\n"
 "iminig web yeldin s wudem awurman."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "&Azen aneqqis (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "&Sekyed dinna kan"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "&Sken aneqqis"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 "&Eǧǧ afaylu n uneqqis akken ad t-tazneḍ ticki neɣ ad t-tneɣleḍ deg wanda-"
 "nniḍen"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "Sefsex tanfeḍ i yiɣelluyen i d-itteddun n lqem n wahil-a"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Sefsex"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Afaylu n uneqqis n wuguren:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "& Sentem"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Tuccḍa: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "Alqaḍ n telɣa ɣef wuguren"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -540,11 +541,11 @@ msgstr ""
 "Tilɣa yettwaleqḍen zemrent ad ttwasnent ɣer yineflayen i usnerni n\n"
 "usnas. Aya yezmer ad yeṭṭef kra n tesdatin."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "Asali n telɣa ɣef wuguren"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -552,40 +553,40 @@ msgstr ""
 "Tilɣa yettwaleqḍen ttwaznent ɣer unagraw n uḍfar n yibugen.\n"
 "Aya yezmer ad yeṭṭef kra n tesdatin."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Yemmug"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "ulac"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "Yettwafren: %s. Afran usgit:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Ifranen:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "Abrid ɣer ufaylu (Kcem akken ad tesfesxeḍ):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "Afaylu ur yelli ara."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "Wa d akaram."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "Akken ad tkemmleḍ, ilaq ad terzuḍ ɣer tansa-a URL:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -593,15 +594,15 @@ msgstr ""
 "Tzemreḍ ad tesnekreḍ iminig tura, neɣ nɣel tansa-a URL ɣer yiminig deg "
 "uselkim-nniḍen."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Senker iminig tura"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr "Ulac ineqqisen n uɣelluy yettrajun. Ɛreḍ --tallelt i wugar n telɣut."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 
@@ -618,27 +619,27 @@ msgstr ""
 "Aru aneqqis yettwabeddelen deg ufaylu d-ittunefken dag umḍiq n uneqqis n "
 "tazwara"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "Snifel CoreFile n uneqqis"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "Snifel ExecutablePath n uneqqis"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "Snifel ProcMaps n uneqqis"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr ""
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -648,31 +649,31 @@ msgid ""
 "be able to retrace crashes that happened on the currently running release."
 msgstr ""
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
 "have installed."
 msgstr ""
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr ""
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr "Akaram n tuffirt i yikemmusen i yettwasadren di sandbox"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -680,49 +681,49 @@ msgstr ""
 "Akaram n yikemmusen ittusfan. Iselkamen d-ittedun ad ḥesben yak akemmus "
 "yettusadren yakan yettwassef daɣen di sandbox agi."
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr "Sbedd akemmus nniḍen di sandbox (yezmer ad d-ittunefk aṭas n tikkal)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
 "neither -g, -o, nor -s are specified)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
 msgstr ""
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 "Abrid i wesisleg n uzadur n yisefka sqlite (lexṣas:ulac aselken n usisleg)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr "Ur rennu ara StacktraceSource ɣer uneqqis."
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "Ur tezmireḍ ara ad tesqedceḍ -C war -Z. Aneḥbus."
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "IH i tuzzna n wiyi am yimeddayen? [y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -730,71 +731,71 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "Akaram n taɣerwaḍt yella yerna mačči d ilem."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "Wali asebter n udlisfus i telqayt."
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 "mmel asfari n usader/asbeddi mi ara yetteddu usbeddi n yikemmusen di sandbox"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Tuccḍa: %s mačči d aselkam. Seḥbes."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
 msgstr ""
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr "Anagraw-ik izmer ur irekked ara tura, ilaq ahat ad yales tanekra."
 
@@ -808,76 +809,76 @@ msgstr "Mel ugur..."
 msgid "Report a malfunction to the developers"
 msgstr "Azen aneqqis ɣef yir tiddin i yisneflayen"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "Suref-aɣ, yela-d uḥbas ur netturaǧu ara n usnas %s."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "Suref-aɣ, yela-d uḥbas ur netturaǧu ara n %s."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "Surfaɣ, %s yemlal-e tuccḍa tagensant."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Azen"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Sken talqayt"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Kemmel"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "Asnas %s yeḥbes ur d-yettarra ara."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "Ahil \"%s\" yeḥbes ur d-yettarra ara."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Akemmus: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "Suref-aɣ, tella-d tuccḍa deg usebded n useɣẓan."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "Asnas %s yemmuger-d tuccḍa tagensant."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "Yella-d uneḥbus ur netturaǧu ara n wesnas %s."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr "Ma temmugreḍ-d uguren sya d asawen, ɛreḍ ad talseḍ asenker i uselkim."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "Anef i wuguren i d-itteddun n wanaw-a"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Ffer talqayt"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -933,7 +934,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>Asali n telɣut n wuguren</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -945,27 +946,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Afaylu n uɣelluy n Apport"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "Eǧǧ-it yemdel"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Ales asenker"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Isem n useqdac:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Awal uffir:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "Alqaḍ n telɣut ɣef wuguren"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -973,6 +974,6 @@ msgstr ""
 "Talɣut i d-yettwaleqḍen ad tettwazen i yisneflayen akken ad wenɛen asnas. "
 "Ayagi yezmer ad yeṭṭef kra n tsedadin."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "Asali n telɣut n wuguren"

--- a/po/kk.po
+++ b/po/kk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2011-04-13 06:20+0000\n"
 "Last-Translator: jmb_kz <Unknown>\n"
 "Language-Team: Kazakh <kk@li.org>\n"
@@ -36,11 +36,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr ""
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -61,21 +61,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "белгісіз бағдарлама"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Кешіріңіз, бірақ \"%s\" бағдарламасы апатты түрде жабылды"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Олқылық (неполадка) %s ішінде"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -84,64 +79,69 @@ msgstr ""
 "есепті жіберу, сіздің компьютеріңізде жады жеткіліксіз болғандықтан мүмкін "
 "емес."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Олқылық (неполадка) %s ішінде"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Қате туралы есеп бұрыс"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "Сізде қате есебіне рұқсатыңыз жоқ."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Қате"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "Осы есепті өңдеу үшін дискілік орын жетіспейді."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "Бұрыс PID"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "Пакет көрсетілмеген"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Пакетті немесе PID көрсетуіңіз қажет. Қосымша ақпарат алу үшін бағдарламаны "
 "--help кілтпенен ашыңыз."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Рұқсат жоқ"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -149,30 +149,30 @@ msgstr ""
 "Көрсетілген үрдіс басқа пайдаланушымен орындалуда. Осы бағдарламаны сол "
 "пайдаланушы атынан не әкімшілік құқықтармен ашыңыз."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "Көрсетілген PID басқа үрдіске меншіктелген."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "%s пакеті жоқ"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "Есепті құру мүмкін емес"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "Қате есебі жаңартылуда"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -180,7 +180,7 @@ msgid ""
 "Please create a new report using \"apport-bug\"."
 msgstr ""
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -192,24 +192,24 @@ msgid ""
 "Do you really want to proceed?"
 msgstr ""
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "Қосымша ақпарат жиналынбады."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "Сіз қандай қате туралы хабарлағыңыз келіп тұр?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Белгісіз белгілеулер (симптомдар)"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "\"%s\" белгілеуі (симптомы) белгісіз."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -220,203 +220,205 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr ""
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Apport нұсқасын баспаға шығару."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr ""
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr "Бұл есеп орнатылмаған бағдарламаға пакетке жатпайды."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Олқылық жайлы есеп бұзылған және де өңделу мүмкін емес."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr ""
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr ""
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr ""
 "Пакеттің атын немесе бастапқы коды бар пакеттің атын анықтау мүмкін емес."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "Веб-шолғышты ашу мүмкін емес"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "%s ашу үшін веб-шолғышты ашу мүмкін емес."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Желілік мәселе"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Желілік мәселе"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Жады жетіспейді"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "Осы есепті өңдеу үшін жүйелік жады жетіспейді."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -427,11 +429,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "Қате сондай-ақ белгілі"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -441,38 +443,37 @@ msgstr ""
 "Сіз осы қате жайлы, өндірушілерге көмектесетін, қосымша қосатын "
 "мәліметтеріңіз бар болуын тексеріңіз."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Жалғастыру үшін кез-келген пернені басыңыз..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "Сіз не жасауды қалайсыз? Мүмкін болатын әрекеттер:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Таңдаңыз (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i байт)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(екілік мәліметтер)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Осы қате есебін өндірушілерге жіберу қажет пе?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -480,52 +481,52 @@ msgstr ""
 "Есеп жіберілгеннен кейін, шолғыштың ашылған терезесінде\n"
 "шығатын форманы толтырыңыз."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "Есепті &жіберу (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr ""
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "Есепті &қарап шығу"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr "Кейінгі жіберу немесе басқа жерге көшіру үшін есеп файлын &сақтау"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr ""
 "Кері қайтару және бағдарламаның осы нұсқасында болатын ендігі қауыздарды "
 "&елемеу (игнорировать)"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Болдырмау"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Мәселе жайлы есеп файлы:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&Растау"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Қате: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "Қате туралы ақпаратты жинау"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -533,11 +534,11 @@ msgstr ""
 "Бағдарламаны жақсарту үшін жиналған мәліметтер бағдарламаның өндірушілеріне\n"
 "жіберілуі мүмкін. Бұл бірнеше минутыңызды алатын болады."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "Қате туралы ақпаратты жіберілу"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -545,40 +546,40 @@ msgstr ""
 "Жиналған мәліметтер қателерді байқау жүйесіне бағытталады.\n"
 "Бұл бірнеше минутыңызды алатын болады."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Дайын"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "жоқ"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "Таңдалған: %s. Бірнеше нұсқалар:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Таңдаулар:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "Файл орналасу жері (болдырмау үшін Enter басыңыз):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "Файл жоқ."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "Бұл бума."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "Әрі қарай жалғастыру үшін сіз келесі сілтеме бойынша өтуіңіз қажет:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -586,16 +587,16 @@ msgstr ""
 "Енді сіз шолғышыңызды ашуға немесе сілтемені басқа компьютерге көшіруіңізге "
 "болады."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Шолғышты дәл қазір ашу"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 "Қауыздар жайлы мәлімдемелер басқалынбады. --help кілтін байқап көріңіз."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 
@@ -610,27 +611,27 @@ msgid ""
 "Write modified report to given file instead of changing the original report"
 msgstr "Түпнұсқалық есепті өзгертпей, өзгертілген есепті басқашалай сақтау"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr ""
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr ""
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr ""
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr ""
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -640,78 +641,78 @@ msgid ""
 "be able to retrace crashes that happened on the currently running release."
 msgstr ""
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
 "have installed."
 msgstr ""
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr ""
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
 msgstr ""
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
 "neither -g, -o, nor -s are specified)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
 msgstr ""
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr ""
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr ""
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "Осы тиеуді жіберу қажет пе? [y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -719,64 +720,64 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "Нысандалған бума бар және бос емес."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr ""
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -784,7 +785,7 @@ msgstr ""
 "Есепті құру үрдісі аяқталуына өте жақын кезде ілініп (зависание) қалды; есеп "
 "көрінген кезде, барлығы дұрыс аяқталғаны."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr "Жүйе тұрақсыз болуы мүмкін, қайта жүктеу қажет болуы мүмкін."
 
@@ -798,76 +799,76 @@ msgstr "Мәселе жайлы хабарлау..."
 msgid "Report a malfunction to the developers"
 msgstr "Қауыз/қате жайлы өндірушілерге хабарлау"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr ""
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -921,7 +922,7 @@ msgstr "Өндірушілерге мәселені шешуге көмекте�
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>Олқылық (неполадка) жайлы мәліметтері жіберілуде</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -933,27 +934,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Apport мәлесе есебі"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr ""
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr ""
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Пайдаланушы аты:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Құпия сөз:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "Қате туралы мәлімет жинау"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -961,6 +962,6 @@ msgstr ""
 "Жиналған мәліметтерді бағдарламаны жақсарту үшін, өндірушілерге жіберуге "
 "болады. Бұл бірнеше минутыңызды алатын болады."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "Қате туралы мәліметті жіберу"

--- a/po/km.po
+++ b/po/km.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2015-04-27 21:46+0000\n"
 "Last-Translator: Martin Pitt <martin@piware.de>\n"
 "Language-Team: Khmer <km@li.org>\n"
@@ -36,11 +36,11 @@ msgstr "របាយការណ៍​បញ្ហា​ប្រព័ន្ធ
 msgid "Please enter your password to access problem reports of system programs"
 msgstr "សូម​បញ្ចូល​ព័ត៌មាន​លម្អិត​របស់​អ្នក​ ដើម្បី​​ចូល​ដំណើរការ​​​របាយការណ៍​បញ្ហា​នៃ​កម្មវិធី​ប្រព័ន្ធ"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "កញ្ចប់​នេះ​ហាក់​បី​ដូច​ជា​ដំឡើង​មិន​ត្រឹមត្រូវ​ទេ"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -59,21 +59,16 @@ msgstr ""
 "អ្នកមាន​កំណែ​កញ្ចប់​ដែល​លែង​ប្រើ​បាន​ដំឡើង ។ សូម​ធ្វើ​វា​​ឲ្យ​កញ្ចប់​ដូច​ខាង​ក្រោម​ប្រសើរ​ឡើង​ ហើយ​ពិនិត្យ​មើល​ថាតើ​"
 "នៅ​តែ​មាន​បញ្ហា​កើត​ឡើង​ទៀត​ដែរឬទេ ៖ %s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "មិន​ស្គាល់​កម្មវិធី"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "សូម​ទោស កម្មវិធី \"%s\" មិន​ត្រឹមត្រូវ"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "បញ្ហា​នៅ​ក្នុង %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -81,62 +76,67 @@ msgstr ""
 "កម្មវិធី​កុំព្យូទ័រ​របស់​អ្នក​មិន​មាន​អង្គ​ចងចាំ​គ្រប់គ្រាន់ ដើម្បី​ធ្វើវិភាគ​ដោយស្វ័យប្រវត្តិ ហើយ​ផ្ញើ​របាយការណ៍​ទៅ​"
 "អ្នក​អភិវឌ្ឍន៍ ។"
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "បញ្ហា​នៅ​ក្នុង %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "របាយការណ៍​បញ្ហា​មិន​ត្រឹមត្រូវ"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "អ្នក​មិន​ត្រូវ​បាន​អនុញ្ញាត​ឲ្យ​ចូល​មើល​របាយការណ៍​បញ្ហា​នេះ ។"
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "កំហុស"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "មិនមាន​ទំហំ​គ្រប់គ្រាន់​ ដើម្បី​ដំណើរការ​របាយការណ៍​នេះ​ទេ ។"
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "PID មិន​ត្រឹមត្រូវ"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "គ្មាន​កញ្ចប់​បាន​បញ្ជាក់​ទេ"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr "អ្នក​ត្រូវ​តែ​បញ្ជាក់​កញ្ចប់ ឬ​ PID ។ ចំពោះ​ព័ត៌មាន​បន្ថែម សូម​មើល --help ។"
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "សិទ្ធិ​ត្រូវ​បាន​បដិសេធ"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -144,30 +144,30 @@ msgstr ""
 "ដំណើរការ​ដែល​បាន​បញ្ជាក់​មិនមែនជា​របស់​អ្នក​ទេ ។ សូម​ដំណើរការ​កម្មវិធី​នេះ​ជា​ម្ចាស់​ដំណើរការ ឬ​ដំណើរការ​"
 "ជា root ។"
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "លេខ​សម្គាល់​ដំណើរការ​ដែល​បាន​បញ្ជាក់ មិន​មែន​ជា​របស់​កម្មវិធី​​នេះ​ទេ ។"
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "ស្គ្រីប​សញ្ញា %s មិន​បាន​កំណត់​កញ្ចប់​ដែល​មាន​ប្រសិទ្ធភាព​ឡើយ"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "គ្មាន​កញ្ចប់ %s ឡើយ"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "មិន​អាច​ធ្វើ​របាយការណ៍​​បាន​ឡើយ"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "ធ្វើ​បច្ចុប្បន្នភាព​របាយការណ៍​​អំពី​បញ្ហា"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -179,7 +179,7 @@ msgstr ""
 "\n"
 "សូម​ធ្វើ​របាយការណ៍​ថ្មី \"apport-bug\" ។"
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -198,24 +198,24 @@ msgstr ""
 "\n"
 "តើ​អ្នក​ពិត​ជា​ចង់​ធ្វើ​បន្ត​ឬ ?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "គ្មាន​ព័ត៌មាន​បន្ថែម​​ដែល​បាន​ប្រមូល​ឡើយ ។"
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "តើ​ប្រភេទ​បញ្ហា​អ្វី​ដែល​អ្នក​ចង់​រាយការណ៍ ?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "មិន​ស្គាល់​សញ្ញា"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "មិន​ស្គាល់​សញ្ញា \"%s\" ។"
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -226,36 +226,36 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr "ក្រោយ​ពេល​​បិទ​សារ​នេះ សូម​ចុច​លើ​​បង្អួច​កម្មវិធី ដើម្បី​រាយការណ៍​អំពី​វា ។"
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "បាន​បរាជ័យ xprop ដើម្បី​កំណត់​លេខ​សម្គាល់​ដំណើរការ​របស់​បង្អួច"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "បញ្ជាក់​ឈ្មោះ​កញ្ចប់ ។"
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "បន្ថែម​ស្លាក​​ខាងក្រៅ​ដើម្បី​រាយការណ៍ ។ អាច​ត្រូវ​បាន​បញ្ជាក់​ពេលវេលា​ច្រើន ។"
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -265,22 +265,22 @@ msgstr ""
 "ប្រសិនបើ​ មិន​ត្រូវ​​បាន​ផ្ដល់​ឲ្យ​ទេ​នោះ បង្ហាញ​បញ្ជី​សញ្ញា​ដែល​មិន​ស្គាល់ ។  (បាន​បញ្ជាក់ ប្រសិនបើ​អាគុយម៉ង់​ត្រូវ​"
 "បាន​ផ្ដល់​ឲ្យ ។)"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "ចុច​លើ​បង្អួច​ដែល​ជា​គោលដៅ​សម្រាប់​បំពេញ​របាយការណ៍​អំពី​បញ្ហា ។"
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "ចាប់ផ្ដើម​ជា​របៀប​​ការ​ធ្វើ​បច្ចុប្បន្នភាព​កំហុស ។ អាច​យក​កញ្ចប់ --ជា​ជម្រើស ។"
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 "ឯកសារ​របាយការណ៍​កំហុស​អំពី​សញ្ញា ។ (បាន​បញ្ជាក់ ប្រសិនបើ​ឈ្មោះ​សញ្ញា​ត្រូវ​បាន​ផ្ដល់​ជា​អាគុយម៉ង់​តែមួយ ។)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -288,7 +288,7 @@ msgstr ""
 "បញ្ជាក់​ឈ្មោះ​កញ្ចប់​ជា​របៀប --កំហុស-ឯកសារ ។ វា​គឺ​ជា​ជម្រើស ប្រសិនបើ --pid ត្រូវ​បាន​បញ្ជាក់ ។ (បាន​"
 "បញ្ជាក់ ប្រសិនបើ​​ឈ្មោះ​កញ្ចប់​ត្រូវ​បាន​ផ្ដល់​ជា​អាគុយម៉ង់​តែមួយ ។)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -297,11 +297,11 @@ msgstr ""
 "បញ្ជាក់​ការ​ដំណើរការ​កម្មវិធី​ជា​របៀប --កំហុស-ឯកសារ ។ ប្រសិនបើ វា​ត្រូវ​បាន​បញ្ជាក់ របាយការណ៍​កំហុស​នឹង​"
 "មាន​ព័ត៌មាន​បន្ថែម ។  (បាន​បញ្ជាក់ ប្រសិនបើ pid ត្រូវ​បាន​ផ្ដល់​ជា​អាគុយម៉ង់​តែមួយ ។)"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "pid ដែល​បាន​ផ្ដល់​ជា​កម្ម​វិធី​ដែល​បាន​ព្យួរ។"
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -310,7 +310,7 @@ msgstr ""
 "របាយការណ៍​គាំង​​ដែល​បាន​ផ្ដល់​ពី​ឯកសារ .apport ឬ .crash ជំនួស​នៅ​ក្នុង%s. ( បាន​បញ្ជាក់​ ប្រសិនបើ​"
 "ឯកសារ​ត្រូវ​បាន​ផ្ដល់​​តែ​អាគុយម៉ង់ ។)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -319,121 +319,123 @@ msgstr ""
 "ជា​របៀប​បំពេញ​កំហុស រក្សាទុក​ព័ត៌មាន​ដែល​បាន​ប្រមូល​នៅ​ក្នុង​ឯកសារ​​ជំនួស​ការ​ធ្វើ​របាយការណ៍​​អំពី​វា ។ ឯកសារ​នេះ​​"
 "អាច​ត្រូវ​បាន​​រាយការណ៍​​ក្រោយ​ពេល​ពី​ម៉ាស៊ីន​ខុសគ្នា ។"
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "បោះពុម្ព​លេខ​កំណែ Apport ។"
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr "វា​នឹង​ចាប់ផ្ដើម apport-retrace នៅ​ក្នុង​បង្អួយ​ស្ថានីយ ដើម្បី​ត្រួតពិនិត្យ​​ភាគ​គាំង ។"
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "រត់​សម័យ  gdb"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "រត់​សម័យ gdb ដោយ​មិន​ទាញ​យក​និមិត្ត​សញ្ញា​បំបាត់​កំហុស"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "ធ្វើ​បច្ចុប្បន្ន %s ជា​មួយ​ដាន​​ជា​​​និមិត្ត​សញ្ញា​ពេញលេញ"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr "របាយការណ៍​អំពី​បញ្ហា​នេះ​អនុវត្ត​កម្មវិធី​ដែល​មិន​ត្រូវ​បាន​ដំឡើង​ទៀត​ឡើយ ។"
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 msgstr "បញ្ហា​បានកើត​ឡើង​ជា​មួយ​កម្មវិធី %s ដែល​បាន​ផ្លាស់ប្ដូរ​តាំង​ពី​​មាន​ការ​គាំង ។"
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "របាយការណ៍​អំពី​បង្ហាញ​នេះ​ខូច ហើយ​មិន​អាច​ធ្វើ​បន្ត​បាន​ទេ ។"
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr ""
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "កំហុស​មួយ​បាន​កើត​ឡើង​ នៅ​ពេល​ព្យាយាម​ដំណើរការ​របាយការណ៍​បញ្ហា​នេះ ៖"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "មិន​អាច​កំណត់​​ ឈ្មោះ​កញ្ចប់​ប្រភព ឬ​កញ្ចប់​បាន​ឡើយ ។"
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "មិន​អាច​ចាប់ផ្ដើម​កម្មវិធី​រុករក​បណ្ដាញ​បាន​ទេ"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "មិន​អាច​ចាប់ផ្ដើម​កម្មវិធី​រុករក​បណ្ដាញ ដើម្បី​បើក %s បាន​ទេ ។"
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "បញ្ហា​បណ្ដាញ"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr "មិន​អាច​តភ្ជាប់​ទៅកាន់​មូលដ្ឋាន​ទិន្នន័យ​គាំង​បាន​ទេ សូម​ពិនិត្យមើល​ការ​តភ្ជាប់​អ៊ីនធឺណិត​របស់​អ្នក ។"
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "បញ្ហា​បណ្ដាញ"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "ការ​ប្រើ​​​អស់​អង្គ​ចងចាំ"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "ប្រព័ន្ធ​របស់​អ្នក​មិន​មាន​អង្គ​ចងចាំ​គ្រប់គ្រាន់ ដើម្បី​ដំណើរការ​របាយការណ៍​គាំង​នេះ​ទេ ។"
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -444,11 +446,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "ស្គាល់​​​អំពី​បញ្ហា​ហើយ"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -457,38 +459,37 @@ msgstr ""
 "បញ្ហា​នេះ​ត្រូវ​បាន​រាយការណ៍​នៅ​ក្នុង​របាយការណ៍​កំហុស ដែល​បង្ហាញ​នៅ​ក្នុង​កម្មវិធី​រុករក​បណ្ដាញ ។ សូម​ពិនិត្យមើល "
 "ប្រសិនបើ​អ្នក​អាច​បន្ថែម​ព័ត៌មាន​បន្ថែម ​​ដែល​​​អា​ផ្ដល់​ជា​ប្រយោជន៍​សម្រាប់​​អ្នក​អ្នក​អភិវឌ្ឍន៍ ។"
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "បញ្ហា​នេះ​​អាច​ត្រូវ​បាន​រាយការណ៍​ទៅ​កាន់​​​អ្នក​អភិវឌ្ឍន៍ ។ អរគុណ !"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "ចុច​គ្រាប់ចុច​ណាមួយ​ដើម្បី​បន្ត..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "តើ​អ្នក​ចង់​ធ្វើ​វា​ដែល​ឬ​ទេ ? ជម្រើស​របស់​អ្នក​គឺ ៖"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "សូម​ជ្រើសរើស (%s) ៖"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i បៃ)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(ទិន្នន័យ​គោល​ពីរ)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "ផ្ញើ​​របាយការណ៍​អំពី​បញ្ហា​ទៅ​កាន់​​​អ្នក​អភិវឌ្ឍន៍ ?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -496,50 +497,50 @@ msgstr ""
 "ក្រោយ​ពេល​ផ្ញើ​របាយការណ៍​អំពី​បញ្ហា សូម​បំពេញ​សំណុំ​បែបបទ​នៅ​ក្នុង\n"
 "​កម្មវិធី​រុករក​បណ្ដាញ​ដែល​​បាន​បើក​ដោយ​ស្វ័យប្រវត្តិ ។"
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "ផ្ញើ​របាយការណ៍ (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "ត្រួតពិនិត្យ​ជា​មូលដ្ឋាន"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "មើល​របាយការណ៍"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr "រក្សាទុក​ឯកសារ​របាយការណ៍​សម្រាប់​ផ្ញើ ឬ​ចម្លង​ទៅ​​ទីតាំង​​ផ្សេង​ទៀត"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "បោះបង់ និង​មិន​អើពើ​ការ​គាំង​របស់​កំណែ​​កម្មវិធី​កម្មវិធី"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "បោះបង់"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "ឯកសារ​របាយការណ៍​អំពី​បញ្ហា ៖"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "អះអាង"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "កំហុស ៖ %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "ប្រមូល​ព័ត៌មាន​អំពី​បញ្ហា"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -547,11 +548,11 @@ msgstr ""
 "ព័ត៌មាន​ដែល​បាន​ប្រមូល​អាច​ត្រូវ​បាន​ផ្ញើ​ទៅ​អ្នក​អភិវឌ្ឍន៍ ដើម្បី​ធ្វើ​ឲ្យ​កម្មវិធី​ប្រសើរ​ឡើង\n"
 " ។ វា​អាច​ចំណាយ​ពេលវេលា​ពីរបី​នាទី ។"
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "ផ្ទុក​ព័ត៌មាន​អំពី​បញ្ហា"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -559,55 +560,55 @@ msgstr ""
 "ព័ត៌មាន​ដែល​បាន​ប្រមូល​កំពុង​​​ត្រូវ​បាន​ផ្ញើ​ទៅកាន់​ប្រព័ន្ធ​តាមដាន​កំហុស ។\n"
 "វា​អាច​ចំណាយ​ពេល​ពីរបី​នាទី ។"
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "ធ្វើ​រួច"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "គ្មាន"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "បាន​ជ្រើស ៖ %s ។ ពហុ​ជម្រើស ៖"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "ជម្រើស ៖"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "ផ្លូវ​ទៅកាន់​ឯកសារ (ចូល​ដើម្បី​បោះបង់) ៖"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "មិន​មាន​ឯកសារ​ទេ ។"
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "វា​ជា​ថត​មួយ ។"
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "ដើម្បី​បន្ត អ្នក​ត្រូវ​មើល​ URL ខាង​ក្រោម ៖"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
 msgstr ""
 "អ្នក​អាច​ចាប់ផ្ដើម​កម្មវិធី​រុករក​ឥឡូវ​នេះ ឬ​ចម្លង URL នេះ​ទៅកាន់​កម្មវិធី​រុករក​នៅ​លើ​កុំព្យូទ័រ​ផ្សេង​ទៀត ។"
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "ចាប់ផ្ដើម​កម្មវិធី​រុករក​ឥឡូវ​នេះ"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr "គ្មាន​របាយការណ៍​គាំង​ឡើយ ។ សាកល្បង​ជំនួយ​សម្រាប់​ព័ត៌មាន​បន្ថែម ។"
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr "កុំ​ដាក់​ដាន​ថ្មី​​​នៅ​ក្នុង​របាយការណ៍ ប៉ុន្តែ​​អាច​សរសេរ​ទាន់ stdout បាន ។"
 
@@ -624,27 +625,27 @@ msgid ""
 "Write modified report to given file instead of changing the original report"
 msgstr "សរសេរ​របាយការណ៍​ដែល​បាន​កែប្រែ​ទៅ​កាន់​ឯកសារ​ដែល​បាន​ផ្ដល់​ជំនួស​ការ​ផ្លាស់ប្ដូរ​របាយការណ៍​ដើម"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr "យក​ធាតុ​ចម្បង​​ចេញ​ពី​របាយការណ៍ ក្រោយ​​ពេល​ការ​ធ្វើ​ឲ្យ​មាន​​ដាន​ជង់​ឡើងវិញ"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "បដិសេធ CoreFile របស់​របាយការណ៍"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "បដិសេធ ExecutablePath របស់​របាយការណ៍"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "បដិសេធ ProcMaps របស់​របាយការណ៍"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "បង្កើត​ព័ត៌មាន​កញ្ចប់​របស់​របាយការណ៍​ឡើង​វិញ"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -658,31 +659,31 @@ msgstr ""
 "ហើយ ។ ចំណុច​អាគុយម៉ង់​ទៅ​កាន់​ការ​កំណត់​រចនាសម្ព័ន្ធ​ប្រព័ន្ធ​ផ្អែក​លើ​ថត ប្រសិនបើ​អ្នក​បញ្ជាក់ \"ប្រព័ន្ធ\" វា​"
 "នឹង​ប្រើ​​ឯកសារ​ការ​កំណត់​រចនាសម្ព័ន្ធ​ប្រព័ន្ធ ប៉ុន្តែ​វា​អាច​​តាមដាន​ភាព​គាំង​ឡើង​វិញ នៅ​ពេល​ដែល​វា​ដំណើរការ​ ។"
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
 "have installed."
 msgstr ""
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr "របាយការណ៍​ទាញ​យក/ដំឡើង វឌ្ឍនភាព​ នៅ​ពេល​ដំឡើង​កញ្ចប់​ទៅកាន់​ sandbox"
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr "បន្ថែម​ខាងដើម timestamps ដើម្បី​ចុះ​កំណត់ហេតុ សម្រាប់​ប្រតិបត្តិការ​ច្រើន"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr "បង្កើតនិងប្រើឃ្លាំងភាគី​ទីបីពីប្រភពដើមដែលបានបញ្ជាក់លម្អិតនៅក្នុងរបាយការណ៍"
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr "ថត​ឃ្លាំង​សម្ងាត់​សម្រាប់​កញ្ចប់​ដែល​បាន​ទាញ​យក​នៅ​ក្នុង sandbox"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -690,12 +691,12 @@ msgstr ""
 "ថត​សម្រាប់​កញ្ចប់​ដែល​មិន​បាន​វេច​ខ្ចប់។ ពេល​អនាគត​ដំណើរការ​នឹង​សម្មត​ថា​កញ្ចប់​ដែល​បាន​ទាញ​យក​រួច​ហើយ​ត្រូវ​បាន​"
 "ស្រង់​ចេញ​ទៅ​ sandbox នេះ។"
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr "ដំឡើង​កញ្ចប់​ខាងក្រៅ​ទៅ​ក្នុង sandbox (អាច​ត្រូវ​បាន​​បញ្ជាក់​​ពេលវេលា​ច្រើន)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -705,37 +706,37 @@ msgstr ""
 "ប្រើ​ នៅ​ពេល​បញ្ជាក់​លេខ​សម្គាល់​​​ភាព​គាំង ដើម្បី​​ផ្ទុក​ដាន​ជង់​ដែល​បាន​តាមដាន​​ឡើង​វិញ (ប្រសិនបើ​មិន​ត្រូវ​​បញ្ជាក់ "
 "-g, -o, និង -s)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
 msgstr ""
 "បង្ហាញ​ដាន​ជង់​ដែល​បាន​តាម​ដាន​ឡើងវិញ សួរ​រក​ការ​អះអាង​មុន​ពេល​ផ្ញើ​វា​ទៅកាន់​មូលដ្ឋាន​ទិន្នន័យ​គាំង ។"
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr "ផ្លូវ​ទៅកាន់​មូលដ្ឋាន​ទិន្នន័យ sqlite​ ស្ទួន (លំនាំដើម ៖ គ្មាន​ការ​ត្រួតពិនិត្យ​ស្ទួន​ឡើង)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr ""
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "អ្នក​មិន​​អាច​ប្រើ -C without -S. Stopping ។"
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "យល់ព្រម​​ក្នុង​ការ​ផ្ញើ​​​ជា​ឯកសារ​ភ្ជាប់ឬ ? [y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -743,25 +744,25 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "មាន​ថត​ទិសដៅ ។"
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "មើល​ទំព័រ​សម្រាប់​ព័ត៌មាន​លម្អិត។"
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "បញ្ជាក់​ឈ្មោះ​ឯកសារ​កំណត់​ហេតុ​ដែល​បាន​ផលិត​ដោយ valgrind"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
 msgstr "ប្រើ sandbox dir (SDIR) ដែល​បាន​បង្កើត​ពី​មុន​ឡើង​វិញ, ប្រសិនបើ​វា​មិន​មាន, បង្កើត​វា​ថ្មី"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -769,48 +770,48 @@ msgstr ""
 "កុំ​បង្កើត ឬ​ប្រើ​ថត sandbox ឡើង​វិញ​សម្រាប់​​និមិត្ត​សញ្ញា​​បំបាត់​កំហុស​បន្ថែម ប៉ុន្តែ​អាស្រ័យ​លើ​និមិត្ត​សញ្ញា​បំបាត់​"
 "កំហុស។"
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
 msgstr "ប្រើ​ថត​ឃ្លាំង​ដែល​បាន​បង្កើត​ពី​មុន​ឡើង​វិញ (CDIR) , ប្រសិនបើ​វា​មិន​ទាន់​មាន, បង្កើត​វា"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr "រាយការណ៍​វឌ្ឍនភាព ទាញ​យក/​ដំឡើង នៅ​ពេល​កំពុង​ទាញ​យក​កញ្ចប់​ទៅ​កាន់ sandbox"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "កំហុស៖ %s មិន​អាន​ប្រតិបត្តិ​បាន បាន​បញ្ឈប់។"
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 "នេះបានកើតឡើងក្នុងអំឡុងពេលការផ្អាកដងមុន និងបានរារាំងប្រព័ន្ធពីការដំណើរការបន្តយ៉ាងត្រឹមត្រូវ ។"
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 "នេះបានកើតឡើងក្នុងអំឡុងពេលការសម្ងំដងមុន និងបានរារាំងប្រព័ន្ធពីការដំណើរការបន្តយ៉ាងត្រឹមត្រូវ ។"
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
 msgstr "បន្ត​ដំណើរការ hung រៀងរាល់​ជិត​បញ្ចប់ ហើយ​នឹង​លេចឡើង​នៅ​ពេល​​ដែល​បញ្ចប់​​ ។"
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr "ប្រព័ន្ធ​របស់​អ្នក​អាច​​គ្មាន​ស្ថេរ​ភាព​​ឥឡូវ​នេះ ត្រូវ​​ការ​​​ចាប់ផ្ដើម​ឡើងវិញ ។"
 
@@ -824,76 +825,76 @@ msgstr "រាយការណ៍​បញ្ហា..."
 msgid "Report a malfunction to the developers"
 msgstr "រាយការណ៍​​កំហុស​ទៅកាន់​អ្នក​អភិវឌ្ឍន៍"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "សូមទោស, កម្មវិធី %s បាន​បញ្ឈប់​ដោយ​មិន​រំពឹង។"
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "សូម​ទោស %s បាន​បិទ​ដោយ​មិន​រំពឹង​ទុក ។"
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "សូម​ទោស %s បាន​ជួប​ប្រទះ​បញ្ហា​ខាង​ក្នុង ។"
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "ផ្ញើ"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "បង្ហាញ​សេចក្ដី​លម្អិត"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "បន្ត"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "កម្មវិធី %s បាន​បញ្ឈប់​ការ​ឆ្លើយតប។"
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "កម្មវិធី \"%s\" បាន​បញ្ឈប់​ការ​ឆ្លើយតប។"
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "កញ្ចប់ ៖ %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "សូម​ទោស បញ្ហា​មួយ​បានកើត​ឡើង​ខណៈ​ពេល​ដំឡើង​កម្មវិធី ។"
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "កម្មវិធី %s មាន​បទពិសោធន៍​កំហុស​ខាងក្រៅ។"
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "កម្មវិធី %s បាន​បិទ​ដោយ​មិន​រំពឹង​ទុក ។"
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr "ប្រសិនបើ​អ្នក​កត់​សម្គាល់​បញ្ហា​បន្ថែម ព្យាយាម​ចាប់ផ្ដើម​កុំព្យូទ័រ​ឡើង​វិញ ។"
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "មិន​អើពើ​នឹង​បញ្ហា​នា​ពេល​អនាគត​នៃ​ប្រភេទ​នេះ"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "លាក់​សេចក្ដី​លម្អិត"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -947,7 +948,7 @@ msgstr "ព័ត៌មាន​កំពុង​ត្រូវ​បាន​
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>ផ្ទុក​ព័ត៌មាន​អំពី​បញ្ហា</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -958,27 +959,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "ឯកសារ​គាំង​របស់ Apport"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "ទុក​ឲ្យ​បិទ"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "ចាប់ផ្ដើម​ឡើង​វិញ"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "ឈ្មោះ​អ្នក​ប្រើ ៖"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "ពាក្យ​សម្ងាត់ ៖"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "ប្រមូល​ព័ត៌មាន​អំពី​បញ្ហា"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -986,6 +987,6 @@ msgstr ""
 "ព័ត៌មាន​ដែល​បាន​ប្រមូល​អាច​ត្រូវ​បាន​ផ្ញើ​ទៅកាន់​អ្នក​អភិវឌ្ឍន៍ ដើម្បី​ធ្វើ​ឲ្យ​កម្មវិធី​ប្រសើរ​ឡើង ។ វា​អាច​ចំណាយ​"
 "ពេលវេលា​ពីរបី​នាទី ។"
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "ផ្ទុក​ព័ត៌មាន​អំពី​បញ្ហា"

--- a/po/kn.po
+++ b/po/kn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2016-03-26 09:34+0000\n"
 "Last-Translator: Neelavar <Unknown>\n"
 "Language-Team: Kannada <kn@li.org>\n"
@@ -36,11 +36,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr ""
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -61,85 +61,85 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "ಅಜ್ಜ್ನಾತ ಪ್ರೋಗ್ರಾಮ್"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "ಕ್ಷಮಿಸಿ %s ಪ್ರೋಗ್ರಾಮ್ ಅನಿರೀಕ್ಷಿತವಾಗಿ ಅಂತ್ಯಗೊಂಡಿದೆ"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "%s ನಲ್ಲಿ ತೊಂದರೆ"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
 msgstr ""
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "%s ನಲ್ಲಿ ತೊಂದರೆ"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "ಅಸಿಂಧುವಾದ ತೊಂದರೆ ವರದಿ"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "ನಿಮಗೆ ಈ ತೊಂದರೆ ವರದಿಯನ್ನು ಪರಿಶೀಲಿಸುವ ಅಧಿಕಾರವಿಲ್ಲ"
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "ದೋಷ"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 "ಈ ತೊಂದರೆ ವರದಿಯನ್ನು ಪರಿಶೀಲಿಸಲು ಬೇಕಾಗುವಷ್ಟು ಸ್ಥಳಾವಕಾಶ ನಿಮ್ಮ ಗಣಕಯಂತ್ರದ "
 "ಡಿಸ್ಕ್(ಮುದ್ರಿಕೆಯಲ್ಲಿ) ನಲ್ಲಿ ಇಲ್ಲ"
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "ಅಮಾನ್ಯವಾದ pid"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "ಯಾವುದೇ ಪ್ಯಾಕೆಜ್ ಹೇಳಲಾಗಿಲ್ಲ"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "ನೀವು ಪ್ಯಾಕೆಜ್ ಅಥವಾ PID ಯನ್ನು ಉಲ್ಲೇಖಿಸಬೇಕು. ಹೆಚ್ಚಿನ ಮಾಹಿತಿಗಾಗಿ --help ಅನ್ನು ನೋಡಿ"
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "ಅನುಮತಿಯು ನಿರಾಕರಿಸಲ್ಪಟ್ಟಿದೆ"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -147,30 +147,30 @@ msgstr ""
 "ಉಲ್ಲೇಖಿಸಿದ ಪ್ರಕ್ರಿಯೆಯು ನಿಮಗೆ ಸಂಬಂಧಿಸಿದಲ್ಲ. ದಯವಿಟ್ಟು ಈ ಅನ್ವಯವನ್ನು ಪ್ರಕ್ರಿಯೆಯ ಯಜಮಾನನಾಗಿ "
 "ಅಥವಾ root ಆಗಿ ಚಾಲನೆ ಮಾಡಿ."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "ಉಲ್ಲೇಖಿಸಿದ ಪ್ರಕ್ರಿಯೆಯ ID ಯಾವುದೇ ಅನ್ವಯಕ್ಕೆ ಸಂಬಂಧಿಸಿದ್ದಲ್ಲ"
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "%s ಪ್ಯಾಕೆಜ್  ಅಸ್ಥಿತ್ವದಲ್ಲಿಲ್ಲ"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "ವರದಿ ತಯಾರಿಸಲು ಸಾಧ್ಯವಿಲ್ಲ"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr ""
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -178,7 +178,7 @@ msgid ""
 "Please create a new report using \"apport-bug\"."
 msgstr ""
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -190,24 +190,24 @@ msgid ""
 "Do you really want to proceed?"
 msgstr ""
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "ಯಾವುದೇ ಹೆಚ್ಚಿನ ಮಾಹಿತಿಯನ್ನು ಸಂಗ್ರಹಿಸಲಾಗಿಲ್ಲ."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "ನೀವು ಯಾವ ವಿಧದ ತೊಂದರೆಯನ್ನು ವರದಿ ಮಾಡಲು ಬಯಸುತ್ತೀರಿ"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "ಅಜ್ಞಾತ ಕುರುಹು"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "\"%s\" ಕುರುಹಿನ ಬಗ್ಗೆ ತಿಳಿದಿಲ್ಲ."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -218,202 +218,204 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr ""
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Apport ನ ಆವೃತ್ತಿ ಸಂಖ್ಯೆಯನ್ನು ಮುದ್ರಿಸು."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr ""
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "ಈ ತೊಂದರೆ ವರದಿ ಹಾನಿಗೊಂಡಿದೆ ಆದುದರಿಂದ ಪರಿಷ್ಕರಣೆ ಮಾಡಲಾಗುತ್ತಿಲ್ಲ"
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr ""
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr ""
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr ""
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "ಜಾಲ ವೀಕ್ಷಕವನ್ನು ಆರಂಭಿಸಲು ಸಾಧ್ಯವಾಗಿಲ್ಲ."
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "%s ಅನ್ನು ತೆರೆಯಲು ಜಾಲ ವೀಕ್ಷಕವನ್ನು ಆರಂಭಿಸಲು ಸಾಧ್ಯವಾಗಿಲ್ಲ."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr ""
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr ""
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "ಮೆಮೊರಿ ಖಾಲಿಯಾಗಿದೆ"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -424,98 +426,97 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "ಈಗಾಗಲೆ ತಿಳಿದಿರುವ ತೊಂದರೆ."
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 msgstr ""
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "ಮುಂದುವರೆಯಲು ಯಾವುದಾದರು ಕೀಲಿಯನ್ನು ಅದುಮಿ..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr ""
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "ದಯವಿಟ್ಟು ಆಯ್ಕೆ ಮಾಡಿ (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr ""
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(ಬೈನರಿ ದತ್ತಾಂಶ)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "ದೋಷ ವರದಿಯನ್ನು ವಿಕಾಸಗಾರರಿಗೆ ರವಾನಿಸುವುದೇ?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
 msgstr ""
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "ವರದಿಯನ್ನು ಕಳುಹಿಸು (%s) (&S)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr ""
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "ವರದಿಯನ್ನು ವೀಕ್ಷಿಸು (&V)"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr ""
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "ರದ್ದುಗೊಳಿಸು(&C)"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "ತೊಂದರೆ ವರದಿ ಕಡತ:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "ಖಚಿತಪಡಿಸು(&C)"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "ದೋಷ: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "ಕುಸಿತದಿಂದ ಮಾಹಿತಿಯನ್ನು ಪಡೆದುಕೊಳ್ಳಲಾಗುತ್ತಿದೆ"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -523,11 +524,11 @@ msgstr ""
 "ಅನ್ವಯವನ್ನು ಸುಧಾರಿಸಲು ಸಂಗ್ರಹಿಸಿದ ಮಾಹಿತಿಯನ್ನು ವಿಕಾಸಗಾರರಿಗೆ ಕಳುಹಿಸಬಹುದು.\n"
 "ಇದು ಕೆಲವು ನಿಮಿಷ ತೆಗೆದು ಕೊಳ್ಳಬಹುದು."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "ತೊಂದರೆ ಮಾಹಿತಿಯನ್ನು ಅಪ್ಲೋಡ್ ಮಾಡಲಾಗುತ್ತಿದೆ"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -535,54 +536,54 @@ msgstr ""
 "ಸಂಗ್ರಹಿಸಿದ ಮಾಹಿತಿಯನ್ನು ದೋಷ ಟ್ರಾಕಿಂಗ್ ವ್ಯವಸ್ಥೆಗೆ ಕಳುಹಿಸಲಾಗುತ್ತಿದೆ.\n"
 "ಇದು ಕೆಲವು ನಿಮಿಷ ತೆಗೆದುಕೊಳ್ಳ್ಬಹುದು."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "ಆಯಿತು(&D)"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "ಯಾವುದೂ  ಅಲ್ಲ"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr ""
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "ಆಯ್ಕೆಗಳು:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr ""
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "ಕಡತ ಅಸ್ತಿತ್ವದಲ್ಲಿಲ್ಲ"
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "ಇದು ಕಡತ ಕೋಶವಾಗಿದೆ"
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr ""
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
 msgstr ""
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "ಜಾಲ ವೀಕ್ಷಕವನ್ನು ಆರಂಭಿಸು"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr "ಹೊಸ ಜಾಡನ್ನು (ಟ್ರೇಸ್) ವರದಿಗೆ ಬರೆಯಬೇಡ, ಬದಲಾಗಿ ಅದನ್ನು stdout ಗೆ ಬರೆ"
 
@@ -597,27 +598,27 @@ msgid ""
 "Write modified report to given file instead of changing the original report"
 msgstr "ಮೂಲ ವರದಿಯನ್ನು ಬದಲಾಯಿಸುವ ಬದಲು ಬದಲಾವಣೆ ಮಾಡಿದ ವರದಿಯನ್ನು ಹೇಳಿದ ಕಡತಕ್ಕೆ ಬರೆ"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr ""
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr ""
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr ""
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr ""
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -627,78 +628,78 @@ msgid ""
 "be able to retrace crashes that happened on the currently running release."
 msgstr ""
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
 "have installed."
 msgstr ""
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr ""
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
 msgstr ""
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
 "neither -g, -o, nor -s are specified)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
 msgstr ""
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr ""
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr ""
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "ಈ ಕಡತಗಳನ್ನು ಲಗತ್ತಿಸಿ ಕಳುಹಿಸಲು ಸಮ್ಮತಿಯೆ? [y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -706,70 +707,70 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr ""
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
 msgstr ""
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 
@@ -783,76 +784,76 @@ msgstr "ಒಂದು ತೊಂದರೆಯನ್ನು ವರದಿ ಮಾಡು
 msgid "Report a malfunction to the developers"
 msgstr "ಒಂದು ಅಸಮರ್ಪಕ ಕಾರ್ಯವನ್ನು ವಿಕಾಸಗಾರರಿಗೆ ವರದಿ ಮಾಡು"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "ಕ್ಷಮಿಸಿ, %s ಅನ್ವಯಿಕವು ಅನಿರೀಕ್ಷಿತವಾಗಿ ನಿಂತುಹೋಗಿದೆ"
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "ಕ್ಷಮಿಸಿ, %s - ಇದು ಆಂತರಿಕ ತೊಂದರೆಯನ್ನು ಅನುಭವಿಸುತ್ತಿದೆ"
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "ಕಳುಹಿಸು"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "ವಿವರಗಳನ್ನು ತೋರಿಸು"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "ಮುಂದುವರಿಸು"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "%s - ಈ ಅನ್ವಯಿಕೆಯು ಸ್ಪಂದಿಸುವುದನ್ನು ನಿಲ್ಲಿಸಿದೆ"
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "%s - ಈ ತಂತ್ರಾಂಶವು ಸ್ಪಂದಿಸುವುದನ್ನು ನಿಲ್ಲಿಸಿದೆ"
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr ""
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr ""
 
@@ -908,7 +909,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr ""
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -920,32 +921,32 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Apport ಕುಸಿತದ ಕಡತ"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr ""
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "ಮರುಪ್ರಾರಂಭಿಸು"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr ""
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr ""
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr ""
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
 msgstr ""
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr ""

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2021-01-23 02:37+0000\n"
 "Last-Translator: Catry <Unknown>\n"
 "Language-Team: Korean <ko@li.org>\n"
@@ -36,11 +36,11 @@ msgstr "시스템 문제 보고"
 msgid "Please enter your password to access problem reports of system programs"
 msgstr "시스템 프로그램의 문제 보고서에 접근하려면 암호를 입력해야 합니다."
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "이 패키지를 올바르게 설치하지 않았습니다."
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -51,7 +51,7 @@ msgstr ""
 "후 다시 시도하시오. 그래도 작동하지 않으면 관련 타사 패키지를 제거하고 다시 "
 "시도하시오."
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -64,21 +64,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "알 수 없는 문제"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "죄송합니다. \"%s\" 프로그램이 예상치 않게 끝났습니다."
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "%s 내의 문제"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -86,64 +81,69 @@ msgstr ""
 "컴퓨터에 자동으로 문제를 분석하여 개발자에게 보고서를 보낼 수 있을 정도의 여"
 "유 메모리가 없습니다."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "%s 내의 문제"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "올바르지 않은 문제 보고서"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "이 문제 보고서에 접근할 수 있는 권한이 없습니다."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "오류"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "디스크 공간이 부족하여 보고서를 처리할 수 없습니다."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr "PID가 지정되지 않음"
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr "PID를 지정해야 합니다. 더 많은 정보는 --help를 통해 확인하시오."
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "유효하지 않은 PID"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr "지정된 프로세스 ID가 존재하지 않습니다."
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr "당신의 PID가 아님"
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr "지정된 프로세스 ID는 당신의 소유가 아닙니다."
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "패키지가 지정되지 않음"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "패키지 혹은 PID를 지정해야 합니다. --help 옵션으로 더 많은 정보를 확인할 수 "
 "있습니다."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "권한 없음"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -151,30 +151,30 @@ msgstr ""
 "선택한 프로세스는 여러분이 실행한 것이 아닙니다. 이 프로그램을 직접 실행하거"
 "나 root 사용자로 실행하십시오."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "확인된 프로세스 ID는 프로그램에 종속되지 않은 것입니다."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "증상 스크립트 %s에서 영향을 받는 패키지를 확인하지 않았습니다."
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "%s 패키지가 존재하지 않습니다"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "보고서를 만들 수 없습니다"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "문제 보고서 갱신"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -185,7 +185,7 @@ msgstr ""
 "거나 이미 닫힌 문제입니다.\n"
 "\"apport-bug\" 명령을 이용해 새 보고서를 만들어주십시오."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -202,24 +202,24 @@ msgstr ""
 "코멘트를 작성할 것을 권장합니다.\n"
 "정말로 이대로 진행하겠습니까?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "어떠한 추가 정보도 수집하지 않습니다."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "어떤 종류의 문제를 보고하시겠습니까?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "알려지지 않은 증상"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "\"%s\"은(는) 알려지지 않은 증상입니다."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -230,36 +230,36 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr "이 메시지를 닫은 후 문제를 보고할 프로그램의 창을 선택해주십시오."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop 프로그램이 창 프로세스 ID를 알아낼 수 없습니다."
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "패키지 이름을 지정합니다."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "보고서에 태그를 추가합니다. 여러 번 지정할 수 있습니다."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -269,16 +269,16 @@ msgstr ""
 "사용합니다. 어떤 것도 사용하지 않으면 알려진 증상의 목록을 표시합다. (하나의 "
 "인수가 주어진 PID가 유일한 인수일 경우 자동으로 실행합니다.)"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "문제를 보고할 프로그램의 창을 선택해주십시오."
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "버그 업데이트 모드로 시작. 추가적으로 --package 명령을 사용할 수 있습니다."
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -286,7 +286,7 @@ msgstr ""
 "문제 증상에 대한 버그 보고. (문제 증상만이 매개 변수로 주어진 경우 이 모드가 "
 "기본입니다)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -294,7 +294,7 @@ msgstr ""
 "--file-bug 모드에서 패키지 이름을 지정합니다. --pid 명령을 지정하면 사용하지 "
 "않을 수 있습니다.(패키지 이름이 유일한 인수일 경우 자동으로 실행합니다.)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -304,11 +304,11 @@ msgstr ""
 "면 버그 보고에 더 많은 정보를 포함하게 됩니다. (PID가 유일한 인수일 경우 자동"
 "으로 실행합니다.)"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "주어진 PID는 응답이 없는 프로그램입니다."
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -317,7 +317,7 @@ msgstr ""
 "%s에서 대기 중인 것 대신 주어진 .apport 혹은 .crash 파일의 충돌을 보고.(유일"
 "한 인수일 경우 자동으로 실행합니다.)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -326,65 +326,67 @@ msgstr ""
 "버그 정리 모드에서 문제를 보고하지 않고 수집한 정보를 파일로 저장합니다. 이 "
 "파일을 이용해 이후 다른 컴퓨터에서 문제를 보고할 수 있습니다."
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Apport 버전 번호를 출력합니다."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr "충돌을 분석하기 위해 터미널 창에서 apport-retrace 명령을 실행합니다."
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "GDB 세션 실행"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "디버그 심볼을 다운로드하지 않고 GDB 세션을 실행합니다."
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "%s을(를) 심볼릭 스택 트레이스로 업데이트합니다."
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr "보내는 리포트 상태 설정을 기억할 수 없습니다."
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 "충돌 보고 상태를 저장하지 못했습니다. 보고 모드를 자동으로 설정할 수 없거나 "
 "아예 설정할 수 없습니다."
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr "보내는 리포트 상태 설정을 기억할 수 없습니다."
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr "이 문제 보고서는 아직 설치하지 않은 프로그램에도 적용됩니다."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 msgstr "충돌 발생 후 바뀐 프로그램 %s에서 문제가 발생했습니다."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "문제 보고서가 손상되어 처리할 수 없습니다."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr "이 보고서는 설치되지 않은 패키지에 대한 것입니다."
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "이 문제를 보고하는 과정에 문제가 발생했습니다:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
@@ -392,23 +394,23 @@ msgstr ""
 "해당 프로그램은 두 가지 버전으로 설치되었습니다, 어느 것에 대한 버그를 보고하"
 "시겠습니까?"
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr "%s 스냅"
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr "%s deb 패키지"
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s 은(는) %s  배포한 스냅에서 제공합니다. 도움이 필요하면 %s 연락하십시오."
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -417,37 +419,37 @@ msgstr ""
 "%s 은(는) %s 배포한 스냅에서 제공합니다. 연락처가 제공되지 않았습니다. 도움"
 "이 필요하면 https://forum.snapcraft.io/ 포럼을 방문하십시오."
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "패키지나 소스 패키지 이름을 알아낼 수 없습니다."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "웹 브라우저를 시작할 수 없습니다"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "웹 브라우저를 이용하여 %s을(를) 열 수 없습니다."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "네트워크 문제"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr "충돌한 데이터베이스에 연결할 수 없습니다. 인터넷 연결을 확인하세요."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "네트워크 문제"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "메모리 부족"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "시스템에 충돌 보고서를 처리할 수 있을 만큼의 여유 메모리가 없습니다."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -458,11 +460,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "이미 알려진 문제"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -471,38 +473,37 @@ msgstr ""
 "이 문제는 웹 브라우저에 표시된 버그 보고서에 이미 보고된 것입니다. 개발자에"
 "게 도움이 될 수 있는 추가 정보를 제공할 수 있는지 확인해 주십시오."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "이미 문제를 개발자에게 보고했습니다. 감사합니다!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "아무 키나 누르면 계속합니다..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "다음 옵션 가운데 어떤 것을 실행하시겠습니까?:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "선택해 주십시오 (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i 바이트)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(바이너리 데이터)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "문제를 개발자에게 보고하시겠습니까?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -510,50 +511,50 @@ msgstr ""
 "문제 보고서가 전송된 후에, 자동으로 열리는 웹 브라우저 내의 문항을\n"
 "작성해 주시기 바랍니다."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "보고서 보내기(&S) - (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "로컬에서 검사(&E)"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "보고서 보기(&V)"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr "나중에 보내거나 다른 곳에 복사해 두기 위해 보고서 파일 저장(&K)"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "이 버전의 프로그램에서 다시 문제가 발생해도 무시하기(&I)"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "취소(&C)"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "문제 보고서 파일:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "확인(&C)"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "오류: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "문제 정보를 모으는 중"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -561,11 +562,11 @@ msgstr ""
 "수집한 정보를 개발자에게 보내 프로그램 개선할 수 있습니다.\n"
 "이 작업은 수 분이 필요할 수 있습니다."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "문제 정보를 업로드하는 중"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -573,57 +574,57 @@ msgstr ""
 "수집한 정보가 버그 추적 시스템으로 전송되고 있습니다.\n"
 "이 과정은 몇 분 정도 걸릴 수 있습니다."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "마침(&D)"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "없음"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "%s. 다중 선택:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "선택:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "파일 경로(취소하려면 엔터 키를 누르세요):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "파일이 존재하지 않습니다."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "이것은 디렉터리입니다."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "계속하려면, 다음 주소를 방문해주십시오:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
 msgstr ""
 "지금 브라우저를 실행하거나 다른 컴퓨터의 브라우저에 이 주소를 복사해주십시오."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "지금 브라우저 실행하기"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 "대기 중인 문제 보고서가 없습니다. --help 옵션을 이용해 더 많은 정보를 확인할 "
 "수 있습니다."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr "새로운 오류 추적 기록을 보고서에 추가하지 않고 STDOUT로 내보냅니다."
 
@@ -639,27 +640,27 @@ msgid ""
 "Write modified report to given file instead of changing the original report"
 msgstr "원본 보고서를 바꾸지 않고, 수정된 보고서를 주어진 파일에 씁니다"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr "스텍 트레이스를 다시 생성한 후 코어 덤프 제거"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "보고서의 코어 파일 덮어쓰기"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "보고서의 실행 경로(ExecutablePath) 덮어쓰기"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "보고서의 프로세스 맵(ProcMaps) 덮어쓰기"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "보고서의 패키지 정보 다시쓰기"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -674,7 +675,7 @@ msgstr ""
 "시스템을 가리킵니다; \"시스템\"을 지정하면 시스템 설정 파일을 사용하지만 그"
 "런 후 현재 실행 중인 배포판에서 발생한 충돌 만을 다시 추적할 수 있습니다."
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
@@ -683,24 +684,24 @@ msgstr ""
 "설치 한 gdb의 버전이 아닌 보고서와 동일한 릴리스를 사용하여 gdb 및 그 종속성"
 "을 설치하기 위한 또 다른 임시 샌드 박스를 빌드하십시오."
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr "샌드박스에 패키지를 설치할 때 다운로드 및 설치 과정을 보고합니다."
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr "배치 작업을 위해 기록 메시지에 시간 기록을 추가합니다."
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr "보고서에 지정한 원본 위치의 외부 저장소를 만들고 사용합니다."
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr "샌드박스에 다운로드한 패키지를 보관할 캐시 디렉터리"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -708,12 +709,12 @@ msgstr ""
 "압축을 푼 패키지를 보관할 디렉터리입니다. 다음 실행 시점부터는 이미 다운로드"
 "한 패키지를 이 샌드박스에 압축을 해제한 것으로 추정합니다."
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr "추가 패키지를 샌드박스에 설치(여러 항목을 지정할 수 있음)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -722,37 +723,37 @@ msgstr ""
 "충돌 데이터베이스 인증 정보를 가진 파일 경로. 스텍 트레이스를 업로드하기 위"
 "한 충돌 ID를 설정할 때 사용합니다.(-g,-o나 -s가 설정되지 않은 경우)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
 msgstr ""
 "스텍 트레이스를 보여주고 오작동(crash) 데이터베이스로 보내기 전에 확인하기."
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr "중복 sqlite 데이터베이스 경로( 기본: 중복 확인 없음)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr "StacktraceSource를 보고서에 추가하지 않기."
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "-S 옵션을 없이 -C 옵션을 사용할 수 없습니다. 멈춥니다."
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "첨부 파일로 보내려면, 확인을 누르시오"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -760,19 +761,19 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "디렉터리는 존재하지만, 파일이 없습니다."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "자세한 내용은 맨 페이지를 확인하십시오."
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "밸그린드가 만든 로그 파일의 이름을 지정"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
@@ -780,7 +781,7 @@ msgstr ""
 "이전에 만든 샌드박스 디렉터리(SDIR)를 다시 사용하거나 - 존재하지 않는 경우 - "
 "만듭니다."
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -788,7 +789,7 @@ msgstr ""
 "추가 디버그 심볼이 사용할 샌드박스 디렉터리를 다시 사용하거나 만들지 않고 설"
 "치한 디버그 심볼에만 의존합니다."
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
@@ -796,22 +797,22 @@ msgstr ""
 "이전에 만든 캐시 디렉터리(SDIR)를 다시 사용하거나 - 존재하지 않는 경우 - 만듭"
 "니다."
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr "패키지를 샌드박스에 설치할 때 다운로드/설치 진행 상태를 보고합니다."
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "오류: %s은(는) 실행할 수 없습니다. 멈춥니다."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -819,7 +820,7 @@ msgstr ""
 "이전에 절전을 했을 때 발생하였고 시스템이 정상적으로 계속 진행하는 것을 차단"
 "하고 있습니다."
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -827,7 +828,7 @@ msgstr ""
 "이전에 최대 절전을 했을 때 발생하였고 시스템이 정상적으로 계속 진행하는 것을 "
 "차단하고 있습니다."
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -835,7 +836,7 @@ msgstr ""
 "재개 과정의 처리가 거의 완료된 후 중단되어, 정상적으로 완료된 것처럼 보였을 "
 "것입니다."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr "현재 시스템이 불안정하여 컴퓨터를 다시 시작해야 합니다."
 
@@ -849,76 +850,76 @@ msgstr "문제 보고..."
 msgid "Report a malfunction to the developers"
 msgstr "개발자에게 버그를 보고합니다"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "프로그램 %s이(가) 예상치 않게 끝났습니다."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "프로그램 %s이(가) 예상치 않게 끝났습니다."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "죄송합니다. %s에 내부 오류가 발생했습니다."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "보내기"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "자세한 내용 보이기"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "계속"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "프로그램 %s이(가) 응답을 하지 않습니다."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "프로그램 \"%s\"이(가) 응답을 하지 않습니다."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "패키지: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "죄송합니다. 소프트웨어 설치 중 오류가 발생했습니다."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "프로그램 %s에 내부 오류가 발생했습니다."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "프로그램 %s이(가) 예상치 않게 끝났습니다."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr "더욱 심각한 문제가 발생한다면 컴퓨터를 다시 시작하십시오."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "앞으로 이런 형식의 문제를 무시합니다."
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "자세한 내용 숨기기"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -974,7 +975,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>문제 정보를 업로드하는 중</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -986,27 +987,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "충돌 파일 보고"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "닫은 채로 두기"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "다시 시작"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "사용자 이름:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "암호:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "문제 정보를 모으는 중"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1014,6 +1015,6 @@ msgstr ""
 "수집한 정보는 프로그램을 개선하기 위해 개발자에게 보낼 수 있습니다. 이 작업"
 "은 수 분이 필요할 수 있습니다."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "문제 정보를 업데이트 하는 중"

--- a/po/ku.po
+++ b/po/ku.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2011-10-07 06:10+0000\n"
 "Last-Translator: rizoye-xerzi <rizoxerzi@gmail.com>\n"
 "Language-Team: Kurdish <ku@li.org>\n"
@@ -40,11 +40,11 @@ msgstr ""
 "Xêra xwe ji bo bigihîjî raporên pirsgirêkê yên bernameyên sîstemê şîfreya "
 "xwe têkeve"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "Ev pakêt wekî ku bi awayekî rast bar bûbe nayê xuyan"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -52,7 +52,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -65,21 +65,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "bernameya nenas"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Xemgînim, bernameya \"%s\" bi awayekî ne dihat hêvîkirin hat girtin."
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Pirsgirêk di %s de"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -87,64 +82,69 @@ msgstr ""
 "Komputera te ne xwediyê têr bîr e ku bixeber vê pirsgirêkê analîz bike û "
 "raporekê ji pisporan re bişîne."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Pirsgirêk di %s de"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Raporkirina pirsgirêkê ya ne derbasdar"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "Destûra te tune tu bigihîjî vê rapora pirsgirêkê."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Çewtî"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "Ji bo kirina vê raporê têr valahiya dîskê tune."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "PID'a nederbasdar"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "Pakêt nehatiye diyarkirin"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Divê tu pakêtekê yan jî PID'ekî dîyarbikî. Ji bo agahiya zêdetir li --help "
 "binêre."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Destûr nehate dayîn"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -152,30 +152,30 @@ msgstr ""
 "Kirara dîyarkirî ne aîdî te ye. Ji kerema xwe ra bernameyê wekî ku xwediyê "
 "kirarê root be bixebitînin."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "ID ya kirarê ku hatiye dîyarkirin ne aîdî bernameyekê ye."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Skrîpta symptomê %s pakêteke tesîrlêbûyî tesbît nekiriye"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Pakêta %s tune"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "Rapor nikare were çêkirin"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "Rapora pirsgirêkê tê rojanekirin"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -187,7 +187,7 @@ msgstr ""
 "\n"
 "Xêra xwe bi bikaranîna \"apport-bug\" raporeke nû çêbike."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -208,24 +208,24 @@ msgstr ""
 "\n"
 "Jidil dixwazî dewam bikî?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "Ti agahiyeke zêdetir nehate civandin."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "Pirsgirêkeke bi çi awayî tu dixwazî rapor bikî?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Nîşaneya nenas"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Nîşaneya \"%s\" nayê zanîn."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -236,7 +236,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -244,32 +244,32 @@ msgstr ""
 "Piştî ku te vê peyamê girt xêra xwe ji bo raporkirina pirsgirêka derbarê vê "
 "de bitikîne ser paceyeke sepanê."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop di tesbîtkirina IDya kirariyê ya paceyê de bi ser neket"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "Navê pakêtê diyar bike."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Etîketekî ekstra li raporê zêde bike. Ji yek caran zêdetir dikare were "
 "diyarkirin."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -279,17 +279,17 @@ msgstr ""
 "yek --pid, ya jîbi tenê --pid ek. Kû yek jî nê dayîn listeya nîşaneyên tên "
 "zanin nîşandide.(Tê wateya ku hebek arguman bê dayîn.)"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "Ji bo tijîkirina rapora pirsgirêkê wekî hedefek bitikîne paceyeke."
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "Di moda rojanekirina çewtiyê de bide destpêkirin. Eger bixwazî dikarî -"
 "package'ek hildî."
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -297,7 +297,7 @@ msgstr ""
 "Di dermafê nîşaneyê de raporeke çewtiyê bipel bike.(Tê wateya ku li şûna "
 "argumanê navê nîşaneyê bê dayîn.)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -306,7 +306,7 @@ msgstr ""
 "diyarkirin, ev girêdayî daxwazê ye. (Eger navê pakêtê wekî yek argumanek "
 "hatibe dayîn.)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -316,11 +316,11 @@ msgstr ""
 "nediyarkirî be, rapora pirsgirêkê wê zêdetir dêtayan bihewîne. (Tê qesdkirin "
 "ku eger PID wekî yek argumenek hatibe dayîn.)"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "Pid'a diyarkirî (id'ya bernameyê) sepanekî nexilasbûyî ye."
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -329,7 +329,7 @@ msgstr ""
 "Rapora çewtiyê li şûna yên ku di %s de li bendê ne ji peldankên .apport an ."
 "crash ragihîne. (Eger navê peldankê wekî yek argumenek be.)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -338,49 +338,49 @@ msgstr ""
 "Di moda tijîkirina çewtiyê de, li şûna ku wan ragihînî agahiyên berhevkirî "
 "qeydê peldankekî bike. Ev peldank paşê ji makîneyek din dikare bê raporkirin."
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Hejmara guhertoya Apport çap bike."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Ev wê ji bo lêkolîna hilweşînê, di paceya termînalê de fermana \"apport-"
 "retrace\" bide xebitandin."
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "Danişîna gdb bixebitîne"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Danişîna gdb'yê bêyî daxistina sembolên neqandina çewtiyan bixebitîne"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Temamiya peldanka %s bi şopa komikê ya sembolîk rojane bike"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr "Mîhengên 'rewşa şandina raportê' nayê bîranîn."
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 "Qeydkirina \"rewşa raporkirina hilweşînê\" bi ser neket. Nikare "
 "\"raporkirina bi otomatîkî\" an jî moda \"qet rapor neke\" eyar bike."
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr "Mîhengên 'rewşa şandina raportê' nayê bîranîn."
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 "Ev rapora çewtiyan li ser bernameyên ku kîjan hêja ne sazkirî be tê sepandin."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
@@ -389,79 +389,81 @@ msgstr ""
 "Bernameya %s ji wexta hilweşînê û pê ve guherî û tê de pirsgirêkek derkete "
 "holê."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Ev rapora pirsgirêkê xerabe ye û nayê kirin."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr "Ev rapor derheqê pakêteke nesazkirî de ye."
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "Gava dixebitî ku vê rapora pirsgirêkê qeyd bike çewtiyek derket:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "Nikare pakêtê destnîşan bike an jî navê pakêtê bibîne."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "Nikare geroka webê bide destpêkirin"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Nikare geroka webê bide destpêkirin ji bo vekirina %s."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Pirsgirêka torê"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Nikare bi danegeha hilweşînê ve bê girêdan, Girêdana xwe yê întenetê kontrol "
 "bike."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Pirsgirêka torê"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Têrnekirina bîrkanê"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "Di pergala te de têr bîr tuneye ku kirara vê rapora çewtiyê bike."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -472,11 +474,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "Pirsgirêk jixwe tê zanîn"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -486,38 +488,37 @@ msgstr ""
 "hatiye raporkirin. Xêra xwe kontrol bike gelo tu dikarî ji bo alîkarbûna "
 "pêşvebiran agahiyeke zêdetir lê zêde bikî an na."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Ev pirsgirêk ji pêşdebiran re jixwe hatiye raporkirin. Mala te ava!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Ji bo berdewamê pê li bişkokekê bikin..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "Tu dixwazî çi bikî? Alternatîvên te:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Xêra xwe bibijêre (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i bayt)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(daneya cot)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Bila raporeke pirsgirêkê ji pêşdebiran re bê şandin?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -525,50 +526,50 @@ msgstr ""
 "Pîştî rapor hat şandin ji kerema xwe ra forma di geroka webê de ku \n"
 "bixweber vebû dagirin."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "&Raporê bişîne (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "&Analîza herêmî bike"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "Raporê &bibîne"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr "Ji bo paşê bişînî yan jî tomar bikî ciye&kî din raporê veşêre"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "Betal yan jî &Derbasbibe di hilweşînên vê bernameyê yên di pêşerojê de"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Betal"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Pela rapora pirsgirêkê:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&Erê bike"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Çewtî: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "Agahiyên pirsgirêkê tên civandin"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -576,11 +577,11 @@ msgstr ""
 "Agahiyên civandî kare bê şandin ji pisporan re ji pêşxistina sepanê.\n"
 "Ev dibe ku çend xulekan bigire."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "Agahiyên pirsgirêkê tên vebarkirin"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -588,40 +589,40 @@ msgstr ""
 "Agahiyên civandî  ji pergala şopandina çewtiyan re tên şandin.\n"
 "Ev dibe ku çend xulekan bigire."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Temam"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "tune"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "Bijartî: %s. Bijartinên pirjimar:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Vebijêrk:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "Riya pelê (\"Enter\" ji bo betalkirinê):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "Pel tune"
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "Ev pêristek e."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "Ji bo berdewamê divê tu serî li URL'ya jêr bidî."
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -629,17 +630,17 @@ msgstr ""
 "Tu karî niha gerokekê bixebitînî, yan jî URL'yê kopî bikî ji bo di "
 "kompûtereke din de binêrî."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Gerokekê bixebitîne"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 "Raporên hilweşînê yê bendewar tunin. Ji bo agahiya zêdetir --help "
 "biceribînin."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr "Di raporê de îşaretên nû daneyne, li şûna wê wan li stdout'ê binivîse."
 
@@ -658,28 +659,28 @@ msgstr ""
 "Li cihê ku tu rapora heqîqî biguherînî, rapora sererastkirî li peldanka ku "
 "hatiye dayîn binivîse"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 "Piştî sererastkirina şopandina komikan kitekita dendikê ji raporê vekişîne."
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "PeldankaDendik a raporê bêhukm bike"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "Riya şixulbar ya raporê (ExecutablePath) bêhukm bike"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "ProcMaps'ên raporê bêhukm bike"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "Agahiyên raporê yên yêdek tamîr bike"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -696,7 +697,7 @@ msgstr ""
 "çaxê tenê karibe here çavkaniya hilweşînên di versiyona berdest de aniha "
 "dixebitin."
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
@@ -706,27 +707,27 @@ msgstr ""
 "versiyonê bi kar bîne, û ji bo barkirina gdb'yê û bestekiyên wê qadeke din a "
 "testê ya demkî çêbike."
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 "Gava ku pakêt li nava sandboxê bêne sazkirin daxistin/sazkirinê rapor bike"
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr "Ji bo karên desteyî li pêşiya peyaman etîketên demê zêde bike"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 "Di raporan de depoyên kesên sêyem yên ku eslên wan diyarkirî çêbike û bi kar "
 "bîne"
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr "Pêrista pêşbîrê yê ji bo pakêtên ku li nava sandboxê hatine daxistin"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -734,14 +735,14 @@ msgstr ""
 "Pêrista ji bo pakêtên nevekirî. Ferz dike ku pakêtên ku jixwe daxistî ne û "
 "wê paşê werin xebitandin jî wê li vê sandbox'ê werin derxistin."
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 "Pakêteke ekstra li nava sandbox'ê bar bike (ji yekî zêdetir dikarî diyar "
 "bikî)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -752,7 +753,7 @@ msgstr ""
 "komikan yên ku ji çavkaniya wan re gihîştî bêne bikaranîn (tenê eger -g, -o, "
 "an -s nehitibin diyarkirin)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -760,30 +761,30 @@ msgstr ""
 "Şopên komikan yên ji nû ve çêkirî nîşan bide û berî ku wan bişînî danegeha "
 "hilweşînê tesdîqê bixwaze."
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr "Riya danegeha kopiya sqlite'ê (ya standard: kontrola kopiyê tine)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr "StacktraceSource'yê îlaweyî raporê neke."
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "Tu nikarî -C'yê bêyî -S bi kar bînî. Tê sekinandin."
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "Bila wekî bestekî werin şandin? [y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -791,19 +792,19 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "Pêrista ku tê hedefkirin jixwe heye û ne vala ye."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "Ji bo dêtayan binêre rûpela man."
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "navê peldanka rojaneyê ya ji alî valgrid ve çêkirî diyar bike"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
@@ -811,7 +812,7 @@ msgstr ""
 "sandbox dir'a (SDIR) ku berê hatiye çêkirin dîsa bi kar bîne an jî eger tine "
 "be, çêbike"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -819,7 +820,7 @@ msgstr ""
 "ji bo zêdetir sembolên neqandina xetayan pêrista sandbox'ê cardin bi kar "
 "neyîne an çêneke, tenê sembolên neqandina xetayan ên sazkirî bi kar bîne."
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
@@ -827,23 +828,23 @@ msgstr ""
 "pêrista pêşbîrê (CDIR) yê ku di berê de hatiye çêkirin cardin bi kar bîne an "
 "jî eger tine be, çêke"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 "gava ku pakêt li sandboxê bar bibin pêşdeçûna daxistin/sazkirinê rapor bike"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Çewtî: %s ne bikarbar e. Tê sekinandin."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -851,7 +852,7 @@ msgstr ""
 "Ev rewş ji ber rawestandinê derketiye holê û bûye asteng ku sîstem bi "
 "awayekî rast dewam bike xebitandinê."
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -859,7 +860,7 @@ msgstr ""
 "Ev hal ji ber xistina xewê ya beriya vê derketiye û nehiştiye ku sîstem rast "
 "dewam bike şixulandinê."
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -867,7 +868,7 @@ msgstr ""
 "Miameleya dawîn li ciyekî nêzî xelasbûnê eliqî ma û wê wekî ku bi awayekî "
 "normal temam bûbe were xuyan."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 "Sîstema te vêga dibe ku bikeve halekî bêqerar û dibe ku ji nû ve destpêkirin "
@@ -883,78 +884,78 @@ msgstr "Pirsgirêkeke ragihîne..."
 msgid "Report a malfunction to the developers"
 msgstr "Ji pêşdebiran re arîzeyeke rapor bike"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "Me bibexşîne, sepana %s bi awayekî nehêvîkirî sekinî."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "Bibore, %s bi awaekî nehêvîkirî hate girtin."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "Bibore, xetayeke navxweyî bi serê %s de hat."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Bişîne"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Kîtekîtan Nîşan bide"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Berdewam"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "Sepana %s cewabdanê sekinand."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "Bernameya \"%s\" cewabdanê sekinandiye."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Pakêt: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "Bibore, gava ku nivîsbarî bar dibû pirsgirêkek derket holê."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "Sepana %s pêrgî xetayeke navxweyî bû."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "Sepana %s bi awayekî nehêvîkirî hate girtin."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr ""
 "Eger zêdetir pirsgirêk derkevin, hewl bide ku kombersa xwe cardin bidî "
 "destpêkirin."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "Di pêşerojê de guh nede pirsgirêkên bi vî awayî."
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Dêtayan Veşêre"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -1010,7 +1011,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>Agahiyên pirsgirêkê tên barkirin</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -1022,27 +1023,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Peldanka hilweşînê a Apport"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "Girtî Bihêle"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Ji nû ve bide destpêkirin"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Navê bikarhêner:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Şîfre:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "Civandina Agahiyên Pirsgirêkê"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1050,6 +1051,6 @@ msgstr ""
 "Agahiyên civandî, ji bo pêşvebirina sepanê ji pêşdebiran re dikare were "
 "şandin. Ev dibe ku çend deqeyan bigire."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "Agahiyên Pirsgirêkê Têne Şandin"

--- a/po/lt.po
+++ b/po/lt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2019-04-13 17:56+0000\n"
 "Last-Translator: Moo <hazap@hotmail.com>\n"
 "Language-Team: Lithuanian <lt@li.org>\n"
@@ -40,11 +40,11 @@ msgstr ""
 "Įveskite slaptažodį, kad prieitumėte prie sistemos programų pranešimų apie "
 "klaidas"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "Atrodo šis paketas įdiegtas neteisingai"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -52,7 +52,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -65,21 +65,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "nežinoma programa"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Atsiprašome, programa „%s“ netikėtai užsidarė"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "%s klaida"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -87,63 +82,68 @@ msgstr ""
 "Kompiuteris neturi pakankamai laisvos atminties, kad automatiškai "
 "išanalizuotų problemą ir išsiųstų ataskaitą kūrėjams."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "%s klaida"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Neteisinga ataskaita apie klaidą"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "Jums neleidžiama prieiti prie ataskaitos apie problemą."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Klaida"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "Nepakanka vietos diske šios ataskaitos apdorojimui."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "Neteisingas PID"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr "Nurodyto proceso ID nėra."
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr "Nėra jūsų PID"
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr "Nurodyto proceso ID nepriklauso jums."
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "Nenurodytas paketas"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Jums reikia nurodyti paketą arba PID. Daugiau informacijos gausite su --help."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Neturite teisės"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -151,30 +151,30 @@ msgstr ""
 "Nurodytas procesas jums nepriklauso. Paleiskite programą kaip proceso "
 "valdytojas ar pagrindinis naudotojas."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "Nurodytas proceso ID nepriklauso programai."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Simptomų scenarijus %s nenustatė paveikto paketo"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Paketas %s neegzistuoja"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "Ataskaitos sukurti nepavyko"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "Atnaujinama problemos ataskaita"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -186,7 +186,7 @@ msgstr ""
 "\n"
 "Prašome sukurti naują pranešimą naudojant „apport-bug“."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -206,24 +206,24 @@ msgstr ""
 "\n"
 "Ar tikrai norite tęsti?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "Jokios papildomos informacijos nesurinkta."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "Apie kokią problemų rūšį norite pranešti?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Nežinomas simptomas"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Simptomas „%s“ yra nežinomas."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -234,7 +234,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -242,31 +242,31 @@ msgstr ""
 "Kai uždarysite šį pranešimą, paspauskite ant programos lango, kad "
 "praneštumėte apie tai."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop nepavyko nustatyti lango proceso ID"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "Nurodykite paketo pavadinimą."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Prie ataskaitos pridėti papildomą žymę. Gali būti nurodyta kelis kartus."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -276,15 +276,15 @@ msgstr ""
 "arba tik --pid. Jei nė vienas neduotas, parodyti žinomų simptomų sąrašą. "
 "(Turima omeny, jei duotas tik vienas argumentas.)"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "Pranešti apie problemą, paspauskite ant lango."
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "Pradėti klaidos atnaujinimo režime. Gali prireikti nebūtino --package."
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -292,7 +292,7 @@ msgstr ""
 "Registruoti pranešimą apie simptomą. (Turima omeny, jei simptomo vardas "
 "duotas kaip vienintelis argumentas.)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -300,7 +300,7 @@ msgstr ""
 "Nurodyti paketo vardą --file-bug režime. Tai neprivaloma, jei nurodytas --"
 "pid. (Turima omeny, jei paketo vardas duotas kaip vienintelis argumentas.)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -310,11 +310,11 @@ msgstr ""
 "pranešimas apie klaidą turės daugiau informacijos. (Numanoma, jei pateiktas "
 "„pid“ kaip vienintelis argumentas.)"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "Pateiktas pid yra užstrigusi programa."
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -323,7 +323,7 @@ msgstr ""
 "Pranešti apie strigtį iš duoto apport ar .crash failo, o ne iš laukiančių "
 "%s. (Turima omeny, jei failas duotas kaip vienintelis argumentas.)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -332,125 +332,127 @@ msgstr ""
 "Pranešimo apie klaidą veiksenoje išsaugoti surinktą informaciją į failą "
 "vietoje perdavimo. Šis failas gali būti perduotas vėliau iš kito kompiuterio."
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Atspausdinti Apport versijos numerį."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Tai terminalo lange paleis „apport-retrace“ ir bus galima išanalizuoti lūžį."
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "Vykdyti gdb sesiją"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Vykdyti gdb sesiją, neparsiunčiant derinimo simbolių"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Atnaujinti %s su visiškai simboliniu dėklo pėdsaku"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr "Ši ataskaita apie problemą yra programos, kuri jau nėra įdiegta."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 msgstr "Problema įvyko su programa %s, kuri pasikeitė nuo strigties įvykio."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Ši ataskaita apie klaidą yra pažeista ir negali būti apdorota."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr ""
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "Įvyko klaida mėginant apdoroti šį pranešimą apie klaidą:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "Nepavyko nustatyti paketo ar pirminio paketo vardo."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "Nepavyko paleisti žiniatinklio naršyklės"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Nepavyko paleisti žiniatinklio naršyklės %s atverti."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Tinklo problema"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Nepavyko prisijungti prie strigčių duomenų bazės, patikrinkite interneto "
 "ryšį."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Tinklo problema"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Atminties išnaudojimas"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Jūsų sistema neturi pakankamai atminties ataskaitai apie strigtį apdoroti."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -461,11 +463,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "Problema jau žinoma"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -475,38 +477,37 @@ msgstr ""
 "rodomoje žiniatinklio naršyklėje. Patikrinkite ar galite pridėti daugiau "
 "informacijos, kuri galėtų būti naudinga kūrėjams."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Apie šią problemą jau buvo pranešta kūrėjams. Ačiū!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Norėdami tęsti, paspauskite bet kurį klavišą..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "Ką norite atlikti? Jūsų parinktys yra:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Prašome pasirinkti (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i baitų)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(dvejetainiai duomenys)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Siųsti pranešimą apie problemą kūrėjams?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -514,51 +515,51 @@ msgstr ""
 "Po to, kai ataskaita apie problemą bus nusiųsta, prašome automatiškai \n"
 "atvertoje žiniatinklio naršyklėje užpildyti formą."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "&Siųsti ataskaitą (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "&Ištirti vietoje"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "&Peržiūrėti ataskaitą"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 "Lai&kyti ataskaitos failą vėlesniam siuntimui ar kopijavimui kur nors kitur"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "Atsisakyti ir &ignoruoti šios programos strigtis ateityje"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Atsisakyti"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Ataskaitos apie problemą failas:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "Pa&tvirtinti"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Klaida: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "Renkama informacija apie problemą"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -566,11 +567,11 @@ msgstr ""
 "Surinkta informacija gali būti nusiųsta kūrėjams, kad jie patobulintų\n"
 "programą. Tai gali užtrukti kelias minutes."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "Išsiunčiama informacija apie problemą"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -578,40 +579,40 @@ msgstr ""
 "Surinkta informacija yra siunčiama į klaidų sekimo sistemą.\n"
 "Tai gali užtrukti kelias minutes."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Baigta"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "nėra"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "Pasirinkta: %s. Daugybinis pasirinkimas:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Pasirinkimai:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "Kelias iki failo (Enter - atsisakyti):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "Failas neegzistuoja."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "Tai katalogas."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "Norėdami tęsti privalote aplankyti šį URL:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -619,17 +620,17 @@ msgstr ""
 "Galite paleisti naršyklę dabar arba nukopijuoti šį URL į naršyklę kitame "
 "kompiuteryje."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Paleisti naršyklę dabar"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 "Nėra laukiančiųjų strigčių ataskaitų. Mėginkite --help daugiau informacijos "
 "gauti."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 "Nedėti naujų pėdsakų į ataskaitą, bet išvesti juos į standartinę išvestį."
@@ -649,27 +650,27 @@ msgstr ""
 "Įrašyti modifikuotą ataskaitą į nurodytą failą, vietoje originalios "
 "ataskaitos keitimo"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr "Pašalinti „core dump“ iš ataskaitos po dėklo pėdsakų atkūrimo."
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "Nustelbti ataskaitos CoreFile"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "Nustelbti ataskaitos ExecutablePath"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "Nustelbti ataskaitos ProcMaps"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "Perdaryti ataskaitos paketų informaciją"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -685,33 +686,33 @@ msgstr ""
 "naudojami sistemos konfigūravimo failai, bet tada galėsite tik atsekti "
 "strigtis, kurios įvyko dabar vykdomoje laidoje."
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
 "have installed."
 msgstr ""
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 "Raportuoti atsiuntimo/įdiegimo eigą kai įdiegiami paketai į smėlio dėžę"
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr "Prie žurnalo pranešimų pridėti laiko žymes"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 "Sukurti ir naudoti trečiųjų šalių saugyklas iš ataskaitose nurodytų šaltinių"
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr "Podėlio katalogas paketams atsiųstiems smėlio dėžėje"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -719,13 +720,13 @@ msgstr ""
 "Katalogas išpakuotiems paketams. Vėlesni paleidimai tars, kad bet kuris jau "
 "atsiųstas paketas yra išpakuotas šioje smėlio dėžėje."
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 "Įdiegti papildomą paketą smėlio dėžėje (gali būti nurodyta daugelį kartų)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -735,7 +736,7 @@ msgstr ""
 "naudojama, kai nurodomas strigties ID atsektiems dėklo pėdsakams išsiųsti "
 "(tik, jei nenurodyti -g, -o, ar -s)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -743,31 +744,31 @@ msgstr ""
 "Rodyti atsektus dėklo pėdsakus ir klausti patvirtinimo prieš siunčiant juos "
 "į strigčių duomenų bazę."
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 "Kelias į dublikatų sqlite duomenų bazę (numatyta r.: netikrinti dublikatų)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr ""
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "Negalite naudoti -C be -S. Stabdoma."
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "Ar siųsti šiuos priedus? [y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -775,19 +776,19 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "Paskirties katalogas egzistuoja ir yra netuščias."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "Išsamesnei informacijai, žiūrėkite vadovo (\"man\") puslapius."
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "nurodyti valgrind kuriamą žurnalo failo pavadinimą"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
@@ -795,7 +796,7 @@ msgstr ""
 "iš naujo naudoti anksčiau sukurtą smėliadėžės katalogą (SDIR) arba, jeigu jo "
 "nėra, jį sukurti"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -803,7 +804,7 @@ msgstr ""
 "papildomiems derinimo simboliams nekurti ar iš naujo nenaudoti smėliadėžės "
 "katalogo, bet pasikliauti tik įdiegtais derinimo simboliais."
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
@@ -811,22 +812,22 @@ msgstr ""
 "iš naujo naudoti anksčiau sukurtą podėlio katalogą (CDIR) arba, jeigu jo "
 "nėra, jį sukurti"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr "įdiegiant paketus į smėliadėžę, pranešti apie atsiuntimo/įdiegimo eigą"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Klaida: %s nėra vykdomasis. Stabdoma."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -834,7 +835,7 @@ msgstr ""
 "Tai įvyko ankstesnio pristabdymo metu ir neleido sistemai tinkamai pratęsti "
 "savo darbą."
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -842,7 +843,7 @@ msgstr ""
 "Tai įvyko ankstesnio užmigdymo metu ir neleido sistemai tinkamai pratęsti "
 "savo darbą."
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -850,7 +851,7 @@ msgstr ""
 "Tęsimo apdorojimas užstrigo prie pat pabaigos ir atrodė, kad buvo atliktas "
 "normaliai."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 "Jūsų sistema dabar gali tapti nestabili ir gali prireikti paleisti OS iš "
@@ -866,77 +867,77 @@ msgstr "Pranešti apie problemą..."
 msgid "Report a malfunction to the developers"
 msgstr "Pranešti apie triktį kūrėjams"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "Atsiprašome, programa „%s“ netikėtai sustojo."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "Atsiprašome, %s netikėtai užsivėrė."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "Atsiprašome, %s patyrė vidinę klaidą."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Siųsti"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Rodyti išsamiau"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Tęsti"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "Programa „%s“ nustojo reaguoti."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "Programa „%s“ nustojo reaguoti."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Paketas: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "Atsiprašome, įvyko klaida diegiant programinę įrangą."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "Programa „%s“ patyrė vidinę klaidą."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "Programa %s netikėtai užsivėrė."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr ""
 "Jei pastebite tolesnių problemų, mėginkite paleisti kompiuterį iš naujo."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "Ignoruoti šio tipo problemas ateityje"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Slėpti detales"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -992,7 +993,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>Siunčiama informacija apie problemą</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -1004,27 +1005,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Apport strigties failas"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "Palikti užvertą"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Paleisti iš naujo"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Naudotojo vardas:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Slaptažodis:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "Renkama informacija apie problemą"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1032,6 +1033,6 @@ msgstr ""
 "Surinkta informacija gali būti nusiųsta kūrėjams programai patobulinti. Tai "
 "gali užtrukti kelias minutes."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "Išsiunčiama informacija apie klaidą"

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2018-04-11 17:57+0000\n"
 "Last-Translator: Rūdolfs Mazurs <Unknown>\n"
 "Language-Team: Latvian <lv@li.org>\n"
@@ -40,11 +40,11 @@ msgstr ""
 "Lūdzu, ievadiet savu paroli, lai piekļūtu sistēmas programmu "
 "problēmziņojumiem"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "Šī pakotne šķiet instalēta nekorekti"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -52,7 +52,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -65,21 +65,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "nezināma programma"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Piedod, bet programma „%s“ negaidīti beidza darboties"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Problēma ar %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -87,62 +82,67 @@ msgstr ""
 "Jūsu datoram trūkst brīvas atmiņas, lai veiktu automātisku problēmas analīzi "
 "un nosūtītu ziņojumu izstrādātājiem."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Problēma ar %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Nepareizs kļūdas ziņojums"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "Jums nav atļauts piekļūt kļūdas ziņojumam."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Kļūda"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "Nepietiek brīvas diska vietas, lai apstrādātu šo ziņojumu."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "Nepareizs PID"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "Nav norādīta pakotne"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr "Jums jānorāda pakotne vai PID. Apskatiet --help, lai uzzinātu vairāk."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Nav tiesību uz procesu"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -150,30 +150,30 @@ msgstr ""
 "Jums nepieder norādītais process. Lūdzu, palaidiet šo programmu kā procesa "
 "īpašnieks vai kā root lietotājs."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "Norādītais procesa ID nepieder programmai."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Simptoma skripts %s nenoteica ietekmēto pakotni"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Pakotne %s neeksistē"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "Neizdodas izveidot ziņojumu"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "Uzlabo ziņojumu par problēmu"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -185,7 +185,7 @@ msgstr ""
 "\n"
 "Lūdzu izveidojiet jaunu ziņojumu izmantojiet \"apport-bug\"."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -206,24 +206,24 @@ msgstr ""
 "\n"
 "Vai jūs patiešām vēlaties turpināt?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "Nekāda papildus informācija netika savākta."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "Par kāda veida problēmu jūs vēlaties ziņot?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Nezināms simptoms"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Simptoms \"%s\" nav zināms."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -234,7 +234,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -242,30 +242,30 @@ msgstr ""
 "Pēc šīs ziņas aizvēršanas, lūdzu, klikšķiniet uz lietotnes loga, lai ziņotu "
 "par tās problēmu."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop neizdevās noteikt loga procesa ID"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "Norādīt pakotnes nosaukumu."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "Pievienot papildu etiķeti atskaitei. Var norādīt vairākas reizes."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -275,16 +275,16 @@ msgstr ""
 "tikai --pid karodziņu. Ja neviens no tiem nav dots, parāda sarakstu ar "
 "zināmiem simptomiem (pieņemot, ka dots viens arguments)."
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "Klikšķiniet uz loga, kas ir problēmas ziņojuma mērķis."
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "Sākt kļūdas atjaunināšanas režīmā. Var pieņemt optionālu --package karodziņu."
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -292,7 +292,7 @@ msgstr ""
 "Aizpildīt kļūdas ziņojumu par simptomu (pieņemot, ka simptoma nosaukums ir "
 "dots kā vienīgais arguments)."
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -300,7 +300,7 @@ msgstr ""
 "Norādiet pakotnes nosaukumu --file-bug režīmā. Tas ir optionāli ja --pid ir "
 "norādīts (pieņemot, ka pakotnes nosaukums ir dots kā vienīgais arguments)."
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -310,11 +310,11 @@ msgstr ""
 "ziņojums saturēs vairāk informācijas. (Tiek pieņemts, ja pid ir padots kā "
 "vienīgais parametrs.)"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "Norādītais procesa identifikators (pid) ir \"uzkārusies\" lietotne"
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -324,7 +324,7 @@ msgstr ""
 "avārijām, kas gaida savu kārtu %s (pieņemot, ka fails ir dots kā vienīgais "
 "arguments)."
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -333,127 +333,129 @@ msgstr ""
 "Kļūdas iesniegšanas režīmā saglabājiet savākto informāciju failā, nevis "
 "ziņojiet par to. Pēc tam uz cita datora šo failu var noziņot."
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Drukāt Apport versijas numuru."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Tas palaidīs apport-retrace termināļa logā, lai sīkāk izpētītu avāriju."
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "Palaist gdb sesiju"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Palaist gdb sesiju bez atkļūdošanas simbolu lejupielādes"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Atjaunināt %s ar pilnīgu simbolisko izsekošanas pavedienu"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 "Šis ziņojums par problēmu attiecas uz programmu, kas vairs nav instalēta "
 "šajā sistēmā."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 msgstr "Problēma notika ar programmu %s, kura ir mainījusies kopš avārijas."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Problēmas ziņojums ir bojāts un to nevar apstrādāt."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr "Šis ziņojums ir par pakotni, kas nav instalēta."
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "Notika kļūda apstrādājot šo problēmu ziņojumu:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "Neizdevās noteikt pakotnes vai pirmkoda pakotnes nosaukumu."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "Neizdevās palaist tīmekļa pārlūku"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Neizdevās palaist tīmekļa pārlūku, lai atvērtu %s."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Tīkla problēma"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Neizdodas savienoties ar avāriju datubāzi, lūdzu pārbaudiet jūsu Internet "
 "savienojumu."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Tīkla problēma"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Atmiņas pārtēriņš"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Jūsu sistēmai nepietiek atmiņas, lai apstrādātu šo ziņojumu par avāriju."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -464,11 +466,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "Jau zināma problēma"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -478,38 +480,37 @@ msgstr ""
 "Lūdzu pārbaudiet, vai jūs varat pievienot papildus informāciju, kas varētu "
 "būt noderīga izstrādātājiem."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Šī problēma jau ir ziņota izstrādātājiem. Paldies!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Lai turpinātu, nospiediet jebkuru taustiņu..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "Ko jūs vēlētos darīt? Jūsu opcijas ir:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Lūdzu izvēlieties (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i baiti)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(bināri dati)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Sūtīt ziņojumu par problēmu izstrādātājiem?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -517,50 +518,50 @@ msgstr ""
 "Pēc tam, kad problēma būs nosūtīta, lūdzu aizpildiet formu, kas tiks\n"
 "automātiski atvērta tīmekļa pārlūkā."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "&Sūtīt ziņojumu (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "&Eksaminēt lokāli"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "Sk&atīt ziņojumu"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr "&Paturēt ziņojumu failu sūtīšanai vēlāk vai kopēšanai uz citurieni"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "Atcelt un &ignorēt šīs programmas versijas tālākās avārijas"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "At&celt"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Problēmas ziņojuma fails:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "Aps&tiprināt"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Kļūda: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "Savāc informāciju par problēmu"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -569,11 +570,11 @@ msgstr ""
 "lietotnes\n"
 "darbību. Tas var aizņemt pāris minūtes."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "Augšupielādē informāciju par problēmu"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -581,56 +582,56 @@ msgstr ""
 "Savāktā informācija tiek nosūtīta uz kļūdu sekošanas sistēmu.\n"
 "Tas var aizņemt pāris minūtes."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Pabeigts"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "nekas"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "Izvēlēts: %s. Vairākas izvēles:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Izvēles:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "Ceļs uz failu (Enter, lai atsauktu):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "Fails nepastāv."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "Tā ir direktorija."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "Lai turpinātu, jums jāapmeklē šekojoša adrese ar URL:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
 msgstr ""
 "Jūs varat palaist pārlūku tagad, vai arī nokopēt šo URL pārlūkā citā datorā."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Palaist pārlūku tagad"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 "Nav gaidošu ziņojumu par avāriju. Mēģiniet --help, lai uzzinātu vairāk."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr "Ziņojumam nepievienot jaunas trases, bet izvadīt tās stdout."
 
@@ -648,27 +649,27 @@ msgid ""
 msgstr ""
 "Raksta izmainītu ziņojumu uz doto failu oriģinālā ziņojuma izmainīšanas vietā"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr "Izņemt kodola izmeti no ziņojuma pēc steka trases reģenerācijas"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "Pārrakstīt ziņojuma CoreFile"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "Pārrakstīt ziņojuma ExecutablePath"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "Pārrakstīt ziņojuma ProcMaps"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "Pārbūvēt ziņojumā iekļauto informāciju par pakotni"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -685,7 +686,7 @@ msgstr ""
 "konfigurācijas faili, bet tad  tas varēs izsekot tikai tām avārijām, kas "
 "notiek pašlaik strādājošā laidienā."
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
@@ -695,28 +696,28 @@ msgstr ""
 "to pašu laidienu kā pārskatam, nevis to, kas ir jau instalētajai gdb "
 "versijai."
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 "Ziņot par lejupielādes/instalēšanas progresu, kad pakotnes tiek instalēts "
 "smilšu kastē."
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr "Pievienot laika zīmogus žurnāla ierakstiem"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 "Izveidot un izmantot trešās puses krātuves no vietām, kas ir norādītas "
 "pārskatos"
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr "Pieglabāt mapi pakotnēm, kas lejupielādētas smilšu kastē"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -724,12 +725,12 @@ msgstr ""
 "Direktorija  neatpakotajām pakotnēm. Nākotnē programma uzskatīs ka jebkura "
 "lejupielādētā pakotne ir arī atarhivēta šeit."
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr "Instalēt papildu pakotni smilšu kastē (var norādīt vairākas reizes)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -739,7 +740,7 @@ msgstr ""
 "tiek izmantots norādot avārijas ID, kad tiek augšupielādētas pārtrasētās "
 "steka trases (tikai ja nav norādīts neviens no -g, -o, vai -s)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -747,31 +748,31 @@ msgstr ""
 "Attēlot pātrasētās steka trases un vaicāt pēc apstiprinājuma pirms sūtīt tās "
 "uz avāriju datubāzi."
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 "Ceļš uz dublikāta sqlite datubāzi (pēc noklusējuma: nepārbaudīt dublikātu)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr "Ziņojumam nepievienot StacktraceSource."
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "Nevar izmantot -C bez -S. Aptur."
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "Sūtīt tos kā pielikumus? [j/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -779,19 +780,19 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "Mērķa direktorija eksistē un nav tukša."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "Skatiet rokasgrāmatu “man”, lai uzzinātu vairāk"
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "norādiet žurnāla datnes nosaukumu, ko veidojis valgrind"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
@@ -799,7 +800,7 @@ msgstr ""
 "atkārtoti izmantot iepriekš izveidoto smilšu kastes direktoriju (SDIR) vai "
 "tādu izveidot, ja tāda neeksistē"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -808,7 +809,7 @@ msgstr ""
 "atkļūdošanas simboliem, bet paļauties tikai uz instalētajiem atkļūdošanas "
 "simboliem."
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
@@ -816,23 +817,23 @@ msgstr ""
 "atkārtoti izmantot iepriekš izveidoto kešatmiņas direktoriju (CDIR) vai tādu "
 "izveidot, ja tāda neeksistē"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 "ziņot lejupielādes/instalēšanas progresu, kad pakotnes instalē smilšu kastē"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Kļūda — %s nav izpildāms. Aptur."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -840,7 +841,7 @@ msgstr ""
 "Tas gadījās iepriekšējā iesnaudināšanas reizē un tas neļāva sistēmai normāli "
 "atsākt darbu."
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -848,7 +849,7 @@ msgstr ""
 "Tas gadījās iepriekšējā iemidzināšanas reizē un tas neļāva sistēmai normāli "
 "atsākt darbu."
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -856,7 +857,7 @@ msgstr ""
 "Atsākšanas process pakārās tuvu beigām, kas radīs iespaidu, ka tas ir "
 "pabeigts normāli."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr "Jūsu sistēma varētu tagad kļūt nestabila, un to vajadzētu pārstartēt."
 
@@ -870,76 +871,76 @@ msgstr "Ziņot par problēmu..."
 msgid "Report a malfunction to the developers"
 msgstr "Ziņot par kļūdainu funkcionalitāti izstrādātājiem"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "Atvainojiet, lietotne %s negaidīti pārstāja strādāt."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "Atvainojiet, %s aizvērās negaidīti."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "Atvainojiet, %s gadījās iekšēja kļūda."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Sūtīt"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Rādīt detaļas"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Turpināt"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "Lietotne %s pārstāja atbildēt."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "Programma \"%s\" pārstāja atbildēt."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Pakotne: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "Atvainojiet, problēma notika instalējot programmatūru."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "Lietotnei %s gadījās iekšējā kļūda"
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "Lietotne %s aizvērās negaidīti."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr "Ja jūs pamanāt tālākas problēmas, mēģiniet pārstartēt datoru."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "Ignorēt šāda veida tālākas problēmas"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Slēpt detaļas"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -995,7 +996,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>Augšupielādē informāciju par problēmu</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -1007,27 +1008,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Apport avārijas fails"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "Atstāt aizvērtu"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Palaist vēlreiz"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Lietotājvārds:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Parole:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "Ievāc informāciju par problēmu"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1035,6 +1036,6 @@ msgstr ""
 "Savāktā informācija var tik nosūtīta izstrādātājiem, lai tie varētu uzlabot "
 "lietotni. Tas var aizņemt dažas minūtes."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "Augšupielādē informāciju par problēmu"

--- a/po/mnw.po
+++ b/po/mnw.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2019-11-05 10:32+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Mon <mnw@li.org>\n"
@@ -36,11 +36,11 @@ msgstr "သၞောတ်လိက်ဒုၚ်စဳရေၚ်ပြဿန
 msgid "Please enter your password to access problem reports of system programs"
 msgstr "သွက်ဂွံလုပ်ကျောဝ်ဒုၚ်စဳရေၚ်ပြဿနာသၞောတ်စက်ဂှ်တက်စုတ်ကုဒ်ဒၠုက်ညိ"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr ""
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -57,111 +57,111 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr ""
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr ""
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr ""
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
 msgstr ""
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr ""
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr ""
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr ""
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr ""
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr ""
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr ""
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr ""
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 msgstr ""
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr ""
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr ""
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr ""
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr ""
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -169,7 +169,7 @@ msgid ""
 "Please create a new report using \"apport-bug\"."
 msgstr ""
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -181,24 +181,24 @@ msgid ""
 "Do you really want to proceed?"
 msgstr ""
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr ""
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr ""
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr ""
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr ""
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -209,202 +209,204 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr ""
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr ""
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr ""
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr ""
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr ""
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr ""
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr ""
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr ""
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr ""
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr ""
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr ""
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr ""
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -412,161 +414,160 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr ""
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 msgstr ""
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "သွက်ဂွံဆက်ကၠောန်ဂှ် ဍဵုကောန်ဍေၚ်မွဲမွဲညိ"
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "မုမိက်ဂွံပရော၊ သွက်မၞးဂွံရုဲဂမၠိုၚ်:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "သ္ပဂုဏ်တုဲ ရုဲကဵု(%s):ညိ"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i bytes)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(binary data)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "ပြဿနာဂမၠိုၚ်ဝွံ ပလံၚ်ပစိုပ်ကဵု developers ဏောဝ်"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
 msgstr ""
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "ပလံ၎်လိက်ဒုၚ်စဳရေၚ်(%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "&စၟဳစၟတ်ပ္ဍဲ"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "ကျောဝ်လိက်ဒုၚ်စဳရေၚ်"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr "&ဂိုၚ်စွံလဝ်ဖှိုၚ်ဒုၚ်စဳရေၚ်သွက်ဂွံပလံၚ်လက်ကြဴဟွံသေၚ်မ္ဂးကူစွံလဝ်မွဲမွဲဒၞါဲ"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "တးပါဲဟွံသေၚ်လ္ပပဂရုကဵုတၚ်လီုလီုသပ်ဝဴversion"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&တးပါဲ"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "ဖှိုၚ်ဒုၚ်စဳရေၚ်ပြဿနာ"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&တုပ်စိုတ်"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "တၚ်ဗၠေတ်:%s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "ပကောံမံၚ်အတၚ်နၚ်ပြဿနာဂမၠိုၚ်"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
 msgstr ""
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "ပ္တိုန်ထ္ၜးတၚ်နၚ်ပြဿနာ"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
 msgstr ""
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&တုဲယျ"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "မုဟွံမွဲ"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr ""
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "ပွမရုဲစှ်ဂမၠိုၚ်"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr ""
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "ဖှိုၚ်ဟွံမွဲ"
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr ""
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "သွက်ဂွံဆက်အာဂှ် လုပ်ပ္ဍဲကဵု URLညိ"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
 msgstr "ပံက် browserမွဲဂွံယျ၊ ဟွံသေၚ်မ္ဂးကူစွံURLပ္ဍဲကဵု browserကောန်ပျူတာတၞဟ်ညိ"
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "ပံက် browser"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 
@@ -581,27 +582,27 @@ msgid ""
 "Write modified report to given file instead of changing the original report"
 msgstr "သၞးပၠေဝ်လိက်ဒုၚ်စဳရေၚ်မူလဂှ် ချူကေတ်တၟိမွဲတုဲ ပ္တိုန်ညိ"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "ကလေၚ်ချူကဵုဖှိုၚ်ဒုၚ်စဳရေၚ်အဓိကညိ"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr ""
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "ကလေၚ်ချူဒုၚ်စဳရေၚ် ProcMapsညိ"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "ကလေၚ်ဒက်ပ္တန်ဒုၚ်စဳရေၚ်တၚ်နၚ် Packageညိ"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -611,78 +612,78 @@ msgid ""
 "be able to retrace crashes that happened on the currently running release."
 msgstr ""
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
 "have installed."
 msgstr ""
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr ""
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
 msgstr ""
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
 "neither -g, -o, nor -s are specified)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
 msgstr ""
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr ""
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr ""
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr ""
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -690,70 +691,70 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "ဂၠံၚ်ဍာန်ဒၞါဲဂှ်တိတ်အာတုဲလေဝ် သှေ်ၜက်မံၚ်ဏီ"
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "ကျောဝ်မုက်လိက်မၞးသွက်သောဲသောဲဗြောဲဗြောဲ"
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "ဖှိုၚ် valgrindမပ္တိတ်လဝ်ဝွံ စုတ်ကဵုယၟုချိုတ်တ်ပၠိုတ်တ်ညိ"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "တၚ်ဗၠေတ် %s ဝွံစကာဟွံဂွံ၊ ဒေါံမံၚ်"
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
 msgstr ""
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 
@@ -767,76 +768,76 @@ msgstr "ဒုၚ်စဳရေၚ်ပြဿနာ"
 msgid "Report a malfunction to the developers"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "အောန်စိုတ်ကွေံရ၊ သပ်ဝဴ %s ဝွံ ဒေါံအာယျ"
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "အောန်စိုတ်ကွေံရ၊ %s ဝွံ ကၟာတ်အာယျ"
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "အောန်စိုတ်ကွေံရ၊ %s ဝွံ ဒှ်မံၚ်ပြဿနာလ္ပာ်ပ္ဍဲ"
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "ပလံၚ်ဗ္စိုပ်"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "ထ္ၜးဗွဲတြး"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "ဆက်အာ"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "သပ်ဝဴ %s ဝွံ ခက်ခုဲဒေါံအာယျ"
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "အစဳအဇန် %sဝွံဒေါံအာယျ"
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "ဓုပ်ကဠာ: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "အခိၚ်ပ္တိုန်စုတ်မံၚ် ပြဿနာနွံမံၚ်ညိည"
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "သပ်ဝဴ %sဝွံ ဒှ်မံၚ်ပြဿနာပ္ဍဲစက်"
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "သပ်ဝဴ %sဝွံ ကၟာတ်အာယျ"
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr "ယဝ်ဆဵုပြဿနာတၞဟ်နူဏံမ္ဂး ကၟာတ် ပံက်ကောန်ပျူတာမၞးတုဲ စမ်ရံၚ်ညိ"
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "ဂကူပြဿနာဏံဝွံ ဟလေတ်ထောံညိ"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "ပၞုက်ထောံတၚ်သောဲသောဲဗြောဲဗြောဲဂမၠိုၚ်"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr ""
 
@@ -890,7 +891,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr ""
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -900,32 +901,32 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "ဖှိုၚ်လီုလီုနူApport"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr ""
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr ""
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr ""
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr ""
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr ""
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
 msgstr ""
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr ""

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2013-04-08 10:39+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Marathi <mr@li.org>\n"
@@ -36,11 +36,11 @@ msgstr "प्रणाली समस्या अहवाल"
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "हे संकुल योग्य प्रकारे स्थापित केलेले दिसत नाही"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -61,21 +61,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "अपरिचीत कार्यक्रम"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "क्षमस्व, कार्यक्रम \"%s\" अनपेक्षितपणे बंद पडला"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "%s यात समस्या"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -83,63 +78,68 @@ msgstr ""
 "आपल्या संगणकावर आपोआप समस्या विश्लेषण आणि विकसकांसाठी एक अहवाल पाठवण्यासाठी अतिरीक्त "
 "मोकळी जागा नाही."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "%s यात समस्या"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "अवैध समस्या अहवाल"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "आपण हा समस्या अहवाल प्रवेश करण्याची परवानगी नाही."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "त्रुटी"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "या अहवालावर प्रक्रिया करण्यासाठी पुरेशी जागा उपलब्ध नाही."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "अवैध पीआयडी"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "पॅकेज निर्दिष्ट केले नाही"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "तुम्ही पॅकेज किंवा पी आय डी निर्देशीत करणे आवश्यक आहे. अधिक माहितीसाठी --help पहा."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "परवानगी नाही"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -147,30 +147,30 @@ msgstr ""
 "निर्दिष्ट प्रक्रिया आपणाशी संबंधित नाही. या कार्यक्रमात प्रक्रिया मालक म्हणून किंवा रूट "
 "म्हणून चालवा."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "निर्दिष्ट कार्यपध्दती ID एक कार्यक्रम संबंधित नाही."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "लक्षण स्क्रिप्ट %s ने प्रभावित पॅकेज निश्चित केले नाही"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "पेकेज %s अस्तित्वात नाही"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "अहवाल निर्माण करू शकत नाही"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "समस्या अहवाल अद्ययावत करत आहे"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -182,7 +182,7 @@ msgstr ""
 "\n"
 "\"apport-bug\" वापर करून नवीन अहवाल तयार करा."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -201,24 +201,24 @@ msgstr ""
 "\n"
 "आपण खरोखर पुढे जायचे?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "अधिक माहिती गोळा केली नाही."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "आपण काय प्रकारची समस्या तक्रार नोंदवू इच्छित आहात?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "अपरिचीत लक्षण"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "लक्षण \"%s\" ज्ञात नाही."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -229,36 +229,36 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr "हा संदेश बंद केल्यानंतर त्याबद्दल एक समस्या कळवण्याची खिडकी वर क्लिक करा."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop विंडो प्रक्रिया आयडी निर्धारित करण्यासाठी अयशस्वी झाले"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "पॅकेज नाव निर्देशित करा."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "अहवाल एक अतिरिक्त टॅग जोडा. अनेक वेळा निर्देशीत करणे शक्य आहे."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -268,21 +268,21 @@ msgstr ""
 "आवश्यक आहे. नाही दिली तर ओळखले लक्षणे यादी प्रदर्शित केली जाईल. (एकच आर्ग्युमेण्ट दिले असेल "
 "तर.)"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "एक समस्या अहवालासाठी लक्ष्य विंडो क्लिक करा."
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "बग अद्ययावत करणे मोडमध्ये सुरू. एक पर्यायी --package घेऊ शकता."
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr "एक लक्षणाबद्दल बग अहवाल. (जर लक्षण नाव एकमेव वितर्क म्हणून दिले जाते तर.)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -290,7 +290,7 @@ msgstr ""
 "--file-bug mode मध्ये पॅकेज नाव निर्देशीत करा. एक --pid निर्दिष्ट केले नसेल तर हे ऐच्छिक "
 "आहे. (जर संकुल नाव एकमेव वितर्क म्हणून दिले तर.)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -299,11 +299,11 @@ msgstr ""
 "--file-bug मोड मध्ये एक रनिंग कार्यक्रम निर्देशीत करा. हे निर्देशीत केल्यास, बग अहवाल "
 "अधिक माहिती असेल. (जर पी आय डी एकमेव वितर्क म्हणून दिले तर.)"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "प्रदान PID एक अडकलेला अनुप्रयोग आहे."
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -312,128 +312,130 @@ msgstr ""
 "%s प्रलंबित विषयाऐवजी दिलेले .apport किंवा .crash फाइल पासून क्रॅश अहवाल द्या. (फाइल "
 "एकमेव वितर्क म्हणून दिले गेले असेल तर.)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Apport आवृत्ती क्रमांक छापा."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "gdb सेशन चालवा"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "डिबग चिन्हे डाउनलोड न करता gdb सेशन चालवा"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "पूर्णपणे प्रतिकात्मक स्टॅक ट्रेसने %s अद्ययावत करा"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr "हा समस्या अहवाल जो आता स्थापित नाही अशा एक कार्यक्रमाला लागू होतो."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr ""
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr ""
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "ही समस्या रिपोर्ट करण्याचा प्रयत्न करताना एक त्रुटी आली:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "संकुल उगम किंवा संकुल नाव निश्चित करू शकत नाही."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "वेब ब्राउजर सुरु करू शकत नाही"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "%s उघडण्याकरिता वेब ब्राउजर सुरु करू शकत नाही."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "संजाळ समस्या"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr "क्रॅश माहितीकोशाला जोडू शकत नाही, आपले इंटरनेट कनेक्शन तपासा."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "संजाळ समस्या"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "स्मृती अपुरी पडली"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "आपल्या प्रणालीमध्ये हा क्रॅश अहवाल प्रक्रिया करण्यासाठी पुरेशी स्मृती नाही."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -444,161 +446,160 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "समस्या अगोदरच माहित आहे"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 msgstr ""
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "ही समस्या आधीच विकसकांकडे आलेली आहे. धन्यवाद!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "पुढे जाण्यास कोणतीही कळ दाबा..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "तुम्हाला काय करायला आवडेल? पर्याय याप्रमाणे आहेत:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "कृपया निवडा (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i बाइट्स)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(बायनरी डेटा)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "विकसकांसाठी समस्या अहवाल पाठवा?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
 msgstr ""
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "बग अहवाल पाठवा (&S) (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "स्थानीयरित्या तपासा (&E)"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "अहवाल बघा (&V)"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr "नंतर किंवा दुसरीकडे कुठेतरी पाठवून कॉपी अहवाल फाईल ठेवा(_K)"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "रद्द करा आणि या कार्यक्रमाच्या या आवृत्तीचे भविष्यातील क्रॅशकडे दुर्लक्ष करा"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "रद्द करा (&C)"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "समस्या अहवाल फाईल :"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "खात्री करा (&C)"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "त्रुटी : %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "समस्या माहिती गोळा करत आहे"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
 msgstr ""
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "समस्या माहिती अपलोड होत आहे"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
 msgstr ""
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "झाले (&D)"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "काही नाही"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "निवडलेले : %s. अनेक पर्याय :"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "पर्याय :"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "फाईलचा पथ (रद्द करण्यासाठी प्रविष्ट करा):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "फाईल अस्तित्वात नाही."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "हि संचयीका आहे."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "सुरू ठेवण्यासाठी, आपण खालील URL ला भेट देणे आवश्यक आहे:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
 msgstr ""
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "ब्राऊजर दाखल करा"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 
@@ -613,27 +614,27 @@ msgid ""
 "Write modified report to given file instead of changing the original report"
 msgstr ""
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr ""
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr ""
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr ""
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr ""
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -643,78 +644,78 @@ msgid ""
 "be able to retrace crashes that happened on the currently running release."
 msgstr ""
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
 "have installed."
 msgstr ""
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr ""
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
 msgstr ""
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
 "neither -g, -o, nor -s are specified)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
 msgstr ""
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr ""
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr ""
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "या संलग्नक म्हणून पाठवण्यासाठी ओके? [हो / नाही]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -722,70 +723,70 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "गंतव्य निर्देशिका विद्यमान आहे आणि रिक्त नाही."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "अधिक माहितीसाठी man पान पहा."
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "वॅलग्रींड निर्मीत लॉग फाइल नाव निर्देशीत करा"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr ""
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
 msgstr ""
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 
@@ -799,76 +800,76 @@ msgstr "समस्या अहवाल सादर करा..."
 msgid "Report a malfunction to the developers"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "क्षमस्व, %s अंतर्गत त्रुटी आली आहे."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "पाठवा"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "तपशील दर्शवा"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "पुढे चला"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "पेकेज : %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "क्षमस्व, सॉफ्टवेअर स्थापित करताना एक समस्या आली."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "अनुप्रयोग %s अंतर्गत त्रुटी आली आहे."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "अनुप्रयोग %s अनपेक्षितपणे बंद झाला आहे."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr "आपणास अजून समस्या आल्यास, संगणक रीस्टार्ट करून पहा."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "या प्रकारच्या समस्येकडे दुर्लक्ष करा"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "तपशील लपवा"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "एप्पोर्ट"
 
@@ -924,7 +925,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>समस्या माहिती अपलोड चालू आहे</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -935,27 +936,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr ""
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "बंद ठेवा"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "पुन्हा प्रक्षेपण करा"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "वापरकर्ता नाव :"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "गुप्तशब्द :"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "समस्या माहिती गोळा करत आहे"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -963,6 +964,6 @@ msgstr ""
 "गोळा माहिती अनुप्रयोग सुधारण्यासाठी विकसकांसाठी पाठविले जाऊ शकते. यास काही मिनिटे "
 "लागू शकतील."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "समस्या माहिती अपलोड करत आहे"

--- a/po/ms.po
+++ b/po/ms.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2019-09-13 17:48+0000\n"
 "Last-Translator: abuyop <Unknown>\n"
 "Language-Team: Malay <ms@li.org>\n"
@@ -40,11 +40,11 @@ msgstr ""
 "Sila masukkan kata laluan anda untuk mencapai laporan masalah bagi program "
 "sistem"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "Pakej ini nampaknya tidak dipasang dengan betul"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -55,7 +55,7 @@ msgstr ""
 "pakej yang ada, sekiranya tidak berfungsi maka buang pakej-pakej pihak "
 "ketiga dan cuba sekali lagi."
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -68,21 +68,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "program tidak diketahui"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Maaf, program \"%s\" terpaksa ditutup tanpa dijangka"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Masalah pada %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -90,64 +85,69 @@ msgstr ""
 "Komputer anda tidak mempunyai ingatan bebas yang mencukupi untuk "
 "menganalisis masalah dan hantar laporan ke pembangun secara automatik."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Masalah pada %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Laporan masalah tidak sah"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "Anda tidak dibenarkan mencapai laporan masalah ini."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Ralat"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "Ruang cakera tidak mencukupi untuk memproses laporan ini."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr "Tiada PID dinyatakan"
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr "Anda perlu nyatakan satu PID. Sila rujuk --help untuk maklumat lanjut."
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "PID tidak sah"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr "ID proses yang dinyatakan tidak wujud."
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr "Bukan PID anda"
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr "ID proses yang dinyatakan bukan milik anda."
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "Tiada pakej dinyatakan"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Anda perlu menyatakan satu pakej atau satu PID. Sila rujuk --help untuk "
 "maklumat lanjut."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Kebenaran dinafikan"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -155,30 +155,30 @@ msgstr ""
 "Proses tersebut bukan milik anda. Sila jalankan program sebagai pemilik "
 "proses atau root."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "ID proses yang ditentukan tidak dimiliki oleh program tersebut."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Skrip simptom %s tidak menentukan pakej yang terjejas"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Pakej %s tidak wujud"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "Tidak dapat mencipta laporan"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "Mengemas kini laporan masalah"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -190,7 +190,7 @@ msgstr ""
 "\n"
 "Sila cipta laporan baru menggunakan \"apport-bug\"."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -211,24 +211,24 @@ msgstr ""
 "\n"
 "Adakah anda ingin meneruskannya?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "Tiada maklumat tambahan dikutip."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "Apakah jenis masalah yang anda ingin laporkan?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Simpton tidak diketahui"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Simptom \"%s\" tidak diketahui"
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -239,7 +239,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -247,31 +247,31 @@ msgstr ""
 "Selepas menutup mesej ini sila klik pada tetingkap aplikasi untuk melaporkan "
 "masalah tersebut."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop gagal memastikan ID proses tetingkap"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "Nyatakan nama pakej."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Tambah satu tag tambahan ke dalam laporan. Boleh dinyatakan beberapa kali."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -281,16 +281,16 @@ msgstr ""
 "hanya --pid. Jika tidak diberikan, papar satu senarai simptom yang "
 "diketahui. (Dilaksanakan jika satu argumen tunggal diberikan.)"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 "Klik satu tetingkap sebagai  satu sasaran untuk failkan satu laporan masalah"
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "Mula dalam mod kemas kini pepijat. Boleh ambil pilihan --package."
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -298,7 +298,7 @@ msgstr ""
 "Failkan satu laporan pepijat mengenai simptom. (Dilaksanakan jika nama "
 "simptom diberikan sebagai argumen sahaja.)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -306,7 +306,7 @@ msgstr ""
 "Nyatakan nama pakej dalam mod --file-bug. Ini merupakan pilihan jika --pid "
 "ditentukan. (Dilaksanakan jika nama pakej diberikan sebagai argumen sahaja.)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -315,11 +315,11 @@ msgstr ""
 "Nyatakan nama pakej dalam mod --file-bug. Ini merupakan pilihan jika --pid "
 "ditentukan. (Dilaksanakan jika nama pakej diberikan sebagai argumen sahaja.)"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "Pid yang disediakan adalah aplikasi kaku."
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -329,7 +329,7 @@ msgstr ""
 "yang ditangguh pada %s. (Dilaksanakan jika fail hanya diberikan sebagai "
 "argumen.)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -339,49 +339,49 @@ msgstr ""
 "selain dari melaporkannya. Fail ini kemudiannya boleh dilaporkan melalui "
 "komputer lain."
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Papar nombor versi Apport."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Tindakan ini akan melancarkan apport-retrace dalam tetingkap terminal untuk "
 "memeriksa kerosakan."
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "Jalankan sesi gdb"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Jalankan sesi gdb tanpa memuat turun simbol nyahpepijat"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Kemas kini %s dengan jejak surihan simbolik penuh"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr "Tidak mengingati tetapan status laporan dihantar"
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 "Menyimpan keadaan pelaporan kerosakan yang gagal. Tidak dapat tetapkan mod "
 "pelaporan auto atau tidak sesekali."
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr "Tidak mengingati tetapan status laporan dihantar"
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 "Laporan masalah ini diterap kepada program yang mana ia tidak dipasang lagi."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
@@ -390,19 +390,21 @@ msgstr ""
 "Masalah berpunca dari program %s yang mana telah berubah semejak kerosakan "
 "berlaku."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Laporan masalah ini sudah rosak dan tidak boleh diproses."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr "Laporan ini berkenaan satu pakej yang tidak dipasang."
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "Satu ralat berlaku semasa cuba memproses laporan masalah ini:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
@@ -410,24 +412,24 @@ msgstr ""
 "Anda telah memasang dua versi aplikasi ini, versi manakah mahu digunakan "
 "untuk melaporkan pepijat?"
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr "snap %s"
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr "pakej deb %s"
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s disediakan oleh snap yang diterbitkan oleh %s. Sila hubungi mereka "
 "melalui %s untuk mendapatkan bantuan."
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -437,41 +439,41 @@ msgstr ""
 "perhubungan telah disediakan; sila lawati forum di https://forum.snapcraft."
 "io/ untuk mendapatkan bantuan."
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "Tidak dapat mengenal pasti pakej atau nama sumber pakej."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "Tidak boleh memulakan pelayar sesawang"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Tidak boleh mulakan pelayar sesawang untuk membuka %s."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Masalah rangkaian"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Tidak dapat menyambung ke pangkalan data kerosakan, sila semak sambungan "
 "internet anda."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Masalah rangkaian"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Kehabisan ingatan"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Sistem anda tidak mempunyai ingatan yang mencukupi untuk memproses laporan "
 "kerosakan ini."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -482,11 +484,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "Masalah sudah pun diketahui"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -496,38 +498,37 @@ msgstr ""
 "dalam pelayar sesawang. Sila semak jika anda boleh menambah maklumat "
 "lanjutan lagi yang dikira boleh dianggap berguna untuk para pembangun."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Masalah ini sudah dilaporkan kepada pembangun. Terima kasih!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Tekan mana-mana kekunci untuk teruskan..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "Apakah yang anda ingin lakukan? Pilihan anda adalah:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Sila pilih (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i bait)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(data binari)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Hantar laporan masalah kepada para pembangun?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -535,52 +536,52 @@ msgstr ""
 "Selepas laporan masalah dihantar, sila isikan borang dalam\n"
 "pelayar sesawang yang terbuka secara automatik."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "&Hantar laporan(%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "&Periksa secara setempat"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "&Lihat laporan"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 "&Simpan dahulu fail laporan untuk dihantarkan kemudian atau salin ke tempat "
 "lain terlebih dahulu"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "Batal dan &abaikan kerosakan di masa hadapan untuk versi program ini"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Batal"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Fail laporan masalah:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&Sahkan"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Ralat: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "Mengutip maklumat masalah"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -589,11 +590,11 @@ msgstr ""
 "mempertingkatkan\n"
 "kualiti aplikasi. Ia mungkin mengambil masa beberapa minit."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "Memuat naik maklumat masalah"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -601,40 +602,40 @@ msgstr ""
 "Maklumat yang dikutip telah dihantar ke sistem penjejakan pepijat.\n"
 "Ia mungkin mengambil masa beberapa minit."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Selesai"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "tiada"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "Dipilih: %s. Pilihan berbilang:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Pilih:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "Laluan ke fail (Enter untuk batal):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "Fail tidak wujud."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "Ini adalah sebuah direktori."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "Untuk teruskan, anda mesti lawati URL berikut:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -642,16 +643,16 @@ msgstr ""
 "Anda boleh lancarkan pelayar sekarang, atau salin URL ini kedalam pelayar "
 "pada komputer lain."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Lancarkan sebuah pelayar sekarang"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 "Tiada laporan kerosakan ditangguhkan. Cuba taip --help untuk maklumat lanjut."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 "Jangan letakkan surihan baru kedalam laporan, tetapi tuliskannya ke stdout."
@@ -671,28 +672,28 @@ msgstr ""
 "Tulis laporan yang diubah suai pada fail yang diberikan selain dari mengubah "
 "laporan asal"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 "Buang longgokan teras dari laporan selepas penjanaan semula surihan tindanan"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "Batalkan laporan CoreFile"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "Batalkan laporan ExecutablePath"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "Batalkan laporan ProcMaps"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "Bina semula laporan maklumat pakej"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -709,7 +710,7 @@ msgstr ""
 "menyurih semula kerosakan yang disebabkan keluaran yang dijalankan semasa "
 "ini."
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
@@ -719,27 +720,27 @@ msgstr ""
 "menggunakan keluaran yang sama sebagai laporan berbanding apa jua versi gdb "
 "yang anda telah pasangkan."
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 "Lapor kemajuan muat turun/pasang bila memasang pakej ke dalam kotak pasir"
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr "Tokok setem masa untuk log mesej, bagi operasi kelompok"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 "Cipta dan guna repositori pihak-ketiga dari asal yang dinyatakan dalam "
 "laporan"
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr "Direktori cache untuk pakej yang dimuat turun dalam kotak pasir"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -748,14 +749,14 @@ msgstr ""
 "menganggap mana-mana pakej yang sudah dimuat turun juga di ekstrak ke dalam "
 "kotak pasir ini."
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 "Pasang pakej tambahan ke dalam kekotak pasir (boleh ditentukan berbilang "
 "kali)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -765,7 +766,7 @@ msgstr ""
 "digunakan bila menentukan ID kerosakan untuk muat naik jejak tindanan yang "
 "dijejakkan semula (hanya jika tidak -g, -o ataupun -s ditentukan)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -773,31 +774,31 @@ msgstr ""
 "Papar jejak tindanan yang dijejakkan semula dan tanya pengesahan sebelum "
 "menghantarnya ke pangkalan data kerosakan."
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 "Laluan ke pangkalan data sqlite pendua (lalai: tiada pemeriksaan penduaan)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr "Jangan tambah StacktraceSource ke dalam laporan."
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "Anda tidak bleh guna -C tanpa -S. Dihentikan."
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "OK untuk menghantar lampiran ini? [y/t]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -805,19 +806,19 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "Destinasi direktori wujud dan berisi."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "Rujuk laman panduan untuk perincian."
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "nyatakan nama fail log yang dihasilkan oleh valgrind"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
@@ -825,7 +826,7 @@ msgstr ""
 "guna semula dir kotak pasir (SDIR) yang digunakan sebelum ini atau, jika ia "
 "tidak wujud, cipta baharu"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -833,7 +834,7 @@ msgstr ""
 "jangan cipta atau guna semula direktori kotak pasir untuk simbol nyahpepijat "
 "tambahan tetapi hanya bergantung pada simbol nyahpepijat yang dipasang."
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
@@ -841,23 +842,23 @@ msgstr ""
 "guna semula dir cache (CDIR) yang dicipta sebelum ini, jika tidak wujud, "
 "cipta baharu"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 "lapor kemajuan muat turun/pasang bila memasang pakej ke dalam kotak pasir"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Ralar: %s bukanlah boleh laku. Menghentikan."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -865,7 +866,7 @@ msgstr ""
 "Ia berlaku ketika tangguh terdahulu, dan menghalang sistem menyambung semula "
 "dengan baik."
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -873,7 +874,7 @@ msgstr ""
 "Ia berlaku ketika hibernasi terdahulu, dan menghalang sistem menyambung "
 "semula dengan baik."
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -881,7 +882,7 @@ msgstr ""
 "Proses pemulihan kaku pada saat-saat akhir dan kelihatan selesai seperti "
 "biasa."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 "Sistem anda akan menjadi tidak stabil sekarang dan mungkin perlu dimulakan "
@@ -897,76 +898,76 @@ msgstr "Lapor satu masalah..."
 msgid "Report a malfunction to the developers"
 msgstr "Lapor satu kerosakan kepada para pembangun"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "Maaf, aplikasi %s telah dihentikan tanpa dijangka."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "Maaf, %s telah ditutup tanpa dijangka."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "Maaf, %s telah mengalami ralat dalaman."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Hantar"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Tunjuk Perincian"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Teruskan"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "Aplikasi %s telah berhenti membalas."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "Program \"%s\" telah berhenti membalas."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Pakej: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "Maaf, masalah berlaku semasa memasang perisian."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "Aplikasi %s telah mengalami ralat dalaman."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "Aplikasi %s telah ditutup tanpa dijangka."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr "Jika anda mengalami masalah, cuba mulakan semula komputer."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "Abai masalah masa hadapan bagi jenis ini"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Sembunyi Perincian"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -1022,7 +1023,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>Memuat naik maklumat masalah</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -1034,27 +1035,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Fail rosak Apport"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "Biarkan Tertutup"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Lancar Semula"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Nama Pengguna:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Kata Laluan:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "Mengutip Maklumat Masalah"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1062,6 +1063,6 @@ msgstr ""
 "Maklumat yang dikutip boleh dihantar kepada para pembangun untuk "
 "dipertingkatkan kualiti aplikasi. Ia mungkin mengambil masa beberapa minit."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "Memuat Naik Maklumat Masalah"

--- a/po/my.po
+++ b/po/my.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2012-09-04 12:14+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Burmese <my@li.org>\n"
@@ -36,11 +36,11 @@ msgstr "System ကိုပြဿနာအစီရင်ခံစာမျာ�
 msgid "Please enter your password to access problem reports of system programs"
 msgstr "မိမိကွန်ပျူတာ၏စနစ်ကိုပြဿနာအစီရင်ခံစာများဝင်ရောက်ကြည့်ရှုရန်သင့် password ကိုရိုက်ထည့်ပေးပါ"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "ဒီ package သည်ကောင်းမွန်စွာမသွင်းထားဘူးဟုထင်ရပါသည်"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -51,7 +51,7 @@ msgstr ""
 "အပ်ဒိတ်လုပ်ပြီးနောက် ထပ်စမ်းကြည့်ပါ၊ ၎င်းသည် အလုပ်မလုပ်ပါက သက်ဆိုင်ရာ third party "
 "ပက်ကေ့ဂျ်များကိုဖယ်ရှားပြီး ထပ်စမ်းကြည့်ပါ။"
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -64,21 +64,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "အမည်မသိပရိုဂရမ်"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "ဆောရီး၊ ပရိုဂရမ် \"%s\" သည်မမျှော်လင့်ပဲပိတ်သွားပါသည်"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "%s တွင်ပြသာနတက်နေပါသည်"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -86,63 +81,68 @@ msgstr ""
 "သင့်ကွန်ပျူတာတွင် ပြဿနာကိုအလိုအလျောက်ခွဲခြမ်းစိတ်ဖြာပြီး ဆော့ဖ်ဝဲရ်ရေးသားသူများထံ အစီရင်ခံစာပေးပို့ရန်အတွက် "
 "လုံလောက်သည့် free memory မရှိပါ။"
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "%s တွင်ပြသာနတက်နေပါသည်"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "ပြဿနာသတင်းပို့ချက်မမှန်ကန်ပါ"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "ဤပြဿနာအစီရင်ခံစာသို့ ဝင်ရောက်ခွင့် သင့်တွင်မရှိပါ။"
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "ချို့ယွင်းချက်"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "ဤအစီရင်ခံစာလုပ်ဆောင်ရန်အတွက် ဒစ်ခ်နေရာမှာ မလုံလောက်ပါ။"
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr "PID မသတ်မှတ်ထားပါ။"
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr "PID သတ်မှတ်ရန် လိုအပ်ပါသည်။ နောက်ထပ်အချက်အလက်များအတွက် --help ကို ကြည့်ပါ။"
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "PID မမှန်ကန်ပါ"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr "သတ်မှတ်ထားသော လုပ်ငန်းစဉ် ID မရှိပါ။"
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr "သင်၏ PID မဟုတ်ပါ။"
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr "သတ်မှတ်ထားသော လုပ်ငန်းစဉ် ID မှာ သင်နှင့်မသက်ဆိုင်ပါ။"
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "ပက်ကေ့ဂျ် သတ်မှတ်ထားခြင်း မရှိပါ။"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "ပက်ကေ့ဂျ်တစ်ခု သို့မဟုတ် PID တစ်ခု သတ်မှတ်ရန် လိုအပ်ပါသည်။ နောက်ထပ်အချက်အလက်များအတွက် --help ကိုကြည့်ပါ။"
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "ခွင့်ပြုချက်ငြင်းပယ်ခြင်းခံရပါသည်"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -150,30 +150,30 @@ msgstr ""
 "သတ်မှတ်ထားသော လုပ်ငန်းစဉ်သည် သင်နှင့် မသက်ဆိုင်ပါ။ ကျေးဇူးပြု၍ ဤပရိုဂရမ်ကို လုပ်ငန်းစဉ်ပိုင်ရှင်အဖြစ် သို့မဟုတ် "
 "root အဖြစ် လုပ်ဆောင်ပါ။"
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "သတ်မှတ်ထားသော လုပ်ငန်းစဉ် ID သည် ပရိုဂရမ်တစ်ခုနှင့် မသက်ဆိုင်ပါ။"
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Symptom script %s သည် ထိခိုက်မှုရှိသောပက်ကေ့ဂျ်ကို မဆုံးဖြတ်နိုင်ပါ။"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Package %s သည်မတည်ရှိပါ"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "report မဖန်တီးနိုင်ပါ"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "ပြဿနာအစီရင်ခံစာကို အပ်ဒိတ်လုပ်နေခြင်း"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -184,7 +184,7 @@ msgstr ""
 "ပိတ်ထားပြီးဖြစ်သည်။\n"
 "ကျေးဇူးပြု၍ \"apport-bug\" ကို အသုံးပြုပြီး အစီရင်ခံစာအသစ်တစ်ခုဖန်တီးပါ။"
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -203,24 +203,24 @@ msgstr ""
 "\n"
 "သင် အမှန်တကယ် ရှေ့ဆက်လိုပါသလား။"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "နောက်ထပ် အချက်အလက် စုဆောင်းထားခြင်းမရှိပါ။"
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "ဘယ်လိုပြဿနာမျိုးကိုသတင်းပို့လိုပါသလား။"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Unknown symptom"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "symptom \"%s\" ကို မသိပါ။"
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -238,37 +238,37 @@ msgstr ""
 "တက်ဘ်တွင် မှန်ကန်သောအက်ပလီကေးရှင်းကို သင်ရှာတွေ့သည်အထိ ရွှေ့ပါ။ လုပ်ငန်းစဉ် ID မှာ ID ကော်လံတွင်ရှိသော "
 "စာရင်းပြုစုထားသည့်နံပါတ်ဖြစ်သည်။"
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 "ဤမက်ဆေ့ဂျ်ကိုပိတ်ပြီးနောက် ၎င်းနှင့်ပတ်သက်သည့် ပြဿနာတစ်ခုကို အစီရင်ခံရန်အတွက် Application Window ကို နှိပ်ပါ။"
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop သည် Window ၏ လုပ်ငန်းစဉ် ID ကို ဆုံးဖြတ်ရန် မအောင်မြင်ပါ။"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr "%(prog)s <သတင်းပို့မှုနံပါတ်>"
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "ပက်ကေ့ဂျ်အမည်ကို သတ်မှတ်ပါ။"
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "အစီရင်ခံစာတွင် အပိုတဂ်တစ်ခု ထည့်ပါ။ အကြိမ်ပေါင်းများစွာ သတ်မှတ်နိုင်ပါသည်။"
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -277,15 +277,15 @@ msgstr ""
 "bug filing မုဒ်တွင် စတင်ပါ။ --package နှင့် optional --pid သို့မဟုတ် --pid တစ်ခုသာ လိုအပ်သည်။ "
 "ပေးထားခြင်းမရှိပါက သိရှိထားသော symptoms စာရင်းကို ပြသပါ။ (အငြင်းအခုံတစ်ခုဖြစ်ပါက ညွှန်းဆိုပါ။)"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "ပြဿနာအစီရင်ခံစာတစ်ခု တင်ရန်အတွက် ပစ်မှတ်အဖြစ် ဝင်းဒိုးတစ်ခုကို နှိပ်ပါ။"
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "bug မွမ်းမံခြင်းမုဒ်တွင် စတင်ပါ။ ရွေးချယ်နိုင်သော --package တစ်ခုကို ယူနိုင်ပါသည်။"
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -293,7 +293,7 @@ msgstr ""
 "Symptom တစ်ခုအကြောင်း bug အစီရင်ခံစာတင်ပါ။ (Symptom အမည်ကို Argument တစ်ခုတည်းအဖြစ် "
 "ပေးထားပါက ညွှန်းဆိုရန်)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -301,7 +301,7 @@ msgstr ""
 "--file-bug မုဒ်တွင် ပက်ကေ့ဂျ်အမည်ကို သတ်မှတ်ပါ။ --pid ကို သတ်မှတ်ထားပါက စိတ်ကြိုက်ရွေးချယ်နိုင်ပါသည်။ "
 "(ပက်ကေ့ဂျ်အမည်ကို Argument တစ်ခုတည်းအဖြစ် ပေးထားပါက ညွှန်းဆိုရန်)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -310,11 +310,11 @@ msgstr ""
 "--file-bug မုဒ်တွင် လုပ်ဆောင်နေသောပရိုဂရမ်ကို သတ်မှတ်ပါ။ ၎င်းကို သတ်မှတ်ထားပါက bug အစီရင်ခံစာတွင် "
 "နောက်ထပ်အချက်အလက်များ ပါဝင်မည်ဖြစ်သည်။ (pid ကို Argument တစ်ခုတည်းအဖြစ်သာ ပေးထားပါက ညွှန်းဆိုရန်)"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "ပေးထားသော pid သည် hanging အက်ပလီကေးရှင်းတစ်ခုဖြစ်သည်။"
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -323,7 +323,7 @@ msgstr ""
 "%s ရှိ ဆိုင်းငံ့ထားသည့်အရာများအစား ပေးထားသည့် .apport သို့မဟုတ် .crash ဖိုင်မှ ပျက်စီးမှုကို အစီရင်ခံပါ။ "
 "( File ကို Argument တစ်ခုတည်းအဖြစ်သာ ပေးထားပါက ညွှန်းဆိုရန်)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -332,87 +332,89 @@ msgstr ""
 "bug တင်သည့်မုဒ်တွင် စုဆောင်းထားသောအချက်အလက်များကို အစီရင်ခံမည့်အစား ဖိုင်တစ်ခုတွင် သိမ်းဆည်းပါ။ ဤဖိုင်ကို "
 "အခြားစက်တစ်ခုမှ နောက်ပိုင်းတွင် အစီရင်ခံနိုင်ပါသည်။"
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Apport ဗားရှင်းနံပါတ်ကိုပရင့်ထုတ်မည်"
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr "ပျက်စီးမှုစစ်ဆေးရန်အတွက် Terminal Window တစ်ခုတွင် appport-retrace ကို ဖွင့်ပေးမည်ဖြစ်သည်။"
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "gdb session ကို ဖွင့်ပါ။"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "debug သင်္ကေတများကို ဒေါင်းလုဒ်မလုပ်ဘဲ gdb session ကို ဖွင့်ပါ။"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "အပြည့်အ၀ symbolic stack trace ဖြင့် %s ကို အပ်ဒိတ်လုပ်ပါ။"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr "ပေးပို့လာသည့် အစီရင်ခံစာအခြေအနေပြသတ်မှတ်ချက်များကို မမှတ်မိနိုင်ပါ။"
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 "ပျက်စီးမှုအစီရင်ခံခြင်းအခြေအနေအား သိမ်းဆည်းခြင်းမှာ မအောင်မြင်ပါ။ အလိုအလျောက် သို့မဟုတ် "
 "အစီရင်ခံခြင်းမုဒ်ကို မည်သည့်အခါမျှ သတ်မှတ်နိုင်မည်မဟုတ်ပါ။"
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr "ပေးပို့လာသည့် အစီရင်ခံစာအခြေအနေပြသတ်မှတ်ချက်များကို မမှတ်မိနိုင်ပါ။"
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr "ဤပြဿနာအစီရင်ခံချက်သည် နောက်ထပ်မထည့်သွင်းရသေးသည့် ပရိုဂရမ်တစ်ခုနှင့် သက်ဆိုင်ပါသည်။"
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 msgstr "ပျက်စီးမှုဖြစ်ပွားပြီးနောက် ပြောင်းလဲခဲ့သည့် ပရိုဂရမ် %s နှင့် ပြဿနာဖြစ်ခဲ့သည်။"
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "ဤပြဿနာအစီရင်ခံစာသည် ပျက်စီးနေပြီး လုပ်ဆောင်နိုင်ခြင်းမရှိပါ။"
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr "ဤအစီရင်ခံစာသည် ထည့်သွင်းမထားသော ပက်ကေ့ခ်ျတစ်ခုနှင့်ပတ်သက်သည်။"
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "ဤပြဿနာအစီရင်ခံစာကို လုပ်ဆောင်ရန် ကြိုးစားနေစဉ် အမှားအယွင်းတစ်ခု ဖြစ်ပေါ်ခဲ့သည် -"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 "သင့်တွင် ဤအက်ပလီကေးရှင်း၏ ဗားရှင်းနှစ်မျိုးကိုထည့်သွင်းထားပြီး မည်သည့်တစ်ခုမှ bug တစ်ခုကို အစီရင်ခံလိုပါသလဲ။"
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr "%s snap"
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr "%s deb package"
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr "%s ကို %s မှ ထုတ်ဝေသော snap မှ ပံ့ပိုးပေးပါသည်။ အကူအညီအတွက် %s မှတစ်ဆင့် ၎င်းတို့ထံ ဆက်သွယ်ပါ။"
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -421,37 +423,37 @@ msgstr ""
 "%s ကို %s မှ ထုတ်ဝေသော snap မှ ပံ့ပိုးပေးပါသည်။ ဆက်သွယ်ရန်လိပ်စာ ပေးမထားပါ။ အကူအညီအတွက် ဖိုရမ် "
 "https://forum.snapcraft.io/ တွင် ဝင်ရောက်ကြည့်ရှုပါ။"
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "ပက်ကေ့ဂျ် သို့မဟုတ် အရင်းအမြစ်ပက်ကေ့ဂျ်အမည်ကို မဆုံးဖြတ်နိုင်ပါ။"
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "Web browser ကိုမဖွင့်နိုင်ပါ"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "%s ဖွင့်ရန် ဝဘ်ဘရောက်ဆာကို စတင်၍မရပါ။"
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "နတ်ဝေါ့ပြသာနာ"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr "ပျက်စီးနေသောဒေတာဘေ့စ်သို့ ချိတ်ဆက်၍မရပါ။ ကျေးဇူးပြု၍ အင်တာနက်ချိတ်ဆက်မှုကို စစ်ဆေးပါ။"
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "နတ်ဝေါ့ပြသာနာ"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Memory exhaustion"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "သင့်စနစ်တွင် ဤပျက်စီးမှုအစီရင်ခံစာလုပ်ဆောင်ရန်အတွက် လုံလောက်သော memory မရှိပါ။"
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -462,11 +464,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "ပြသာနာကိုသိရှိပြီးပါပြီ။"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -475,38 +477,37 @@ msgstr ""
 "ဤပြဿနာကို ဝဘ်ဘရောက်ဆာတွင် ပြသထားသည့် bug အစီရင်ခံစာတွင် အစီရင်ခံထားပြီးဖြစ်သည်။ ကျေးဇူးပြု၍ "
 "ဆော့ဖ်ဝဲရ်ရေးသားသူများအတွက် အထောက်အကူဖြစ်နိုင်သည့် နောက်ထပ်အချက်အလက်များထည့်သွင်းနိုင်ရန် စစ်ဆေးပါ။"
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "ဒီပြသာနာကို developer များသို့ပို့ပြီးပါပြီ။ ကျေးဇူးတင်ရှိပါသည်။"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "ဆက်လုပ်ရန်ကီးဘုတ်မှခလုတ်တစ်ခုခုကိုနှိပ်ပါ"
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "သင်ဘာလုပ်လိုပါသလဲ။ သင်၏ရွေးချယ်မှု့များကတော့ -"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "ကျေးဇူးပြုပြီးရွေးပါ (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i bytes)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(binary data)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "developer ဆီသို့ပြသာနာများကို သတင်းပို့မည်"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -514,50 +515,50 @@ msgstr ""
 "ပြဿနာအစီရင်ခံစာပေးပို့ပြီးပါက ကျေးဇူးပြု၍ \n"
 "အလိုအလျောက်ဖွင့်ထားသော Web Browser တွင် ဖောင်ဖြည့်ပါ။"
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "&S အစီရင်ခံစာကိုပို့မည်  (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "locally အလိုက် &_E ဆန်းစစ်ပါ။"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "&V အစီရင်ခံစာကိုကြည့်မည်"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr "နောက်မှပေးပို့ခြင်း သို့မဟုတ် အခြားတစ်နေရာသို့ကူးယူခြင်းတို့အတွက် အစီရင်ခံစာဖိုင်ကို &K သိမ်းဆည်းထားပါ။"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "ဤပရိုဂရမ်ဗားရှင်း၏ အနာဂတ် ပျက်စီးမှုများကို ပယ်ဖျက်ပြီး &i လျစ်လျူရှုပါ။"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&C ပယ်ဖျက်မည်"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "ပြဿနာအစီရင်ခံစာဖိုင် -"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&C အတည်ပြုမည်"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "ချို့ယွင်းချက် - %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "ပြသာနာအချက်အလက်များကိုစုစည်းနေပါသည်"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -566,11 +567,11 @@ msgstr ""
 "ပေးပို့နိုင်ပါသည်။ \n"
 "၎င်းမှာ မိနစ်အနည်းငယ် ကြာနိုင်ပါသည်။"
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "ပြဿနာအချက်အလက်ကို အပ်လုဒ်တင်ခြင်း။"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -578,56 +579,56 @@ msgstr ""
 "စုဆောင်းထားသောအချက်အလက်များကို bug ခြေရာခံစနစ်သို့ ပေးပို့နေပါသည်။\n"
 "၎င်းမှာ မိနစ်အနည်းငယ် ကြာနိုင်ပါသည်။"
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&D ပြီးပါပြီ"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "ဘာမှမဟုတ်"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "ရွေးထားသည် - %s။ Multiple choices:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "ရွေးချယ်မှု့များ -"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "ဖိုင်တင်ရန် လမ်းကြောင်း (ပယ်ဖျက်ရန် ထည့်သွင်းပါ)။"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "ဖိုင်မတည်ရှိပါ"
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "ဤအရာမှာ လမ်းညွှန်တစ်ခုဖြစ်ပါသည်။"
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "ဆက်လက်သွားရန်အတွက် အောက်ပါ URL ကိုအလည်သွားမှရမည် -"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
 msgstr ""
 "သင်သည် ဘရောက်ဆာကို ယခုဖွင့်နိုင်သည် သို့မဟုတ် ဤ URL ကို အခြားကွန်ပျူတာရှိ ဘရောက်ဇာတစ်ခုသို့ ကူးယူနိုင်ပါသည်။"
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "browser တစ်ခုကိုဖွင့်မည်"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 "ဆိုင်းငံ့ထားသော ပျက်စီးမှုအစီရင်ခံစာများမရှိပါ။ နောက်ထပ်အချက်အလက်များအတွက် --help တွင် ရှာဖွေပါ။"
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr "တင်ပြမှုတွင်လမ်းကြောင်းသစ်များမထည့်ပါနှင့် သို့သော် stdout တွင်ရေးပါ"
 
@@ -642,27 +643,27 @@ msgid ""
 "Write modified report to given file instead of changing the original report"
 msgstr "မူလတင်ပြချက်ကို ပြင်မည့်အစား အသစ်ပြင်ထားသောတင်ပြချက်ကိုရေး၍ပေးပါ"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr "ခြေရာခံမှုထုတ်ပြန်ပြီးနောက် ပင်မပြဿနာအစုကို တင်ပြမှုမှဖယ်ထုတ်ပါ"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "တင်ပြမှုရဲ့ အဓိကဖိုင်ကို ပြင်ရေးပါ"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "တင်ပြမှုရဲ့ ခွင့်ပြုလမ်းကြောင်းကိုပြင်ရေးပါ"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "တင်ပြမှုရဲ့ ProcMaps ကိုပြင်ရေးပါ"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "တင်ပြမှုရဲ့ ပက်ကေ့ချ်အချက်အလက်ကို ပြန်တည်ဆောက်ပါ"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -677,7 +678,7 @@ msgstr ""
 "အကယ်၍သင့်အနေဖြင့်စနစ်ဟုသတ်မှတ်လျှင် ၎င်းတို့သည် စနစ်ရဲ့စီမံပြီးသားဖိုင်တွေကိုအသုံးပြုမည်။သို့သော် "
 "ပျက်စီးမှုလမ်းကြောင်းများကိုသာသိနိုင်ပြီးယခုလက်ရှိထွက်ရှိမှုတွင်သာအကြုံးဝင်သည်။"
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
@@ -686,26 +687,26 @@ msgstr ""
 "သင်ထည့်သွင်းထားသည့် မည်သည့် gdb ဗားရှင်းမဆိုထက် အစီရင်ခံစာကဲ့သို့ တူညီသောထွက်ရှိမှုကို အသုံးပြု၍ gdb နှင့် ၎င်း၏ "
 "dependencies တို့ကို ထည့်သွင်းရန်အတွက် နောက်ထပ် ယာယီ sandbox ကို တည်ဆောက်ပါ။"
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 "ပက်ကေ့ဂျ်များကို sandbox တွင် ထည့်သွင်းသည့်အခါ ဒေါင်းလုဒ်လုပ်ခြင်း/ထည့်သွင်းခြင်းတိုးတက်မှုကို အစီရင်ခံပါ။"
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr "အတွဲလိုက်လုပ်ဆောင်မှုအတွက် မက်ဆေ့ချ်များမှတ်တမ်းတင်ရန် timestamps ထည့်ပါ။"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 "အစီရင်ခံစာများတွင် သတ်မှတ်ထားသည့် မူရင်းများမှ third-party repositories ကို ဖန်တီးပြီး အသုံးပြုပါ။"
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr "sandbox တွင် ဒေါင်းလုဒ်လုပ်ထားသော ပက်ကေ့ဂျ်များအတွက် ကက်ရှ်လမ်းညွှန်"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -713,12 +714,12 @@ msgstr ""
 "ဖြည်ချထားသောပက်ကေ့ဂျ်များအတွက် လမ်းညွှန်ခြင်း။ အနာဂတ်လုပ်ဆောင်မှုများအနေဖြင့် ဒေါင်းလုဒ်လုပ်ထားသော "
 "မည်သည့်ပက်ကေ့ခ်ျကိုမဆို ဤ sandbox သို့ ဖြည်ချသည်ဟု ယူဆပါမည်။"
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr "sandbox တွင် အပိုပက်ကေ့ဂျ်တစ်ခုထည့်သွင်းပါ။ (အကြိမ်ပေါင်းများစွာ သတ်မှတ်နိုင်သည်။)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -728,38 +729,38 @@ msgstr ""
 "ပြန်လည်ခြေရာခံထားသော stack ခြေရာခံများကို အပ်လုဒ်လုပ်ရန်အတွက် ပျက်စီး ID တစ်ခုသတ်မှတ်သည့်အခါတွင် ၎င်းကို "
 "အသုံးပြုပါသည်။ (-g၊ -o၊ သို့မဟုတ် -s တို့ကို သတ်မှတ်ထားခြင်းမရှိမှသာဖြစ်ပါသည်။)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
 msgstr ""
 "ပြန်လည်ခြေရာခံထားသော stack traces ပြသပြီး ပျက်စီးမှုဒေတာဘေ့စ်သို့မပို့မီ အတည်ပြုချက်တောင်းပါ။"
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 "ထပ်နေသော sqlite ဒေတာဘေ့စ်သို့ လမ်းကြောင်းပြခြင်း (မူလ- ထပ်နေခြင်းကို စစ်ဆေးထားခြင်းမရှိပါ။)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr "အစီရင်ခံစာတွင် StacktraceSource မထည့်ပါနှင့်။"
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "-S မရှိရင် -C ကို သုံးလို့မရပါဘူး။ ရပ်တန့်ခြင်း။"
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "၎င်းတို့ကို ပူးတွဲပါဖိုင်များအဖြစ် ပေးပို့ရန် အိုကေမလား။ [y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -767,25 +768,25 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "ဦးတည်ရာလမ်းကြောင်းရှိ၍ ၎င်းမှာ ဗလာမဟုတ်ပါ။"
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "အသေးစိတ်အချက်များအတွက် man page ကို ကြည့်ပါ။"
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "valgrind ကထုတ်လုပ်ဃဖိုင်အမည်ကိုသတ်မှတ်"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
 msgstr "ယခင်က ဖန်တီးထားသော sandbox dir (SDIR) ကို ပြန်သုံးပါ သို့မဟုတ် မရှိပါက ၎င်းကို ဖန်တီးပါ။"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -793,36 +794,36 @@ msgstr ""
 "နောက်ထပ် debug symbol များအတွက် sandbox လမ်းညွှန်တစ်ခု ဖန်တီးခြင်း သို့မဟုတ် ပြန်လည်အသုံးပြုခြင်း "
 "မပြုလုပ်ဘဲ ထည့်သွင်းထားသည့် debug symbol များပေါ်တွင်သာ အမှီပြုပြီးဆောင်ရွက်ပါ။"
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
 msgstr "ယခင်က ဖန်တီးထားသော cache dir (CDIR) ကို ပြန်သုံးပါ သို့မဟုတ် မရှိပါက ၎င်းကို ဖန်တီးပါ။"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 "ပက်ကေ့ဂျ်များကို sandbox တွင် ထည့်သွင်းသည့်အခါ ဒေါင်းလုဒ်လုပ်ခြင်း/ထည့်သွင်းခြင်းတိုးတက်မှုကို အစီရင်ခံပါ။"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "အမှားအယွင်း - %s သည် အကောင်ထည်ဖော်နိုင်သော အရာမဟုတ်ပါ။ ရပ်တန့်နေပါသည်။"
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 "၎င်းသည် ယခင် Suspend ကာလအတွင်း ဖြစ်ပွားခဲ့ပြီး စနစ်ကောင်းမွန်စွာ ပြန်လည်စတင်နိုင်စေရန် တားဆီးခဲ့သည်။"
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -830,13 +831,13 @@ msgstr ""
 "၎င်းသည် ယခင် Hibernation ကာလအတွင်း ဖြစ်ပွားခဲ့ပြီး စနစ်ကောင်းမွန်စွာ ပြန်လည်စတင်နိုင်စေရန် "
 "တားဆီးခဲ့သည်။"
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
 msgstr "resume လုပ်ငန်းစဉ်သည် ပြီးဆုံးခါနီးတွင် မပြီးပြတ်နိုင်ဘဲ သာမန်အားဖြင့် ပြီးဆုံးသွားပုံပေါ်သည်။"
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr "သင့်စနစ်သည် ယခု မတည်မငြိမ်ဖြစ်လာနိုင်ပြီး ပြန်လည်စတင်ရန် လိုအပ်နိုင်ပါသည်။"
 
@@ -850,76 +851,76 @@ msgstr "ပြသာနာတစ်ခုကိုသတင်းပို့မ
 msgid "Report a malfunction to the developers"
 msgstr "malfunction တစ်ခုကို ဆော့ဖ်ဝဲရေးသားသူများထံ တိုင်ကြားပါ။"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "ဆောရီး application %s သည်ရုပ်တရက်ရပ်သွားသည်။"
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "ဆောရီး %s သည်မမျှော်လင့်ပဲပိတ်သွားပါသည်"
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "ဆောရီး, %s သည်အတွင်းပိုင်းပြသာနာတက်နေသည်။"
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "ပို့မည်။"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "အသေးစိတ်များကို ဖော်ပြပါ။"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "ဆက်လုပ်"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "ဒီ application %s တုံ့ပြန်ရပ်တန့်ခဲ့သည်။"
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "အဆိုပါအစီအစဉ်ကို \"%s\" တုန့်ပြန်ရပ်တန့်ခဲ့သည်။"
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Package: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "ဆောရီး၊ ဆော့ဝဲလ်သွင်းနေစဉ်ပြသာနာအနည်းငယ်ရှိသည်။"
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "အက်ပလီကေးရှင်း %s သည် အတွင်းပိုင်းအမှားအယွင်းတစ်ခု ကြုံတွေ့နေရပါသည်။"
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "application %s သည်မမျှော်လင့်ပဲပိတ်သွားသည်"
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr "နောက်ထပ်ပြသာနာများကိုတွေ့ရှိပါက သင်၏ကွန်ပြူတာကိုပိတ်ပြီးပြန်ဖွင့်ခြင်းဖြင့်ကြိုးစားကြည့်ပါ"
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "ဒီလိုအမျိုးအစားပြသာနာများကိုလစ်လျူရှုမည်"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "အချက်အလက်များကို ဖျောက်ထားမည်"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -975,7 +976,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b> ပြဿနာ အချက်အလက်ကို အပ်လုဒ်တင်ခြင်း</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -987,27 +988,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Apport crash file"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "ပိတ်လိုက်မည်"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "ပြန်ဖွင့်မည်"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "အသုံးပြုသူအမည် −"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "စကားဝှက် −"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "ပြသာနာအချက်အလက်များကိုစုစည်းနေပါသည်"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1015,6 +1016,6 @@ msgstr ""
 "ဒီ application ကောင်းမွန်စေရန်အတွက် စုဆောင်းရရှိသည့်အချက်အလက်များကို  developer များထံသို့ပို့မည်။ "
 "မိနစ်အနည်းငယ်ကြာနိုင်ပါသည်။"
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "ပြဿနာ အချက်အလက် အပ်လုဒ်တင်ခြင်း။"

--- a/po/my.po
+++ b/po/my.po
@@ -8,15 +8,15 @@ msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2023-07-21 16:31+0200\n"
-"PO-Revision-Date: 2012-09-04 12:14+0000\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"PO-Revision-Date: 2023-04-15 09:39+0000\n"
+"Last-Translator: Wint Theingi Aung <Unknown>\n"
 "Language-Team: Burmese <my@li.org>\n"
 "Language: my\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2022-12-07 14:36+0000\n"
-"X-Generator: Launchpad (build 41e7553f8097ce3a683f90e835708cbe7bf0006c)\n"
+"X-Launchpad-Export-Date: 2023-07-21 14:36+0000\n"
+"X-Generator: Launchpad (build 2bfac4503c7b6a57e9a8acd782035a16f97e2ddb)\n"
 
 #: ../apport/com.ubuntu.apport.policy.in.h:1
 msgid "Collect system information"
@@ -267,6 +267,7 @@ msgstr "အစီရင်ခံစာတွင် အပိုတဂ်တစ�
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
+"%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 
 #: ../apport/ui.py:1072
 msgid ""
@@ -758,11 +759,11 @@ msgstr "၎င်းတို့ကို ပူးတွဲပါဖိုင�
 #: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
-msgstr ""
+msgstr "%(prog)s <report> <target directory>"
 
 #: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
-msgstr ""
+msgstr "ဖိုင်ပြန်ဖွင့်ရန်အတွက် သတင်းပို့ပါ"
 
 #: ../bin/apport-unpack.py:33
 msgid "directory to unpack report to"

--- a/po/nb.po
+++ b/po/nb.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2015-04-27 21:47+0000\n"
 "Last-Translator: Martin Pitt <martin@piware.de>\n"
 "Language-Team: Norwegian Bokmål <nb@li.org>\n"
@@ -38,11 +38,11 @@ msgstr "Feilrapporter for system"
 msgid "Please enter your password to access problem reports of system programs"
 msgstr "Skriv inn passordet ditt for å få tilgang til systemets feilrapporter"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "Denne pakken ser ikke ut til å være korrekt installert"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -50,7 +50,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -63,21 +63,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "ukjent program"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Beklager, programmet \"%s\" ble uventet avsluttet"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Problem i %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -85,62 +80,67 @@ msgstr ""
 "Datamaskinen din har ikke nok tilgjengelig minne for å kunne analysere og "
 "rapportere problemet automatisk."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Problem i %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Ugyldig problemrapport"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "Du har ikke tilgang til denne feilrapporten."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Feil"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "Det er ikke nok ledig diskplass til å behandle denne rapporten."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "Ugyldig prosess-id (PID)"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "Ingen pakke er spesifisert"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr "Du må spesifisere en pakke eller PID: Se --hjelp for mer informasjon."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Adgang nektet"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -148,30 +148,30 @@ msgstr ""
 "Den valgte prosessen tilhører ikke deg. Kjør dette programmet som eieren av "
 "prosessen eller som root."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "Den valgte prosess-IDen tilhører ikke noe program."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Symptomskript %s fant ingen berørte pakker"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Pakken %s finnes ikke"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "Kan ikke lage rapport"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "Oppdaterer problemrapport"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -183,7 +183,7 @@ msgstr ""
 "\n"
 "Vennligst lag en ny rapport ved å bruke «apport-bug»."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -203,24 +203,24 @@ msgstr ""
 "\n"
 "Ønsker du å fortsette?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "Ingen tilleggsinformasjon har blitt samlet inn."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "Hva slags problem vil du rapportere?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Ukjent symptom"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Symptomet \"%s\" er ukjent."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -231,7 +231,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -239,30 +239,30 @@ msgstr ""
 "Vennligst klikk på et programvindu etter at du har lukket denne meldingen, "
 "slik at du kan sende en feilrapport om problemet."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "«xprop» fant ikke vinduets prosess-ID"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "Angi pakkenavn."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "Legg til et ekstra stikkord i rapporten. Kan nevnes flere ganger."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -272,15 +272,15 @@ msgstr ""
 "kun --pid. Hvis ingen av disse er gitt vises en liste over kjente symptomer. "
 "(Underforstått at ett argument blir gitt)"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "Klikk på det aktuelle vinduet for å sende en feilrapport om problemet."
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "Start i feiloppdateringmodus. Aksepterer en alternativ --pakke."
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -288,7 +288,7 @@ msgstr ""
 "Send en feilmelding om et problem. (Underforstått hvis problemnavn er gitt "
 "som eneste argument)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -296,7 +296,7 @@ msgstr ""
 "Oppgi pakkenavn i --file-bug-modus. Dette er valgfritt hvis --pid er gitt. "
 "(Underforstått hvis pakkenavn er gitt som eneste argument.)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -306,11 +306,11 @@ msgstr ""
 "spesifisert, vil feilrapporten inneholde mer informasjon. (Dette er allerede "
 "implisert hvis «pid» oppgis som eneste argument.)"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "Den oppgitte pid-en er en applikasjon som henger."
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -319,7 +319,7 @@ msgstr ""
 "Rapporter kræsj fra en gitt .apport- eller .crash-fil i stedet for de "
 "gjeldende i %s. (Underforstått hvis en fil er gitt som eneste argument)."
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -329,46 +329,46 @@ msgstr ""
 "i stedet for å rapportere den. Filen kan innrapporteres senere, for eksempel "
 "fra en annen maskin."
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Skriv ut Apport-versjonsnummeret."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Dette vil starte apport-retrace i et terminalvindu for å undersøke krasjen."
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "Kjør gdb-økt"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Kjør gdb-økt uten å laste ned feilrapporteringssymboler"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Oppdater %s med symbolsk stabelsporing"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 "Denne problemrapporten gjelder et program som ikke lenger er installert."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
@@ -377,78 +377,80 @@ msgstr ""
 "Problemet skjedde med programmet %s, som har endret seg siden kræsjen "
 "oppstod."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Denne feilrapporten er skadet, og kan ikke behandles."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr "Denne rapporten gjelder en pakke som ikke er installert."
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "En feil oppstod da denne feilrapporten skulle behandles:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "Kunne ikke bestemme pakken eller kildepakkens navn."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "Kunne ikke starte nettleser"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Kunne ikke starte nettleseren for å åpne %s."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Nettverksfeil"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Kan ikke koble til krasjdatabasen, vennligst sjekk internettforbindelsen."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Nettverksfeil"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Minne fullt"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "Systemet ditt har ikke nok minne til å behandle denne krasjrapporten."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -459,11 +461,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "Problemet er allerede kjent"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -473,38 +475,37 @@ msgstr ""
 "nettleseren. Hvis du har mer informasjon som kan hjelpe utviklerne å løse "
 "problemet, bør du legge det til i rapporten."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Dette problemet er allerede rapportert til utviklerne. Takk!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Trykk en tast for å fortsette..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "Hva vil du gjøre? Alternativene dine er:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Vennligst velg (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i bytes)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(binære data)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Send problemrapport til utviklerne?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -512,52 +513,52 @@ msgstr ""
 "Etter at problemrapporten har blitt sendt: vennligst fyll ut skjemaet i den\n"
 "automatisk åpnede nettleseren."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "&Send rapport (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "&Undersøk lokalt"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "&Vis rapport"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 "&Behold rapportfilen for å sende den senere eller kopiere den til et annet "
 "sted"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "Avbryt og &ignorer framtidige krasj i denne programversjonen"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Avbryt"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Problemrapportfil:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&Bekreft"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Feil: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "Samler probleminformasjon"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -565,11 +566,11 @@ msgstr ""
 "Den innsamlede informasjonen kan sendes til utviklerne for å forbedre\n"
 "programmet. Dette kan ta et par minutter."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "Laster opp probleminformasjon"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -577,40 +578,40 @@ msgstr ""
 "Den innsamlede informasjonen sendes til feilsporingssystemet.\n"
 "Dette kan ta et par minutter."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Fullført"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "ingen"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "Valgt: %s. Flere valg:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Valg:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "Filbane (Enter for å avbryte):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "Filen eksisterer ikke."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "Dette er en mappe."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "For å fortsette, må du gå til følgende URL:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -618,15 +619,15 @@ msgstr ""
 "Du kan starte en nettleser nå, eller kopiere denne URL-en til en nettleser "
 "på en annen maskin."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Start nettleseren nå"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr "Ingen ventende krasjrapporter. Prøv --help for mer informasjon."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr "Legg ikke til flere meldinger i rapporten, skriv de heller til stdout."
 
@@ -645,29 +646,29 @@ msgstr ""
 "Skriv den endrede rapporten til en gitt fil i stedet for å andre den "
 "opprinnelige rapporten"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 "Fjern kjerne-informasjon fra rapporten etter \"stack trace\" er opprettet på "
 "nytt"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "Overstyr rapportens kjernefil"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "Overstyr rapportens kjøresti"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "Overstyr rapportens ProcMaps"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "Gjennoppbygg pakkeinformasjonen i rapporten"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -683,7 +684,7 @@ msgstr ""
 "konfigurasjonsfiler brukt, men da vil du bare kunne spore en kræsj hvis den "
 "oppstod på utgivelsen som kjører nå."
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
@@ -692,26 +693,26 @@ msgstr ""
 "Sett opp en midlertidig sandkasse og installer samme versjon av gdb + "
 "tilbehør som rapporten i stedet for versjonen av gdb du har installert nå."
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 "Rapporter nedlastings- og installasjonsfremdrift når pakker blir installert "
 "i sandkassa."
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr "Sett tidsstempler i starten av logg-meldinger, for bunthåndtering"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr "Lag og bruk tredjepartslager fra kilder som er valgt i rapporter"
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr "Legg pakkenedlastinger for sandkassa i hurtiglageret"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -719,12 +720,12 @@ msgstr ""
 "Mappe for utpakkede pakker. Senere kjøringer vil basere seg på at nedlastede "
 "pakker også har blitt pakket ut til denne sandkassa."
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr "Installer en ekstrapakke i sandkassa (kan spesifiseres flere ganger)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -734,37 +735,37 @@ msgstr ""
 "brukes til å spesifisere en krasj-ID når krasjrapporten lastes opp (kun hvis "
 "hverken -g, -o, eller -s spesifiseres)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
 msgstr ""
 "Vis krasjrapporten og be om bekreftelse før den sendes til krasjdatabasen."
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr "Sti til kopien av sqlite-databasen. (Forvalgt: ikke se etter kopier)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr "Ikke ta med StacktraceSource i feilrapport."
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "Du kan ikke bruke -C uten -S. Stopper."
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "OK å sende disse som vedlegg? [j/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -772,19 +773,19 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "Målmappe finnes og er ikke tom."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "Se programmets bruksanvisning («man»-side) for mer informasjon."
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "spesifiser navn på loggfilen som produseres av valgrind"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
@@ -792,7 +793,7 @@ msgstr ""
 "bruk en tidligere opprettet sandkassemappe (SDIR), eller opprett den hvis "
 "den ikke eksisterer"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -800,7 +801,7 @@ msgstr ""
 "Bruk kun installerte feilsøkingssymboler, i stedet for å opprette eller "
 "bruke en eksisterende sandkassemappe for flere symboler."
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
@@ -808,24 +809,24 @@ msgstr ""
 "bruk en tidligere opprettet hurtiglagermappe (CDIR), eller opprett en hvis "
 "det ikke eksisterer"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 "rapporter nedlastings- og installasjonsfremdrift når pakker installeres i "
 "sandkassa"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Feil: %s er ikke et kjørbart program. Stopper."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -833,7 +834,7 @@ msgstr ""
 "Dette oppstod mens maskinen stod i hvilemodus, og hindret systemet fra å "
 "våkne skikkelig."
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -841,7 +842,7 @@ msgstr ""
 "Dette oppstod mens maskinen stod i dvalemodus, og hindret systemet fra å "
 "våkne skikkelig."
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -849,7 +850,7 @@ msgstr ""
 "Gjenopptagelsen hang seg opp nær slutten og det vil synes som om denne "
 "fullførte normalt."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr "Systemet ditt kan bli ustabilt nå, og kan måtte startes på nytt."
 
@@ -863,76 +864,76 @@ msgstr "Rapporter et problem"
 msgid "Report a malfunction to the developers"
 msgstr "Rapporter en feil til utviklerne"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "Beklager. Programmet %s har fått en uventet stans."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "Beklager. %s har lukket seg uventet."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "Beklager, det har skjedd en intern feil med %s."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Send"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Vis detaljer"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Fortsett"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "Programmet %s svarer ikke."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "Programmet \"%s\" svarer ikke."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Pakke: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "Beklager. Et problem oppstod under installasjon av programvare."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "Programmet %s har hatt en intern feil."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "Programmet %s lukket seg uventet."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr "Prøv å starte datamaskinen på nytt hvis det oppstår flere problemer"
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "Ignorer denne typen problemer i fremtiden"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Skjul detaljer"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -988,7 +989,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>Laster opp feilinformasjon</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -1000,27 +1001,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Apport-krasjfil"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "Forbli lukket"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Start på nytt"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Brukernavn:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Passord:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "Samler informasjon om feil"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1028,6 +1029,6 @@ msgstr ""
 "Den innsamlede informasjonen kan sendes til utviklerne for å forbedre "
 "programmet. Dette kan ta noen minutter."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "Laster opp informasjon om feil"

--- a/po/nds.po
+++ b/po/nds.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2011-10-07 06:10+0000\n"
 "Last-Translator: mafix <launchpad@marfix.net>\n"
 "Language-Team: German, Low <nds@li.org>\n"
@@ -36,11 +36,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr ""
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -57,111 +57,111 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr ""
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr ""
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr ""
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
 msgstr ""
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr ""
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Ungültiger Problem Rapport"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr ""
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr ""
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr ""
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr ""
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr ""
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 msgstr ""
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr ""
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr ""
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr ""
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr ""
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -169,7 +169,7 @@ msgid ""
 "Please create a new report using \"apport-bug\"."
 msgstr ""
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -181,24 +181,24 @@ msgid ""
 "Do you really want to proceed?"
 msgstr ""
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr ""
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr ""
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr ""
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr ""
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -209,202 +209,204 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr ""
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr ""
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr ""
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr ""
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr ""
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr ""
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr ""
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr ""
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr ""
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr ""
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr ""
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr ""
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -412,161 +414,160 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr ""
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 msgstr ""
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr ""
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr ""
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr ""
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr ""
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr ""
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr ""
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
 msgstr ""
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr ""
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr ""
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr ""
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr ""
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr ""
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr ""
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr ""
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr ""
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr ""
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
 msgstr ""
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr ""
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
 msgstr ""
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr ""
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr ""
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr ""
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr ""
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr ""
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr ""
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr ""
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr ""
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
 msgstr ""
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr ""
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 
@@ -581,27 +582,27 @@ msgid ""
 "Write modified report to given file instead of changing the original report"
 msgstr ""
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr ""
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr ""
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr ""
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr ""
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -611,78 +612,78 @@ msgid ""
 "be able to retrace crashes that happened on the currently running release."
 msgstr ""
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
 "have installed."
 msgstr ""
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr ""
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
 msgstr ""
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
 "neither -g, -o, nor -s are specified)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
 msgstr ""
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr ""
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr ""
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr ""
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -690,70 +691,70 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr ""
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
 msgstr ""
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 
@@ -767,76 +768,76 @@ msgstr "Rapportiere ein Problem..."
 msgid "Report a malfunction to the developers"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr ""
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr ""
 
@@ -890,7 +891,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr ""
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -900,32 +901,32 @@ msgstr ""
 msgid "Apport crash file"
 msgstr ""
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr ""
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr ""
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr ""
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr ""
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr ""
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
 msgstr ""
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr ""

--- a/po/ne.po
+++ b/po/ne.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2015-12-27 16:39+0000\n"
 "Last-Translator: sarojdhakal <Unknown>\n"
 "Language-Team: Nepali <ne@li.org>\n"
@@ -36,11 +36,11 @@ msgstr "प्रणाली समस्या प्रतिवेदनह�
 msgid "Please enter your password to access problem reports of system programs"
 msgstr "कृपया प्रणाली कार्यक्रम को समस्या रिपोर्ट पहुँच गर्न आफ्नो पासवर्ड प्रविष्ट  गर्नुहोस"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr ""
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -57,111 +57,111 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "अज्ञात उपक्रम"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "माफ गर्नुहोस्, \"%s\" उपक्रम अप्रत्याशित बन्द भयो।"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "%s मा समस्या"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
 msgstr ""
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "%s मा समस्या"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "अवैध समस्या प्रतिवेदन"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "तपाईंले यो समस्या रिपोर्ट पहुँच गर्न अनुमति छैन।"
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "त्रुटि"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "अवैध PID"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "निर्दिष्ट नगरिएको प्यकेज"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "इजाजत अस्वीकार गरियो"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 msgstr ""
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr ""
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "%s प्याकेज अस्तित्वमा छैन"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "प्रतिवेदन सिर्जना गर्न सकिएन"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "समस्या प्रतिवेदन अद्यावधिक गर्दै"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -169,7 +169,7 @@ msgid ""
 "Please create a new report using \"apport-bug\"."
 msgstr ""
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -181,24 +181,24 @@ msgid ""
 "Do you really want to proceed?"
 msgstr ""
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "कुनै अतिरिक्त जानकारी संकलन गरिएन ।"
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "तपाईले कस्तो समस्या प्रतिवेदन गर्न चाहनुहुन्छ?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "अज्ञात लक्षण"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "\"%s\" लक्षण विदित छैन।"
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -209,51 +209,51 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "प्याकेज नाम खुलाउनुहोस्"
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -261,152 +261,154 @@ msgstr ""
 "कुनै लक्षण सम्बन्धी त्रुटि प्रतिवेदन दर्ता गर्नुहोस्। (जब लक्षण नाम नै एकमात्र तर्क भएमा लागू "
 "हुने)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr ""
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "gdb सत्र चलाउनुहोस्"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "यो समस्या रिपोर्ट क्षतिग्रस्त छ र अघी बढ्न सकिदैन।"
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr ""
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr ""
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr ""
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "वेब ब्राउजर सुरु गर्न सकिएन"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "%s खोल्न वेब ब्राउजर सुरु गर्न सकिएन।"
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "सञ्जाल समस्या"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "सञ्जाल समस्या"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "मेमोरी सकियो"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -417,161 +419,160 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "पूर्वविदित समस्या"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 msgstr ""
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "जारी राख्नको लागि कुनै कुञ्जी थिच्नुहोस्..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "तपाईं के गर्न चाहनु हुन्छ? तपाईंको विकल्प हो:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "छान्नुहोस् (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i बाइट)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(बायनरी डेटा)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "यो समस्याको प्रतिवेदन डेभेलोपरहरूलाई पठाउन चाहनुहुन्छ ?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
 msgstr ""
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "प्रतिवेदन पठाउनुहोस् (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "स्थानीयरूपमा जाँच गर्नुहोस्"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "प्रतिवेदन हेर्नुहोस्"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr ""
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "रद्द गर्नुहोस् (&C)"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "समस्या रिपोर्ट फाइल:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "सुनिश्चित गर्नुहोस्"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "त्रुटि: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "समस्या जानकारी सङ्कलन हुँदैछ​।"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
 msgstr ""
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "समस्याको जानकारी अपलोड हुदैछ​।"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
 msgstr ""
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "सकियो"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "कुनै पनि हैन"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "छानिएको: %s। विकल्पहरू:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "चयनहरू:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "फाइल मार्ग (रद्द गर्न प्रविष्ट गर्नुहोस्):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "फाइल अवस्थित छैन ।"
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "यो डारेक्टरी हो।"
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "जारी राख्न, तपाईं निम्न URL मा जानैपर्ने हुन्छ:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
 msgstr ""
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "अहिले नै ब्राउजर सुरु गर्नुहोस्"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 
@@ -586,27 +587,27 @@ msgid ""
 "Write modified report to given file instead of changing the original report"
 msgstr ""
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr ""
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr ""
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr ""
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr ""
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -616,78 +617,78 @@ msgid ""
 "be able to retrace crashes that happened on the currently running release."
 msgstr ""
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
 "have installed."
 msgstr ""
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr ""
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
 msgstr ""
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
 "neither -g, -o, nor -s are specified)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
 msgstr ""
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr ""
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr ""
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "यो सङ्लग्नहरू पठाउन चाहनुहुन्छ ? [y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -695,75 +696,75 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "गन्तव्य निर्देशिका अवस्थित छ तथा खाली छैन"
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "विस्तृत जानकारीका लागि man page हेर्नुहोस् !"
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "भलग्रिन्डद्वारा उत्पादित लग फाइलको नाम निर्दिष्ट गर्नुहोस्"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
 msgstr ""
 "पहिलै बनाईएको sandbox dir (SDIR) पुनःप्रयोग गर्नुहोस वा यदि अवस्थित छैन भने बनाउनुहोस"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
 msgstr ""
 "पहिलै बनाईएको  cache dir (CDIR) पुनःप्रयोग गर्नुहोस वा यदि अवस्थित छैन भने बनाउनुहोस"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 "स्यान्डबक्स मा प्याकेजहरू स्थापना गर्दा डाउनलोड / उन्नति गरेर स्थापना रिपोर्ट गर्नुहोस"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "त्रुटी: %s सञ्चालन गर्न सकिएन। रोक्दै ।"
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 "यो अघिल्लो निलम्बित हुने समयमा भयो र​ सिस्टमलाई राम्रो सङं पुन: शुरू हुन बाट रोक्यो।"
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 "यो अघिल्लो हाइबर्नेसन् हुने समयमा भयो र​ सिस्टमलाई राम्रो सङं पुन: शुरू हुन बाट रोक्यो।"
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
 msgstr ""
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr "तपाईंको सिस्टम अब अस्थिर बन्न सक्छ र फेरि सुरु गर्न आवश्यक हुन सक्छ।"
 
@@ -777,76 +778,76 @@ msgstr "समस्या रिपोर्ट गर्नुहोस्..."
 msgid "Report a malfunction to the developers"
 msgstr "डेवलपर्सलाई काम नगरे रिपोर्ट गर्नुहोस्"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "माफ गर्नुहोस्, अनुप्रयोग %s अचानक रोकिएको छ।"
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "माफ गर्नुहोस्, %s अचानक बन्द भएको छ।"
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "माफ गर्नुहोस् , %s ले अन्तरिक त्रुटीको सामना गरेको छ।"
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "पठाउनुहोस्"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "विवरण देखाउनुहोस्।"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "जारी राख्नुहोस"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "अनुप्रयोग %s ले जवाफ दिन बन्द गरेको छ।"
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "प्रोग्राम %s ले जवाफ दिन बन्द गरेको छ।"
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "प्याकेज: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "माफ गर्नुहोस्, सफ्टवेयर स्थापना गर्दा त्रुटी भयो।"
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "माफ गर्नुहोस् , अनुप्रयोग %s ले आन्तरिक त्रुटीको सामना गरेको छ।"
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "माफ गर्नुहोस्, अनुप्रयोग %s अचानक बन्द भएको छ।"
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr "अरु समस्याहरू आइपरेमा , कम्प्युटर पुनःसुरु गर्न प्रयास गर्नुहोस्।"
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "यस प्रकारका समस्याहरूलाई भविष्यमा वेवास्ता गर्नुहोस्"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "विवरण लुकाउनु॒होस्"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "एपोर्ट"
 
@@ -902,7 +903,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>समस्याको जानकारी अपलोड हुदैछ​।</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -912,32 +913,32 @@ msgstr "एकत्र जानकारी बग ट्रयाकिङ �
 msgid "Apport crash file"
 msgstr "एपोर्ट क्र्यास प्रतिवेदनहरू"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "बन्द नै छोड्नुहोस्।"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "पुनः खोल्नुहोस्"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "प्रयोगकर्ता-नाम:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "पासवर्ड:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "समस्या जानकारी सङ्कलन हुँदैछ​।"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
 msgstr ""
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "समस्याको जानकारी अपलोड हुदैछ​।"

--- a/po/nl.po
+++ b/po/nl.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2022-04-01 10:43+0000\n"
 "Last-Translator: Hannie Dumoleyn <Unknown>\n"
 "Language-Team: Nederlands <nl_NL@li.org>\n"
@@ -42,11 +42,11 @@ msgstr ""
 "Voer uw wachtwoord in om toegang te krijgen tot de probleemrapporten van "
 "systeemprogramma's"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "Dit pakket lijkt niet juist te zijn geïnstalleerd"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -57,7 +57,7 @@ msgstr ""
 "indexen van beschikbare pakketten heeft bijgewerkt. Als dat niet werkt, "
 "verwijder dan gerelateerde pakketten van derden en probeer het nogmaals."
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -71,21 +71,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "onbekend programma"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Excuses, het programma \"%s\" werd onverwachts afgesloten"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Probleem in %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -93,62 +88,67 @@ msgstr ""
 "Uw computer heeft onvoldoende vrij werkgeheugen om het probleem automatisch "
 "te analyseren en een rapport naar de ontwikkelaars te sturen."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Probleem in %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Ongeldig probleemrapport"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "U bent niet bevoegd om dit probleemrapport te bekijken."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Fout"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "Er is onvoldoende schijfruimte om dit rapport te verwerken."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr "Geen PID gespecifieerd"
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr "U dient een PID te specifiëren. Gebruik --help voor meer informatie."
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "Ongeldig PID"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr "De opgegeven proces-ID bestaat niet."
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr "Niet uw ID"
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr "De opgegeven proces-ID is niet van u."
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "Geen pakket opgegeven"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr "U moet een pakket of PID opgeven. Zie --help voor meer informatie."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Toegang geweigerd"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -156,30 +156,30 @@ msgstr ""
 "U bent niet de eigenaar van het opgegeven proces. Voer dit programma uit als "
 "proceseigenaar of als root."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "Het opgegeven proces-PID behoort niet tot een programma."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Symptoom-script %s kon geen betrokken pakket bepalen"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Pakket %s bestaat niet"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "Kan rapport niet aanmaken"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "Probleemrapport aan het bijwerken"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -191,7 +191,7 @@ msgstr ""
 "\n"
 "Maak alstublieft een nieuw rapport aan met \"apport-bug\"."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -211,24 +211,24 @@ msgstr ""
 "\n"
 "Wilt u echt doorgaan?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "Geen extra informatie verzameld."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "Wat voor soort probleem wilt u rapporteren?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Onbekend symptoom"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Het symptoom \"%s\" is onbekend."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -246,7 +246,7 @@ msgstr ""
 "voeren. Blader op het tabblad Processen totdat u de juiste toepassing vindt. "
 "De proces-ID is het nummer dat wordt vermeld in de ID-kolom."
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -254,32 +254,32 @@ msgstr ""
 "Nadat u dit bericht heeft gesloten dient u op een venster te klikken om "
 "daarvoor een probleem te rapporteren."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop kon het proces-ID niet bepalen van het venster"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "Pakketnaam opgeven"
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Voeg een extra tag aan het rapport toe. Dit kan meerdere keren worden "
 "opgegeven."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -290,16 +290,16 @@ msgstr ""
 "met bekende symptomen getoond worden. (Impliciet als een enkel argument is "
 "opgegeven.)"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "Klik het venster aan waar u een rapport voor wilt indienen"
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "In modus voor het updaten van bugs starten. Mogelijk met optioneel --package."
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -307,7 +307,7 @@ msgstr ""
 "Een foutrapport over een symptoom indienen. (Impliciet als symptoomnaam het "
 "enige argument is.)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -315,7 +315,7 @@ msgstr ""
 "Pakketnaam in --file-bug-modus opgeven. Dit is optioneel als een --pid is "
 "opgegeven. (Impliciet als pakketnaam het enige argument is.)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -324,11 +324,11 @@ msgstr ""
 "Indien u een programma uitvoert in de --file-bug modus, zal het bugrapport "
 "meer informatie bevatten."
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "De gegeven PID is een vastgelopen toepassing."
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -338,7 +338,7 @@ msgstr ""
 "plaats van de wachtende rapporten in %s. (Impliciet als file het enige "
 "argument is.)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -348,50 +348,50 @@ msgstr ""
 "bestand in plaats van het aan te melden. U kunt dit bestand dan op een later "
 "tijdstip vanaf een andere computer aanmelden."
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Het versienummer van Apport weergeven."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Dit zal apport-retrace starten in een terminalvenster om de crash te "
 "onderzoeken."
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "gdb-sessie draaien"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "gdb-sessie draaien zonder debugsymbolen te downloaden"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Update %s met volledige symbolic stack trace"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr "Instellingen voor rapportstatus verzenden kunnen niet worden onthouden"
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 "Het opslaan van de crashrapportagestatus is mislukt. Instellen van de "
 "automatische of nooit-rapportagemodus is niet mogelijk."
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr "Instellingen voor rapportstatus verzenden kunnen niet worden onthouden"
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 "Dit probleemrapport verwijst naar een programma dat niet meer geinstalleerd "
 "is."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
@@ -400,20 +400,22 @@ msgstr ""
 "Het probleem deed zich voor bij het programma %s dat gewijzigd werd sinds "
 "het voorvallen van de crash."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Dit probleemrapport is beschadigd en kan niet worden verwerkt."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr "Deze melding is over een pakket dat niet geïnstalleerd is."
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr ""
 "Er is een fout opgetreden bij de poging deze probleemrapportage te verwerken:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
@@ -421,24 +423,24 @@ msgstr ""
 "U heeft twee versies van deze toepassing geïnstalleerd; voor welke versie "
 "wilt u een fout rapporteren?"
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr "%s snap"
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr "%s deb package"
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s wordt geleverd door een snap uitgebracht door %s. Neem contact met hen op "
 "via %s voor hulp."
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -447,39 +449,39 @@ msgstr ""
 "%s wordt geleverd door een snap uitgebracht door %s. Er is geen contactadres "
 "beschikbaar; bezoek het forum op https://forum.snapcraft.io/ voor hulp."
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "Kon de naam van het pakket of het bronpakket niet bepalen."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "Kon de webbrowser niet starten"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Kon de webbrowser niet starten om %s te openen."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Netwerkprobleem"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Verbinding met crash-database mislukt, controleer uw internetverbinding."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Netwerkprobleem"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Geheugen vol"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Uw systeem heeft onvoldoende geheugen om dit foutenrapport te verwerken."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -490,11 +492,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "Probleem reeds bekend"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -504,38 +506,37 @@ msgstr ""
 "webbrowser wordt weergegeven. Controleer of u extra informatie kunt "
 "toevoegen die voor de ontwikkelaars nuttig kan zijn."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Dit probleem is al doorgegeven aan de ontwikkelaars. Dank u wel!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Druk op een toets om door te gaan..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "Wat wilt u doen? U kunt kiezen uit:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Maak uw keuze (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i bytes)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(binaire gegevens)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Probleemrapport naar de ontwikkelaars sturen?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -543,51 +544,51 @@ msgstr ""
 "Zodra het probleemrapport is verzonden, wordt u verzocht het formulier\n"
 "in de automatisch geopende webbrowser in te vullen."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "Rapport ver&sturen (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "Lokaal &onderzoeken"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "Rapport weerge&ven"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 "Rapportbestand bewaren voor latere verzending, of om elders heen te &kopiëren"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "Annuleren en toekomstige vastlopers van deze programmavers&ie negeren"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Annuleren"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Probleemrapport-bestand:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "Be&vestigen"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Fout: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "Bezig met verzamelen van probleeminformatie"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -595,11 +596,11 @@ msgstr ""
 "De verzamelde informatie kan naar de ontwikkelaars worden verzonden om\n"
 "de toepassing te verbeteren. Dit kan enkele minuten duren."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "Bezig met versturen van foutgegevens"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -607,40 +608,40 @@ msgstr ""
 "De verzamelde informatie wordt naar het foutbeheersysteem verzonden.\n"
 "Dit kan enkele minuten duren."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "Geree&d"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "geen"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "Geselecteerd: %s. Meerdere keuzes:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Keuzes:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "Pad naar het bestand (Enter om te annuleren):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "Bestand bestaat niet."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "Dit is een map."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "Om verder te gaan moet u het volgende adres bezoeken:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -648,16 +649,16 @@ msgstr ""
 "U kunt nu een browser starten, of dit adres in een browser op een andere "
 "computer openen."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "De browser nu starten"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 "Geen crashrapporten in de wachtrij. Probeer --help voor meer informatie."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 "Nieuwe traces naar stdout schrijven in plaats van ze te plaatsen in het "
@@ -678,28 +679,28 @@ msgstr ""
 "Gewijzigd rapport naar opgegeven bestand schrijven in plaats van het "
 "originele bestand bij te werken"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 "De coredump verwijderen uit het rapport na hergeneratie van de stacktrace"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "CoreFile van rapport overschrijven"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "ExecutablePath van rapport overschrijven"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "ProcMaps van rapport overschrijven"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "Pakketinformatie van rapport opnieuw aanmaken"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -716,7 +717,7 @@ msgstr ""
 "van het systeem gebruikt worden. Er kunnen dan alleen crashes nagelopen "
 "worden op de huidige uitgave."
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
@@ -726,28 +727,28 @@ msgstr ""
 "afhankelijkheden, met gebruikmaking van dezelfde versie als het rapport, in "
 "plaats van de gdb-versie die u hebt geïnstalleerd."
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 "Voortgang van download/installatie rapporteren wanneer er pakketten in een "
 "sandbox worden geïnstalleerd."
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr "Tijdsaanduiding vooraan in logberichten invoegen, voor batchverwerking"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 "Softwarebronnen van derden, uit bronnen die in rapporten gespecificeerd "
 "zijn,  aanmaken en gebruiken"
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr "Cache-map voor pakketten die gedownload worden in de sandbox"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -756,13 +757,13 @@ msgstr ""
 "uitgegaan worden dat  elk reeds gedownloade pakket  ook naar deze zandbak is "
 "uitgepakt."
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 "Extra pakket in de sandbox installeren (kan meerdere keren opgegeven worden)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -772,7 +773,7 @@ msgstr ""
 "wordt gebruikt bij het opgeven van een crash-ID om gehertraceerde "
 "stacktraces te uploaden (alleen als -g, -o en -s niet zijn opgegeven)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -780,32 +781,32 @@ msgstr ""
 "Gehertraceerde stacktraces tonen en om bevestiging vragen alvorens te "
 "verzenden naar de crash-database."
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 "Pad naar de dubbele sqlite-database (standaard: geen controle voor "
 "duplicaten)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr "StacktraceSource niet toevoegen aan het rapport."
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "U kunt niet -C zonder -S gebruiken. Wordt stopgezet."
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "Deze bijlagen verzenden? [y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -813,19 +814,19 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "Doelmap bestaat en is niet leeg."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "Zie man-pagina voor details."
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "geef de naam op van het logbestand dat door valgrind is gemaakt"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
@@ -833,7 +834,7 @@ msgstr ""
 "gebruik een eerder aangemaakte uitprobeermap (sandbox) (SDIR) opnieuw, of "
 "maak hem aan als deze niet bestaat"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -841,7 +842,7 @@ msgstr ""
 "u moet geen uitprobeermap maken of hergebruiken voor extra debugsymbolen; "
 "vertrouw alleen op geïnstalleerde debugsymbolen."
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
@@ -849,24 +850,24 @@ msgstr ""
 "gebruik een eerder aangemaakte cache dir (CDIR) opnieuw, of maak hem aan als "
 "deze niet bestaat"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 "rapporteren van de download/installatie-voortgang wanneer pakketten in "
 "sandbox worden geïnstalleerd"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Fout: %s is geen uitvoerbaar bestand. Wordt stopgezet."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -874,7 +875,7 @@ msgstr ""
 "Dit gebeurde tijdens een eerdere pauzestand, waardoor het systeem niet op de "
 "juiste wijze herstart werd."
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -882,7 +883,7 @@ msgstr ""
 "Dit gebeurde tijdens een eerdere slaapstand, waardoor het systeem niet op de "
 "juiste wijze herstart werd."
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -890,7 +891,7 @@ msgstr ""
 "Het ontwakingsproces liep vlak voor het einde vast en zag eruit alsof het "
 "compleet geslaagd was."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 "Uw systeem kan nu instabiel worden en moet mogelijk opnieuw worden opgestart."
@@ -905,77 +906,77 @@ msgstr "Een probleem rapporteren..."
 msgid "Report a malfunction to the developers"
 msgstr "Rapporteer een fout aan de ontwikkelaars"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "Helaas is de toepassing %s onverwacht gestopt."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "%s is helaas onverwachts gesloten."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "Er is in %s helaas een interne fout opgetreden."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Versturen"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Details tonen"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Doorgaan"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "De toepassing %s reageert niet meer."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "Het programma ‘%s’ geageert niet meer."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Pakket: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "Er is helaas een fout opgetreden bij het installeren van de software."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "In de toepassing %s is een interne fout opgetreden."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "De toepassing %s werd onverwachts gesloten."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr ""
 "Als er nog steeds problemen zijn, probeer dan de computer opnieuw te starten."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "Dit type problemen in de toekomst negeren"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Details verbergen"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -1031,7 +1032,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>Bezig met het versturen van probleeminformatie</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -1043,27 +1044,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Apport-crashbestand"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "Gesloten laten"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Opnieuw starten"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Gebruikersnaam:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Wachtwoord:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "Bezig met verzamelen van probleeminformatie"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1071,6 +1072,6 @@ msgstr ""
 "De verzamelde informatie kan naar de ontwikkelaars worden gestuurd om de "
 "toepassing te verbeteren. Dit kan enkele minuten duren."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "Probleeminformatie wordt geüpload"

--- a/po/oc.po
+++ b/po/oc.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2021-05-23 19:19+0000\n"
 "Last-Translator: Quentin PAGÈS <Unknown>\n"
 "Language-Team: Occitan (post 1500) <oc@li.org>\n"
@@ -40,11 +40,11 @@ msgstr ""
 "Picatz vòstre senhal per accedir a de rapòrts de problèmas de programas "
 "sistèma"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "Sembla qu'aqueste paquet es pas installat corrèctament."
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -55,7 +55,7 @@ msgstr ""
 "a jorn los indexes dels paquets disponibles, se fonciona pas, suprimissètz "
 "los paquets tèrces ligats e tornatz ensajar."
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -66,21 +66,16 @@ msgstr ""
 "Las versions installadas d'unes paquets son obsoletas. Metètz a jorn los "
 "paquets seguents, puèi verificatz se lo problèma es encara present :%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "programa desconegut"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "O planhèm, lo programa « %s » a quitat d'un biais imprevist"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Problèma dins %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -88,63 +83,68 @@ msgstr ""
 "Vòstre ordenador possedís pas pro de memòria liura per analisar "
 "automaticament lo problèma e mandar un rapòrt als desvolopaires."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Problèma dins %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Rapòrt d'incident invalid"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "Sètz pas autorizat a accedir aqueste rapòrt d'incident."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Error"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "I a pas pro d'espaci de disc disponible per tractar aqueste rapòrt."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr "Cap de PID especificat"
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr "Devètz especificar un PID. Vejatz --help per mai d’informacions."
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "PID invalida"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr "L'ID de processus indicat existís pas."
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr "Pas vòstre PID"
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr "L’identificant de processus indicat vos aparten pas."
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "Cap de paquet pas especificat"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Vos cal precisar un paquet o un PID. Utilizatz --help per mai d'informacions."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Autorizacion refusada"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -152,30 +152,30 @@ msgstr ""
 "Lo processus especificat vos aparten pas. Executatz aqueste programa en tant "
 "que proprietari del processus o en tant qu'administrator (root)."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "L'ID de processus especificat aparten pas a cap de programa."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "L'escript  %s a pas pogut determinar un paquet afectat"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Lo paquet %s existís pas"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "Impossible de crear lo rapòrt"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "Mesa a jorn del rapòrt d'incident"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -186,7 +186,7 @@ msgstr ""
 "tampat o s'agís d'un doblon.\n"
 "Creatz un rapòrt novèl en utilizant « apport-bug »."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -204,24 +204,24 @@ msgstr ""
 "\"apport-bug\"  e de ne far un comentari dins lo bug inicial.  \n"
 "Sètz segur que volètz contunhar ?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "Cap d'informacion suplementària es pas estada collectada."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "Quin tipe de problèma volètz senhalar ?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Simptòma desconegut"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Lo simptòma « %s » es desconegut."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -232,7 +232,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -240,32 +240,32 @@ msgstr ""
 "Aprèp la tampadura d'aqueste messatge, clicatz sus la fenèstra de "
 "l'aplicacion per la quala volètz senhalar un problèma."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop a pas pogut determinar l'ID del processus de la fenèstra"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "Indicatz lo nom del paquet."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Apondre un marcador suplementari pel rapòrt. Pòt èsser especificat mantun "
 "còp."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -275,15 +275,15 @@ msgstr ""
 "opcion, o simplament --pid. Se n'i a pas cap de provesit, aficha una lista "
 "de simptòmas coneguts. (Implicit se un sol argument es provesit.)"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "Clicatz sus la fenèstra per la quala volètz senhalar un problèma."
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "Començar en mòde « mesa a jorn de bug ». Accèpta l'opcion --package"
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -291,7 +291,7 @@ msgstr ""
 "Efectua un senhalament de bug a prepaus d'un simptòma. (Implicit se lo nom "
 "del simptòma es donat coma argument unic.)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -300,7 +300,7 @@ msgstr ""
 "pid es especificat. (Implicit se lo nom del paquet es donat coma argument "
 "unic.)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -310,11 +310,11 @@ msgstr ""
 "especificat, lo rapòrt de bug contendrà mai d'informacions. (implicita se "
 "l’identificant del processus es passat coma argument unic)"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "Lo pid provesit es una aplicacion que respond pas."
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -324,7 +324,7 @@ msgstr ""
 "partir de los que son en espèra dins %s. (Implicit se lo fichièr es donat "
 "coma argument unic.)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -334,51 +334,51 @@ msgstr ""
 "un fichièr puslèu que de generar un rapòrt. Aqueste fichièr poirà èsser "
 "utilizat pus tard a partir d'una autra maquina per mandar un rapòrt."
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Aficha lo numèro de version d'Apport."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Aquò va aviar apport-retrace dins una fenèstra de terminal per examinar lo "
 "crash."
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "Aviar una session gdb"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Executar la session gdb sens telecargar los simbòls de desbugatge"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Mesa a jorn de %s amb una traça de la pila totalament simbolica"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-"Impossible de se remembrar dels paramètres d'estat del rapòrt de mandadís"
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 "L’enregistrament de l’estat dels rapòrts de plantatge a fracassat. "
 "Definicion impossibla del mòde de senhalament ;automatic o desactivat."
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+"Impossible de se remembrar dels paramètres d'estat del rapòrt de mandadís"
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 "Aqueste rapòrt d'incident s'aplica a un logicial qu'es pas pus installat per "
 "aquesta distribucion."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
@@ -386,21 +386,23 @@ msgid ""
 msgstr ""
 "Lo problèma concernís lo programa %s qu'a cambiat dempuèi lo plantatge."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Aqueste rapòrt d'incident es damatjat e pòt pas èsser tractat."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr "Aqueste senhalament es a prepaus d’un paquet qu’es pas installat."
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr ""
 "Una error s'es producha al moment del tractament d'aqueste rapòrt "
 "d'anomalia :"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
@@ -408,24 +410,24 @@ msgstr ""
 "Avètz doas version installadas d’aquesta aplicacion, per la quala volètz "
 "senhalar un bug ?"
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr "snap %s"
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr "paquet deb %s"
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s es provesit per un snap publicat per %s. Contactatz-los via %s per "
 "obténer d’ajuda."
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -435,41 +437,41 @@ msgstr ""
 "fornida ; consultatz lo forum a l’adreça https://forum.snapcraft.io/ per "
 "obténer d’ajuda."
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "Impossible de determinar lo nom del paquet o del paquet font."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "Impossible d'aviar lo navigador web"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Impossible d'aviar lo navigador web per dobrir %s."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Problèma de ret"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Impossible de se connectar a la basa de donadas dels plantatges. Verificatz "
 "vòstra connexion a l'Internet."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Problèma de ret"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Memòria saturada"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Vòstre sistèma dispausa pas de pro de memòria per tractar aqueste rapòrt "
 "d'incident."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -480,11 +482,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "Problèma ja conegut"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -494,38 +496,37 @@ msgstr ""
 "vòstre navigador. Verificatz se podètz apondre d'informacions "
 "complementàrias susceptiblas d'ajudar los desvolopaires."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Aqueste problèma es ja estat senhalat als desvolopaires. Mercé !"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Quichatz sus una tòca per contunhar..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "Qué volètz far ? Las causidas possiblas son :"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Fasètz una causida (%s) :"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i octets)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(donadas binàrias)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Mandar un rapòrt d'errors als desvolopaires ?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -533,53 +534,53 @@ msgstr ""
 "Un còp que lo rapòrt d'incident serà estat mandat, completatz lo\n"
 "formulari dobèrt automaticament dins vòstre navigador Web."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "&Mandar lo rapòrt (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "&Examinar en local"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "&Veire lo rapòrt"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 "&Conservar lo fichièr del rapòrt per lo mandar ulteriorament o lo copiar "
 "endacòm"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr ""
 "Anullar e &ignorar los plantatges venents d'aquesta version del programa"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Anullar"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Fichièr del rapòrt d'incident :"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&Confirmar"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Error : %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "Collècta d'informacions ligadas al problèma"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -587,11 +588,11 @@ msgstr ""
 "Las informacions collectadas pòdon èsser mandadas als desvolopaires per \n"
 "melhorar l'aplicacion. Aquò pòt prene qualques minutas."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "Mandadís de las informacions ligadas al problèma"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -599,40 +600,40 @@ msgstr ""
 "Las informacions collectadas son mandadas al sistèma de seguit de bugs.\n"
 "Aquò pòt prene qualques minutas."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Acabat"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "pas cap"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "Seleccionat : % s. Causida multipla :"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Causida multipla :"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "Emplaçament del fichièr (tòca Entrada per anullar) :"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "Lo fichièr existís pas."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "Aquò's un repertòri."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "Per contunhar, vos cal anar a aquela adreça :"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -640,17 +641,17 @@ msgstr ""
 "Podètz dobrir un navigador Web ara, o picar aquesta URL dins un navigador "
 "sus un autre ordenador."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Aviar un navigador Web ara"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 "Pas cap de rapòrt d'incident en espèra. Ensajatz --help per mai "
 "d'informacions."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 "Plaçar pas las « traças » novèlas dins lo rapòrt de bug, mas los escriure "
@@ -671,29 +672,29 @@ msgstr ""
 "Escriu lo rapòrt dins un fichièr donat puslèu que de modificar lo rapòrt "
 "d'origina."
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 "Suprimir l'imatge memòria (core dump) del compte rendut aprèp regeneracion "
 "de l'estat de la pila"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "Espotir lo fichièr d'imatge memòria (CoreFile) del rapòrt"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "Espotir l'emplaçament de l'executable (ExecutablePath) del rapòrt"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "Espotir la lista dels processus (ProcMaps) del rapòrt"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "Tornar construire las informacions suls paquets del rapòrt"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -710,7 +711,7 @@ msgstr ""
 "fichièrs de configuracion del sistèma seràn utilizats, mas sols los "
 "plantatges de la version en cors d'execucion poiràn èsser traçats."
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
@@ -720,29 +721,29 @@ msgstr ""
 "sas dependéncias en utilizant la meteissa version que la del rapòrt puslèu "
 "que la version de GDB qu'avètz installada."
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 "Senhalar l'avançament del telecargament/de l'installacion pendent "
 "l'installacion de paquets dins lo nauc de sabla."
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr ""
 "Prefixar un orodatatge als messatges de jornal, per un tractament per lòts"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 "Crear e utilizar de depauses tèrces a partir d'originas especificadas dins "
 "de rapòrts"
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr "Repertòri de cache pels paquets telecargats dins lo nauc de sabla"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -750,14 +751,14 @@ msgstr ""
 "Repertòri pels paquets descompressats. Las execucions futuras presumiràn "
 "qu'un paquet ja telecargat serà tanben extrait dins aqueste nauc de sabla."
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 "Installar un paquet suplementari dins lo nauc de sabla (pòt èsser "
 "especificat mantun còp)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -768,7 +769,7 @@ msgstr ""
 "plantatge per cargar l'estat de la pila (solzment se -g, -o o -s son pas "
 "especificats)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -776,32 +777,32 @@ msgstr ""
 "Afichar l'estat de la pila reconstituida e demandar una confirmacion abans "
 "de lo mandar a la basa de donadas dels plantatges."
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 "Emplaçament de la còpia de la banca de donadas SQLite (per defaut : pas de "
 "verificacion de la còpia)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr "Apondre pas StacktraceSource al rapòrt."
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "Podètz pas utilizar -C sens -S. Arrèst."
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "D'acòrdi per mandar aquò coma pèças juntas ? [y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -809,19 +810,19 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "Lo dorsièr de destinacion existís ja e es pas void."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "Vejatz la pagina de manual per mai de detalhs."
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "especifica lo nom del fichièr jornal produit per valgrind"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
@@ -829,7 +830,7 @@ msgstr ""
 "reütilizar un repertòri de nauc de sabla (« sandbox ») (SDIR) creat "
 "precedentament o, s'existís pas, lo crear"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -837,7 +838,7 @@ msgstr ""
 "crear pas o reütilizar pas un repertòri sandbox per de simbòls de desbugatge "
 "addicionals mas s'apuejar solament suls simbòls de desbugatge instaltats."
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
@@ -845,24 +846,24 @@ msgstr ""
 "reütilizar un repertòri de cache (CDIR) precedentament creat o, s'existís "
 "pas, lo crear"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 "afichar la progression del telecargament e de l'installacion al moment de "
 "l'installacion de paquets dins lo nauc de sabla (« sandbox »)"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Error : %s es pas un executable. Arrèst."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -870,7 +871,7 @@ msgstr ""
 "Aquò s'es produit precedentament al moment d'una mesa en velha e a empachat "
 "lo sistèma de se reaviar corrèctament."
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -878,7 +879,7 @@ msgstr ""
 "Aquò s'es produit precedentament al moment d'una mesa en velha perlongada e "
 "a empachat lo sistèma de se reaviar corrèctament."
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -886,7 +887,7 @@ msgstr ""
 "Lo processus de represa s'es blocat juste abans d'arribar a son tèrme e "
 "apareisserà coma s'èra acabat normalament."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 "Ara, vòstre sistèma se pòt far instable e pòt aver besonh d'èsser reaviat."
@@ -901,77 +902,77 @@ msgstr "Senhalar un problèma..."
 msgid "Report a malfunction to the developers"
 msgstr "Senhalar un disfoncionament als desvolopaires"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "O planhèm, %s s'es arrestada d'un biais inesperat."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "O planhèm, %s a quitat d'un biais imprevist."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "O planhèm, %s a rencontrat una error intèrna."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Mandar"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Afichar los detalhs"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Contunhar"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "L'aplicacion %s a daissat de respondre."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "Lo programa \"%s\" a daissat de respondre."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Paquet : %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr ""
 "O planhèm, una error s'es produita al moment de l'installacion del logicial."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "L'aplicacion %s a patit una error intèrna."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "L'aplicacion %s a quitat d'un biais imprevist."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr "En cas de problèmas mai, ensajatz de reaviar vòstre ordenador."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "Ignorar los problèmas d'aquesta mena que venon"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Amagar los detalhs"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apòrt"
 
@@ -1027,7 +1028,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>Mandadís de las informacions ligadas a l'incident</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -1039,27 +1040,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Fichièr d'arrèst brutal d'Apport"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "Daissar tampat"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Reaviar"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Nom d'utilizaire :"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Senhal :"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "Collècta de las informacions ligadas al problèma"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1067,6 +1068,6 @@ msgstr ""
 "Las informations collectadas pòdon èsser mandadas als desvolopaires per "
 "melhorar l'aplicacion. Aquò pòt prene qualques minutas."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "Mandadís de las informacions ligadas al problèma"

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2014-02-02 00:14+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Punjabi <pa@li.org>\n"
@@ -36,11 +36,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr ""
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -57,111 +57,111 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr ""
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr ""
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr ""
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
 msgstr ""
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr ""
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr ""
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr ""
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr ""
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr ""
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr ""
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr ""
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 msgstr ""
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr ""
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr ""
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr ""
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr ""
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -169,7 +169,7 @@ msgid ""
 "Please create a new report using \"apport-bug\"."
 msgstr ""
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -181,24 +181,24 @@ msgid ""
 "Do you really want to proceed?"
 msgstr ""
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr ""
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr ""
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr ""
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr ""
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -209,202 +209,204 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr ""
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr ""
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr ""
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr ""
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr ""
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr ""
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr ""
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr ""
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr ""
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr ""
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr ""
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr ""
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -412,161 +414,160 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr ""
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 msgstr ""
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr ""
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr ""
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr ""
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr ""
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr ""
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr ""
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
 msgstr ""
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr ""
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr ""
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr ""
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr ""
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr ""
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr ""
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr ""
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr ""
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr ""
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
 msgstr ""
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr ""
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
 msgstr ""
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr ""
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr ""
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr ""
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr ""
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr ""
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr ""
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr ""
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr ""
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
 msgstr ""
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr ""
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 
@@ -581,27 +582,27 @@ msgid ""
 "Write modified report to given file instead of changing the original report"
 msgstr ""
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr ""
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr ""
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr ""
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr ""
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -611,78 +612,78 @@ msgid ""
 "be able to retrace crashes that happened on the currently running release."
 msgstr ""
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
 "have installed."
 msgstr ""
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr ""
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
 msgstr ""
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr "ਸੈਂਡ ਬੌਕਸ  ਵਿੱਚ ਵਾਧੂ ਪੈਕਿਜ ਇੰਸਟਾਲ (ਇਸਨੂੰ ਕਈ ਵਾਰ  ਨਿਸ਼ਚਤ ਕੀਤਾ ਜਾ ਸਕਦਾ ਹੈ)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
 "neither -g, -o, nor -s are specified)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
 msgstr ""
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr ""
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr ""
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr ""
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -690,70 +691,70 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "ਵਿਸਥਾਰ ਲਈ ਮੈਨ ਪੇਜ ਵੇਖੋ।"
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "ਗਲਤੀ: %s ਚੱਲਣਯੋਗ ਨਹੀਂ ਹੈ। ਬੰਦ ਹੋ ਰਿਹਾ ਹੈ।"
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
 msgstr ""
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 
@@ -767,76 +768,76 @@ msgstr "ਸਮੱਸਿਆ ਰਿਪੋਰਟ"
 msgid "Report a malfunction to the developers"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "ਭੇਜੋ"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "ਵੇਰਵਾ ਵੇਖੋ"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "ਜਾਰੀ ਰੱਖੋ"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "ਪੈਕੇਜ: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "ਅਫਸੋਸ, ਸਾਫਟਵੇਅਰ ਇੰਸਟਾਲ ਕਰਨ ਦੌਰਾਨ ਗਲਤੀ ਆਈ ਹੈ।"
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "ਐਪਲੀਕੇਸ਼ਨ %s ਨੂੰ ਅੰਦਰੂਨੀ ਗਲਤੀ ਆਈ ਹੈ।"
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "ਐਪਲੀਕੇਸ਼ਨ %s ਅਚਾਨਕ ਬੰਦ ਹੋ ਗਈ ਹੈ।"
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "ਵੇਰਵਾ ਓਹਲੇ"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr ""
 
@@ -890,7 +891,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr ""
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -900,32 +901,32 @@ msgstr ""
 msgid "Apport crash file"
 msgstr ""
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "ਬੰਦ ਰਹਿਣ ਦਿਓ"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "ਮੁੜ-ਚਲਾਓ"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "ਯੂਜ਼ਰ-ਨਾਂ:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "ਪਾਸਵਰਡ:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr ""
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
 msgstr ""
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2021-01-07 22:33+0000\n"
 "Last-Translator: Marek Adamski <Unknown>\n"
 "Language-Team: Polish <pl@li.org>\n"
@@ -37,11 +37,11 @@ msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 "Aby uzyskać dostęp do raportów o błędach systemowych, należy wprowadzić hasło"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "Prawdopobnie pakiet został zainstalowany nieprawidłowo"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -52,7 +52,7 @@ msgstr ""
 "zaktualizowaniu indeksów dostępnych pakietów, jeśli to nie zadziała, usunąć "
 "powiązane pakiety dostawców zewnętrznych i spróbować ponownie."
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -65,21 +65,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "nieznany program"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Przepraszamy, program %s został niespodziewanie zakończony"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Wystąpił problem w %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -87,68 +82,73 @@ msgstr ""
 "Komputer nie posiada wystarczającej ilości wolnej pamięci, aby automatycznie "
 "przeanalizować problem i zgłosić błąd do twórców programu."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Wystąpił problem w %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Nieprawidłowe zgłoszenie o błędzie"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "Brak dostępu do zgłoszenia o błędzie."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Błąd"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 "Brak wystarczającej ilości wolnego miejsca na dysku, aby przetworzyć to "
 "zgłoszenie."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr "Nie określono PID"
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 "Należy podać PID. Więcej informacji dostępnych po wpisaniu --help w "
 "terminalu."
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "Nieprawidłowy identyfikator procesu"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr "Podany ID procesu nie istnieje."
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr "Nie Twój PID"
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr "Podany ID procesu nie należy do Ciebie."
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "Nie określono pakietu"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Należy określić pakiet lub identyfikator procesu. Proszę użyć opcji --help, "
 "aby uzyskać więcej informacji."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Brak dostępu"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -156,30 +156,30 @@ msgstr ""
 "Określony proces nie jest własnością bieżącego użytkownika. Proszę uruchomić "
 "ten program jako właściciel procesu lub jako administrator."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "Określony identyfikator procesu nie powiązany jest z żadnym programem."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Skrypt symptomu %s nie określił pakietu"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Pakiet %s nie istnieje"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "Nie można utworzyć raportu"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "Uaktualnianie zgłoszenia o błędzie"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -191,7 +191,7 @@ msgstr ""
 "\n"
 "Proszę zgłosić błąd używając narzędzia \"apport-bug\"."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -212,24 +212,24 @@ msgstr ""
 "\n"
 "Kontynuować?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "Nie zebrano dodatkowych informacji."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "Jaki rodzaj zgłoszenia ma zostać wysłany?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Nieznany symptom"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Symptom \"%s\" jest nieznany"
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -248,7 +248,7 @@ msgstr ""
 "Na karcie Procesy przewiń, aż znajdziesz odpowiedni program. Identyfikator "
 "procesu to numer podany w kolumnie Identyfikator."
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -256,32 +256,32 @@ msgstr ""
 "Po zamknięciu tej wiadomości, proszę kliknąć okno programu, aby zgłosić jego "
 "błąd."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 "Nie udało się określić identyfikatora okna procesu przy użyciu programu xprop"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr "%(prog)s <numer raportu>"
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "Określa nazwę pakietu"
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "Dodaje dodatkową etykietę do zgłoszenia. Można użyć kilkukrotnie."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 "%(prog)s [opcje] [symptom|pid|pakiet|ścieżka programu|plik .apport/.crash]"
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -291,17 +291,17 @@ msgstr ""
 "opcjonalnie --pid, lub tylko opcji --pid. Jeśli żadna opcja nie zostanie "
 "użyta, wyświetlona zostanie lista symptomów."
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "Zgłasza błąd programu wskazanego kliknięciem w okno docelowe"
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "Uruchomia w trybie aktualizacji zgłoszenia błędu. Można użyć z opcją --"
 "package."
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -309,7 +309,7 @@ msgstr ""
 "Zgłasza błąd dotyczący symptomu (wymuszone jeśli podano nazwę symptomu jako "
 "parametr)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -317,7 +317,7 @@ msgstr ""
 "Określa nazwę pakietu w trybie zgłaszania błędu. Opcjonalne, jeśli użyto "
 "opcję --pid (wymuszone, jeśli podano nazwę pakietu jako parametr)."
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -326,11 +326,11 @@ msgstr ""
 "Określa program w trybie zgłaszania błędu. Dodaje do zgłoszenia większą "
 "ilość informacji (pid jest podany jako jedyny parametr)."
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "Podany pid to numer zawieszonej aplikacji."
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -340,7 +340,7 @@ msgstr ""
 "crash zamiast oczekujących w %s (wymuszone, jeśli określono plik jako "
 "parametr)."
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -349,66 +349,68 @@ msgstr ""
 "Zapisuje informacje o błędzie do pliku, zamiast zgłaszać go. Raport zawarty "
 "w pliku, może być zgłoszony później z innego komputera."
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Wypisuje informacje o wersji"
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr "Analiza awarii w terminalu za pomocą apport-retrace"
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "Rozpoczyna sesję gdb"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Rozpoczęcie sesji gdb bez pobierania symboli debugowania"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Aktualizacja %s z pomocą fully symbolic stack trace"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr "Nie można zapamiętać ustawień statusu wysyłania zgłoszeń"
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 "Zapisywanie stanu zgłaszania awarii nie powiodło się. Nie można ustawić "
 "trybu automatycznego lub nigdy nie zgłaszania."
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr "Nie można zapamiętać ustawień statusu wysyłania zgłoszeń"
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr "Zgłoszenie błędu dotyczy programu, który nie jest już zainstalowany."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 msgstr "Problem dotyczy programu %s, który został zmieniony od czasu awarii."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr ""
 "To zgłoszenie o błędzie jest uszkodzone i nie może zostać przetworzone."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr "To zgłoszenie dotyczące pakietu, który nie jest zainstalowany."
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "Wystąpił błąd podczas próby zgłoszenia błędu:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
@@ -416,24 +418,24 @@ msgstr ""
 "Zainstalowane są dwie wersje tego programu. Której wersji użyć do zgłoszenia "
 "błędu?"
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr "Snap %s"
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr "Pakiet deb %s"
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s dostarczono przez snap opublikowany przez %s. Należy skontakować się za "
 "pomocą %s, aby uzyskać pomoc."
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -443,41 +445,41 @@ msgstr ""
 "kontaktowego; należy odwiedzić forum pod adresem https://forum.snapcraft."
 "io/, aby uzyskać pomoc."
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "Nie można ustalić pakietu lub nazwy pakietu źródłowego."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "Nie można uruchomić przeglądarki internetowej"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Nie można uruchomić przeglądarki internetowej, aby otworzyć %s."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Problem z siecią"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Nie można połączyć się z bazą danych awarii, proszę sprawdzić połączenie "
 "internetowe."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Problem z siecią"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Pamięć wyczerpana"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "System nie dysponuje wystarczającą ilością pamięci, aby przetworzyć raport "
 "błędu."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -488,11 +490,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "Błąd został już zgłoszony"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -502,38 +504,37 @@ msgstr ""
 "internetowej. Proszę sprawdzić, czy można dodać jakiekolwiek dalsze "
 "informacje, które mogą być pomocne twórcom programu."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Programiści zostali już poinformowani o tym problemie. Dziękujemy!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Proszę wcisnąć dowolny klawisz, aby kontynuować..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "Co zrobić? Możliwe działania:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Proszę wybrać (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i bajtów)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(dane binarne)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Zgłosić błąd twórcom programu?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -541,51 +542,51 @@ msgstr ""
 "Gdy raport zostanie wysłany, proszę wypełnić formularz\n"
 "w automatycznie otwartej przeglądarce internetowej."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "Wy&słanie zgłoszenia (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "&Zbadanie lokalnie"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "&Wyświetlenie zgłoszenia"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 "Pozostawienie pli&ku zgłoszenia w celu późniejszego wysłania lub skopiowania"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "Anulowanie i &ignorowanie przyszłych awarii tej wersji programu"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Anulowanie"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Plik zgłoszenia:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&Potwierdź"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Błąd: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "Zbieranie informacji o błędzie"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -593,11 +594,11 @@ msgstr ""
 "Zebrane informacje mogą zostać wysłane do twórców, aby ulepszyć\n"
 "program. To może potrwa kilka minut."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "Wysyłanie informacji o problemie"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -605,40 +606,40 @@ msgstr ""
 "Zebrane informacje są wysyłane do systemu zgłaszania błędów.\n"
 "To może potrwać kilka minut."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Gotowe"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "brak"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "Zaznaczono: %s. Wielokrotny wybór:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Wybór:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "Ścieżka do pliku (wciśnięcie klawisza ENTER anuluje działanie):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "Plik nie istnieje."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "To jest katalog."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "Aby kontynuować, należy otworzyć następujący adres URL:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -646,17 +647,17 @@ msgstr ""
 "Można teraz uruchomić przeglądarkę internetową, albo wkleić ten adres URL do "
 "przeglądarki na innym komputerze."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Uruchom przeglądarkę"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 "Nie ma oczekujących zgłoszeń awarii. Proszę użyć opcji --help, aby uzyskać "
 "więcej informacji."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 "Nie dodaje nowych śladów do zgłoszenia tylko wypisuje je na standardowe "
@@ -677,27 +678,27 @@ msgstr ""
 "Napisz zmienione zgłoszenie dla danego pliku zamiast zmieniać oryginalne "
 "zgłoszenie"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr "Usuwa zrzut pamięci ze zgłoszenia po regeneracji śladu stosu."
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "Zastąp CoreFile raportu"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "Zastąp ExecutablePath raportu"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "Zastąp ProcMaps raportu"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "Przebudowuje informacje o pakiecie w zgłoszeniu"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -714,7 +715,7 @@ msgstr ""
 "śledzenie i analiza (retrace) problemów, które miały miejsce w bieżąco "
 "zainstalowanym wydaniu systemu."
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
@@ -724,29 +725,29 @@ msgstr ""
 "przy użyciu tej same wersji co zgłoszenie, a nie dowolną wersję gdb, którą "
 "zainstalowano."
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 "Wyświetl pasek postępu pobierania/instalowania podczas instalowania pakietów "
 "w piaskownicy"
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr ""
 "Dodanie informacji o czasie do logów dla operacji trybu wsadowego (batch "
 "operation)"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 "Utwórz i użyj repozytoriów osób trzecich ze źródeł określonych w raportach"
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr "Określa katalog podręczny pakietów pobieranych do piaskownicy"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -754,12 +755,12 @@ msgstr ""
 "Katalog dla nierozpakowanych pakietów. Przyszłe użycie domyślnie założy, że "
 "każdy z już pobranych pakietów, jest również rozpakowany do tego sandboxa."
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr "Instaluje dodatkowy pakiet w piaskownicy (można użyć wiele razy)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -769,7 +770,7 @@ msgstr ""
 "używana podczas podawania identyfikatora problemu w celu przesłania ponownie "
 "prześledzonego śladu stosu (tylko jeśli nie użyto -g, -o, oraz -s)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -777,32 +778,32 @@ msgstr ""
 "Wyświetla ponownie wyśledzone ślady stosu i pyta o potwierdzenie przez "
 "wysłaniem ich do bazy błędów."
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 "Ścieżka do zduplikowanej bazy danych sqlite (domyślnie: bez wyszukiwania "
 "duplikatów)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr "Nie dodawaj StracktraceSource do zgłoszenia."
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "Nie można użyć -C bez -S. Zatrzymywanie."
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "Wysłać to jako załączniki? [y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr "%(prog)s <raport>> <katalog docelowy>"
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr "Plik raportu do rozpakowania"
 
@@ -810,26 +811,26 @@ msgstr "Plik raportu do rozpakowania"
 msgid "directory to unpack report to"
 msgstr "katalog do rozpakowania raportu"
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "Katalog docelowy istnieje i nie jest pusty."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "Zajrzyj na stronę podręcznika systemowego po więcej szczegółów."
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "Podaj nazwę pliku logów, generowanych przez valgrind"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
 msgstr ""
 "Ponowne użycie istniejącego już katalogu sandbox (SDIR) lub jego utworzenie"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -837,20 +838,20 @@ msgstr ""
 "Katalog sandbox nie zostanie utworzony ani użyty ponownie dla dodatkowych "
 "symboli debugowania. Polegamy tylko na symbolach już zainstalowanych."
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
 msgstr ""
 "Ponowne użycie istniejącego już katalogu cache (CDIR) lub jego utworzenie"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 "Raportowanie postępu pobierania/instalacji podczas instalowania pakietów do "
 "sandbox"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
@@ -858,12 +859,12 @@ msgstr ""
 "plik wykonywalny, który jest uruchamiany przez narzędzie memcheck programu "
 "valgrind do wykrywania wycieków pamięci"
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Błąd: nie można wykonać %s. Zatrzymywanie."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -871,7 +872,7 @@ msgstr ""
 "Wydarzyło się to podczas poprzedniego stanu wstrzymania i uniemożliwiło "
 "systemowi poprawne przejście do normalnego stanu pracy."
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -879,7 +880,7 @@ msgstr ""
 "Wydarzyło się to podczas poprzedniego stanu uśpienia i uniemożliwiło "
 "systemowi poprawne przejście do normalnego stanu pracy."
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -887,7 +888,7 @@ msgstr ""
 "Wznawianie zawiesiło się bardzo blisko końca tego procesu i wygląda na "
 "ukończony poprawnie."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 "System może być niestabilny, dlatego może być wymagane jego ponowne "
@@ -903,77 +904,77 @@ msgstr "Zgłaszanie błędu"
 msgid "Report a malfunction to the developers"
 msgstr "Zgłasza twórcom błędy działania oprogramowania"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "Niestety, program %s niespodziewanie wstrzymał pracę."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "Przepraszamy, %s został niespodziewanie zakończony."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "Przepraszamy, wystąpił wewnętrzny błąd działania %s."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Wyślij"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Wyświetl szczegóły"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Kontynuuj"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "Program %s przestał odpowiadać."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "Program „%s” przestał odpowiadać."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Pakiet: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "Przepraszamy, wystąpił błąd podczas instalowania oprogramowania."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "Wystąpił wewnętrzny błąd programu %s."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "Program %s został niespodziewanie zakończony."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr ""
 "Jeśli wystąpią kolejne awarie, proszę spróbować ponownie uruchomić komputer."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "Ignorowanie problemów tego typu w przyszłości"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Ukryj szczegóły"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -1029,7 +1030,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>Wysyłanie informacji o błędzie</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -1041,27 +1042,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Plik zgłoszenia Apport"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "Pozostaw zakończony"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Uruchom ponownie"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Nazwa użytkownika:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Hasło:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "Zbieranie informacji o problemie"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1069,6 +1070,6 @@ msgstr ""
 "Zebrane informacje mogą zostać wysłane do twórców programu w celu jego "
 "usprawnienia. To może potrwać kilka minut."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "Wysyłanie informacji o błędzie"

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2022-07-13 12:35+0000\n"
 "Last-Translator: Hugo Carvalho <hugokarvalho@hotmail.com>\n"
 "Language-Team: Portuguese <pt@li.org>\n"
@@ -40,11 +40,11 @@ msgstr ""
 "Por favor introduza a sua password para aceder a relatórios de problemas "
 "relativos a programas de sistema"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "Este pacote não parece estar instalado corretamente"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -55,7 +55,7 @@ msgstr ""
 "os índices dos pacotes disponíveis; se isso não funcionar, remova os pacotes "
 "de terceiros relacionados e tente novamente."
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -68,21 +68,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "programa desconhecido"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Desculpe, o programa %s fechou inesperadamente"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Problema em %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -90,64 +85,69 @@ msgstr ""
 "O seu computador não tem memória livre suficiente para analisar "
 "automáticamente o problema e enviar um relatório para os programadores."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Problema em %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Relatório do problema inválido"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "Você não tem autorização para aceder ao relatório deste problema."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Erro"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 "Não tem espaço livre suficiente no disco para processar este relatório."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr "PID não foi especificado"
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr "Precisa especificar um PID. Veja --help para obter mais informação."
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "PID inválido"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr "O ID do processo especificado não existe."
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr "Não é o seu PID"
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr "O ID do processo especificado não lhe pertence."
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "Nenhum pacote especificado"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Deve especificar um pacote ou um PID. Veja --help para mais informações."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Permissão negada"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -155,30 +155,30 @@ msgstr ""
 "O processo especificado não lhe pertence. Por favor execute este programa "
 "como dono do processo ou como \"root\"."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "O ID de processo especificado não pertence a um programa."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "O script de sintoma %s não determinou um pacote afetado."
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "O pacote %s não existe"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "Não foi possível criar relatório"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "Actualizando relatório de problemas"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -190,7 +190,7 @@ msgstr ""
 "\n"
 "Por favor, crie um novo relatório usando \"apport-bug\"."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -210,24 +210,24 @@ msgstr ""
 "\n"
 "Deseja realmente continuar?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "Nenhuma informação adicional colectada."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "Que tipo de problema quer reportar?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Sintoma desconhecido"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "O sintoma \"%s\" não é conhecido"
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -246,7 +246,7 @@ msgstr ""
 "Sistema. No separador Processos, deslocar com o rato até encontrar a "
 "aplicação correcta. O ID de processo é o número listado no ID da coluna."
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -254,32 +254,32 @@ msgstr ""
 "Após fechar esta mensagem, clique por favor na janela da aplicação para "
 "relatar um problema sobre ela."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop falhou ao determinar a ID do processo da janela"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr "%(prog)s <report number>"
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "Especifique o nome do pacote"
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Adicione uma marca extra ao relatório. Pode ser especificada várias vezes."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -289,16 +289,16 @@ msgstr ""
 "só um --pid. Se não for indicado nenhum, exibir uma lista de sintomas "
 "conhecidos. (Implícito se dor indicado um único argumento.)"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "Clique uma janela como alvo para preencher um relatório de problemas."
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "Iniciar em modo de actualização de erros. Pode levar um --package opcional."
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -306,7 +306,7 @@ msgstr ""
 "Submeter um relatório de bugs sobre um sintoma. (Implícito se for indicado "
 "um nome do sintoma como um único argumento.)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -315,7 +315,7 @@ msgstr ""
 "especificado. (Automático se um nome de pacote é fornecido como único "
 "argumento.)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -325,11 +325,11 @@ msgstr ""
 "especificado, o relatório de erros irá conter mais informações. (Implícito "
 "se pid for apenas argumento.)"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "O pid fornecido é uma aplicação pendente."
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -339,7 +339,7 @@ msgstr ""
 "arquivos pendentes em %s. (Automático se o arquivo é fornecido como único "
 "argumento)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -349,48 +349,48 @@ msgstr ""
 "vez de a relatar. Este ficheiro pode ser relatado mais tarde a partir de uma "
 "máquina diferente."
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Imprime o número da versão do Apport"
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr "Vai ser lançado apport-retrace no terminal para examinar o erro."
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "Executar sessão gdb"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Executar sessão gdb sem transferir símbolos de depuração"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Atualização %s com o conjunto simbolico do stack trace."
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr "Não me lembro de enviar o relatório estado de configurações"
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 "Falha ao guardar o relatório de estado de falhas. Impossível definir como "
 "automático ou no modo nunca relatar."
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr "Não me lembro de enviar o relatório estado de configurações"
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 "Este relatório de problema aplica-se a um programa que já não se encontra "
 "instalado."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
@@ -399,45 +399,47 @@ msgstr ""
 "O problema aconteceu com o programa %s  que alterou desde que o crash "
 "ocorreu."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Este relatório de problema está danificado e não pode ser processado."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr "Este relatório é sobre o pacote que não foi instalado."
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr ""
 "Ocorreu um erro durante a tentativa de processamento deste relatório de "
 "problema:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 "Tem duas versões instaladas deste programa, de qual quer reportar um erro?"
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr "snap %s"
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr "pacote deb %s"
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s é fornecido por um snap publicado por %s. Contacte-os através de %s para "
 "obter ajuda."
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -447,41 +449,41 @@ msgstr ""
 "endereço de contacto; visite o fórum em https://forum.snapcraft.io/ para "
 "obter ajuda."
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "Não foi possível determinar o nome do pacote ou pacote fonte."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "Não é possível iniciar o navegador web"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Não é possível iniciar o navegador web para abrir %s"
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Problema na rede"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Não é possível estabelecer a ligação à base de dados de falhas, por favor "
 "verifique a sua ligação à Internet."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Problema na rede"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Exaustão da memória"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "O seu sistema não tem memória suficiente para processar o relatório desta "
 "paragem."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -492,11 +494,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "Problema já conhecido"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -506,38 +508,37 @@ msgstr ""
 "web. Por favor, verifique se poderá adicionar mais alguma informação que "
 "possa ser útil aos programadores."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Este problema já foi relatados aos programadores. Obrigado!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Prima qualquer tecla para continuar..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "O que gostaria de fazer? As suas opções são:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Por favor escolha (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i bytes)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(dados binários)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Enviar o relatório do problema para os programadores?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -546,51 +547,51 @@ msgstr ""
 "formulário na\n"
 "janela do navegador web que é aberta automaticamente."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "&Enviar relatório (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "&Examine localmente"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "&Ver relatório"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 "&Manter o ficheiro do relatório para enviar depois ou copiar para outro local"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "Cancelar e &ignorar futuros erros desta versão da aplicação"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Cancelar"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Ficheiro com o relatório do problema:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&Confirmar"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Erro: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "A recolher informações sobre o problema"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -599,11 +600,11 @@ msgstr ""
 "melhorar\n"
 "a aplicação. Isto pode demorar alguns minutos."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "A enviar informações do problema"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -611,40 +612,40 @@ msgstr ""
 "A informação recolhida está a ser enviada ao sistema de rastreio de erros.\n"
 "Isto pode demorar alguns minutos."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Concluído"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "nenhum"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "Seleccionado: %s. Opções:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Escolhas:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "Caminho para o ficheiro (Enter para cancelar):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "O ficheiro não existe."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "Isto é um directório."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "Para continuar, tem que visitar o seguinte URL:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -652,15 +653,15 @@ msgstr ""
 "Pode iniciar um navegador agora, ou copiar este URL para um navegador noutro "
 "computador."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Iniciar um navegador agora"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr "Nenhum relatório de erro pendente. Tente --help para mais informações."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 "Não colocar as novas análises no relatório, mas mostrá-las na saída padrão."
@@ -680,27 +681,27 @@ msgstr ""
 "Escreve o relatório modificado para um determinado ficheiro ao invés de "
 "alterar o relatório original"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr "Remove o core dump do relatório após a regeneração da análise da pilha"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "Substituir relatório CoreFile"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "Substituir relatório ExecutablePath"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "Substituir relatório ProcMaps"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "Reconstruir o relatório de informação do pacote"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -717,7 +718,7 @@ msgstr ""
 "configuração de ficheiros,mas só assim poderás  refazer os crashes  na "
 "execução que vai decorrendo."
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
@@ -727,27 +728,27 @@ msgstr ""
 "dependências utilizando a mesma versão que o relatório em vez de qualquer "
 "outra versão do gdb que instalou."
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 "Apresentar o progresso download/instalar quando ao instalar os pacotes no "
 "sandbox."
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr "Preceder timestamps  para registar mensagens , para operação em lotes."
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 "Cria e usa repositórios de terceiros de origens especificadas nos relatórios."
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr "Directoria temporária para pacotes transferidos no sandbox"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -755,13 +756,13 @@ msgstr ""
 "Diretório para os pacotes descompactados.Futuramente irá assumir que o "
 "download dos pacotes  é também extraído para este sandbox."
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 "Instalar um pacote extra no sandbox (pode ser especificado várias vezes)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -771,7 +772,7 @@ msgstr ""
 "erros. Isto é usado ao especificar a ID de erros para enviar os rastreios de "
 "erros rastreados (apenas se nem -g, -o, ou -s estarem especificados)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -779,32 +780,32 @@ msgstr ""
 "Mostrar rastreios de erros rastreados e perguntar por confirmação antes de "
 "os enviar para a base de dados de erros."
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 "Caminho para a base de dados de duplicados sqlite (por omissão: sem "
 "verificação de duplicação)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr "Não acrescente StacktraceSource ao relatório."
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "Não pode usar -C sem -S. A parar.."
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "OK para enviar estes como anexos? [y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr "%(prog)s <report> <target directory>"
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr "Relatar ficheiro a descompactar"
 
@@ -812,19 +813,19 @@ msgstr "Relatar ficheiro a descompactar"
 msgid "directory to unpack report to"
 msgstr "diretório para relatório descompactado"
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "Directório de destino existe mas não está vazio"
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "Veja a página do man para detalhes"
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "Especificar o nome de registo do ficheiro produzido pelo valgrind."
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
@@ -832,7 +833,7 @@ msgstr ""
 "re-utilize um directório de sandbox (SDIR) criado préviamente ou, se não "
 "existe, crie um"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -840,7 +841,7 @@ msgstr ""
 "Não criar ou reutilizar um diretório  sandbox para símbolos de depuração "
 "adicionais  mas confiar somente em símbolos de depuração instalados."
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
@@ -848,13 +849,13 @@ msgstr ""
 "Reutilizar um cache dir (CDIR) criado anteriormente ou,se não existir,criá-"
 "lo."
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 "reportar o progresso do download/instalar durante a instalação dos pacotes "
 "do sandbox."
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
@@ -862,12 +863,12 @@ msgstr ""
 "o executável que é executado sob a ferramenta memcheck da valgrind para a "
 "deteção de fugas de memória"
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Erro: %s não é um executável. A parar."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -875,7 +876,7 @@ msgstr ""
 "Isto ocorreu durante uma suspensão anterior, e não permitiu ao sistema "
 "acordar corretamente."
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -883,7 +884,7 @@ msgstr ""
 "Isto ocorreu durante uma hibernação anterior, e não permitiu ao sistema "
 "acordar corretamente."
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -891,7 +892,7 @@ msgstr ""
 "O processo foi terminado muito perto do final, e pareceu-nos que foi "
 "completado normalmente."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 "O seu sistema pode ficar instável agora e poderá necessitar de ser "
@@ -907,76 +908,76 @@ msgstr "Comunicar um problema..."
 msgid "Report a malfunction to the developers"
 msgstr "Comunique um mau funcionamento aos programadores"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "Lamentamos, a aplicação %s terminou inesperadamente."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "Desculpe, %s fechou inesperadamente."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "Desculpe, %s sofreu um erro interno."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Enviar"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Mostrar Detalhes"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Continuar"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "A aplicação %s parou de responder."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "O programa \"%s\" parou de responder."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Pacote: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "Desculpe, ocorreu um problema durante a instalação do software."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "A aplicação %s sofreu um erro interno."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "A aplicação %s fechou inesperadamente."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr "Se notar mais problemas, tente reiniciar o computador."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "Ignorar futuros problemas deste tipo"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Esconder Detalhes"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -1032,7 +1033,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>A enviar informação sobre o problema</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -1044,27 +1045,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Ficheiro de crash do Apport"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "Manter fechado"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Reiniciar"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Nome de utilizador:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Palavra-Passe:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "A Recolher Informações sobre o Problema"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1072,6 +1073,6 @@ msgstr ""
 "A informação recolhida pode ser enviada aos programadores para que a "
 "aplicação possa ser melhorada. Isto pode demorar alguns minutos."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "A Enviar Informações sobre o Problema"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2014-12-30 18:25+0000\n"
 "Last-Translator: Salomão Carneiro de Brito <salomaocar@gmail.com>\n"
 "Language-Team: Portuguese (Brazil) <pt_BR@li.org>\n"
@@ -40,11 +40,11 @@ msgstr ""
 "Por favor, informe sua senha para acessar os relatórios de problemas dos "
 "programas do sistema"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "Este pacote não parece estar instalado corretamente"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -52,7 +52,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -65,21 +65,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "programa desconhecido"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Desculpe, o programa \"%s\" fechou inesperadamente"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Problema em %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -87,64 +82,69 @@ msgstr ""
 "Seu computador não possui memória suficiente para analisar automaticamente o "
 "problema e enviar um relatório aos desenvolvedores."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Problema em %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Relatório do problema inválido"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "Você não tem permissão para acessar esse relatório de problema."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Erro"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "Não há espaço suficiente em disco para processar este relatório."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "PID inválido"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "Nenhum pacote especificado"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Você precisa especificar o pacote ou o PID. Veja --help para mais "
 "informações."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Permissão negada"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -152,30 +152,30 @@ msgstr ""
 "O processo especificado não pertence a você. Por favor, execute este "
 "programa como dono do processo ou como usuário root."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "O ID do processo especificado não pertence a um programa."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "O script de sintoma %s não determinou um pacote afetado."
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "O pacote %s não existe."
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "Não foi possível criar o relatório"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "Atualizando o relatório de problema"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -186,7 +186,7 @@ msgstr ""
 "está duplicado ou já foi fechado.\n"
 "Por favor, crie um novo relatório utilizando o \"apport-bug\""
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -206,24 +206,24 @@ msgstr ""
 "\n"
 "Você realmente deseja continuar?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "Nenhuma informação adicional foi coletada."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "Que tipo de problema você deseja informar?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Sintoma desconhecido"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "O sintoma \"%s\" não é conhecido."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -234,7 +234,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -242,31 +242,31 @@ msgstr ""
 "Depois de fechar esta mensagem, por favor, clique na janela do aplicativo "
 "para relatar um problema sobre ele."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop falhou ao determinar a ID do processo da janela"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "Especificar o nome do pacote."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Adicione um rótulo a mais ao relatório. Pode ser especificado várias vezes."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -276,15 +276,15 @@ msgstr ""
 "pid, ou somente um --pid. Se nenhum é fornecido, mostra uma lista de "
 "sintomas conhecidos. (Automático se um único argumento é fornecido)"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "Clique na janela como alvo para preencher um relatório de problema."
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "Iniciar em modo de atualização de erro. Aceita o parâmetro --package."
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -292,7 +292,7 @@ msgstr ""
 "Submete um relatório de bug sobre um sintoma. (Automático se um nome de "
 "sintoma é fornecido como único argumento)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -301,7 +301,7 @@ msgstr ""
 "especificado. (Automático se um nome de pacote é fornecido como único "
 "argumento)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -311,11 +311,11 @@ msgstr ""
 "relatório de erro conterá mais informações. (Implícito se pid for dado como "
 "único argumento.)"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "O pid fornecido é de uma aplicação pendente."
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -325,7 +325,7 @@ msgstr ""
 "arquivos pendentes em %s. (Automático se o arquivo é fornecido como único "
 "argumento)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -335,47 +335,47 @@ msgstr ""
 "arquivo em vez de relatá-las. Esse arquivo pode ser reportado mais tarde ou "
 "de outra máquina."
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Imprimir o número da versão do Apport."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Isto irá executar o apport-retrace em uma janela de Terminal para examinar a "
 "falha."
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "Executar sessão gdb"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Executar sessão gdb sem baixar símbolos de depuração"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Atualizar %s com rastreamento de pilha totalmente simbólico"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 "Este problema relatado se aplica a um programa que não está mais instalado."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
@@ -384,81 +384,83 @@ msgstr ""
 "O problema aconteceu com o programa %s que mudou desde que o problema "
 "ocorreu."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Este relatório de erros está danificado e não pode ser processado."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr ""
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "Um erro ocorreu ao tentar processar esse relatório de problema:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "Não foi possível determinar o pacote ou nome do pacote fonte."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "Não é possível iniciar navegador web"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Não é possível iniciar navegador web para abrir %s."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Problema na rede"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Não é possível conectar em uma base de dados quebrada, por favor verifique "
 "sua conexão com a internet."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Problema na rede"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Memória exaurida"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Seu sistema não tem memória o suficiente para processar este relatório de "
 "erro."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -469,11 +471,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "Problema já informado"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -483,38 +485,37 @@ msgstr ""
 "Por favor, verifique se você pode adicionar alguma informação adicional que "
 "possa ser útil aos desenvolvedores."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "O problema já foi reportado aos desenvolvedores. Obrigado!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Pressione qualquer tecla para continuar..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "O que você gostaria de fazer? Suas opções são:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Por favor escolha (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i bytes)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(dados binários)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Enviar o relatório do problema aos desenvolvedores?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -522,52 +523,52 @@ msgstr ""
 "Depois que o relatório do problema for enviado, por favor preencha o \n"
 "formulário que será aberto automaticamente no navegador web."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "&Enviar relatório (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "&Examinar localmente"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "&Ver relatório"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 "&Manter arquivo do relatório para enviar mais tarde ou copiar para outro "
 "lugar."
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "Cancelar e &ignorar futuros travamentos dessa versão do programa."
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Cancelar"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Arquivo do relatório de problema:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&Confirmar"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Erro: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "Coletando informações sobre o problema"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -575,11 +576,11 @@ msgstr ""
 "A informação coletada pode ser enviada aos desenvolvedores para melhorar\n"
 "o aplicativo. Isso pode demorar alguns minutos."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "Enviando informações sobre o problema"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -588,40 +589,40 @@ msgstr ""
 "erros.\n"
 "Isso pode demorar alguns minutos."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Pronto"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "nenhum"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "Selecionado: %s. Multiplas opções:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Escolhas:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "Caminho para o arquivo (Enter para cancelar):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "O arquivo não existe."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "Isto é um diretório."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "Para continuar, você deve visitar a seguinte URL:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -629,17 +630,17 @@ msgstr ""
 "Você pode executar um navegador agora, ou copiar esta URL dentro de um "
 "navegador em outro computador."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Executar o navegador agora"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 "Nenhum relatório de travamentos pendente. Tente --help para maiores "
 "informações."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 "Não colocar as novas análises no relatório, mas mostrá-las na saída padrão."
@@ -659,27 +660,27 @@ msgstr ""
 "Escrever relatório modificado para determinado arquivo ao invés de alterar o "
 "relatório original"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr "Remove o core dump do relatório após a regeneração da análise da pilha"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "Sobrescrever os relatórios \"CoreFile\""
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "Sobrescrever os relatórios \"ExecutablePath\""
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "Sobrescrever os relatórios \"ProcMaps\""
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "Reconstruir o relatório de informação do pacote"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -696,33 +697,33 @@ msgstr ""
 "configuração do sistema, mas então será capaz de rastrear somente falhas que "
 "ocorreram na versão em execução no momento."
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
 "have installed."
 msgstr ""
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 "Relatar progresso ao baixar/instalar durante instalação do pacotes na área "
 "local"
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr "Inserir hora antes das mensagens de registro, para operações em lote"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr "Diretório de cache para pacotes baixados na área local"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -730,14 +731,14 @@ msgstr ""
 "Diretório para pacotes descompactados. Execuções futuras assumirão que "
 "qualquer pacote obtido via download também será extraído nesta área local."
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 "Instalar um pacote extra na área local (pode ser especificado múltiplas "
 "vezes)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -748,7 +749,7 @@ msgstr ""
 "para carregar o rastreamento de pilha refeito (somente se não -g, -o, nem -s "
 "forem especificadas)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -756,32 +757,32 @@ msgstr ""
 "Exibir rastreamentos de pilhas refeitos e pedir confirmação antes de enviá-"
 "los para o banco de dados de falhas."
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 "Caminho para o banco de dados de duplicados do SQLite (padrão: nenhuma "
 "verificação duplicação)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr ""
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "Você não pode usar -C sem -S. Interrompendo."
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "OK para enviar estes como anexos? [y / n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -789,19 +790,19 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "Diretório de destino existe e não está vazio."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "Consulte o manual para detalhes."
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "especificar o nome do arquivo de log produzido pelo valgrind"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
@@ -809,7 +810,7 @@ msgstr ""
 "reutilizar um diretório para área local criado anteriormente (SDIR) ou, caso "
 "este não exista, criar um"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -817,7 +818,7 @@ msgstr ""
 "não criar ou reutilizar um diretório de área local para símbolos de "
 "depuração adicionais, confie apenas nos símbolos de depuração instalados."
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
@@ -825,35 +826,35 @@ msgstr ""
 "reutilizar um diretório de cache (CDIR) criado previamente ou, caso não "
 "exista, criar um"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 "reportar download/progresso de instalação ao instalar pacotes na área local"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Erro: %s não é um executável. Interrompendo."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -861,7 +862,7 @@ msgstr ""
 "O processo foi terminado muito perto do final, e nos parece que foi "
 "completado normalmente."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 "Seu sistema poderá se tornar instável agora e poderá ser necessário reiniciá-"
@@ -877,76 +878,76 @@ msgstr "Informar um problema..."
 msgid "Report a malfunction to the developers"
 msgstr "Relatar um mal-funcionamento aos desenvolvedores"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "Desculpe, o aplicativo %s parou de funcionar inesperadamente."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "Desculpe, %s fechou inesperadamente."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "Desculpe, %s apresentou um erro interno."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Enviar"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Mostrar detalhes"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Continuar"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "O aplicativo %s parou de responder."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "O programa \"%s\" parou de responder."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Pacote: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "Desculpe, ocorreu um problema durante a instalação do programa."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "O aplicativo %s apresentou um erro interno."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "O aplicativo %s foi fechado inesperadamente."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr "Se você observar outros problemas, tente reiniciar o computador."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "Ignorar futuros problemas deste tipo"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Ocultar detalhes"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -1002,7 +1003,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>Enviando informações sobre o problema</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -1014,27 +1015,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Arquivo Apport falhou"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "Deixe fechado"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Reexecutar"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Nome de usuário:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Senha:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "Coletando Informações sobre o Problema"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1042,6 +1043,6 @@ msgstr ""
 "As informações coletadas podem ser enviadas aos desenvolvedores para "
 "melhorar aplicativo. Isto pode demorar alguns minutos."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "Enviando Informações sobre o Problema"

--- a/po/ro.po
+++ b/po/ro.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2014-02-25 13:57+0000\n"
 "Last-Translator: Marian Vasile <marianvasile1972@gmail.com>\n"
 "Language-Team: Romanian Gnome Team <gnomero-list@lists.sourceforge.net>\n"
@@ -41,11 +41,11 @@ msgstr ""
 "Pentru a accesa rapoartele despre problemele cu programele sistemului "
 "trebuie să vă introduceți parola"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "Se pare că acest pachet nu este instalat corect"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -53,7 +53,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -66,21 +66,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "program necunoscut"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Programul „%s” s-a întrerupt într-un mod neașteptat"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Problemă în %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -88,65 +83,70 @@ msgstr ""
 "Calculatorul dumneavoastră nu dispune de suficientă memorie pentru a analiza "
 "automat problema și a trimite un raport despre eroare programatorilor."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Problemă în %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Raport de probleme nevalid"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "Accesul la raport nu vă este permis."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Eroare"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 "Nu există suficient spațiu disponibil pe disc pentru a procesa acest raport."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "PID nevalid"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "Nu a fost specificat niciun pachet"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Trebuie să specificați un pachet sau un PID. Pentru mai multe informații "
 "consultați --help."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Permisiune refuzată"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -154,30 +154,30 @@ msgstr ""
 "Procesul selectat nu aparține acestui utilizator. Executați acest program în "
 "calitate de proprietar al procesului sau de utilizator „root”."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "Identificatorul de proces specificat nu aparține unui program."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Scriptul pentru simptome %s, nu a detectat niciun pachet afectat"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Pachetul %s nu există"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "Raportul nu poate fi creat"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "Se actualizează raportul de probleme"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -189,7 +189,7 @@ msgstr ""
 "\n"
 "Creați un nou raport, utilizând „apport-bug”."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -210,24 +210,24 @@ msgstr ""
 "\n"
 "Sigur doriți să continuați?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "Nu au fost colectate informații suplimentare."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "Ce fel de problemă doriți să raportați?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Simptom necunoscut"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Simptomul „%s” nu este cunoscut."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -238,7 +238,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -246,32 +246,32 @@ msgstr ""
 "După închiderea acestui mesaj faceți clic pe fereastra unei aplicații pentru "
 "a raporta o problemă despre ea."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop nu a reușit să determine ID-ul de proces al ferestrei"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "Specificați numele pachetului."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Adăugă o etichetă suplimentară raportului. Pot fi specificate mai multe "
 "etichete."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -282,17 +282,17 @@ msgstr ""
 "este prezent, atunci afișează o listă de simptome cunoscute. (Implicit, dacă "
 "se transmite un singur argument)."
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "Clic pe o fereastră pentru a raporta o problemă despre aceasta."
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "Pornește în modul de actualizare a defecțiunii. Poți lua un --package "
 "opțional."
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -300,7 +300,7 @@ msgstr ""
 "Trimite un raport de defecțiune despre un simptom. (Implicit, dacă numele "
 "simptomului este dat ca singurul argument.)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -309,7 +309,7 @@ msgstr ""
 "este specificat. (Implicit dacă numele pachetului este dat ca singurul "
 "argument)."
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -319,11 +319,11 @@ msgstr ""
 "acest lucru este specificat, raportul de eroare va conține mai multe "
 "informații. (Opțiune implicită dacă PID este unicul argument.)"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "PID-ul furnizat identifică o aplicație care nu mai răspunde."
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -332,7 +332,7 @@ msgstr ""
 "Raportează avaria din fișierul .apport sau .crash și nu a celor în așteptare "
 "din %s. (Implicit, dacă fișierul este dat ca singurul argument.)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -342,46 +342,46 @@ msgstr ""
 "fișier, în loc de a le raporta. Acest fișier poate fi apoi raportat mai "
 "târziu de pe o altă mașină."
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Tipărește numărul de versiune al Apport."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Această comandă va lansa apport-retrace într-o fereastră terminal pentru a "
 "examina eroarea."
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "Rulare sesiune gdb"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Rulați o sesiune gdb fără descărcarea simbolurilor pentru depanare"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Actualizați %s cu urmărirea întregii stive"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr "Acest raport se referă la un program care nu mai este instalat."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
@@ -390,82 +390,84 @@ msgstr ""
 "Problema a apărut la programul %s, care a fost modificat față de momentul "
 "apariției erorii."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Acest raport de probleme este deteriorat și nu poate fi procesat."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr ""
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr ""
 "A apărut o eroare în încercarea de a procesa raportarea acestei probleme:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "Numele pachetului sau al pachetului sursă nu a putut fi determinat."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "Nu s-a putut porni navigatorul web"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Nu s-a putut porni navigatorul web pentru a deschide %s."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Problemă de rețea"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Nu s-a reușit conexiunea la baza de date despre avarii, verificați "
 "conexiunea la internet."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Problemă de rețea"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Epuizarea memoriei"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Sistemul nu dispune de suficientă memorie pentru a procesa acest raport de "
 "avarie."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -476,11 +478,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "Problemă deja cunoscută"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -490,38 +492,37 @@ msgstr ""
 "navigatorul web. Verificați dacă puteți adăuga informații suplimentare care "
 "ar putea fi utile programatorilor."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Această problemă a fost raportată deja dezvoltatorilor. Vă mulțumim!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Pentru a continua, apăsați orice tastă..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "Ce doriți să faceți? Opțiunile sunt:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Alegeți (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i octeți)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(date binare)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Trimiteți programatorilor raportul problemei?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -529,53 +530,53 @@ msgstr ""
 "După trimiterea raportului problemei, completați formularul din pagina "
 "deschisă automat."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "&Trimite raportul (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "&Examinează local"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "&Vizualizare raport"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 "&Păstrează fișierul de raport pentru a fi trimis ulterior sau copiat în altă "
 "parte"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr ""
 "Renunță și &ignoră viitoarele avarii ale acestei versiuni a programului"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Renunță"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Fișier raport problemă:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&Confirmă"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Eroare: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "Se colectează informațiile despre problemă"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -583,11 +584,11 @@ msgstr ""
 "Informațiile colectate pot fi trimise programatorilor pentru a\n"
 "îmbunătăți aplicația. Ar putea dura câteva minute."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "Se încarcă informațiile despre problemă"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -595,40 +596,40 @@ msgstr ""
 "Informațiile colectate sunt trimise sistemului de urmărire a defecțiunilor.\n"
 "Ar putea dura câteva minute."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Gata"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "niciunul"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "Selectat: %s. Variante multiple:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Variante:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "Calea către fișier (apăsați pe Enter pentru a anula):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "Fișierul nu există."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "Acesta este un dosar."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "Pentru a continua, trebuie să accesați următorul URL:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -636,17 +637,17 @@ msgstr ""
 "Puteți lansa un navigator acum sau copiați acest URL într-un navigator pe "
 "alt calculator."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Lansează un navigator"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 "Nu există nici un raport de avarie în curs. Pentru mai multe informații, "
 "consultați --help."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr "Nu include noile trasări în raport, ci scrie-le la stdout."
 
@@ -665,28 +666,28 @@ msgstr ""
 "Scrie raportul modificat într-un fișier dat în loc de a schimba raportul "
 "original"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 "Șterge core-dump-ul din raport după regenerarea trasării stivei apelurilor"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "Înlocuiește CoreFile din raport"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "Înlocuiește ExecutablePath din raport"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "Înlocuiește ProcMaps din raport"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "Reconstruiește informațiile despre pachet din raport"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -703,33 +704,33 @@ msgstr ""
 "de configurare ale sistemului, însă în acest mod vor putea fi urmărite numai "
 "erorile apărute în versiunea curentă."
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
 "have installed."
 msgstr ""
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 "Arată progresul descărcării/instalării pentru instalarea pachetelor în zona "
 "protejată"
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr "Adaugă marcaje de timp mesajelor din jurnale, pentru operații în bloc"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr "Dosarul cache pentru pachetele descărcate în zona protejată"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -738,14 +739,14 @@ msgstr ""
 "presupune că orice pachet deja descărcat este, de asemenea, extras în acest "
 "dosar izolat."
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 "Instalează un pachet suplimentar în zona protejată (poate fi specificat de "
 "mai multe ori)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -756,7 +757,7 @@ msgstr ""
 "pentru a trimite trasările de stivă de apeluri retrasate (doar dacă niciuna "
 "dintre -g, -o și -s nu au fost specificate)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -764,32 +765,32 @@ msgstr ""
 "Afișează trasările de stivă de apeluri retrasate și cere confirmarea înainte "
 "de a le trimite în baza de date despre avarii."
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 "Calea către baza de date sqlite duplicată (implicit: fără verificarea "
 "duplicatelor)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr ""
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "Nu puteți utiliza -C fără -S. Se oprește."
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "Se trimit aceste atașamente? [y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -797,19 +798,19 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "Dosarul destinație există și nu este gol."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "Pentru detalii consultați paginile manualului."
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "specificați numele fișierului jurnal produs de valgrind"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
@@ -817,7 +818,7 @@ msgstr ""
 "reutilizează un dosar izolat (sandbox) creat anterior (SDIR) sau, dacă nu "
 "există, creați unul"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -826,7 +827,7 @@ msgstr ""
 "suplimentare pentru depanare ci se bazează numai pe simbolurile pentru "
 "depanare instalate."
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
@@ -834,36 +835,36 @@ msgstr ""
 "reutilizează un dosar cache (CDIR) creat anterior sau, dacă nu există, "
 "creați unul"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 "raportează progresul pentru descărcare/instalare la instalarea pachetelor în "
 "dosarul izolat"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Eroare: %s nu este un fișier executabil. Se oprește."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -871,7 +872,7 @@ msgstr ""
 "Procesul de revenire s-a blocat aproape de final și a părut că s-a terminat "
 "normal."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 "Sistemul poate deveni instabil acum și ar putea fi necesar să fie repornit."
@@ -886,76 +887,76 @@ msgstr "Raportează o problemă..."
 msgid "Report a malfunction to the developers"
 msgstr "Raportează o eroare programatorilor"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "Ne pare rău, aplicația %s s-a oprit pe neașteptate."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "%s s-a închis neașteptat."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "%s a produs o eroare internă."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Trimite"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Arată detalii"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Continuă"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "Aplicația %s nu mai răspunde."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "Programul \"%s\" nu mai răspunde."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Pachet: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "A apărut o problemă la instalarea programului."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "Aplicația %s a întâmpinat o eroare internă."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "Aplicația %s s-a închis neașteptat."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr "Dacă întâmpinați alte probleme, încercați să reporniți calculatorul."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "Ignoră viitoarele probleme de acest tip"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Ascunde detaliile"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -1011,7 +1012,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>Se trimit informațiile despre problemă</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -1023,27 +1024,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Fișier despre o avarie Apport"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "Păstrează închis"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Repornire"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Nume utilizator:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Parolă"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "Se colectează informațiile problemei"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1051,6 +1052,6 @@ msgstr ""
 "Informațiile colectate pot fi trimise dezvoltatorilor pentru a îmbunătății "
 "aplicația. Acest lucru poate dura câteva minute."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "Se încarcă informațiile problemei"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2019-11-01 10:51+0000\n"
 "Last-Translator: Sandro <Unknown>\n"
 "Language-Team: Russian <ru@li.org>\n"
@@ -39,11 +39,11 @@ msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 "Введите свой пароль для доступа к отчётам об ошибках в системных программах"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "Возможно, этот пакет установлен неправильно"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -54,7 +54,7 @@ msgstr ""
 "индексов доступных пакетов. Если это не помогает, тогда удалите "
 "соответствующие сторонние пакеты и попробуйте ещё раз."
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -67,21 +67,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "неизвестная программа"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Извините, программа %s аварийно завершила свою работу"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Неполадка в %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -89,66 +84,71 @@ msgstr ""
 "В вашем компьютере недостаточно свободной памяти, чтобы автоматически "
 "проанализировать неполадку и отправить отчет разработчикам."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Неполадка в %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Неверный отчёт об ошибке"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "У вас нет доступа к отчёту о неполадке."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Ошибка"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "Недостаточно места на диске для обработки этого отчёта."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr "Не указан идентификатор процесса (PID)"
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 "Необходимо указать идентификатор процесса (PID). Смотрите --help для "
 "получения дополнительной информации."
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "Неверный PID"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr "Указанный ID процесса не существует."
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr "Не ваш PID"
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr "Указанный ID процесса не принадлежит вам."
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "Не указан пакет"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Необходимо указать пакет или PID. Запустите программу с ключом --help для "
 "получения дополнительной информации."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "В доступе отказано"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -156,30 +156,30 @@ msgstr ""
 "Указанный процесс запущен другим пользователем. Запустите эту программу с "
 "правами владельца процесса или администратора системы."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "Указанный PID принадлежит другому процессу."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Симптоматический скрипт %s не может определить затронутый пакет"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Пакет %s не существует"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "Невозможно создать отчет"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "Обновление отчета о проблеме"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -189,7 +189,7 @@ msgstr ""
 "Вы не являетесь отправителем или получателем отчета об этой проблеме, "
 "возможно отчет уже существует или уже был закрыт."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -210,24 +210,24 @@ msgstr ""
 "\n"
 "Вы действительно хотите продолжить?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "Дополнительная информация не была собрана."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "О какой проблеме вы бы хотели сообщить?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Неизвестный симптом"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Симптом «%s» не известен"
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -246,7 +246,7 @@ msgstr ""
 "Запустите его и найдите интересующее приложение на вкладке Процессы. "
 "Идентификатор процесса — номер, указанный в столбце ID."
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -254,31 +254,31 @@ msgstr ""
 "После закрытия этого сообщения, пожалуйста, щелкните по окну приложения, "
 "чтобы сообщить о проблеме."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop не удалось определить ID процесса этого окна"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr "%(prog)s <номер отчёта>"
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "Задайте имя пакета."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "Добавить дополнительный тег в отчет. Может быть указан несколько раз."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 "%(prog)s [параметры] [симптом|pid|пакет|путь к программе|.apport/.crash файл]"
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -289,17 +289,17 @@ msgstr ""
 "отображает список известных симптомов. (Применяется, когда передан "
 "единственный аргумент.)"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "Щелкните по целевому окну для заполнения отчёта о проблеме."
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "Запустить в режиме обновления ошибки. Может принимать дополнительный ключ --"
 "package."
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -307,7 +307,7 @@ msgstr ""
 "Отправить отчёт об ошибке с симптомом. (Применяется, когда название симптома "
 "передано в качестве единственного параметра.)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -315,7 +315,7 @@ msgstr ""
 "Указать имя пакета в режиме --file-bug. Необязательно, если указан --pid. "
 "(Применяется, когда имя пакета передано в качестве единственного параметра.)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -325,11 +325,11 @@ msgstr ""
 "отчет будет содержать больше информации. (Подразумевается, что pid — "
 "единственный указанный аргумент.)"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "Указанный идентификатор принадлежит процессу, который не отвечает."
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -339,7 +339,7 @@ msgstr ""
 "ожидаемых в %s. (Применяется, когда файл передан в качестве единственного "
 "параметра.)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -348,48 +348,48 @@ msgstr ""
 "При работе в режиме отправки отчета, сохраняет информацию в файле вместо ее "
 "отправки. Этот файл можно будет отправить позднее или с другого компьютера."
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Напечатать номер версии Apport."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Будет произведён запуск «apport-retrace» в окне терминала для выполнения "
 "проверки аварийного завершения работы."
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "Запустить сеанс gdb"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Запустить сеанс gdb, не выполняя загрузку отладочных символов"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Обновить %s с полным отслеживанием символического стека"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr "Не удаётся запомнить настройки статуса отправки отчёта"
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 "Не удалось сохранить состояние отчета о сбое. Не удается установить режим "
 "авто или никогда."
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr "Не удаётся запомнить настройки статуса отправки отчёта"
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr "Этот отчет о проблеме относится к программе, которая не установлена."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
@@ -398,19 +398,21 @@ msgstr ""
 "Неполадка произошла с программой %s, в которую были внесены изменения с "
 "момента её аварийного завершения работы."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Этот отчёт о неполадке повреждён и не может быть обработан."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr "Это отчёт о пакете, который не установлен."
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "Произошла ошибка при попытке обработать это сообщение о неполадке:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
@@ -418,24 +420,24 @@ msgstr ""
 "У вас установлено две версии этого приложения. Об ошибке в какой из них вы "
 "хотите сообщить?"
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr "%s snap-пакет"
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr "%s deb-пакет"
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s предоставлен в виде snap-пакета и опубликован %s. Для получения помощи "
 "свяжитесь с ними по %s."
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -444,39 +446,39 @@ msgstr ""
 "%s предоставлен в виде snap-пакета и опубликован %s. Контактный адрес не "
 "указан. Для получения помощи посетите форум https://forum.snapcraft.io/."
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "Не удалось определить имя пакета или имя пакета с исходным кодом."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "Не удалось запустить веб-браузер"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Не удалось запустить веб-браузер, чтобы открыть %s."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Неполадка с сетью"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Не удается подключиться к базе данных по сбоям, пожалуйста, проверьте "
 "подключение к Интернету."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Неполадка с сетью"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Недостаток памяти"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "В системе недостаточно памяти для обработки этого отчёта об ошибке."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -487,11 +489,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "О неполадке уже известно"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -501,38 +503,37 @@ msgstr ""
 "браузере. Пожалуйста, проверьте, можете ли вы добавить в него иную полезную "
 "информацию, которая могла бы помочь разработчикам."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Сообщение о неисправности отправлено разработчикам. Спасибо за помощь!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Чтобы продолжить, нажмите любую клавишу..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "Что вы хотите сделать? Возможные варианты:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Пожалуйста, выберите (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i байт)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(двоичные данные)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Отправить отчёт об ошибке разработчикам?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -540,51 +541,51 @@ msgstr ""
 "После того, как отчёт будет отправлен, заполните форму\n"
 "в автоматически открывшемся окне браузера."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "&Отправить отчёт (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "&Локальная проверка"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "&Просмотреть отчёт"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 "&Сохранить файл отчёта для последующей отправки или копирования куда-либо"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "Отменить и &игнорировать будущие сбои в этой версии программы"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "О&тменить"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Файл отчёта о проблеме:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&Подтвердить"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Ошибка: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "Сбор информации о проблеме"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -592,11 +593,11 @@ msgstr ""
 "Собранная информация может быть направлена разработчикам\n"
 "для улучшения приложения. Это может занять несколько минут."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "Передача информации о неполадке"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -604,40 +605,40 @@ msgstr ""
 "Собранная информация направляется в систему отслеживания ошибок.\n"
 "Это может занять несколько минут."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Готово"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "пусто"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "Выбрано: %s. Несколько вариантов:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Выбор:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "Путь к файлу (Enter — отмена):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "Файл не существует."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "Это — директория."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "Чтобы продолжить, вы должны пройти по следующему адресу:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -645,15 +646,15 @@ msgstr ""
 "Теперь вы можете открыть браузер или скопировать URL в браузер на другой "
 "компьютер."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Запустить браузер"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr "Нет ожидающих сообщений о сбоях. Попробуйте ключ --help."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 "Не добавлять новые трассировки в отчет, а посылать на стандартный вывод."
@@ -672,27 +673,27 @@ msgid ""
 msgstr ""
 "Сохранить измененный отчет в файл вместо изменения оригинального отчета"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr "Удалить дамп ядра из отчёта после восстановления трассировки стека"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "Заменить CoreFile в отчёте"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "Заменить ExecutablePath в отчёте"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "Заменить ProcMaps в отчёте"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "Заново построить информацию о пакетах в отчёте"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -709,7 +710,7 @@ msgstr ""
 "обнаружения аварийных ситуаций, произошедших в выпуске системы, работающем в "
 "данный момент."
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
@@ -719,28 +720,28 @@ msgstr ""
 "зависимостей, используя вместо установленной у вас версии gdb выпуск, "
 "совпадающий с отчётом."
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 "Сообщать о ходе выполнения загрузки/установки пакетов во временную среду"
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr ""
 "Добавлять временные отметки до сообщений в журнале, для групповых операций"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 "Создавать и использовать сторонние репозитории из источников, указанных в "
 "отчётах"
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr "Папка для сохранения пакетов, загружаемых во временную среду"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -748,14 +749,14 @@ msgstr ""
 "Директория для распаковки пакетов. При последующих запусках все уже "
 "загруженные пакеты будут распаковываться в это изолированное окружение."
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 "Установить во временную среду дополнительный пакет (может указываться "
 "несколько раз)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -765,7 +766,7 @@ msgstr ""
 "при указании ID сбоя для отправки трассировок стека (только когда -g, -o или "
 "-s не указаны)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -773,31 +774,31 @@ msgstr ""
 "Отобразить трассировки и запросить подтверждение перед их отправкой в базу "
 "данных сбоев."
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 "Путь к дублирующей базе данных sqlite (по умолчанию: без проверки дубликатов)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr "Не прилагать StacktraceSource к отчёту."
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "Нельзя использовать -C без -S. Остановка."
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "Отправить эти приложения? [y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr "%(prog)s <отчёт> <целевой каталог>"
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr "Файл отчёта для распаковки."
 
@@ -805,19 +806,19 @@ msgstr "Файл отчёта для распаковки."
 msgid "directory to unpack report to"
 msgstr "Каталог для распаковки отчёта."
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "Папка назначения существует и не пуста."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "Смотрите подробности в man-странице."
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "укажите имя log-файла для valgrind"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
@@ -825,7 +826,7 @@ msgstr ""
 "использовать ранее созданный каталог песочницы (SDIR) или создать его если "
 "он не существует"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -833,7 +834,7 @@ msgstr ""
 "не создавать и не использовать каталог песочницы для дополнительных символов "
 "отладки, а полагаться лишь на установленные символы отладки."
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
@@ -841,12 +842,12 @@ msgstr ""
 "использовать ранее созданный каталог кэша (CDIR) или создать его если он не "
 "существует"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 "показывать прогресс загрузки/установки во время установки пакетов в песочницу"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
@@ -854,12 +855,12 @@ msgstr ""
 "Исполняемый файл, который запускается с помощью инструмента Valgrind "
 "memcheck для обнаружения утечки памяти."
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Ошибка: %s — не исполняемый файл. Остановка."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -867,7 +868,7 @@ msgstr ""
 "Это произошло во время предыдущего ждущего режима, что не даёт системе "
 "правильно выйти из него."
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -875,7 +876,7 @@ msgstr ""
 "Это произошло во время предыдущего спящего режима, что не даёт системе "
 "правильно выйти из него."
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -883,7 +884,7 @@ msgstr ""
 "Процесс создания отчёта завис очень близко к завершению; для нормального "
 "завершения он должен был появиться."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr "Система может стать нестабильной, возможно потребуется перезагрузка."
 
@@ -897,79 +898,79 @@ msgstr "Сообщить о неполадке..."
 msgid "Report a malfunction to the developers"
 msgstr "Сообщить о недоработке разработчикам"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "Извините, приложение %s внезапно завершилось."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "Извините, %s было непредвиденно закрыто."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "Извините, возникла внутренняя ошибка %s."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Отправить"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Показать подробности"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Продолжить"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "Приложение «%s» перестало отвечать."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "Программа «%s» перестала отвечать."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Пакет: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr ""
 "Извините, обнаружена неполадка во время установки программного обеспечения."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "В приложении %s произошла внутренняя ошибка."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "Приложение %s внезапно закрылось."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr ""
 "При возникновении этой неполадки в дальнейшем попробуйте перезапустить "
 "компьютер."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "Игнорировать этот тип неполадок в дальнейшем"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Скрыть подробности"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -1025,7 +1026,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>Передача сведений о неполадке</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -1037,27 +1038,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Файл отчета Apport"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "Оставить закрытым"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Перезапустить"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Имя пользователя:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Пароль:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "Сбор информации о неполадке"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1065,6 +1066,6 @@ msgstr ""
 "Собранную информацию можно отправить разработчикам чтобы улучшить "
 "приложение. Это может занять несколько минут."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "Передача информации о неполадке"

--- a/po/sc.po
+++ b/po/sc.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2010-08-01 10:24+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Sardinian <sc@li.org>\n"
@@ -36,11 +36,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr ""
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -61,21 +61,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "Programa disconnotu"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Nos dispiaghet; su programa \"%s\" s'est serradu de botu."
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Problema in %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -83,64 +78,69 @@ msgstr ""
 "Sa computadora tua no tenet bastante memòria lìbera pro analizare su "
 "problema automaticamente e pro imbiare un avisu a sos tècnicos."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Problema in %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Avisu de problema no vàlidu"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "No as permissu pro atzèdere a custu avisu de problema."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Errore"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "No b'at bastante ispàtziu in su discu pro protzessare cust'avisu."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "PID no vàlidu."
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "Perunu pachete seletzionadu"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Deves ispecificare unu pachete o unu PID. Consulta --help pro àere pius "
 "informatziones."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Permissu negadu."
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -148,30 +148,30 @@ msgstr ""
 "Su protzessu ispecificadu no t'apartenit. Eseguire custu programa comente "
 "proprietàriu de su protzessu o comente superutente."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "Su ID de protzessu ispecificadu no apartenit a perunu programa."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr ""
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr ""
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr ""
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -179,7 +179,7 @@ msgid ""
 "Please create a new report using \"apport-bug\"."
 msgstr ""
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -191,24 +191,24 @@ msgid ""
 "Do you really want to proceed?"
 msgstr ""
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr ""
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr ""
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr ""
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr ""
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -219,202 +219,204 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr ""
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr ""
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr ""
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "S'avisu de su problema s'est guastadu e no podet èssere protzessadu."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr ""
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr ""
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr ""
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr ""
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr ""
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr ""
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr ""
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr ""
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -425,161 +427,160 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr ""
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 msgstr ""
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr ""
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr ""
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr ""
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr ""
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr ""
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr ""
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
 msgstr ""
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr ""
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr ""
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr ""
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr ""
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr ""
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr ""
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr ""
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr ""
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr ""
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
 msgstr ""
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr ""
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
 msgstr ""
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr ""
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr ""
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr ""
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr ""
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr ""
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr ""
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr ""
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr ""
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
 msgstr ""
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr ""
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 
@@ -594,27 +595,27 @@ msgid ""
 "Write modified report to given file instead of changing the original report"
 msgstr ""
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr ""
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr ""
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr ""
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr ""
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -624,78 +625,78 @@ msgid ""
 "be able to retrace crashes that happened on the currently running release."
 msgstr ""
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
 "have installed."
 msgstr ""
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr ""
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
 msgstr ""
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
 "neither -g, -o, nor -s are specified)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
 msgstr ""
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr ""
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr ""
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr ""
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -703,70 +704,70 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr ""
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
 msgstr ""
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 
@@ -780,76 +781,76 @@ msgstr ""
 msgid "Report a malfunction to the developers"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr ""
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr ""
 
@@ -903,7 +904,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr ""
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -913,32 +914,32 @@ msgstr ""
 msgid "Apport crash file"
 msgstr ""
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr ""
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr ""
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr ""
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr ""
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr ""
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
 msgstr ""
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr ""

--- a/po/sd.po
+++ b/po/sd.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2018-11-11 06:23+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Sindhi <sd@li.org>\n"
@@ -36,11 +36,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr ""
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -57,111 +57,111 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr ""
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr ""
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "مسعلي ۾ %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
 msgstr ""
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "مسعلي ۾ %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr ""
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr ""
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr ""
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr ""
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr ""
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr ""
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 msgstr ""
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr ""
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr ""
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr ""
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr ""
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -169,7 +169,7 @@ msgid ""
 "Please create a new report using \"apport-bug\"."
 msgstr ""
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -181,24 +181,24 @@ msgid ""
 "Do you really want to proceed?"
 msgstr ""
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr ""
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr ""
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr ""
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr ""
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -209,202 +209,204 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr ""
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr ""
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr ""
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr ""
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr ""
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr ""
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr ""
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr ""
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr ""
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr ""
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr ""
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr ""
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -412,161 +414,160 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr ""
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 msgstr ""
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr ""
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr ""
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr ""
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr ""
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr ""
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr ""
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
 msgstr ""
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr ""
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr ""
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr ""
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr ""
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr ""
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr ""
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr ""
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr ""
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr ""
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
 msgstr ""
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr ""
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
 msgstr ""
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr ""
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr ""
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr ""
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr ""
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr ""
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr ""
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr ""
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr ""
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
 msgstr ""
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr ""
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 
@@ -581,27 +582,27 @@ msgid ""
 "Write modified report to given file instead of changing the original report"
 msgstr ""
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr ""
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr ""
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr ""
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr ""
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -611,78 +612,78 @@ msgid ""
 "be able to retrace crashes that happened on the currently running release."
 msgstr ""
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
 "have installed."
 msgstr ""
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr ""
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
 msgstr ""
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
 "neither -g, -o, nor -s are specified)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
 msgstr ""
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr ""
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr ""
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr ""
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -690,70 +691,70 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr ""
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
 msgstr ""
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 
@@ -767,76 +768,76 @@ msgstr ""
 msgid "Report a malfunction to the developers"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr ""
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr ""
 
@@ -890,7 +891,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr ""
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -900,32 +901,32 @@ msgstr ""
 msgid "Apport crash file"
 msgstr ""
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr ""
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr ""
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr ""
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr ""
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr ""
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
 msgstr ""
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr ""

--- a/po/se.po
+++ b/po/se.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2012-08-17 12:37+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Northern Sami <se@li.org>\n"
@@ -36,11 +36,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr ""
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -57,111 +57,111 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr ""
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr ""
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr ""
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
 msgstr ""
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr ""
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr ""
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr ""
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Meattáhus"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr ""
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr ""
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Ii beasa deikke"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 msgstr ""
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr ""
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr ""
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr ""
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr ""
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -169,7 +169,7 @@ msgid ""
 "Please create a new report using \"apport-bug\"."
 msgstr ""
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -181,24 +181,24 @@ msgid ""
 "Do you really want to proceed?"
 msgstr ""
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr ""
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr ""
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr ""
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr ""
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -209,202 +209,204 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr ""
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr ""
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr ""
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr ""
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr ""
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr ""
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr ""
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr ""
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr ""
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr ""
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr ""
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr ""
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -412,161 +414,160 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr ""
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 msgstr ""
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr ""
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr ""
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr ""
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i stávvala)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(binára dáhtaid)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr ""
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
 msgstr ""
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr ""
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr ""
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr ""
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr ""
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "G&askkalduhtte"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr ""
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&Nanne"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Meattáhus: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr ""
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
 msgstr ""
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr ""
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
 msgstr ""
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Geargan"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "ii mihkkige"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr ""
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr ""
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr ""
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr ""
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr ""
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr ""
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
 msgstr ""
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr ""
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 
@@ -581,27 +582,27 @@ msgid ""
 "Write modified report to given file instead of changing the original report"
 msgstr ""
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr ""
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr ""
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr ""
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr ""
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -611,78 +612,78 @@ msgid ""
 "be able to retrace crashes that happened on the currently running release."
 msgstr ""
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
 "have installed."
 msgstr ""
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr ""
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
 msgstr ""
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
 "neither -g, -o, nor -s are specified)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
 msgstr ""
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr ""
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr ""
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr ""
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -690,70 +691,70 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr ""
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
 msgstr ""
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 
@@ -767,76 +768,76 @@ msgstr ""
 msgid "Report a malfunction to the developers"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Sádde"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Čájet bienaid"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Joatkke"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Páhkka: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Čiega &bienaid"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -890,7 +891,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr ""
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -900,32 +901,32 @@ msgstr ""
 msgid "Apport crash file"
 msgstr ""
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr ""
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr ""
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Geavaheaddjinamma:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Beassansátni:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr ""
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
 msgstr ""
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr ""

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2011-10-07 06:10+0000\n"
 "Last-Translator: Janith Sampath Bandara <sbslive@gmail.com>\n"
 "Language-Team: Sinhalese <si@li.org>\n"
@@ -36,11 +36,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr ""
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -57,111 +57,111 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "නොදන්නා වැඩසටහන"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "සමාවෙන්න, \"%s\" වැඩසටහන අනපේක්ෂිතව අවසන්විය"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "%s හි ගැටලුවක්"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
 msgstr ""
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "%s හි ගැටලුවක්"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "අවලංගු ගැටලුවක් වාර්තාවිනි"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr ""
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "දෝෂය"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr ""
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr ""
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "අවසර දීමට නොහැක"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 msgstr ""
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr ""
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr ""
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr ""
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr ""
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -169,7 +169,7 @@ msgid ""
 "Please create a new report using \"apport-bug\"."
 msgstr ""
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -181,24 +181,24 @@ msgid ""
 "Do you really want to proceed?"
 msgstr ""
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr ""
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr ""
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr ""
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr ""
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -209,202 +209,204 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr ""
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr ""
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr ""
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr ""
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr ""
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr ""
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr ""
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr ""
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr ""
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr ""
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr ""
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr ""
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -412,161 +414,160 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr ""
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 msgstr ""
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr ""
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr ""
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr ""
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr ""
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(ද්ව්‍යංගී දත්ත)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr ""
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
 msgstr ""
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr ""
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr ""
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr ""
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr ""
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr ""
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr ""
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr ""
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr ""
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr ""
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
 msgstr ""
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr ""
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
 msgstr ""
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr ""
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr ""
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr ""
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr ""
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr ""
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr ""
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr ""
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr ""
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
 msgstr ""
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr ""
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 
@@ -581,27 +582,27 @@ msgid ""
 "Write modified report to given file instead of changing the original report"
 msgstr ""
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr ""
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr ""
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr ""
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr ""
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -611,78 +612,78 @@ msgid ""
 "be able to retrace crashes that happened on the currently running release."
 msgstr ""
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
 "have installed."
 msgstr ""
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr ""
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
 msgstr ""
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
 "neither -g, -o, nor -s are specified)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
 msgstr ""
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr ""
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr ""
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr ""
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -690,70 +691,70 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr ""
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
 msgstr ""
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 
@@ -767,76 +768,76 @@ msgstr ""
 msgid "Report a malfunction to the developers"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "යවන්න"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "විස්තර පෙන්වන්න"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "ඉදිරියට යන්න"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "පැකේජය: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "තොරතුරු සඟවන්න"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr ""
 
@@ -890,7 +891,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr ""
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -900,32 +901,32 @@ msgstr ""
 msgid "Apport crash file"
 msgstr ""
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "වසා තබන්න"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "යළි දියත් කරන්න"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "පරිශීලක නාමය:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "මුරපදය:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr ""
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
 msgstr ""
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr ""

--- a/po/sk.po
+++ b/po/sk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2019-11-10 11:57+0000\n"
 "Last-Translator: Ľuboš Mudrák <lubosmudrak@azet.sk>\n"
 "Language-Team: Slovak <sk@li.org>\n"
@@ -40,11 +40,11 @@ msgstr ""
 "Zadajte prosím svoje heslo, aby mohol byť problém systémového programu "
 "nahlásený."
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "Vyzerá to tak, že tento balík nie je nainštalovaný korektne"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -52,7 +52,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -65,21 +65,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "neznámy program"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Prepáčte, program \"%s\" neočakávane skončil"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Problém v %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -87,63 +82,68 @@ msgstr ""
 "Váš počítač nemá dosť voľnej pamäte na automatickú analýzu problému a "
 "poslanie hlásenia vývojárom."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Problém v %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Neplatné hlásenie problému"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "Nemáte povolený prístup k tomuto hláseniu o probléme."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Chyba"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "Nie je dostatok voľného miesta na disku na spracovanie tohto hlásenia."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "Neplatné PID"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr "Proces s zadaným identifikátorom neexistuje."
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr "Proces s zadaným identifikátorom vám nepatrí."
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "Nebol špecifikovaný žiadny balík"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Je potrebné špecifikovať balík alebo PID. Pozrite --help pre viac informácií."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Prístup odmietnutý"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -151,30 +151,30 @@ msgstr ""
 "Nemáte dosah na označený proces. Prosím, spustite program ako jeho vlastník, "
 "alebo ako root."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "Zadaný identifikátor procesu nepatrí k programu."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Skript %s nebol schopný určiť postihnutý balík"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Balík %s neexistuje"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "Nie je možné vytvoriť hlásenie"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "Aktualizuje sa hlásenie o probléme"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -186,7 +186,7 @@ msgstr ""
 "\n"
 "Prosím vytvorte nové hlásenie pomocou \"apport-bug\"."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -206,24 +206,24 @@ msgstr ""
 "\n"
 "Naozaj chcete pokračovať?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "Neboli zozbierané žiadne dodatočné informácie."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "Aký druh problému chcete nahlásiť?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Neznámy príznak"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Príznak \"%s\"  nie je známy."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -234,7 +234,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -242,30 +242,30 @@ msgstr ""
 "Pre nahlásenie problému s aplikáciou kliknite, prosím, po zavretí tejto "
 "správy na okno aplikácie."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop nedokázal zistiť identifikátor procesu okna"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "Zadajte názov balíka."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "Pridať k hláseniu značku navyše. Môže byť zadaná viackrát."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -275,17 +275,17 @@ msgstr ""
 "alebo len --pid. Ak nie je zadaný ani jeden z nich, zobrazí sa zoznam "
 "známych príznakov. (Predpokladané ak je zadaný len jeden argument.)"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "Kliknite na okno ktoré bude cieľom pre vyplnenia hlásenia o chybe."
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "Začnite v režime aktualizácie chyby. Môžete použiť voliteľný argument --"
 "package."
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -293,7 +293,7 @@ msgstr ""
 "Vytvorte chybové hlásenie o príznaku. (Predpokladané ak je zadané ako jediný "
 "argument názov príznaku.)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -301,7 +301,7 @@ msgstr ""
 "Zadajte názov balíka v režime --file-bug. Je to voliteľné ak je zadaný --"
 "pid. (Predpokladané ak je zadané ako jediný argument názov.)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -311,11 +311,11 @@ msgstr ""
 "hlásenie obsahovať viac informácií. (Ak je číslo procesu uvedené ako jediný "
 "argument.)"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "Poskytnutý pid je zamrznutá aplikácia."
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -324,7 +324,7 @@ msgstr ""
 "Nahláste pád z daného .apport alebo .crash súboru namiesto zostávajúcich v "
 "%s. (Predpokladané ak je zadaný ako jediný argument súbor.)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -333,124 +333,126 @@ msgstr ""
 "Uložiť hlásenie do súboru namiesto priameho odosielania. Tento súbor môže "
 "byť nahlásený neskôr aj z iného zariadenia."
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Zobraziť čislo verzie programu Apport."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr "Týmto spustíte apport-retrace v terminálovom okne na preskúmanie pádu."
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "Spustiť gdb reláciu"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Spustiť gdb reláciu bez sťahovania ladiacich symbolov"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Aktualizovať %s pomocou úplného symbolického trasovania zásobníku"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 "Toto hlásenie problému sa vzťahuje na program, ktorý už nie je nainštalovaný."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 msgstr "Problém bol zaznamenaný v programe %s, ktorý bol po páde zmenený."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Toto hlásenie problému je poškodené a nie je možné ho spracovať."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr "Toto hlásenie je o balíku, ktorý nie je nainštalovaný."
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "Nastala chyba počas spracovania hlásenia o chybe:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "Nedá sa zistiť balík alebo zdrojový názov balíka."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "Nepodarilo sa spustiť internetový prehliadač"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Nepodarilo sa spustiť internetový prehliadač pre otvorenie %s."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Problém siete"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Nie je možné sa pripojiť do databázy pádov, prosím, skontrolujte vaše "
 "internetové pripojenie."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Problém siete"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Vyčerpanie pamäte"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "Váš systém nemá dostatok pamäti na spracovanie chybového hlásenia."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -461,11 +463,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "Problém je už známy"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -475,38 +477,37 @@ msgstr ""
 "prehliadači. Skontrolujte, prosím, či môžete doplniť ďalšie informácie, "
 "ktoré môžu byť nápomocné pre vývojárov."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Tento problém bol už nahlásený vývojárom. Ďakujeme!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Pokračujte stlačením ľubovoľného klávesu..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "Čo by ste radi urobili? Vaše možnosti sú:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Prosím, zvoľte (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i bajtov)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(binárne dáta)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Odoslať hlásenie o chybe vývojárom?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -514,52 +515,52 @@ msgstr ""
 "Po odoslaní hlásenia o chybe, vyplňte, prosím, formulár v\n"
 "automaticky otvorenom internetovom prehliadači."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "&Odoslať hlásenie (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "&Preskúmať lokálne"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "&Pozrieť hlásenie"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 "&Uchovať súbor s hlásením pre neskoršie odoslanie alebo kopírovanie na iné "
 "miesto"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "Zrušiť a &ignorovať budúce pády tejto verzie programu"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Zrušiť"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Súbor hlásenia problému:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&Potvrdiť"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Chyba: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "Získavajú sa údaje o probléme"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -567,11 +568,11 @@ msgstr ""
 "Zhromaždené informácie môžu byť odoslané vývojárom na zlepšenie\n"
 "aplikácie. Môže to trvať pár minút."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "Nahrávam informácie o probléme"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -579,40 +580,40 @@ msgstr ""
 "Zhromaždené informácie sa posielajú systému na sledovanie chýb.\n"
 "Môže to trvať pár minút."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Dokončené"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "žiadny"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "Zvolené: %s. Viaceré voľby:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Voľby:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "Cesta k súboru (Enter pre zrušenie):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "Súbor neexistuje."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "Toto je adresár."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "Aby ste pokračovali, musíte navštíviť následujúce URL:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -620,16 +621,16 @@ msgstr ""
 "Môžete teraz spustiť prehliadač, alebo skopírovať URL do prehliadača na inom "
 "počítači."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Okamžite spustiť prehliadač"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 "Žiadne zostávajúce chybové hlásenia. Skúste --help pre viac informácií."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr "Nepridávať nové traces do hlásenia, ale vypísať ich do stdout."
 
@@ -648,27 +649,27 @@ msgstr ""
 "Zapísať upravené hlásenie do daného súboru namiesto pozmenenia pôvodného "
 "hlásenia"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr "Odstrániť core dump z hlásenia po obnove stack trace"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "Prepísať CoreFile hlásenia"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "Prepísať ExecutablePath hlásenia"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "Prepísať ProcMaps hlásenia"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "Znova zostaviť informácie o balíku pre hlásenie"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -684,32 +685,32 @@ msgstr ""
 "uvediete \"system\", tak budú použité systémové konfiguračné súbory, ale "
 "potom bude možné retrasovať havárie iba pre aktuálne spustené verzie."
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
 "have installed."
 msgstr ""
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 "Hlásiť postup sťahovania/inštalácie pri inštalácii balíčkov do sandboxu"
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr "Pre dávkové spracovanie vložiť časové razítko pred správu do logu"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -717,12 +718,12 @@ msgstr ""
 "Priečinok pre rozbalené súbory. Všetky následne stiahnuté a rozbalené "
 "balíčky tu budú k dispozícii."
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr "Nainštalovať do sandboxu extra balík (môže byť zadaný viackrát)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -732,7 +733,7 @@ msgstr ""
 "sa, keď sa zadáva identifikátor pádu na odoslanie retraced traces zásobníka "
 "(len keď ani -g, -o a -s nie sú zadané)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -740,31 +741,31 @@ msgstr ""
 "Zobraziť retraced traces zásobníka a vypýtať si potvrdenie predtým ako sú "
 "odoslané do databázy pádov."
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 "Cesta k duplicitnej sqlite databáze (predvolené: žiadna kontrola duplikátov)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr "Nepridávať do hlásenia StacktraceSource."
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr ""
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "Pripravený na odoslanie ako prílohy? [y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -772,53 +773,53 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "Cieľový adresár existuje a nie je prázdny."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 "hlásiť postup sťahovania/inštalácie pri inštalácii balíčkov do sandboxu"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Chyba: %s nie je spustiteľný. Zastavujem."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -826,7 +827,7 @@ msgstr ""
 "Toto sa stalo v priebehu minulého uspania do pamäti a zabránilo systému v "
 "prebudení."
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -834,7 +835,7 @@ msgstr ""
 "Toto sa stalo v priebehu minulého uspania na disk a zabránilo systému v "
 "prebudení."
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -842,7 +843,7 @@ msgstr ""
 "Počas obnovy sa spracovanie zastavilo teste pri konci a preto sa zdá že "
 "skončilo normálne."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 "Váš systém sa teraz môže stať nestabilným a môže byť potrebné ho reštartovať."
@@ -857,76 +858,76 @@ msgstr "Ohlásiť problém..."
 msgid "Report a malfunction to the developers"
 msgstr "Oznámiť nefunkčnosť vývojárom"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "Prepáčte, aplikácia %s bola neočakávane ukončená."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "Prepáčte, %s bol neočakávane ukončený."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "Prepáčte, %s zaznamenal vnútornú chybu."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Odoslať"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Zobraziť podrobnosti"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Pokračovať"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "Aplikácia %s neodpovedá."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "Program „%s“ neodpovedá."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Balík: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "Prepáčte, pri inštalácii softvéru sa vyskytla chyba."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "V aplikácii %s došlo k chybe."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "Aplikácia %s bola neočakávane ukončená."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr "Ak zaznamenáte ďalšie problémy, skúste reštartovať počítač."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "Ignorovať budúce problémy tohto typu"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Skryť podrobnosti"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -982,7 +983,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>Nahrávajú sa informácie o probléme</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -994,27 +995,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Apport crash súbor"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "Ponechať zatvorené"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Znova spustiť"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Používateľské meno:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Heslo:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "Získavajú sa informácie o probléme"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1022,6 +1023,6 @@ msgstr ""
 "Zozbierané informácie môžu byť odoslané vývojárom pre zlepšenie aplikácie. "
 "Môže to trvať pár minúť."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "Odosielajú sa informácie o probléme"

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2015-04-27 21:46+0000\n"
 "Last-Translator: Andrej Znidarsic <andrej.znidarsic@gmail.com>\n"
 "Language-Team: Slovenian <sl@li.org>\n"
@@ -38,11 +38,11 @@ msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 "Vnesite svoje geslo za dostop do poročil o težavah s sistemskimi programi"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "Videti je, da ta paket ni nameščen pravilno"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -50,7 +50,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -63,21 +63,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "neznam program"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Program \"%s\" se je nepričakovano zaprl"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Težava v %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -85,62 +80,67 @@ msgstr ""
 "Vaš računalnik nima dovolj prostega pomnilnika za samodejno preučevanje "
 "težave in pošiljanje poročila razvijalcem."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Težava v %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Neveljavno poročilo o napaki"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "Dostop do poročila o napaki je bil zavrnjen."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Napaka"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "Na disku ni dovolj prostora za obdelavo tega poročila."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "Neveljaven PID"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "Naveden ni noben paket"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr "Navesti morate paket ali PID. Oglejte si --help za več podrobnosti."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Dovoljenje je zavrnjeno"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -148,30 +148,30 @@ msgstr ""
 "Navedeno opravilo ne pripada vam. Zaženite ta program kot lastnik opravila "
 "ali kot skrbnik."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "Naveden ID opravila ne pripada programu."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Skript simptoma %s ni zaznal prizadetega paketa"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Paket %s ne obstaja"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "Ni mogoče ustvariti poročila"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "Posodabljanje poročila o težavi"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -183,7 +183,7 @@ msgstr ""
 "\n"
 "Ustvarite novo poročilo z uporabo \"apport-bug\"."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -203,24 +203,24 @@ msgstr ""
 "\n"
 "Ali želite resnično nadaljevati?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "Dodatni podatki niso bili pridobljeni."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "O kakšni vrsti težave bi radi poročali?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Neznan simptom"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Simptom \"%s\" ni znan."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -231,7 +231,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -239,30 +239,30 @@ msgstr ""
 "Po zaprtju tega sporočila kliknite na okno programa za poročanje težav o "
 "njem."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop ni uspelo določevanje ID-ja opravila okna"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "Navedite ime paketa."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "Doda dodatno oznako poročilu. Določite jo lahko večkrat."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -272,17 +272,17 @@ msgstr ""
 "pdi, ali pa samo --pid. Če ne podate nobenega izmed naštetih, bo prikazan "
 "seznam znanih simptomov. (Privzeto, ko je podan samo en argument)."
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "Kliknite na okno kot cilj za izpolnjevanje poročila o težavi."
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "Zaženi v načinu posodabljanja hroščev. Lahko dodate izbiren parameter --"
 "package."
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -290,7 +290,7 @@ msgstr ""
 "Vloži prijavo hrošča o simptomu. (predpostavljeno, če je ime simptoma dano "
 "kot edini argument.)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -298,7 +298,7 @@ msgstr ""
 "V načinu --file-bug navedite ime paketa. Če je --pid podan, to ni obvezno. "
 "(Privzeto, ko je kot edini argument podano ime paketa)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -308,11 +308,11 @@ msgstr ""
 "poročilo o hrošču vsebovalo več podrobnosti (predpostavljeno, če je pid dan "
 "kot edini argument.)."
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "Program s posredovanom pid-jem se je obesil."
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -321,7 +321,7 @@ msgstr ""
 "Poroča o sesutju iz dane datoteke .apport ali .crah namesto iz čakajočih v "
 "%s. (Predpostavljeno, če je datoteka dana kot edini argument)."
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -330,123 +330,125 @@ msgstr ""
 "V načinu poročanja hrošča zbrane podatke shrani v datoteko namesto "
 "poročanja. To datoteko lahko uporabite za poročanje kasneje z druge naprave."
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Izpiši številko različice Apporta."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr "To bo v terminalu zagnalo apport-retrace za preučevanje sesutja."
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "Poženi sejo gdb"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Poženi sejo gdb brez prejemanja razhroščevalnih simbolov"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Posodobi %s s polno simbolično sledjo sklicev"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr "To poročilo o težavi se nanaša na program, ki ni več nameščen."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 msgstr "Težava se je zgodila s programom %s, ki se je od sesutja spremenil."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Poročilo o težavi je poškodovano, zato njegova obdelava ni mogoča."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr ""
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "Med poskusom obdelave tega poročila o hrošču je prišlo do težave:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "Ni bilo mogoče določiti imena paketa ali izvornega paketa."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "Spletnega brskalnika ni mogoče zagnati"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Spletni brskalnik ne more odpreti %s."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Težava z omrežjem"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Ni se mogoče povezati z zbirko podatkov o napakah. Preverite svojo "
 "internetno povezavo."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Težava z omrežjem"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Pomnilnik je zapolnjen"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "Vašemu sistemu je zmanjkalo pomnilnika za obdelavo poročila o sesutju."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -457,11 +459,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "Težava je že znana"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -471,38 +473,37 @@ msgstr ""
 "prikazano v spletnem brskalniku. Preverite, če lahko dodate še kakšen "
 "podatek, ki bi lahko pomagal razvijalcem."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Ta težava je bila že poročana razvijalcem. Hvala vam!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Pritisnite katerokoli tipko za nadaljevanje ..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "Kaj želite storiti? Vaše možnosti so:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Prosimo izberite (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i bajtov)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(binarni podatki)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Ali želite poročilo o napaki poslati razvijalcem?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -510,51 +511,51 @@ msgstr ""
 "Ko bo poročilo o težavi poslano, izpolnite obrazec v\n"
 "samodejno odprtem spletnem brskalniku."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "&Pošlji poročilo (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "&Preuči krajevno"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "&Ogled poročila"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 "O&bdrži datoteko o poročilu za kasnejše pošiljanje ali kopiranje kam drugam"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "P&rekliči in prezri nadaljnja sesutja te različice programa"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Prekliči"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Datoteka s poročilom o napaki:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "Po&trdi"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Napaka: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "Zbiranje podatkov o napaki"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -562,11 +563,11 @@ msgstr ""
 "Zbrani podatki lahko pošljete razvijalcem za izboljšanje\n"
 "programa. To lahko traja nekaj minut."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "Pošiljajo se podatki o težavi"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -574,40 +575,40 @@ msgstr ""
 "Zbrani podatki se pošiljajo v sledilni sistem hroščev.\n"
 "To lahko traja nekaj minut."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Končano"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "brez"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "Izbrano: %s. Več izbir:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Izbire:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "Pot do datoteke (Enter za preklic):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "Datoteka ne obstaja."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "To je mapa."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "Za nadaljevanje morate obiskati naslednji URL:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -615,16 +616,16 @@ msgstr ""
 "Sedaj lahko zaženete svoj spletni brskalnik ali prekopirate URL v brskalnik "
 "na drugem računalniku."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Zaženi spletni brskalnik zdaj"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 "Brez čakajočih poročil o sesutju. Za več podrobnosti poizkusite s --help."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr "Ne dajaj novih sledi v poročilo temveč jih izpiši v stdout."
 
@@ -642,27 +643,27 @@ msgid ""
 msgstr ""
 "Zapiše spremenjeno poročilo v dano datoteko namesto spreminjanja izvirnega"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr "Odstrani izpis jedra iz poročila po ponovni izgradnji sledi sklada"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "Prepiši jedrno datoteko poročila"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "Prepiši izvedljivo pot poročila"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "Prepiši ProcMap poročila"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "Znova izgradi podatke o paketih v poročilu"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -678,34 +679,34 @@ msgstr ""
 "uporabil sistemske nastavitvene datoteke, vendar boste lahko ponovno sledili "
 "sesutjem, ki se zgodijo na trenutno izvajajoči se izdaji."
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
 "have installed."
 msgstr ""
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 "Poročaj o napredku prejema/namestitve med nameščanje paketov v peskovnik"
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr "Pripni časovne žige sporočilom dnevnika za paketna opravila"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 "Ustvarite in uporabite skladišča tretjih oseb iz izvorov določenih v "
 "poročilih"
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr "Mapa predpomnilnika za pakete prejete v peskovnik"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -713,12 +714,12 @@ msgstr ""
 "Imenik nepakiranih paketov. Naslednji zagoni programa bodo zagotovili, da se "
 "bodo vsi prejeti paketi razširjali v ta peskovnik."
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr "Namesti dodaten paket v peskovnik (lahko je določeno večkrat)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -728,7 +729,7 @@ msgstr ""
 "uporabljeno ob navedbi ID sesutja za pošiljanje znova načrtanih sledi "
 "skladov (samo, če -g, -o in -s niso navedeni)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -736,32 +737,32 @@ msgstr ""
 "Prikaži znova narčrtane sledi sklada in vprašaj za potrditev pred njihovim "
 "pošiljanjem v podatkovno zbirko sesutij."
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 "Pot do podatkovne zbirke dvojnika sqlite (privzeto: ni preverjanja za "
 "dvojnike)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr ""
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "Ne morete uporabiti -C brez -S. Ustavljanje."
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "Ali je pošiljanje teh prilog vredu? [y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -769,19 +770,19 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "Ciljna mapa ne obstaja ali pa ni prazna."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "Oglejte si stran priročnika za podrobnosti."
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "določite ime datoteke dnevnika, ki ga je ustvaril valgrind"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
@@ -789,7 +790,7 @@ msgstr ""
 "ponovno uporabi prejšnje ustvarjeno mapo sandbox (SDIR) ali jo ustvari, če "
 "še ne obstaja"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -797,7 +798,7 @@ msgstr ""
 "ne ustvari ali ponovno uporabi mapo sandobox za dodatne simbole "
 "razhroščevanja ampak se zanašj le na nameščene simbole razhroščevanja."
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
@@ -805,22 +806,22 @@ msgstr ""
 "ponovno uporabi prejšnje ustvarjen predpomnilnik mape (CDIR) ali jo ustvari, "
 "če še ne obstaja"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr "poroča napredek prejema /namestitve ob namestitvi paketa v sandbox"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Napaka: %s ni izvedljiva datoteka. Ustavljanje."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -828,7 +829,7 @@ msgstr ""
 "To se je zgodilo med prejšnjim stanjem v pripravljenost in je preprečilo, da "
 "bi se sistem normalno zagnal."
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -836,7 +837,7 @@ msgstr ""
 "To se je zgodilo med prejšnjim stanjem mirovanja in je preprečilo, da bi se "
 "sistem normalno zagnal."
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -844,7 +845,7 @@ msgstr ""
 "Obdelava nadaljevanja se je obesila blizu konca in bo videti, kot da se je "
 "pravilno zaključila."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 "Vaš sistem lahko postane nestabilen in ga bo morda treba znova zagnati."
@@ -859,76 +860,76 @@ msgstr "Pošlji poročilo o težavi ..."
 msgid "Report a malfunction to the developers"
 msgstr "Poročajte napačno delovanje razvijalcem"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "Oprostite, program %s se je nepričakovano končal."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "Oprostite, program %s se je nepričakovano zaprl."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "Oprostite, v programu %s je prišlo do notranje napake."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Pošlji"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Pokaži podrobnosti"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Nadaljuj"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "Program %s se ne odziva."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "Program \"%s\" se ne odziva."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Paket: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "Med nameščanjem programa je prišlo do napake."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "V programu %s je prišlo do notranje napake."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "Program %s se je nepričakovano zaprl."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr "Če opazite nadaljnje težave, poskusite s ponovnim zagonom računalnika."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "Prezri prihodnje težave te vrste"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Skrij podrobnosti"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -984,7 +985,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>Pošiljanje podatkov o nastali težavi</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -996,27 +997,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Datoteka poročila o sesutju"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "Pusti zaprto"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Znova zaženi"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Uporabniško ime:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Geslo:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "Zbiranje podrobnosti o težavi"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1024,6 +1025,6 @@ msgstr ""
 "Zbrane podatke lahko pošljete razvijalcem za izboljšanje programa. To lahko "
 "vzame nekaj minut."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "Pošiljanje podrobnosti o težavah"

--- a/po/sq.po
+++ b/po/sq.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2015-04-27 21:46+0000\n"
 "Last-Translator: Vilson Gjeci <vilsongjeci@gmail.com>\n"
 "Language-Team: Albanian <sq@li.org>\n"
@@ -40,11 +40,11 @@ msgstr ""
 "Ju lutem vendosni fjalëkalimin tuaj që të keni akses në raportet e "
 "problemeve të programeve së sistemit."
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "Kjo paketë duket se nuk është instaluar në mënyrë korrekte"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -52,7 +52,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -66,21 +66,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "program i panjohur"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Na vjen keq, programi \"%s\" u mbyll papritur"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Problem në %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -88,65 +83,70 @@ msgstr ""
 "Kompjuteri juaj nuk ka kujtesë të lirë sa duhet për të analizuar "
 "automatikisht problemin dhe për t'i dërguar një raport zhvilluesve."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Problem në %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Raportim i pavlefshëm i problemit"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "Juve nuk ju lejohet të hyni në këtë raportim të problemit."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Gabim"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 "Nuk ka hapësirë të disponueshme disku sa duhet për të përpunuar këtë raport."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "PID i Pavlefshëm"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "Nuk është përcaktuar asnjë paketë"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Juve ju nevojitet të specifikoni një paketë apo një PID. Shikoni --help për "
 "më tepër informacion."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Leja ju mohohet"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -154,30 +154,30 @@ msgstr ""
 "Proçesi i përcaktuar nuk ju përket juve. Ju lutemi niseni këtë program si "
 "posedues i tij ose si rrënjë."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "ID-ja e specifikuar e proçesit nuk i përket një programi."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Skripti i simptomës %s nuk përcaktoi një paketë të ndikuar"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Paketa %s nuk ekziston"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "Nuk mund të krijoj raport"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "Duke përditësuar raportin e problemit"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -189,7 +189,7 @@ msgstr ""
 "\n"
 "Ju lutemi të krijoni një raport të ri duke përdorur \"apport-bug\"."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -209,24 +209,24 @@ msgstr ""
 "\n"
 "Dëshironi me të vërtetë të vazhdoni?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "Nuk u mblodh informacion shtesë."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "Çfarë lloj problemi dëshironi të raportoni?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Simptomë e panjohur"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Simptoma \"%s\" nuk njihet."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -237,7 +237,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -245,31 +245,31 @@ msgstr ""
 "Pasi ta mbyllni këtë mesazh ju lutemi të klikoni në dritaren e programit për "
 "të raportuar një problem të lidhur me të."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop dështoi në përcaktimin e ID të proçesit të dritares"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "Specifiko emrin e paketës."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Shtojini një etiketë më shumë raportit. Mund të specifikohet shumë herë."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -279,18 +279,18 @@ msgstr ""
 "pid, ose vetëm një --pid. Nëse asnjë nuk jepet, shfaq një listë të "
 "simptomave të njohura. (Vendoset nëse jepet vetëm një argument.)"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 "Kliko një ditare si shënjestër për të krijuar një raport rreth problemit."
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "Nise në mënyrë të përditësimit të gabimit. Mund të marrë një --paketë "
 "opsionale."
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -298,7 +298,7 @@ msgstr ""
 "Krijoni një raport defekti për një simptomë. (Vendoset nëse emri i simptomës "
 "jepet vetëm si një argument.)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -307,7 +307,7 @@ msgstr ""
 "specifikohet një --pid. (Emri i paketës së vendosur jepet vetëm si një "
 "argument.)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -317,11 +317,11 @@ msgstr ""
 "informacioni i gabimit do të përmbajë më tepër informacion. (Implikohet nëse "
 "pid është dhënë vetëm si argument)."
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "Pid i dhënë është një program në pritje."
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -330,7 +330,7 @@ msgstr ""
 "Raporto gabimin nga skedari i dhënë .apport ose .crash në vend të atyre që "
 "presin në %s. (Vendoset nëse skedari është dhënë vetëm si argument.)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -340,127 +340,129 @@ msgstr ""
 "një skedar në vend që ta raportoni atë. Ky skedar mund të raportohet më vonë "
 "nga një makinë tjetër."
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Printo numrin e versionit të Apport."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Kjo do të nise apport-retrace në një dritare terminali për të shqyrtuar "
 "gabimin."
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "Nis seksionin gdb"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Nis seksionin gdb pa shkarkuar simbolet e gabimeve"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Përditëso %s pa gjurmë të plota simbolike"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr "Ky problem ka të bëjë me një program i cili nuk është më i instaluar."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 msgstr "Problemi ndodhi me programin %s i cili ndryshoi që kur ndodhi gabimi."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Ky raportim i problemit është i dëmtuar dhe nuk mund të shqyrtohet."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr ""
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr ""
 "Ndodhi një gabim gjatë përpjekjes për të përpunuar këtë raport të problemit:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "Nuk mund të përcaktojmë emrin e paketës apo të burimit të saj."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "Nuk jemi në gjendje të nisim shfletuesin e Internetit"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Nuk jemi në gjendje të nisim shfletuesin e Internetit për të hapur %s."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Problem i rrjetit"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Nuk mund të lidhemi me databazën e dëmtimeve, ju lutemi të kontrolloni "
 "lidhjen tuaj me Internetin."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Problem i rrjetit"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Kujtesa u lodh"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Sistemi juaj nuk ka kujtesë sa duhet për të proçeduar këtë raport dëmtimi."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -471,11 +473,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "Problemi i njohur tashmë"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -485,38 +487,37 @@ msgstr ""
 "shfletuesin e Internetit. Ju lutemi kontrolloni nëse mund të shtoni "
 "infromacion të mëtejshëm i cili mund të ndihmojë krijuesit."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Ky problem ju është raportuar tashmë zhvilluesve. Faleminderit!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Shtypni çdo buton për të vazhduar..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "Çfarë do të donit të bënit? Opsionet tuaja janë:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Ju lutemi zgjidhni (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i bytes)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(të dhëna binare)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Tò dërgojë një raport rreth problemit krijuesve?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -524,52 +525,52 @@ msgstr ""
 "Pasi raporti i problemit të jetë dërguar, ju lutemi mbushni formularin tek\n"
 "Shfletuesi i Internetit që hapet automatikisht."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "&Dërgoni raportin (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "&Shqyrtoje lokalisht"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "&Shfaqeni raportin"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 "&Mbajeni skedarin e raportit për ta dërguar më vonë ose për ta kopjuar diku "
 "tjetër"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "Anullo dhe &injoro prishjet e mëvonshme të këtij versioni të programit"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Anulo"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Skedari i raportimit të problemit:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&Konfirmo"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Gabimi: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "Duke mbledhur informacion për problemin"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -577,11 +578,11 @@ msgstr ""
 "Informacioni i mbledhur mund t'iu dërgohet zhvilluesve për të përmirësuar\n"
 "programin. kjo mund të zgjasë disa minuta."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "Duke ngarkuar informacionin e problemit"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -589,40 +590,40 @@ msgstr ""
 "Informacioni i mbledhur po i dërgohet sistemit të gjurmimit të gabimeve.\n"
 "Kjo mund të zgjasë disa minuta."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&U Bë"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "asnjë"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "U zgjodh: %s. Zgjidhje të shumëfishta:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Zgjedhjet:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "Shtegu për tek skedari (Enter për ta anulluar):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "Skedari nuk ekziston."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "Kjo është një direktori."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "Për të vazhduar, ju duhet të vizitoni URL-në që vijon:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -630,17 +631,17 @@ msgstr ""
 "Ju mund të nisni një shfletues tani, ose të kopjoni URL-në në një shfletues "
 "në një kompjuter tjetër."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Nise shfletuesin tani"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 "Nuk ka raporte dëmtimi të ngelura pezull. Provoni --help për më tepër "
 "informacion."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr "Mos vendosni gjurmë të reja në raport, por shkruajini ato në stdout."
 
@@ -659,27 +660,27 @@ msgstr ""
 "Shkruajeni raportin e modifikuar në skedarin e dhënë dhe mos modifikoni "
 "raportin origjinal."
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr "Hiqeni core dump nga raporti pas rigjenerimit të gjurmës së stack"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "Mbishkruaje CoreFile të raportit"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "Mbishkruaje ExecutablePath të raportit"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "Mbishkruaj ProcMaps të raportit"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "Rindërto informacionin e paketave të raportit"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -696,7 +697,7 @@ msgstr ""
 "skedarët e konfigurimit të sistemit, por më pas do të jetë në gjendje vetëm "
 "të gjurmojë dëmitmet që kanë ndodhur në këtë version të programit."
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
@@ -706,28 +707,28 @@ msgstr ""
 "e saj duke përdorur të njëjtin version si raporti në vend të çfarëdo "
 "versioni të gdb që ju keni instaluar."
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 "Raporto progresin e shkarkimit/instalimit kur instalon paketat në kutinë e "
 "rërës"
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr "Vendosu gjurmë kohore mesazheve në hyrje, për veprime në grupe"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 "Krijo dhe përdor magazina të palëve të treta nga origjinat e specifikuara në "
 "raporte"
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr "Drejtoria e ruajtjes së paketave të shkarkuara në kutinë e rërës"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -736,13 +737,13 @@ msgstr ""
 "çdo paketë e shkarkuar tashmë shtë gjithashtu e ekstraktuar në këtë kuti "
 "rëre."
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 "Instalo një paketë shtesë në kutinë e rërës (mund të specifikohet shumë herë)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -752,7 +753,7 @@ msgstr ""
 "informacionit. Kjo përdoret kur specifikoni një ID të rënies në ngarkimin e "
 "gjurmëve të tërhequra (vetëm nëse as -g, -o apo -s nuk janë specifikuar)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -760,31 +761,31 @@ msgstr ""
 "Shfaq gjurmët e tërhequra të bllokimit dhe kërko për konfirmim para se ti "
 "dërgosh ato në databazën e dëmtimit."
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 "Shtegu për tek databaza e dyfishuar sqlite (nuk ka kërkim për të dyfishta)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr ""
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "S'mund të përdorni -C pa -S. Po ndalohet."
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "OK për t'i dërguar këtosi bashkangjitje? [y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -792,19 +793,19 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "Direktoria e destinacionit ekziston dhe nuk është bosh."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "Shiko faqen e manualit për detaje."
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "specifikoni emrin e skedarit prodhuar nga valgrind"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
@@ -812,7 +813,7 @@ msgstr ""
 "përdorni përsëri një direktori sanbox (SDIR) që është përdorur më pare. Nëse "
 "nuk ekziston, krijo një të re"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -820,7 +821,7 @@ msgstr ""
 "mos krijo apo ripërdor asnjë direktori sandbox per simbolet rregulluese "
 "shtesë, por mbështetu ne simbolet rregulluese të instaluara"
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
@@ -828,23 +829,23 @@ msgstr ""
 "ripërdor një direktori cache (CDIR) të përdorur më pare, ose, në qoftë se "
 "nuk ekziston, krijo një"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 "trego progresin e shkarkimit/instalimit kur instalohen paketa në sandbox"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Gabim: %s nuk është i ekzekutueshëm. Po ndalohet."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -852,7 +853,7 @@ msgstr ""
 "Kjo ndodhi gjatë një pezullimi të mëparshëm dhe e pengoi sistemin që të "
 "rinisë siç duhet."
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -860,7 +861,7 @@ msgstr ""
 "Kjo ndodhi gjatë një hibernimi të mëparshëm dhe e pengoi sistemin që të nisë "
 "siç duhet."
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -868,7 +869,7 @@ msgstr ""
 "Proçesi i rinisjes u bllokua shumë afër fundit dhe siç duket është "
 "kompletuar normalisht."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 "Sistemi juaj mund të bëhet i paqëndrueshëm tani dhe mund të ketë nevojë të "
@@ -884,76 +885,76 @@ msgstr "Raporto një problem..."
 msgid "Report a malfunction to the developers"
 msgstr "Raportoni një mosfunksionim tek krijuesit"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "Më vjen keq, programi %s ndali papritmas."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "Na vjen keq, %s u mbyll papritmas."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "Na vjen keq, %s ka hasur në një gabim të brendshëm."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Dërgo"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Shfaq Detajet"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Vazhdo"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "Programi %s nuk po përgjigjet më."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "Programi \"%s\" nuk po përgjigjet më."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Paketa: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "Na vjen keq, ndodhi një problem gjatë instalimit të programit."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "Programi %s ka hasur në një gabim të brendshëm."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "Programi %s u mbyll papritmas."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr "Nëse vini re probleme të mëtejshme, provoni të rindizni kompjuterin."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "Shpërfilli problemet e mëvonshme të këtij lloji"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Fshihi Detajet"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -1009,7 +1010,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>Po ngarkojmë informacionin e problemit</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -1021,27 +1022,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Skedar i defekteve të Apport"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "Lëre të Mbyllur"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Rinise"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Emri i Përdoruesit:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Fjalëkalimi:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "Duke Mbledhur Informacion për Problemin"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1049,6 +1050,6 @@ msgstr ""
 "Informacioni i mbledhur mund t'iu dërgohet krijuesve për të përmirësuar "
 "programin. Kjo mund të zgjasë disa minuta."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "Duke Ngarkuar Informacionin e Problemit"

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2020-11-22 09:43+0000\n"
 "Last-Translator: Мирослав Николић <miroslavnikolic@rocketmail.com>\n"
 "Language-Team: српски <gnome-sr@googlegroups.org>\n"
@@ -39,11 +39,11 @@ msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 "Унесите вашу лозинку да приступите извештавању проблема системских програма"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "Изгледа да овај пакет није исправно инсталиран"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -54,7 +54,7 @@ msgstr ""
 "индекса доступних пакета, ако то не ради тада уклоните одговарајући пакет "
 "треће стране и покушајте поново."
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -67,21 +67,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "непознат програм"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Извините, програм „%s“ је неочекивано затворен"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Проблем у „%s“"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -89,63 +84,68 @@ msgstr ""
 "Ваш рачунар нема довољно слободне меморије да самостално анализира проблем и "
 "пошаље извештај ауторима."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Проблем у „%s“"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Неисправан извештај о проблему"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "Вама није допуштено да приступите извештају овог проблема."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Грешка"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "Нема довољно простора на диску за обрађивање овог извештаја."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr "Нема наведеног ПИБ-а"
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr "Треба да наведете ПИБ. Видите „--help“ за више података."
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "Неисправан ПИБ"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr "Наведени ИБ процеса не постоји."
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr "Није ваш ПИД"
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr "Наведени ИБ процеса не припада вама."
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "Ниједан пакет није наведен"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Треба да одредите пакет или ПИБ. Погледајте „--help“ за више информација."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Приступ је одбијен"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -153,30 +153,30 @@ msgstr ""
 "Наведени процес не припада вама. Покрените овај програм као власник процеса "
 "или као администратор."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "Наведени ПИБ не припада програму."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Скрипта симптома „%s“ није одредила ниједан подутицајни пакет"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Пакет „%s“ не постоји"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "Не могу да направим извештај"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "Освежавам извештај о проблему"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -188,7 +188,7 @@ msgstr ""
 "\n"
 "Направите нови извештај користећи „apport-bug“."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -207,24 +207,24 @@ msgstr ""
 "\n"
 "Да ли заиста желите да наставите?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "Нису прикупљене додатне информације."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "О каквом проблему желите да известите?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Непознати симптом"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Симптом „%s“ није познат."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -235,7 +235,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -243,30 +243,30 @@ msgstr ""
 "Након затварања ове поруке кликните на прозор неког програма да известите о "
 "његовом проблему."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "икспроп није успео да одреди ИБ процеса прозора"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "Наводи назив пакета."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "Додаје додатну ознаку извештају. Може бити одређено више пута."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -277,17 +277,17 @@ msgstr ""
 "приказаће списак познатих симптома. (Подразумева се ако је дат само један "
 "аргумент.)"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "Притисните на прозор као циљ да попуните извештај о проблему."
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "Биће покренут у режиму слања грешке. Може да садржи опционални пакет (--"
 "package)."
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -295,7 +295,7 @@ msgstr ""
 "Попуниће извештај грешке о симптому. (Подразумева се ако је назив симптома "
 "дат као једини аргумент.)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -304,7 +304,7 @@ msgstr ""
 "изборно ако је одређен пиб (--pid). (Подразумева се ако је назив пакета дат "
 "као једини аргумент.)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -314,11 +314,11 @@ msgstr ""
 "извештај о грешци ће садржати више информација. (Подразумева се ако је пиб "
 "дат као једини аргумент.)"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "Обезбеђени пиб је проблематичан програм."
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -327,7 +327,7 @@ msgstr ""
 "Пријављује о урушавању из дате „.apport“ или „.crash“ датотеке уместо једне "
 "приправне у „%s“. (Подразумева се ако је датотека дата као једини аргумент.)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -337,47 +337,47 @@ msgstr ""
 "да шаље извештај. Датотека може бити послата касније и са неког другог "
 "рачунара."
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Приказује број издања Апорта."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr "Ово ће покренути „apport-retrace“ у прозору терминала да испита пад."
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "Покреће гдб сесију"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Покреће гдб сесију без преузимања симбола уклањања грешака"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Освежи „%s“ потпуном симболичком трасом спремника"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr "Не могу да запамтим подешавања стања извештаја слања"
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 "Чување стања извештаја о урушавању није успело. Не могу да подесим режим "
 "извештавања на самостално или никада."
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr "Не могу да запамтим подешавања стања извештаја слања"
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 "Овај извештај о проблему се односи на програм који није више инсталиран."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
@@ -386,20 +386,22 @@ msgstr ""
 "Проблем се догодио са програмом „%s“ који се изменио од када је дошло до "
 "урушавања."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Овај извештај о грешци је оштећен и не може бити обрађен."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr "Овај извештај је о пакету који није инсталиран."
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr ""
 "Дошло је до грешке док сам покушавао да обрадим извештај о овом проблему:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
@@ -407,24 +409,24 @@ msgstr ""
 "Имате инсталирана два издања овог програма, о коме желите да поднесете "
 "извештај о грешци?"
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr "%s прилепак"
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr "%s деб пакет"
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "„%s“ је обезбеђено прилепком објављеним од „%s“. Обратите им се путем „%s“ "
 "за помоћ."
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -433,40 +435,40 @@ msgstr ""
 "„%s“ је обезбеђено прилепком објављеним од „%s“. Нема адресе за контакт; "
 "посетите форум на „https://forum.snapcraft.io/ “ за помоћ."
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "Не могу да утврдим пакет или изворни назив пакета."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "Не могу да покренем прегледника интернета"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Не могу да покренем прегледника интернета да бих отворио „%s“."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Проблем са мрежом"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Не могу да успоставим везу са базом података о урушавањима, проверите везу "
 "са интернетом."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Проблем са мрежом"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Недостатак меморије"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Ваш систем нема довољно меморије да обради овај извештај о паду система."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -477,11 +479,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "Проблем је већ познат"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -491,38 +493,37 @@ msgstr ""
 "интернета. Проверите да ли можете да додате било какву додатну информацију "
 "која би могла да буде од помоћи ауторима."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Овај проблем је већ пријављен програмерима. Хвала вам!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Притисните неки тастер да наставите..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "Шта желите да урадите? Ваше могућности су:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Изаберите (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i бајта)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(бинарни подаци)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Да ли желите да пошаљете извештај програмерима?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -530,52 +531,52 @@ msgstr ""
 "Након обављеног слања извештаја о проблему, попуните формулар \n"
 "у самостално отвореном прегледнику интернета."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "&Пошаљи извештај (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "&Испитај локално"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "&Прикажи извештај"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 "&Задржи датотеку извештаја за касније слање или умножавање на неко друго "
 "место"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "Откажи и &занемари будуће грешке у раду овог издања програма"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Откажи"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Датотека извештаја о проблему:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&Потврди"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Грешка: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "Прикупљам информације о проблему"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -583,11 +584,11 @@ msgstr ""
 "Прикупљене информације могу бити послате програмерима ради\n"
 "побољшања програма. То може потрајати неколико минута."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "Шаљем информације о проблему"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -595,40 +596,40 @@ msgstr ""
 "Прикупљене информације се шаљу систему за праћење грешака.\n"
 "Ово може потрајати неколико минута."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Урађено"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "ништа"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "Изабрано: %s. Више избора:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Избори:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "Путања до датотеке („Унеси“ да откажете):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "Датотека не постоји."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "Ово је директоријум."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "Да наставите, морате да посетите следећу адресу:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -636,16 +637,16 @@ msgstr ""
 "Сада можете покренути прегледника, или умножити ову адресу у прегледнику на "
 "неком другом рачунару."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Покрени прегледника сада"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 "На чекању нема извештаја о паду. Пробајте „--help“ за више информација."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 "Неће унети нове трагове у извештај, већ ће их записати на стандардни излаз."
@@ -665,29 +666,29 @@ msgstr ""
 "Записује измењени извештај у задату датотеку уместо да мења оригинални "
 "извештај"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 "Уклања језгро припремљеног из извештаја након поновног стварања спремника "
 "путање"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "Замењује кључну датотеку извештаја"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "Замењује извршну путању извештаја"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "Замењује мапе процеса извештаја"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "Обнавља информације пакета извештаја"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -704,7 +705,7 @@ msgstr ""
 "бити у стању да испрати урушавања која се дешавају на тренутно покренутом "
 "издању."
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
@@ -714,27 +715,27 @@ msgstr ""
 "зависности користећи исто издање које има извештај уместо издања гдб-а које "
 "сте ви инсталирали."
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 "Извештава о напредовању преузетог/инсталираног приликом инсталације пакета у "
 "пробном систему"
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr "Придодаје ознаку времена порукама дневника, за групну радњу"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 "Направи и користи ризнице трећих страна од изворних наведених у извештајима"
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr "Директоријум оставе за пакете преузете у пробном систему"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -742,13 +743,13 @@ msgstr ""
 "Директоријум за нераспаковане пакете. Наредна покретања ће подразумевати да "
 "је било који већ преузети пакет такође извучен у овом издвојеном окружењу."
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 "Инсталира један посебан пакет у пробном систему (може бити одређен више пута)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -759,7 +760,7 @@ msgstr ""
 "пронађене трагове спремника (само ако ни „-g“, ни „-o“, ни „-s“ нису "
 "наведени)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -767,31 +768,31 @@ msgstr ""
 "Приказује пронађене трагове спремника и тражи потврду пре него што их пошаље "
 "у базу података о урушавањима."
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 "Путања до двоструке базе података скулајта (основно: без провере дупликата)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr "Не додаје „Извор руте штека“ у извештај."
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "Не можете да користите „-C“ без „-S“. Заустављам."
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "Да ли је у реду да пошаљем ове као прилоге? [y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -799,19 +800,19 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "Одредишни директоријум постоји и није празан."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "Погледајте страницу упутства за појединости."
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "наводи назив датотеке дневника коју произведе валгринд"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
@@ -819,7 +820,7 @@ msgstr ""
 "поново користи претходно направљени директоријум пробног система (СДИР) или, "
 "ако не постоји, прави га"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -828,7 +829,7 @@ msgstr ""
 "исправљања грешака већ се ослања само на инсталиране симболе исправљања "
 "грешака."
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
@@ -836,24 +837,24 @@ msgstr ""
 "поново користи претходно направљени директоријум оставе (СДИР) или, ако не "
 "постоји, прави га"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 "извештава о напредовању преузетог/инсталираног приликом инсталације пакета у "
 "пробном систему"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Грешка: „%s“ није извршни. Стајем."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -861,7 +862,7 @@ msgstr ""
 "Ово се догодило за време претходне обуставе, и спречило је систем да настави "
 "исправно."
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -869,7 +870,7 @@ msgstr ""
 "Ово се догодило за време претходног замрзавања, и спречило је систем да "
 "настави исправно."
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -877,7 +878,7 @@ msgstr ""
 "Процес настављања се „заледио“ при самом крају и све је изгледало као да је "
 "успешно завршен."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 "Ваш систем сада може постати нестабилан и може бити потребно да га поново "
@@ -893,76 +894,76 @@ msgstr "Пријавите проблем..."
 msgid "Report a malfunction to the developers"
 msgstr "Пријавите грешке у раду програмерима"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "Извините, програм „%s“ се неочекивано зауставио."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "Извините, „%s“ се неочекивано затворио."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "Извините, „%s“ је наишао на унутрашњу грешку."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Пошаљи"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Прикажи појединости"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Настави"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "Програм „%s“ је престао да одговара."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "Програм „%s“ је престао да одговара."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Пакет: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "Извините, дошло је до проблема приликом инсталирања софтвера."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "Програм „%s“ је наишао на унутрашњу грешку."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "Програм „%s“ се неочекивано затворио."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr "Ако приметите будуће проблеме, покушајте поново да покренете рачунар."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "Занемари будуће проблеме ове врсте"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Сакриј детаље"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Апорт"
 
@@ -1018,7 +1019,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>Шаљем информације о проблему</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -1030,27 +1031,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Датотека урушавања Апорта"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "Остави затворено"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Поново покрени"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Корисник:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Лозинка:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "Прикупљам информације о проблему"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1058,6 +1059,6 @@ msgstr ""
 "Прикупљене информације могу бити послате програмерима ради побољшања "
 "програма. То може потрајати неколико минута."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "Шаљем информације о проблему"

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2022-10-16 12:22+0000\n"
 "Last-Translator: Arve Eriksson <Unknown>\n"
 "Language-Team: Swedish <sv@li.org>\n"
@@ -38,11 +38,11 @@ msgstr "Systemfelrapporter"
 msgid "Please enter your password to access problem reports of system programs"
 msgstr "Ange ditt lösenord för att komma åt systemprogrammens felrapporter"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "Detta paket verkar inte ha installerats korrekt"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -53,7 +53,7 @@ msgstr ""
 "uppdatering av indexet över tillgängliga paket; om det inte fungerar kan du "
 "ta bort berörda tredjepartspaket och försöka igen."
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -66,21 +66,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "okänt program"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Tyvärr, programmet \"%s\" avslutades oväntat"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Problem i %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -88,64 +83,69 @@ msgstr ""
 "Din dator har inte tillräckligt med ledigt minne för att automatiskt "
 "analysera problemet och skicka en rapport till utvecklarna."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Problem i %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Ogiltig felrapport"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "Du tillåts inte komma åt denna problemrapport."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Fel"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 "Det finns inte tillräckligt mycket diskutrymme för att behandla denna "
 "rapport."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr "Ingen PID angavs"
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr "Du måste ange en PID. Se --help för mer information."
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "Ogiltig PID"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr "Den angivna process-ID:n finns inte."
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr "Inte din PID"
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr "Den angivna process-ID:n tillhör inte dig."
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "Inget paket angivit"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr "DU måste ange ett paket eller en PID. Se --help för mer information."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Åtkomst nekad"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -153,30 +153,30 @@ msgstr ""
 "Den angivna processen tillhör inte dig. Kör det här programmet som "
 "processägaren eller som root."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "Det angivna process-id:t tillhör inte något program."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Symtomskriptet %s fastställde inte ett påverkat paket"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Paketet %s finns inte"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "Kan inte skapa rapporten"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "Uppdaterar problemrapporten"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -188,7 +188,7 @@ msgstr ""
 "\n"
 "Skapa en ny rapport med \"apport-bug\"."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -208,24 +208,24 @@ msgstr ""
 "\n"
 "Vill du verkligen fortsätta?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "Ingen ytterligare information har samlats in."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "Vilken typ av problem vill du rapportera?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Okänd symptom"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Symptomen \"%s\" är inte känd."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -243,7 +243,7 @@ msgstr ""
 "Processer, rulla tills du hittar programmet ifråga. Process-ID är numret som "
 "anges i ID-kolumnen."
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -251,30 +251,30 @@ msgstr ""
 "Efter att du stängt detta meddelande kan du klicka på ett programfönster för "
 "att rapportera ett problem med det."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop misslyckades med att fastställa process-ID för fönstret"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr "%(prog)s <rapportnummer>"
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "Ange paketnamn."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "Lägg till en extra tagg till rapporten. Kan anges flera gånger."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr "%(prog)s [alternativ] [symtom|pid|paket|sökväg|.apport-/.crash-fil]"
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -284,15 +284,15 @@ msgstr ""
 "bara en --pid. Om ingen anges så visas en lista över kända symptom. "
 "(Standard om ett enda argument anges.)"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "Klicka på ett fönster för att rapportera ett problem med det."
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "Starta i feluppdateringsläge. Kan ta emot en valfri --package."
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -300,7 +300,7 @@ msgstr ""
 "Skicka in en felrapport om ett symptom. (Standard om symptomnamnet anges som "
 "enda argument.)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -308,7 +308,7 @@ msgstr ""
 "Ange paketnamn i läget --file-bug. Detta är valfritt om en --pid anges. "
 "(Standard om paketnamnet anges som enda argument.)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -318,11 +318,11 @@ msgstr ""
 "felrapporten att innehålla mer information (underförstått om pid anges som "
 "enda argument.)"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "Det givna pid:t är ett program som har låst sig."
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -331,7 +331,7 @@ msgstr ""
 "Rapportera kraschen från angiven fil med ändelsen .apport eller .crash "
 "istället för de väntande i %s. (Standard om filen anges som enda argument.)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -341,50 +341,50 @@ msgstr ""
 "istället för att rapportera. Denna fil kan sedan rapporteras in från en "
 "annan dator."
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Skriv ut versionsnummer för Apport."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Detta kommer starta apport-retrace i ett terminalfönster för att undersöka "
 "kraschen."
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "Kör GDB-session"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Kör GDB-session utan att ladda ner felsökningssymboler"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Uppdatera %s med fullständigt symbolisk stackspårning"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr "Kan inte komma ihåg inställningar för att skicka rapportstatus"
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 "Kunde inte spara kraschrapporttillstånd. Kan inte sätta lägena 'auto' eller "
 "'rapportera aldrig'."
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr "Kan inte komma ihåg inställningar för att skicka rapportstatus"
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 "Denna problemrapport gäller för ett program som inte längre finns "
 "installerat."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
@@ -393,19 +393,21 @@ msgstr ""
 "Problemet inträffade med programmet %s, vilket har ändrats sedan kraschen "
 "hände."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Den här problemrapporten är skadad och kan inte behandlas."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr "Den här rapporten berör ett paket som inte är installerat."
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "Ett fel inträffade när den här problemrapporten skulle bearbetas:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
@@ -413,24 +415,24 @@ msgstr ""
 "Du har två versioner av det här programmet installerade; vilken vill du "
 "lämna en felrapport för?"
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr "%s snap"
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr "%s deb-paket"
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s tillhandahålls som en snap, utgiven av %s. Kontakta dem via %s om du "
 "behöver hjälp."
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -439,40 +441,40 @@ msgstr ""
 "%s tillhandahålls som en snap, utgiven av %s. Ingen kontaktinformation "
 "finns; besök forumet på https://forum.snapcraft.io/ om du behöver hjälp."
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "Kunde inte bestämma paketet eller källpaketets namn."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "Kunde inte starta webbläsaren"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Kunde inte starta webbläsaren för att öppna %s."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Nätverksproblem"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Kan inte ansluta till kraschdatabasen. Kontrollera din internetanslutning."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Nätverksproblem"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Slut på minne"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "Ditt system har inte tillräckligt mycket minne att behandla den här "
 "kraschrapporten."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -483,11 +485,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "Problemet är redan känt"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -497,38 +499,37 @@ msgstr ""
 "webbläsaren. Kontrollera om du kan lägga till ytterligare information som "
 "kan vara av användning för utvecklarna."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Problemet har redan rapporterats till utvecklarna. Tack!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Tryck på valfri tangent för att fortsätta..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "Vad vill du göra? Dina möjligheter är:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Välj (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i byte)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(binär data)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Skicka problemrapport till utvecklarna?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -536,51 +537,51 @@ msgstr ""
 "Efter att problemrapporten har skickats kan du fylla i formuläret i den\n"
 "webbläsare som automatiskt öppnas."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "&Skicka rapport (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "Und&ersök lokalt"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "&Visa rapport"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 "&Behåll rapportfilen för senare sändning eller kopiera den någon annanstans"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "Avbryt och &ignorera framtida krascher av denna programversion"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Avbryt"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Fil för problemrapport:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&Bekräfta"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Fel: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "Samlar probleminformation"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -588,11 +589,11 @@ msgstr ""
 "Den insamlade informationen kan skickas till utvecklarna för att förbättra\n"
 "programmet. Det kan ta några minuter att genomföra."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "Skickar probleminformation"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -600,40 +601,40 @@ msgstr ""
 "Den insamlade informationen skickas till felhanteringssystemet.\n"
 "Det här kan ta några minuter."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Färdig"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "inget"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "Markerat: %s. Flera val:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Val:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "Sökväg till fil (Enter för att avbryta):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "Filen finns inte."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "Detta är en katalog."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "Du måste besöka följande URL för att fortsätta:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -641,15 +642,15 @@ msgstr ""
 "Du kan starta en webbläsare nu eller kopiera denna URL in i en webbläsare på "
 "en annan dator."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Starta en webbläsare nu"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr "Inga väntande kraschrapporter. Prova --help för mer information."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 "Lägg inte in nya bakåtspårningar i rapporten, men skriv dem till standard ut."
@@ -669,28 +670,28 @@ msgstr ""
 "Skriv ändrad rapport till angiven fil istället för att ändra den "
 "ursprungliga rapporten"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 "Ta bort minnesutskriften från rapporten efter omgenerering av stackspårning"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "Åsidosätt rapportens CoreFile"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "Åsidosätt rapportens ExecutablePath"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "Åsidosätt rapportens ProcMaps"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "Bygg om rapportens paketinformation"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -707,7 +708,7 @@ msgstr ""
 "kommer då endast kunna bakåtspåra krascher som skedde i den utgåva som nu "
 "körs."
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
@@ -717,29 +718,29 @@ msgstr ""
 "med samma utgåva som i rapporten, istället för din installerade version av "
 "gdb."
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 "Rapportera förlopp för hämtning/installation när paket installeras i "
 "sandlådan"
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr ""
 "Lägg till tidsstämplar längst fram i loggmeddelanden, för automatiserade "
 "åtgärder"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 "Skapa och använd tredjepartsförråd från platser specificerade i rapporter"
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr "Mellanlagringskatalog för paket som hämtas i sandlådan"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -747,12 +748,12 @@ msgstr ""
 "Katalog för uppackade paket. Framtida körningar kommer anta att alla paket "
 "som laddats ner också packas upp i denna sandlåda."
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr "Installera ett extrapaket i sandlådan (kan anges flera gånger)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -762,7 +763,7 @@ msgstr ""
 "används när ett krasch-id anges för att skicka upp retraced stackspårningar "
 "(endast om ingen av -g, -o, eller -s har angivits)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -770,32 +771,32 @@ msgstr ""
 "Visa retraced stackspårningar och fråga efter bekräftelse innan de skickas "
 "till kraschdatabasen."
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 "Sökväg till den duplicerade sqlite-databasen (standard: ingen kontroll av "
 "duplikat)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr "Lägg inte till StacktraceSource i rapporten."
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "Du kan inte använda -C utan -S. Stoppar."
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "OK att skicka dessa som bilagor? [y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr "%(prog)s <rapport> <destinationsmapp>"
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr "Rapportfil att packa upp"
 
@@ -803,19 +804,19 @@ msgstr "Rapportfil att packa upp"
 msgid "directory to unpack report to"
 msgstr "mapp att packa upp till"
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "Målkatalogen finns och är inte tom."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "Se manualsidorna för ytterligare detaljer."
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "Specifiera logfilens namn som skapades av valgrind"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
@@ -823,7 +824,7 @@ msgstr ""
 "återanvänd en tidigare skapad sandlåda dir (SDIR) eller, om det inte finns, "
 "skapa den"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -831,7 +832,7 @@ msgstr ""
 "Skapa inte eller återanvand en sandlåda-katalog för ytterligare avbuggning "
 "symboler, men lita enbart på installerade avbuggningsymboler"
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
@@ -839,13 +840,13 @@ msgstr ""
 "Återanvänd en tidigare skapad Cache dir (CDIR) eller, om den inte finns, "
 "skapa den."
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 "Rapportera nedladdning/installationsframsteg när du installerar paket i "
 "sandlådan"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
@@ -853,12 +854,12 @@ msgstr ""
 "körfilen som körs under valgrinds memcheck-verktyg för att upptäcka "
 "minnesläckor"
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Error: %s är inte körbar. Stoppar."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -866,7 +867,7 @@ msgstr ""
 "Detta inträffade under ett föregående vänteläge, och hindrade systemet från "
 "att fortsätta korrekt."
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -874,7 +875,7 @@ msgstr ""
 "Detta inträffade under ett föregående viloläge, och hindrade systemet från "
 "att fortsätta korrekt."
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -882,7 +883,7 @@ msgstr ""
 "Återgångsprocessen hängde sig mycket nära slutet och kommer att se ut att ha "
 "slutförts normalt."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr "Ditt system kan nu bli instabilt och kan behöva att startas om."
 
@@ -896,76 +897,76 @@ msgstr "Rapportera ett problem..."
 msgid "Report a malfunction to the developers"
 msgstr "Rapportera ett fel till utvecklarna"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "Tyvärr, programmet %s stannade oväntat."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "Tyvärr, %s har oväntat stängts av."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "Tyvärr, %s har påträffat ett internt fel."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Skicka"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Visa information"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Fortsätt"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "Programmet %s svarar inte."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "Programmet ”%s” har slutat svara."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Paket: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "Tyvärr, ett problem inträffade vid installation av program."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "Programmet %s stötte på ett internt fel."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "Programmet %s har oväntat stängts av."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr "Starta om datorn om problemen fortsätter."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "Ignorera fortsatta problem av samma typ"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Dölj information"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -1021,7 +1022,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>Skickar probleminformation</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -1033,27 +1034,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Kraschrapportsfil för Apport"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "Lämna stängd"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Starta igen"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Användarnamn:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Lösenord:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "Samlar probleminformation"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1061,6 +1062,6 @@ msgstr ""
 "Den insamlade informationen kan skickas till utvecklarna för att förbättra "
 "programmet. Det här kan ta några minuter."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "Skickar probleminformation"

--- a/po/szl.po
+++ b/po/szl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2019-06-04 16:41+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Silesian <szl@li.org>\n"
@@ -36,11 +36,11 @@ msgstr "Reporty problymōw systymowych"
 msgid "Please enter your password to access problem reports of system programs"
 msgstr "Wkludź hasło, żeby dostać dostymp do reportōw ô błyndach systymowych"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "Tyn paket niy wyglōndo na zainstalowany noleżnie"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -61,21 +61,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "niyznōmy program"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Program %s niyspodzianie sie zawar"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Problym we %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -83,64 +78,69 @@ msgstr ""
 "We kōmputrze niy styko wolnyj pamiyńci, coby autōmatycznie przeanalizować "
 "problym i zgłosić feler do twōrcōw programu."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Problym we %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Niynoleżne zgłoszynie ô błyndzie"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "Niy mosz dostympu do tego zgłoszynio ô błyndzie."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Feler"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "Na dysku niy styko wolnego placu, coby przetworzić to zgłoszynie."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "Niynoleżny idyntyfikatōr procesu"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr "Ôkryślōny idyntyfikatōr procesu niy istnieje."
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr "Niy twōj PID"
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr "Ôkryślōny idyntyfikatōr procesu niy noleży do ciebie."
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "Niy ôkryślōno paketu"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Trzeba ôkryślić paket abo idyntyfikatōr procesu. Użyj ôpcyje --help, coby "
 "dostać wiyncyj informacyji."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Brak dostympu"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -148,30 +148,30 @@ msgstr ""
 "Ôkryślōny proces niy noleży do ciebie. Ôtwōrz tyn program jako posiedziciel "
 "procesu abo root."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "Ôkryślōny idyntyfikatōr procesu niy noleży do programu."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Skrypt symptōmu %s niy ôkryślōł tykniyntego paketu"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Paket %s niy istnieje"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "Niy idzie stworzić reportu"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "Uaktualnianie zgłoszynio ô błyńdzie"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -183,7 +183,7 @@ msgstr ""
 "\n"
 "Zgłoś feler bez noczynie „apport-bug”."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -203,24 +203,24 @@ msgstr ""
 "\n"
 "Na isto chcesz kōntynuować?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "Żodne ekstra informacyje niy były zebrane."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "Jaki problym chcesz zgłosić?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Niyznōmy symptōm"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Symptōm „%s” je niyznōmy."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -231,37 +231,37 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 "Po zawrzyniu tyj wiadōmości kliknij ôkno programu, coby zgłosić jego problym."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop niy poradziōł znojś idyntyfikatora procesu tego ôkna"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "Ôkryśl miano paketu."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "Przidowo ekstra etyketa do zgłoszynio. Idzie użyć pora razy."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -271,17 +271,17 @@ msgstr ""
 "ôpcjōnalnie --pid, abo ino ôpcyje --pid. Jeźli żodno ôpcyjo niy ôstanie "
 "użyto, pokoż wykoz symptōmōw."
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "Kliknij w ôkno jako cyj do wysłanio zgłoszynio problymu."
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "Zacznij w trybie aktualizacyje zgłoszynio błyndu. Idzie użyć z ôpcyjōm --"
 "package."
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -289,7 +289,7 @@ msgstr ""
 "Zgłoś błōnd ô symptōmie (wymuszōne, jeźli było podano miano symptōmu za "
 "parameter)."
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -297,7 +297,7 @@ msgstr ""
 "Ôkryśl miano paketu w trybie --file-bug. Ôpcjōnalne, jeźli użyto była ôpcyjo "
 "--pid (wymuszōne, jeźli było podano miano paketu za jedyny parameter)."
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -307,11 +307,11 @@ msgstr ""
 "bydzie wiyncyj informacyji  (wymuszōne, jak pid je podany za jedyny "
 "parameter)."
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "Podany pid to numer zawieszōnyj aplikacyje."
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -321,7 +321,7 @@ msgstr ""
 "zamiast tych, co czekajōm w %s (wymuszōne, jeźli zbiōr bōł dany za jedyny "
 "parameter)."
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -330,125 +330,127 @@ msgstr ""
 "Zapisuje informacyje ô błyndzie do zbioru zamiast zgłoszać go. Report "
 "zawarty we zbiorze, może być zgłoszōny niyskorzij z inkszego kōmputra."
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Pokoż informacyje ô wersyji Apport."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr "Analiza awaryje w terminalu ze pōmocōm apport-retrace."
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "Ôtwōrz sesyjo gdb"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Ôtwōrz sesyjo gdb bez pobiyranio symbolōw debugowanio"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Aktualizacyjo %s ze pōmocōm fully symbolic stack trace"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr "Niy pamiyntōm sztelōnkōw sztandu wysyłanio reportōw"
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 "Spamiyntowanie sztandu reportowanio błyndu sie niy podarziło. Niy szło "
 "nasztalować trybu auto abo trybu niy reportowanio nigdy."
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr "Niy pamiyntōm sztelōnkōw sztandu wysyłanio reportōw"
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr "Zgłoszynie problymu tyko programu, co już niyma zainstalowany."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 msgstr "Problym tyko programu %s, co bōł zmiyniōny ôd czasu awaryje."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Te zgłoszynie ô problymie je poprzniōne i niy może być przetworzōne."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr "To zgłoszynie tyko paketu, co niyma zainstalowany."
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "Trefiōł sie feler w czasie prōby zgłoszynio błyndu:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "Niy idzie znojś paketu abo miana paketu zdrzōdłowego."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "Niy idzie ôtworzić przeglōndarki internetowyj"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Niy idzie ôtworzić przeglōndarki internetowyj, żeby ôtworzić %s."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Problym z necym"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Niy idzie połōnczyć sie z bazōm danych awaryji, wejzdrzij na swoje "
 "połōnczynie internetowe."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Problym z necym"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Pamiyńć spotrzebowano"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "Systymowi niy styko pamiyńci, coby przetworzić tyn report błyndu."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -459,11 +461,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "Problym je już znōmy"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -473,38 +475,37 @@ msgstr ""
 "internetowyj. Wejzdrzij, eli idzie przidać jake dalsze informacyje, co mogōm "
 "być pōmōc twōrcōm programu."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Programisty sōm już poinformowani ô tym problymie. Dziynkujymy!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Wciś leda kery knefel, żeby kōntynuować..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "Co chcesz zrobić? Możesz:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Ôbier (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i bajtōw)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(dane binarne)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Zgłosić problym twōrcōm programu?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -512,50 +513,50 @@ msgstr ""
 "Jak report bydzie wysłany, to wypołnij formular\n"
 "we autōmatycznie ôtwartyj przeglōndarce internetowyj."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "Wyślij &report (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "&Zbadej lokalnie"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "&Pokoż report"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr "Ôstow zbiōr reportu, żeby niys&korzij wysłać go abo skopiować"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "Pociep i &ignoruj prziszłe awaryje tyj wersyje programu"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Pociep"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Zbiōr reportu problymu:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&Potwiyrdź"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Błōnd: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "Zbiyranie informacyji ô błyndzie"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -563,11 +564,11 @@ msgstr ""
 "Zebrane informacyje mogōm być wysłane do twōrcōw, coby ulepszyć\n"
 "program. To może potrwać pora minut."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "Wysyłanie informacyje ô problymie"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -575,40 +576,40 @@ msgstr ""
 "Zebrane informacyje sōm wysyłane do systymu zgłoszanio felerōw.\n"
 "To może potrwać pora minut."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Gotowe"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "brak"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "Zaznaczōno: %s. Wielokrotny ôbiōr:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Ôbiōr:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "Drōga do zbioru (ENTER, żeby pociepnōńć):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "Zbiōr niy istnieje."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "To je katalog."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "Coby kōntynuować, trzeba ôtworzić ta adresa URL:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -616,17 +617,17 @@ msgstr ""
 "Idzie teroz ôtworzić przeglōndarka internetowo, abo wrazić ta adresa URL do "
 "przeglōndarki na inkszym kōmputrze."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Ôtwōrz teroz przeziyroczka"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 "Niy ma zgłoszyń awaryje, co czekajōm. Użyj ôpcyje --help, coby dostać "
 "wiyncyj informacyji."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr "Niy przidowej nowych szlakōw do zgłoszynio ino wypisuj je do stdout."
 
@@ -645,28 +646,28 @@ msgstr ""
 "Wpisz zmiyniōne zgłoszynie do danego zbioru zamiast zmiyniać ôryginalne "
 "zgłoszynie"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 "Skasuj ściepniyńcie spamiyńci ze zgłoszynio po regyneracyji szlaku sztapla."
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "Zastōmp CoreFile reportu"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "Zastōmp ExecutablePath reportu"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "Zastōmp ProcMaps reportu"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "Przebuduj informacyje ô pakecie we zgłoszyniu"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -683,7 +684,7 @@ msgstr ""
 "jyny śledzynie i analiza (retrace) awaryji, co sie trefiyły w teroźnie "
 "zainstalowanym wydaniu systymu."
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
@@ -693,29 +694,29 @@ msgstr ""
 "bez użycie tego samego wydanio jak we reporcie zamiast wersyje gdb, co mosz "
 "zainstalowano."
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 "Pokazuj posek postympu pobiyranio/instalowanio w czasie instalowanio paketōw "
 "do zandkastle"
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr ""
 "Przidanie informacyje ô czasie do logów dlo ôperacyje trybu wsadowego (batch "
 "operation)"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 "Stwōrz i użyj repozytoriōw ôsōb trzecich ze zdrzōdeł ôkryślōnych w reportach"
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr "Katalog podrynczny paketōw pobiyranych do zandkastle"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -723,12 +724,12 @@ msgstr ""
 "Katalog na niyrozpakowane pakety. Prziszłe użycie założy, iże kożdy z już "
 "pobranych paketōw je tyż rozpakowany do tyj zandkastle."
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr "Instaluje ekstra paket do zandkastle (idzie użyć wiyncyj jak roz)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -738,7 +739,7 @@ msgstr ""
 "czasie podowanio idyntyfikatora awaryje, żeby przesłać prześledzōne na nowo "
 "szlaki sztapla (ino jeźli niy były użyte -g, -o, ani -s)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -746,32 +747,32 @@ msgstr ""
 "Pokoż wyśledzone na nowo szlaki sztapla i pytej ô potwierdzynie przed "
 "wysłaniym ich do bazy awaryji."
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 "Drōga do stuplowanyj bazy danych sqlite (wychodnie: bez wyszukowanio "
 "tuplikatōw)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr "Niy dodowej StacktraceSource do tego reportu."
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "Niy idzie użyć -C, jak niy ma -S. Zastawianie."
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "Wysłać to za przidowki? [y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -779,19 +780,19 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "Katalog cylu istnieje i niyma prōzny."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "Wejzdrzij na strōna podryncznika po wiyncyj informacyji."
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "podej miano zbioru logōw, co je gyneruje valgrind"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
@@ -799,7 +800,7 @@ msgstr ""
 "użyj zaś wcześnij stworzōnego katalogu zandkastle (SDIR) abo, jak go niy ma, "
 "stwōrz go"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -807,7 +808,7 @@ msgstr ""
 "niy twōrz ani niy używej katalogu zandkastle na ekstra symbole debugowanio, "
 "ino polygej na już zainstalowanych symbolach."
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
@@ -815,24 +816,24 @@ msgstr ""
 "użyj zaś wcześnij stworzōnego katalogu cache (CDIR) abo, jak go niy ma, "
 "stwōrz go"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 "pokazuj posek postympu pobiyranio/instalowanio w czasie instalowanio paketōw "
 "do zandkastle"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Błōnd: niy idzie wykōnać %s. Zastawianie."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -840,7 +841,7 @@ msgstr ""
 "Trefiyło sie to w czasie poprzednigo uspanio i niy przizwolyło systymowi na "
 "noleżne ôbudzynie."
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -848,7 +849,7 @@ msgstr ""
 "Trefiyło sie to w czasie poprzednij hibernacyje i niy przizwolyło systymowi "
 "na noleżne ôbudzynie."
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -856,7 +857,7 @@ msgstr ""
 "Proces budzynio zawiesiōł sie bardzo blisko kōńca i bydzie wyglōndać, choćby "
 "skōńczōł normalnie."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr "Systym może być niysztabilny, bez to może być potrzebny restart."
 
@@ -870,76 +871,76 @@ msgstr "Zgłoś problym..."
 msgid "Report a malfunction to the developers"
 msgstr "Zgłoś twōrcōm błyndy fungowanio"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "Program %s niyspodzianie stanōł."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "Program %s niyspodzianie sie zawar."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "Trefiōł sie wewnyntrzny błōnd %s."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Wyślij"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Pokoż informacyje"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Dalij"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "Program %s przestoł ôdpowiadać."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "Program „%s” przestoł ôdpowiadać."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Paket: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "Trefiōł sie problym przi instalowaniu ôprogramowanio."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "Trefiōł sie wewnyntrzny błōnd programu %s."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "Program %s niyspodzianie sie zawar."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr "Jeźli pokożōm sie dalsze problymy, to sprōbuj zrestartować kōmputer."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "Ignorowanie problymōw tyj zorty w prziszłości"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Skryj informacyje"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -995,7 +996,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>Wysyłanie informacyje ô błyńdzie</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -1007,27 +1008,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Zbiōr zgłoszynio Apport"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "Ôstow zawarty"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Ôtwōrz na nowo"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Miano ôd używocza:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Hasło:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "Zbiyranie informacyji ô problymie"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1035,6 +1036,6 @@ msgstr ""
 "Zebrane informacyje mogōm być wysłane do twōrcōw, coby ulepszyć program. To "
 "może potrwać pora minut."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "Wysyłanie informacyje ô problymie"

--- a/po/ta.po
+++ b/po/ta.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ta(3)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2012-03-10 22:25+0000\n"
 "Last-Translator: Sarrvesh <sarrfriend@gmail.com>\n"
 "Language-Team: tamil <Ubuntu-l10n-tam@lists.ubuntu.com>\n"
@@ -38,11 +38,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr ""
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -50,7 +50,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -59,21 +59,16 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr ""
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr ""
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "%s இல் இடர்பாடு"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -81,91 +76,96 @@ msgstr ""
 "தங்கள் கணிப்பொறியில் தேவையான இடம் இல்லாததால் மென்பொருட்களை ஆராய்ந்து பிரச்சனைகளை "
 "தெரிவிக்க இயலவில்லை"
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "%s இல் இடர்பாடு"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr ""
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "இந்தப்  பிழை அறிக்கையை அணுக தங்களுக்கு அனுமதி கிடையாது"
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "பிழை"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "இப் பிழை அறிக்கையைக் கையாள போதிய இடம் தங்கள் கணிப்பொறியில் இல்லை."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr ""
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr ""
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "அனுமதி மறுக்கப்பட்டது"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 msgstr ""
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr ""
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr ""
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "அறிக்கையை உருவாக்க இயலவில்லை"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr ""
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -173,7 +173,7 @@ msgid ""
 "Please create a new report using \"apport-bug\"."
 msgstr ""
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -185,24 +185,24 @@ msgid ""
 "Do you really want to proceed?"
 msgstr ""
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr ""
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "எத்தகையப் பிழையை அறிவிக்க விரும்புகிறீர்கள்?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr ""
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr ""
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -213,202 +213,204 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr ""
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr ""
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr ""
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr ""
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr ""
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "இந்தப்  பிழை அறிக்கையைக்  கையாளும்போது  பிழை ஏற்பட்டுள்ளது"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "பொதிகளின் அல்லது மூல தொகுப்புகளின் பெயரை நிர்ணயிக்க முடியவில்லை."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr ""
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr ""
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr ""
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr ""
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr ""
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -416,161 +418,160 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr ""
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 msgstr ""
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr ""
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr ""
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr ""
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr ""
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr ""
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr ""
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
 msgstr ""
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr ""
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr ""
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr ""
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr ""
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr ""
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr ""
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr ""
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr ""
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr ""
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
 msgstr ""
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "பிரச்னையின் தகவலைப் பதிவேற்றப்படுகிறது"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
 msgstr ""
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr ""
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr ""
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr ""
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr ""
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr ""
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr ""
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr ""
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr ""
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
 msgstr ""
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr ""
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 
@@ -585,27 +586,27 @@ msgid ""
 "Write modified report to given file instead of changing the original report"
 msgstr ""
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr ""
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr ""
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr ""
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr ""
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -615,78 +616,78 @@ msgid ""
 "be able to retrace crashes that happened on the currently running release."
 msgstr ""
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
 "have installed."
 msgstr ""
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr ""
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
 msgstr ""
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
 "neither -g, -o, nor -s are specified)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
 msgstr ""
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr ""
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr ""
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr ""
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -694,70 +695,70 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr ""
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
 msgstr ""
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 
@@ -771,76 +772,76 @@ msgstr ""
 msgid "Report a malfunction to the developers"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr ""
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "அப்போர்ட்"
 
@@ -894,7 +895,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr ""
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -904,32 +905,32 @@ msgstr ""
 msgid "Apport crash file"
 msgstr ""
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr ""
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr ""
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "பயனாளர் பெயர்:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "கடவுச் சொல்:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr ""
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
 msgstr ""
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "பிரச்னையின் தகவலைப் பதிவேற்றப்படுகிறது"

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2012-04-20 15:01+0000\n"
 "Last-Translator: RajaSekharReddy Genupula <Unknown>\n"
 "Language-Team: Telugu <te@li.org>\n"
@@ -36,11 +36,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "ఈ ప్యాకేజీ సరిగ్గా ఇన్స్టాల్ కాదు అనిపిస్తుంది"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -57,21 +57,16 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "తెలియని కార్యక్రమం"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "క్షమించాలి, కార్యక్రమం \"% s\" అనుకోకుండా మూసివేయబడింది"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr ""
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -79,92 +74,97 @@ msgstr ""
 "మీ కంప్యూటర్ ఆటోమేటిక్గా సమస్య విశ్లేషించేందుకు మరియు డెవలపర్లకు ఒక నివేదిక పంపేందుకు తగినంత ఉచిత "
 "మెమరీ లేదు."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr ""
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "చెల్లని సమస్య నివేదిక"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "సమస్య నివేదిక ప్రవేశ సౌలబ్య మునకు  మీకు  అనుమతి లేదు"
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "దోషము"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "ఈ నివేదిక ప్రాసెస్ చేయడానికి తగినంత డిస్క్ స్థలం అందుబాటులో  లేదు."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "చెల్లని PID"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "ప్యాకేజీ పేర్కొనలేదు"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr "మీరు ఒక ప్యాకేజీ లేదా ఒక PID పేర్కొనాలి. చూడండి  --help మరింత సమాచారం కొరకు ."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "అనుమతి నిరాకరించబడింది"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 msgstr ""
 "పేర్కొన్న ప్రక్రియ మీకు సంబంధించినది కాదు. ప్రక్రియ యజమాని లేదా, root  లాగ ఈ ప్రోగ్రామ్ రన్ చెయ్యండి."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "పేర్కొన్న ప్రక్రియ ID ఒక కార్యక్రమానికి సంబంధించినది కాదు."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "లక్షణం లిపి% s ఒక బాధిత ప్యాకేజీ గుర్తించేందుకు లేదు"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "ప్యాకేజీ% s లేదు"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "నివేదిక సృష్టించడం సాధ్యం కాదు"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "సమస్య నివేదిక నవీకరిస్తోంది"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -174,7 +174,7 @@ msgstr ""
 "మీరు ఈ సమస్య నివేదిక యొక్క రిపోర్టర్ లేదా చందాదారుల కాదు, లేదా నివేదిక నకిలీ లేదా ఇప్పటికే మూసివేయబడింది.\n"
 "\"apport-bug\" ఉపయోగించి ఒక నివేదిక రూపొందించండి."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -186,24 +186,24 @@ msgid ""
 "Do you really want to proceed?"
 msgstr ""
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "అదనపు సమాచారం సేకరించ లేదు"
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr ""
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr ""
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr ""
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -214,202 +214,204 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr ""
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr ""
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr ""
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "ఈ సమస్య నివేదిక పాడైనది మరియు ప్రక్రియ సాద్యం  కాదు"
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr ""
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "ఈ సమస్య నివేదిక ప్రాసెస్ చేసేటప్పుడు ఒక దోషం ఏర్పడింది:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr ""
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr ""
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr ""
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr ""
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr ""
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr ""
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -417,161 +419,160 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr ""
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 msgstr ""
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr ""
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr ""
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr ""
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr ""
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr ""
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr ""
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
 msgstr ""
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr ""
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr ""
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr ""
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr ""
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr ""
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr ""
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr ""
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr ""
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr ""
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
 msgstr ""
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr ""
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
 msgstr ""
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr ""
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr ""
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr ""
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr ""
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr ""
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr ""
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr ""
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr ""
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
 msgstr ""
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr ""
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 
@@ -586,27 +587,27 @@ msgid ""
 "Write modified report to given file instead of changing the original report"
 msgstr ""
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr ""
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr ""
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr ""
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr ""
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -616,78 +617,78 @@ msgid ""
 "be able to retrace crashes that happened on the currently running release."
 msgstr ""
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
 "have installed."
 msgstr ""
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr ""
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
 msgstr ""
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
 "neither -g, -o, nor -s are specified)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
 msgstr ""
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr ""
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr ""
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr ""
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -695,70 +696,70 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr ""
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
 msgstr ""
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 
@@ -772,76 +773,76 @@ msgstr ""
 msgid "Report a malfunction to the developers"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr ""
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr ""
 
@@ -895,7 +896,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr ""
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -905,32 +906,32 @@ msgstr ""
 msgid "Apport crash file"
 msgstr ""
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr ""
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr ""
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr ""
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr ""
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr ""
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
 msgstr ""
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr ""

--- a/po/tg.po
+++ b/po/tg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2015-04-27 21:47+0000\n"
 "Last-Translator: Martin Pitt <martin@piware.de>\n"
 "Language-Team: Tajik <tg@li.org>\n"
@@ -40,11 +40,11 @@ msgstr ""
 "Лутфан, пароли худро ворид кунед, то ин ки ба гузоришҳои мушкилиҳои "
 "барномаҳои системавӣ дастрасӣ пайдо кунед"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "Чунин менамояд, ки ин баста ба таври дуруст насб нашудааст"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -52,7 +52,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -65,21 +65,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "барномаи номаълум"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Мутаассифона, барномаи \"%s\" ногаҳонан пӯшида шуд"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Мушкилӣ дар %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -87,64 +82,69 @@ msgstr ""
 "Компютери шумо барои ба таври худкор ташхис кардани мушкилӣ ва фиристодани "
 "гузориш ба таҳиягарон ҳофизаи озоди кофӣ надорад."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Мушкилӣ дар %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Гузориши мушкилӣ беэътибор аст"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "Шумо наметавонед ба ин гузориши мушкилӣ дастрасӣ пайдо кунед."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Хатогӣ"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "Барои коркарди ин гузориш фазои диск кофӣ нест."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "PID беэътибор"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "Ягон баста муайян нашудааст"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Шумо бояд баста ё PID-ро муайян кунед. Барои маълумоти бештар \"--help\"-ро "
 "истифода баред."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Дастарсӣ манъ аст"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -152,30 +152,30 @@ msgstr ""
 "Раванди муайяншуда ба шумо тааллуқ надорад. Лутфан, ин барномаро ҳамчун "
 "раванди root иҷро кунед."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "ID-и раванди муайяншуда ба барнома тааллуқ надорад."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Скрипти нишонаи %s бастаи таъсиргирифтаро муайян накард"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Бастаи %s вуҷуд надорад"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "Гузориш эҷод намешавад"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "Навсозии гузориши мушкилӣ"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -187,7 +187,7 @@ msgstr ""
 "\n"
 "Лутфан, гузориши навро тавассути \"apport-bug\" эҷод кунед."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -208,24 +208,24 @@ msgstr ""
 "\n"
 "Шумо воқеан мехоҳед идома диҳед?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "Ягон маълумоти иловагӣ ҷамъ карда намешавад."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "Шумо мехоҳед кадом намуди мушкилиро гузориш диҳед?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Мушкилии номаълум"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Мушкилии \"%s\" номаълум аст."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -236,7 +236,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -244,32 +244,32 @@ msgstr ""
 "Баъд аз пӯшидани ин паём, лутфан, ба равзанаи барнома зер кунед, то ин ки "
 "мушкилии онро гузориш диҳед."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop ID-и раванди равзанаро муайян карда натавонист"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "Муайян кардани номи баста."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 "Иловакунии барчаспи иловагӣ ба гузориш. Метавонад якчанд маротиба муайян "
 "карда шавад."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -280,17 +280,17 @@ msgstr ""
 "нашуда бошад, рӯйхати нишонаҳои маълум намоиш дода мешавад. (Агар аргументи "
 "ягона дода шавад, ба кор меояд.)"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "Ба равзанае зер кунед ва мушкилиро гузориш диҳед."
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "Оғоз кардан дар ҳолати навсозии хатогиҳо. Метавонад \"--package\"-и "
 "ихтиёриро гирад."
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -298,7 +298,7 @@ msgstr ""
 "Фиристодани гузориши хатогӣ оид ба нишона. (Танҳо агар номи нишона танҳо "
 "ҳамчун аргумент дода шудааст, тааллуқ дорад.)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -307,7 +307,7 @@ msgstr ""
 "бошад, ин ихтиёрӣ мебошад. (Агар ба номи баста танҳо як аргумент дода шавад, "
 "ба кор меояд.)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -317,11 +317,11 @@ msgstr ""
 "карда шавад, гузориши хатогӣ маълумоти бештарро дар бар мегирад.  (Агар ба "
 "pid танҳо як аргумент дода шавад, ба кор меояд.)"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "Pid-и пешниҳодшуда барномаи боздошта мебошад."
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -331,7 +331,7 @@ msgstr ""
 "мунтазир дар %s. (Агар файл ҳамчун аргументи ягона дода шавад, истифода "
 "мешавад.)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -341,46 +341,46 @@ msgstr ""
 "он ба файл захира кунед. Ин файл метавонад баъдан дар компютери дигар "
 "гузориш дода шавад."
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Чоп кардани рақами версияи Apport."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Ин apport-retrace-ро дар равзанаи терминал аз нав оғоз мекунад, то ин ки "
 "нокомӣ ташхис карда шавад."
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "Иҷро кардани ҷаласаи gdb"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Иҷро кардани ҷаласаи gdb бе боргирии аломатҳои ислоҳи хатоҳо"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Навсозӣ кардани %s бо пайгирии аломатии анбора"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr "Гузориши мушкилӣ ба барномае тааллуқ дорад, ки дигар насб нашудааст."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
@@ -389,79 +389,81 @@ msgstr ""
 "Мушкилӣ бо барномаи %s ба вуҷуд омад, ки аз лаҳзаи ба вуҷуд омадани нокомӣ "
 "тағйир ёфт."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Гузориши мушкилӣ вайроншуда мебошад ва наметавонад коркард шавад."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr ""
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "Ҳангоми кӯшиши коркарди ин гузориши мушкилӣ хатогӣ ба вуҷуд омад:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "Баста ё номи бастаи аслӣ муайян карда нашуд."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "Браузер оғоз намешавад"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Барои кушодани %s браузер оғоз намешавад."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Мушкилии шабака"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Ба пойгоҳи иттилоотии нокомӣ пайваст шудан нашуд, лутфан, пайвасти Интернети "
 "худро санҷед."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Мушкилии шабака"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Ҳофиза кофӣ нест"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "Системаи шумо барои коркарди ин гузориши нокомӣ ҳофизаи кофӣ надорад."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -472,11 +474,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "Мушкилӣ аллакай дониста мебошад"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -486,38 +488,37 @@ msgstr ""
 "гузориш дода шуда буд. Лутфан, санҷед, ки оё шумо метавонед ягон маълумоти "
 "бештарро илова кунед, ки метавонад барои таҳиягарон фоидаовар бошад."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Ин мушкилӣ аллакай ба таҳиягарон гузориш дода шуд. Ташаккур ба шумо!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Барои идома додан ягон тугмаеро зер кунед..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "Шумо мехоҳед чӣ кор кунед? Имконот зерин аст:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Лутфан интихоб кунед (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i байт)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(иттилооти дуӣ)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Гузориши мушкилиро ба таҳиягарон мефиристед?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -525,52 +526,52 @@ msgstr ""
 "Баъд аз фиристодани гузориши мушкилӣ, лутфан, шаклро дар\n"
 "браузере, ки ба таври худкор кушода мешавад, пур кунед."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "&Фиристодани гузориш (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "&Санҷиши маҳаллӣ"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "&Намоиш додани гузориш"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 "&Нигоҳ доштани файли гузориш барои фиристодани баъдина ё нусхабардорӣ ба "
 "ҷойи дигар"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "Бекор кунед ва &нокомиҳои ояндаи ин версияи барномаро нодида гузаронед"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Бекор кардан"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Гузориши мушкилӣ ҳамчун:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&Тасдиқ кардан"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Хатогӣ: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "Ҷамъкунии маълумоти мушкилӣ"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -578,11 +579,11 @@ msgstr ""
 "Маълумоти ҷамъшуда метавонад барои беҳтар кардани барнома ба таҳиягарон \n"
 "фиристода шавад. Ин метавонад якчанд дақиқаро гирад."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "Боркунии иттилооти мушкилӣ"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -590,40 +591,40 @@ msgstr ""
 "Маълумоти ҷамъшуда ба системаи пайгирии хатогиҳо фиристода шуда истодааст. \n"
 "Ин метавонад якчанд дақиқаро гирад."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Тайёр"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "ҳеҷ"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "Интихобшуда: %s. Интихобҳои чандгона:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Интихобҳо:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "Масири файл (Барои бекор кардан тугмаи \"Enter\"-ро зер кунед):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "Файл вуҷуд надорад."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "Ин директория мебошад."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "Барои идома додан, шумо бояд ба суроғаи URL-и зерин ташриф оред:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -631,17 +632,17 @@ msgstr ""
 "Шумо метавонед ҳозир браузерро иҷро кунед, ё ки ин URL-ро дар браузери "
 "компютери дигар гузоред."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Ҳозир иҷро кардани браузер"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 "Ягон гузориши интихори нокомиҳо вуҷуд надорад. Барои маълумоти бештар "
 "фармони \"--help\"-ро истифода баред."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr "Пайгириҳои навро ба гузориш нагузоред, онҳоро ба stdout нависед."
 
@@ -660,28 +661,28 @@ msgstr ""
 "Навиштани гузориши тағйирёфта ба файли додашуда ба ҷойи тағйир додани "
 "гузориши аслӣ"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 "Тоза кардани дампи мағз аз гузориш баъд аз эҷодкунии дубораи пайгирии анбора"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "Бекор кардани CoreFile-и гузориш"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "Бекор кардани ExecutablePath-и гузориш"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "Бекор кардани ProcMaps-и гузориш"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "Аз нав сохтани маълумоти баста"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -698,32 +699,32 @@ msgstr ""
 "системаро истифода мебарад, аммо он гоҳ метавонад танҳо нокомиҳоеро, ки дар "
 "релизи ҷории иҷрошаванда ба вуҷуд омаданд, дубора рад мекунад."
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
 "have installed."
 msgstr ""
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 "Гузориш додани раванди боргирӣ/насбкунӣ ҳангоми насбкунии бастаҳо ба регдон"
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr "Гузоштани вақт ба паёмҳои сабти рӯйдодҳо, барои амалиётҳои гурӯҳӣ"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr "Директорияи зерҳофиза барои бастаҳое, ки дар регдон боргирӣ шудаанд"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -731,14 +732,14 @@ msgstr ""
 "Директория барои бастаҳои баровардашуда. Иҷрокуниҳои оянда ҳисоб мекунанд, "
 "ки бастаи аллакай боргиришуда ба ин регдон низ бароварда шудааст."
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 "Насб кардани бастаи иловагӣ ба регдон (метавонад якчанд маротиба муайян "
 "карда шавад)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -748,7 +749,7 @@ msgstr ""
 "истифода мешавад, ки барои боркунии пайгириҳои дубора радшудаи анбора ID-и "
 "нокомӣ муайян карда мешавад (танҳо он гоҳ, ки -g, -o, ё -s муайян нашудааст)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -756,32 +757,32 @@ msgstr ""
 "Намоиш додани пайгириҳои радшудаи дубора ва пурсидани тасдиқнома пеш аз "
 "фиристодани онҳо ба пойгоҳи иттилоотии нокомиҳо."
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 "Масир ба пойгоҳи иттилоотии такрории sqlite (пешфарз: бе санҷиши такрориҳо)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr ""
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr ""
 "Шумо наметавонед \"-C\"-ро бе \"-S\" истифода баред. Амал қатъ карда шуд."
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "Инҳоро ҳамчун замимаҳо мефиристонед? [y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -789,20 +790,20 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "Директорияи таъинотӣ вуҷуд дорад ва холӣ намебошад."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "Барои тафсилот ба саҳифаи man нигаред."
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr ""
 "муайян кардани номи файли сабти рӯйдодҳо, ки бо valgrind эҷод карда шудааст"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
@@ -810,7 +811,7 @@ msgstr ""
 "истифодаи дубораи директорияи қаблан эҷодшудаи регдон (SDIR), ё дар ҳолати "
 "мавҷуд набудан, эҷод кардани он"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -819,7 +820,7 @@ msgstr ""
 "ё  аз нав истифода набаред, танҳо ба аломатҳои насбшудаи ислоҳи хатоҳо асос "
 "ёбед."
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
@@ -827,35 +828,35 @@ msgstr ""
 "истифодаи дубораи директорияи қаблан эҷодшудаи зерҳофиза (CDIR), ё дар "
 "ҳолати мавҷуд набудан, эҷод кардани он"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 "гузориш додани раванди боргирӣ/насбкунӣ ҳангоми насбкунии бастаҳо ба регдон"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Хатогӣ: %s иҷро намешавад. Амал қатъ карда шуд."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -863,7 +864,7 @@ msgstr ""
 "Коркарди оғози дубора дар назди анҷом боздошта шуд, ва ҳамчун бомуваффақият "
 "ба анҷомрасида намоён мегардад."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 "Ҳозир системаи шумо метавонад ноустувор гардад ва бояд бозоғозӣ карда шавад."
@@ -878,78 +879,78 @@ msgstr "Гузориши мушкилӣ..."
 msgid "Report a malfunction to the developers"
 msgstr "Гузориш додани амали нодуруст ба таҳиягарон"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "Мутаассифода, барномаи %s ногаҳонан пӯшида шуд."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "Мутаассифона, %s ногаҳонан пӯшида шуд."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "Мутаассифона, %s бо хатогии дохилӣ дучор шуд."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Фиристодан"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Намоиш додани тафсилот"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Давом додан"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "Барномаи %s ҷавоб намедиҳад."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "Барномаи \"%s\" ҷавоб намедиҳад."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Баста: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "Мутаассифона, ҳангоми насбкунии нармафзор мушкилие ба вуҷуд омад."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "Барномаи %s дорои хатогии дарунӣ мебошад."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "Барномаи %s ногаҳон қатъ шудааст."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr ""
 "Агар шумо мушкилиҳои дигарро бинед, кӯшиш кунед, ки компютерро бозоғозӣ "
 "намоед."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "Нодида гирифтани мушкилиҳои ояндаи ин намуд"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Пинҳон кардани тафсилот"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -1005,7 +1006,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>Маълумоти мушкилӣ бор шуда истодааст</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -1017,27 +1018,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Файли нокомии Apport"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "Пӯшида нигоҳ доред"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Аз нав иҷро кардан"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Номи корбар:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Парол:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "Ҷамъкунии маълумоти мушкилӣ"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1045,6 +1046,6 @@ msgstr ""
 "Маълумоти ҷамъшуда метавонад барои беҳтар кардани барнома ба таҳиягарон "
 "фиристода шавад. Ин метавонад якчанд дақиқаро гирад."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "Боркунии иттилооти мушкилӣ"

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2023-03-28 16:30+0000\n"
 "Last-Translator: Rockworld <sumoisrock@gmail.com>\n"
 "Language-Team: Thai <th@li.org>\n"
@@ -36,11 +36,11 @@ msgstr "การรายงานปัญหาระบบ"
 msgid "Please enter your password to access problem reports of system programs"
 msgstr "โปรดป้อนรหัสผ่านเพื่อเข้าถึงรายงานปัญหาของโปรแกรมระบบ"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "ดูเหมือนว่าแพคเกจนี้จะไม่ได้ถูกติดตั้งอย่างถูกต้อง"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -60,21 +60,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "โปรแกรมนี้ไม่รู้จัก"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "ขออภัย โปรแกรม \"%s\" ปิดลงโดยไม่คาดหมาย"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "ปัญหาใน %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -82,62 +77,67 @@ msgstr ""
 "ระบบของคุณไม่มีหน่วยความจำเหลือเพีัยงพอที่จะทำการตรวจสอบ, วิเคราะปัญหา "
 "และส่งรายงานกลับไปที่นักพัฒนาได้"
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "ปัญหาใน %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "รายงานปัญหาไม่ถูกต้อง"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "คุณไม่ได้รับอนุญาตให้ดูรายงานปัญหานี้"
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "ผิดพลาด"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "พื้นที่ว่างบนดิืสไม่พอสำหรับดำเนินการกับรายงานนี้ได้"
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr "ไม่ได้ระบุ PID ไว้"
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr "คุณจำเป็นต้องระบุ PID ด้วย ดูที่ --help สำหรับข้อมูลเพิ่มเติม"
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "PID ไม่ถูกต้อง"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr "ID โปรเซสที่ระบุไม่มีอยู่"
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr "ไม่ใช่ PID ของคุณ"
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr "ID โปรเซสที่ระบุไม่ได้เป็นของคุณ"
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "ไม่ได้ระบุแพกเกจ"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr "คุณต้องระบุแพกเกจสักตัวหรือเลข PID ดู --help สำหรับข้อมูลเพิ่มเติม"
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "ไม่ได้รับสิทธิ์"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -145,30 +145,30 @@ msgstr ""
 "กระบวนการที่ระบุไม่ใช่ของคุณ "
 "โปรดเรียกใช้โปรแกรมนี้ในฐานะเจ้าของกระบวนการหรือในฐานะผู้ดูแลระบบขั้นสูง"
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "ID ของกระบวนการที่ระบุไม่ใช่ของโปรแกรมใด"
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "สคริปต์อาการ %s ไม่ได้กำหนดแพกเกจที่ได้รับผลกระทบ"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "ไม่มีแพกเกจ %s อยู่"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "ไม่สามารถสร้างรายงานได้"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "กำลังปรับข้อมูลรายงานปัญหา"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -179,7 +179,7 @@ msgstr ""
 "\n"
 "โปรดสร้างรายงานใหม่โดยใช้ \"apport-bug\""
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -198,24 +198,24 @@ msgstr ""
 "\n"
 "คุณต้องการดำเนินการต่อไปหรือไม่?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "ไม่มีการรวบรวมข้อมูลเพิ่มเติมใด ๆ"
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "ปัญหาแบบใดที่คุณต้องการที่จะรายงาน?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "อาการที่ไม่รู้จัก"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "ไม่รู้จักอาการ \"%s\""
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -226,36 +226,36 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr "หลังจากที่ปิดข้อความนี้แล้ว โปรดคลิกบนหน้าต่างโปรแกรมเพื่อรายงานปัญหานี้"
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop ไม่สามารถกำหนด ID โปรเซสของหน้าต่างได้"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "ระบุชื่อแพกเกจ"
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "เพิ่มแท็กพิเศษไปในรายงาน สามารถระบุได้หลาย ๆ ครั้ง"
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -265,21 +265,21 @@ msgstr ""
 "ถ้าไม่ใส่อาร์กิวเมนต์ดังกล่าว ให้แสดงรายการอาการที่รู้ว่าเกิดขึ้น "
 "(ไม่ทำงานถ้าใส่เพียงอาร์กิวเมนต์เดียว)"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "คลิกหน้าต่างเพื่อเป็นเป้าหมายสำหรับรายงานปัญหา"
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "เริ่มทำงานในโหมดอัปเดตปัญหา สามารถใช้อาร์กิวเมนต์ --package พร้อมตัวเลือกได้"
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr "รายงานปัญหาเกี่ยวกับอาการ (ไม่ทำงานถ้าชื่ออาการถูกใส่เพียงอาร์กิวเมนต์)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -287,7 +287,7 @@ msgstr ""
 "ระบุชื่อแพกเกจในโหมด --file-bug ถ้าระบุ --pid นี่จะเป็นตัวเลือก "
 "(ไม่ทำงานถ้าชื่อแพกเกจถูกใส่เพียงอาร์กิวเมนต์)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -296,11 +296,11 @@ msgstr ""
 "ระบุโปรแกรมที่กำลังทำงานในโหมด --file-bug ถ้ามีการระบุ "
 "รายงานปัญหาจะประกอบด้วยข้อมูลเพิ่มเติม  (ไม่ทำงานถ้า pid ถูกใส่เพียงอาร์กิวเมนต์)"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "pid ที่ระบุเป็นโปรแกรมที่ทำงานค้างอยู่"
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -309,7 +309,7 @@ msgstr ""
 "รายงานความล้มเหลวจากแฟ้ม .apport หรือ .crash ที่ให้มาแทนที่กำลังรออยู่ใน %s "
 "(ไม่ทำงานถ้าแฟ้มถูกใส่เพียงอาร์กิวเมนต์)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -318,86 +318,88 @@ msgstr ""
 "ในโหมดรายงานปัญหา บันทึกข้อมูลที่รวบรวมเป็นแฟ้มแทนที่จะรายงาน "
 "แฟ้มนี้สามารถเก็บไว้รายงานได้ทีหลังโดยใช้เครื่องอื่นได้"
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "พิมพ์หมายเลขรุ่น Apport"
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "การดำเนินการนี้จะเป็นการเรียกใช้ apport-retrace ในหน้าต่างเทอร์มินัลเพื่อตรวจสอบความล้มเหลว"
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "เรียกใช้วาระ gdb"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "เรียกใช้วาระ gdb session โดยไม่ต้องดาวน์โหลดสัญลักษณ์การดีบั๊ก"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "อัปเดต %s พร้อมข้อมูลการติดตามสแตกเชิงสัญลักษณ์"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr "ไม่สามารถจดจำค่าตั้งสถานะการส่งรายงานได้"
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 "การบันทึกสถานะการรายงานข้อขัดข้องล้มเหลว ไม่สามารถตั้งโหมดอัตโนมัติหรือไม่รายงานเลยได้"
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr "ไม่สามารถจดจำค่าตั้งสถานะการส่งรายงานได้"
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr "รายงานปัญหานี้จะนำไปใช้กับโปรแกรมที่ไม่ได้ติดตั้งอีกต่อไป"
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 msgstr "มีปัญหาเกิดขึ้นกับโปรแกรม %s ซึ่งมีการเปลี่ยนแปลงตั้งแต่เกิดความล้มเหลวขึ้น"
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "รายงานปัญหาเสียหายทำให้ไม่สามารถดำเนินการต่้อได้"
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr "รายงานนี้เกี่ยวกับแพคเกจที่ไม่ได้ติดตั้ง"
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "เกิดข้อผิดพลาดขณะพยายามประมวลผลการรายงานปัญหานี้:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr "คุณมีแอปพลิเคชันนี้ติดตั้งอยู่สองเวอร์ชัน คุณต้องการรายงานบั๊กของเวอร์ชันไหน"
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr "%s snap"
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr "%s แพคเกจ deb"
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -406,38 +408,38 @@ msgstr ""
 "%s จัดหาโดย snap ที่เผยแพร่โดย %s และไม่ได้มีการระบุที่อยู่ติดต่อไว้ ให้เยี่ยมชมกระดานสนทนาที่ "
 "https://forum.snapcraft.io/ เพื่อขอความช่วยเหลือ"
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "ไม่สามารถกำหนดแพกเกจหรือชื่อแพกเกจต้นฉบับได้"
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "ไม่สามารถเริ่มเว็บเบราว์เซอร์ได้"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "ไม่สามารถเริ่มเว็บเบราว์เซอร์เพื่อเปิด %s"
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "ปัญหาเครือข่าย"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "ไม่สามารถเชื่อมต่อไปที่ฐานข้อมูลความล้มเหลวได้ โปรดตรวจสอบการเชื่อมต่ออินเทอร์เน็ตของคุณ"
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "ปัญหาเครือข่าย"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "หน่วยความจำหมด"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "ระบบของคุณมีหน่วยความจำไม่เพียงพอสำหรับประมวลผลการรายงานปัญหานี้"
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -448,11 +450,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "ปัญหาที่ทราบแล้ว"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -461,38 +463,37 @@ msgstr ""
 "ปัญหานี้ถูกรายงานอยู่แล้วในรายงานปัญหาที่แสดงในเว็บเบราว์เซอร์ "
 "โปรดตรวจสอบว่าคุณสามารถเพิ่มข้อมูลเพิ่มเติมที่อาจเป็นประโยชน์ต่อนักพัฒนาได้หรือไม่"
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "ปัญหานี้ถูกรายงานให้ทางผู้พัฒนาไปแล้ว ขอขอบคุณ!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "กดปุ่มใดๆ เพื่อดำเนินการต่อ..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "คุณต้องการทำอะไร? ตัวเลือกของคุณคือ:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "โปรดเลือก (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i ไบต์)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(binary data)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "ต้องการส่งรายงานปัญหาไปยังนักพัฒนาหรือไม่?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -500,50 +501,50 @@ msgstr ""
 "หลังจากที่รายงานปัญหาถูกส่งไปแล้ว โปรดกรอกข้อมูลลงในแบบฟอร์ม\n"
 "ในโปรแกรมท่องเว็บที่เปิดขึ้นมาโดยอัตโนมัติ"
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "&ส่งรายงาน (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "&ตรวจในเครื่อง"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "&ดูรายงาน"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr "&เก็บแฟ้มรายงานไว้ส่งทีหลังหรือคัดลอกไปไว้ในที่อื่น ๆ"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "ยกเลิกและเพิกเ&ฉยต่อการขัดข้องครั้งหน้าของโปรแกรมรุ่นนี้"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&ยกเลิก"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "แฟ้มรายงานปัญหา:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&ยืนยัน"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "ผิดพลาด: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "กำลังรวบรวมข้อมูลของปัญหา"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -551,11 +552,11 @@ msgstr ""
 "ข้อมูลที่รวบรวมมาสามารถส่งไปให้นักพัฒนาเพื่อให้ทำการปรับปรุงโปรแกรมได้\n"
 "การดำเนินการนี้จะใช้เวลาเพียงไม่กี่นาที"
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "กำลังอัปโหลดข้อมูลปัญหา"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -563,40 +564,40 @@ msgstr ""
 "ข้อมูลที่รวบรวมมากำลังจะถูกส่งไปยังระบบติด\n"
 "ตามบั๊ก การดำเนินการนี้จะใช้เวลาเพียงไม่กี่นาที"
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&เสร็จแล้ว"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "ไม่มี"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "เลือกแล้ว: %s. หลายตัวเลือก:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "ตัวเลือก:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "เส้นทางมายังแฟ้ม (กด Enter เพื่อยกเลิก):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "แฟ้มไม่มีอยู่"
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "นี่คือไดเรกทอรี"
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "เพื่อดำเนินการต่อ คุณจะต้องไปยัง URL:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -604,15 +605,15 @@ msgstr ""
 "คุณสามารถเปิดโปรแกรมท่องเว็บได้แล้วตอนนี้ หรือคัดลอก URL "
 "นี้ไปยังโปรแกรมท่องเว็บบนคอมพิวเตอร์เครื่องอื่น"
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "เปิดเบราว์เซอร์เดี๋ยวนี้"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr "ไม่มีรายงานปัญหาที่รออยู่ ลองเรียกคำสั่ง --help เพื่อดูข้อมูลเพิ่มเติม"
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr "ไม่ต้องเพิ่มการติดตามใหม่ลงในรายงาน แต่ให้เขียนไปที่ stdout"
 
@@ -628,27 +629,27 @@ msgid ""
 "Write modified report to given file instead of changing the original report"
 msgstr "เขียนรายงานที่ปรับเปลี่ยนไปที่แฟ้มที่ระบุแทนที่จะเปลี่ยนรายงานดั้งเดิม"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr "เอาบันทึกหลักออกจากรายงานหลังจากที่สร้างการติดตามสแตกใหม่แล้ว"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "แทนที่ CoreFile ของรายงาน"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "แทนที่ ExecutablePath ของรายงาน"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "แทนที่ ProcMaps ของรายงาน"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "สร้างรายงานข้อมูลแพกเกจใหม่"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -663,7 +664,7 @@ msgstr ""
 "ก็จะใช้เพียงแฟ้มกำหนดค่าของระบบ "
 "แต่จะสามารถทำได้เพียงติดตามความล้มเหลวที่เกิดขึ้นเมื่อใช้รุ่นที่กำลังใช้งานอยู่ในขณะนี้เท่านั้น"
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
@@ -672,24 +673,24 @@ msgstr ""
 "สร้าง Sandbox ใหม่ชั่วคราวสำหรับติดตั้ง gdb และแพกเกจอื่นๆ "
 "ที่เกี่ยวข้องโดยใช้รุ่นเดียวกับรายงานแทน gdb รุ่นที่คุณได้ติดตั้งไว้"
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr "รายงานความคืบหน้าในการดาวน์โหลด/ติดตั้งระหว่างติดตั้งแพกเกจไปที่ Sandbox"
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr "ขึ้นต้นการประทับเวลาในข้อความปูม สำหรับดำเนินการชุดงาน"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr "สร้างและใช้ที่เก็บจากบุคคลที่สามจากแหล่งข้อมูลที่ระบุไว้ในรายงาน"
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr "ไดเรกทอรีแคชสำหรับแพกเกจที่ดาวน์โหลดใน Sandbox"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -697,12 +698,12 @@ msgstr ""
 "ไดเรกทอรีสำหรับแพกเกจที่ยังไม่ได้แยก "
 "การเรียกใช้งานครั้งต่อไปก็จะถือว่าแพกเกจที่ดาวน์โหลดไว้ถูกแยกไปที่ Sandbox แล้ว"
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr "ติดตั้งแพกเกจพิเศษไปที่ Sandbox (สามารถระบุได้หลายครั้ง)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -712,36 +713,36 @@ msgstr ""
 "ID ความล้มเหลวเพื่ออัปโหลดการติดตามสแตกที่มีการติดตามใหม่ (เฉพาะเมื่อไม่ได้ระบุ -g, -o, หรือ "
 "-s)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
 msgstr "แสดงการติดตามสแตกที่ติดตามใหม่และร้องขอการยืนยันก่อนที่จะส่งไปที่ฐานข้อมูลความล้มเหลว"
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr "เส้นทางที่ไปยังฐานข้อมูล sqlite ที่ทำซ้ำ (ค่าปริยาย: ไม่มีการตรวจสอบการทำซ้ำ)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr "ไม่ต้องเพิ่ม StacktraceSource ไว้ในรายงาน"
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "คุณไม่สามารถใช้ -C โดยไม่ใช้ -S ได้ กำลังหยุดทำงาน"
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "ต้องการส่งเป็นสิ่งที่แนบมาหรือไม่? [y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -749,25 +750,25 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "ไดเรกทอรีปลายทางมีอยู่และไม่ว่างเปล่า"
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "ดูที่ Man page สำหรับรายละเอียดเพิ่มเติม"
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "ระบุชื่อแฟ้มปูมที่สร้างขึ้นโดย valgrind"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
 msgstr "นำ ไดเรกทอรี Sandbox (SDIR) ที่สร้างไว้ก่อนหน้านี้มาใช้ใหม่ หรือสร้างขึ้นมาถ้าเกิดไม่มีอยู่"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -775,40 +776,40 @@ msgstr ""
 "ไม่ต้องสร้างหรือนำไดเรกทอรี Sandbox มาใช้ใหม่สำหรับสัญลักษณ์การดีบั๊ก "
 "แต่ให้อ้างอิงเฉพาะสัญลักษณ์การดีบั๊กที่ติดตั้งเท่านั้น"
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
 msgstr "ใช้ไดเรกทอรีแคช (CDIR) ที่สร้างไว้ก่อนหน้านี้มาใช้ใหม่ หรือสร้างขึ้นมาถ้าเกิดไม่มีอยู่"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr "รายงานความคืบหน้าของการดาวน์โหลด/ติดตั้งระหว่างติดตั้งแพกเกจไปที่ Sandbox"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "ผิดพลาด: %s ไม่ใช่แฟ้มปฏิบัติการ กำลังหยุดทำงาน"
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr "นี่เกิดขึ้นระหว่างการพักเครื่องครั้งที่ผ่านมา และป้องกันไม่ให้ระบบทำงานต่อได้อย่างถูกต้อง"
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr "นี่เกิดขึ้นระหว่างการไฮเบอร์เนตครั้งที่ผ่านมา และป้องกันไม่ให้ระบบทำงานต่อได้อย่างถูกต้อง"
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -816,7 +817,7 @@ msgstr ""
 "การดำเนินการที่กำลังจะดำเนินการต่อไปนั้นหยุดทำงานชั่วคราวเมื่อใกล้จะจบแล้ว "
 "และจะเสร็จสมบูรณ์โดยปกติ"
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr "ระบบของคุณอาจไม่เสถียรแล้วในขณะนี้ และต้องเริ่มการทำงานของระบบใหม่"
 
@@ -830,76 +831,76 @@ msgstr "รายงานปัญหา..."
 msgid "Report a malfunction to the developers"
 msgstr "รายงานการทำงานผิดพลาดไปที่เหล่านักพัฒนา"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "ขออภัย โปรแกรม %s หยุดทำงานอย่างกะทันหัน"
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "ขออภัย %s ปิดลงอย่างกะทันหัน"
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "ขออภัย %s ประสบปัญหาภายใน"
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "ส่ง"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "แสดงรายละเอียด"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "ทำต่อไป"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "โปรแกรม %s หยุดตอบสนองแล้ว"
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "โปรแกรม \"%s\" หยุดตอบสนองแล้ว"
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "แพกเกจ: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "ขออภัย เกิดปัญหาขณะติดตั้งซอฟต์แวร์"
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "โปรแกรม %s ประสบปัญหาภายใน"
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "โปรแกรม %s ปิดลงอย่างกะทันหัน"
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr "ถ้าคุณประสบปัญหาเพิ่มเติม ให้ลองเริ่มการทำงานของคอมพิวเตอร์ใหม่อีกครั้ง"
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "เพิกเฉยต่อปัญหาครั้งหน้าของประเภทนี้"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "ซ่อนรายละเอียด"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -953,7 +954,7 @@ msgstr "กำลังรวบรวมข้อมูลซึ่งช่ว
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>กำลังอัปโหลดข้อมูลของปัญหา</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -963,27 +964,27 @@ msgstr "ข้อมูลที่รวบรวมมากำลังจะ
 msgid "Apport crash file"
 msgstr "แฟ้มความล้มเหลว Apport"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "ปล่อยให้ปิดไป"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "เรียกใหม่"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "ชื่อผู้ใช้:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "รหัสผ่าน:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "กำลังรวบรวมข้อมูลปัญหา"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -991,6 +992,6 @@ msgstr ""
 "ข้อมูลที่รวบรวมมาสามารถส่งไปให้นักพัฒนาเพื่อให้ปรับปรุงโปรแกรมได้ "
 "การกระทำนี้จะใช้เวลาเพียงไม่กี่นาที"
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "กำลังปรับปรุงข้อมูลของปัญหา"

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2023-02-08 11:17+0000\n"
 "Last-Translator: Sabri Ünal <Unknown>\n"
 "Language-Team: Turkish <tr@li.org>\n"
@@ -38,11 +38,11 @@ msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 "Lütfen sistem programlarının problem raporlarına ulaşmak için şifrenizi girin"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "Bu paket doğru yüklenmiş gibi görünmüyor."
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -53,7 +53,7 @@ msgstr ""
 "güncelleştirdikten sonra yeniden deneyin, eğer bu işinizi görmezse ilişkili "
 "üçüncü parti paketleri kaldırıp yeniden deneyin."
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -66,21 +66,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "bilinmeyen program"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Üzgünüm, \"%s\" programı beklenmedik şekilde kapandı"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "%s'de problem"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -88,65 +83,70 @@ msgstr ""
 "Bilgisayarınız otomatik olarak sorunu analiz etmek ve geliştiricilere rapor "
 "göndermek için yeterli boş belleğe sahip değil."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "%s'de problem"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Geçersiz sorun raporu"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "Bu hata raporuna erişmeye izniniz yok."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Hata"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "Bu raporu işlemek için yeterli disk alanı yok."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr "PID belirtilmemiş"
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 "PID belirtmeniz gerekiyor. Daha fazla bilgi için --help sayfasını inceleyin."
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "Geçersiz PID"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr "Belirtilen işlem kimliği mevcut değil."
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr "Sizin İşlem Kimliğiniz değil"
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr "Belirtilen işlem kimliği size ait değil."
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "Hiçbir paket belirtilmemiş"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Bir paket veya PID belirtmelisiniz. Daha fazla bilgi için --help çıktısına "
 "bakın."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "İzin verilmedi"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -154,30 +154,30 @@ msgstr ""
 "Belirtilen süreç size ait değil. Lütfen bu programı süreç sahibi veya root "
 "olarak çalıştırın."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "Belirlenen işlem ID'si bir programa ait değil."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Symptom betiği %s etkin bir paket tanımlamadı"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "%s pakedi bulunamadı"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "Rapor oluşturulamıyor"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "Sorun raporu güncelleniyor"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -189,7 +189,7 @@ msgstr ""
 "\n"
 "Lütfen ''apport-bug'' kullanarak yeni bir rapor oluşturun."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -210,24 +210,24 @@ msgstr ""
 "\n"
 "Gerçekten devam etmek istiyor musunuz?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "Hiçbir ek bilgi toplanmadı."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "Ne tür bir sorun bildirmek istiyorsunuz?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Bilinmeyen belirti"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "\"%s\" belirtisi bilinmiyor."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -246,7 +246,7 @@ msgstr ""
 "İşlemler sekmesinde doğru uygulamayı bulana kadar kaydırın.  İşlem kimliği, "
 "kimlik sütununda listelenen numaradır."
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -254,31 +254,31 @@ msgstr ""
 "Bu iletiyi kapattıktan sonra lütfen bununla ilgili sorunu bildirmek için bir "
 "uygulama penceresine tıklayın."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop, pencrenin işlem kimliğini saptamada başarısız oldu"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr "%(prog)s <report number>"
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "Paket adı belirtin."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "Rapora fazladan bir etiket ekleyin. Birçok kez belirtilmiş olabilir."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -288,15 +288,15 @@ msgstr ""
 "--pid gerektirir. Eğer hiçbiri belirtilmezse, bilinen belirtilerin listesini "
 "göster. (Kastedilen; eğer tek bir argüman verilirse.)"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "Bir sorunu bildirmek için hedef olarak bir pencereye tıklayın."
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "Hata güncelleme kipinde başlat. Seçime bağlı --package alınabilir."
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -304,7 +304,7 @@ msgstr ""
 "Bir belirti için hata raporu dosyala. (Kastedilen; eğer belirti adı sadece "
 "argüman olarak verilirse.)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -312,7 +312,7 @@ msgstr ""
 "--dosya-hata modunda paket adını belirtin. Bir -pid belirtilmişse, bu "
 "seçenek opsiyoneldir. (Paket adı tek argüman olarak verilmişse uygulanır.)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -322,11 +322,11 @@ msgstr ""
 "belirtilmişse, hata raporu daha fazla ayrıntı içerecektir.(PID 'in tek "
 "parametre olarak verilmesi durumu kastedilmiştir)"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "Belirtilen pid (program id) askıdaki bir uygulama"
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -335,7 +335,7 @@ msgstr ""
 "Hata raporunu %s'te beklemekte olanlar yerine .apport veya .crash "
 "dosyalarından bildirin. (Eğer dosya adı verilen tek argüman ise)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -344,48 +344,48 @@ msgstr ""
 "Hata belirtme kipinde, toplanan bilgileri raporlamak yerine onları bir "
 "dosyaya kaydedin. Bu dosya daha sonra farklı bir makineden raporlanabilir."
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Apport sürüm numarasını yazdır."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Bu, çökmeyi incelemek için bir uçbirim penceresinde \"apport-retrace\" "
 "komutunu çalıştıracak."
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "gdb oturumunu çalıştır"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "gdb oturumunu böcek temizleme simgelerini indirmeden çalıştır"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "%s dosyasını tümüyle sembolik küme iziyle güncelle"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr "Rapor gönderme durum ayarları hatırlanamıyor"
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 "Çökme rapor durumu kaydetme başarısız. Otomatik veya asla bildirme kipi "
 "ayarlanamıyor."
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr "Rapor gönderme durum ayarları hatırlanamıyor"
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr "Bu problem raporu, artık yüklü olmayan bir programa ait."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
@@ -393,43 +393,45 @@ msgid ""
 msgstr ""
 "Çökme olduktan sonra değişime uğrayan %s yazılımıyla ilgili sorun oluştu."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Bu sorun raporu hasarlı, bu nedenle işlenemiyor."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr "Bu rapor kurulmamış paketler hakkındadır."
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "Bu sorun raporunu işlemeye çalışırken bir hata oluştu:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 "Bu uygulamanın iki versiyonu kurulmuş, bildireceğiniz hata hangisine ait?"
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr "%s snap paketi"
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr "%s deb paketi"
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s, %s tarafından yayınlanan bir snap aracılığıyla sağlanmaktadır. Yardım "
 "için %s aracılığıyla iletişime geçin."
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -439,38 +441,38 @@ msgstr ""
 "adresi bulunmamaktadır; yardım için https://forum.snapcraft.io/ adresindeki "
 "forumu ziyaret edin."
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "Paket ya da kaynak kod paketi adı belirlenemedi."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "Ağ tarayıcı başlatılamıyor"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "%s açmak için ağ tarayıcı başlatılamıyor."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Ağ sorunu"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Çöküş veritabanına bağlanılamıyor, lütfen internet bağlantınızı kontrol edin."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Ağ sorunu"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Yetersiz bellek"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "Sisteminiz bu çökme raporunu işlemek için yeterli belleğe sahip değil."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -481,11 +483,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "Sorun önceden bildirilmiş"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -495,38 +497,37 @@ msgstr ""
 "bildirilmiş. Lütfen geliştiricilere yardımcı olabilecek ek bir bilgi ekleyip "
 "ekleyemeyeceğinize bakın."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Bu sorun daha önce geliştiricilere bildirildi. Teşekkür ederiz!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Devam etmek için bir tuşa basın..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "Ne yapmak istersiniz? Seçenekleriniz:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Lütfen seçin (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i sekiz ikil)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(ikili veri)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Hata raporu geliştiricilere gönderilsin mi?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -534,52 +535,52 @@ msgstr ""
 "Problem raporu gönderildikten sonra, lütfen web tarayıcınızda otomatik\n"
 "olarak açılan  sayfada yer alan formu doldurun."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "Rapor &Gönder (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "Yerel olarak &İncele"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "Rapor Görüntü&le"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 "&Rapor dosyasını, daha sonra gönderme veya başka bir yere kopyalanması için "
 "saklayın."
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "Programın bu sürümünün gelecekteki çökmelerini iptal et ve &yoksay"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Vazgeç"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Sorun rapor dosyası:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&Onayla"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Hata: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "Sorun bilgileri toplanıyor"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -588,11 +589,11 @@ msgstr ""
 "gönderilebilir. \n"
 "Bu birkaç dakika sürebilir."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "Sorun bilgileri yükleniyor"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -600,40 +601,40 @@ msgstr ""
 "Toplanan bilgiler hata takip sistemi için gönderiliyor.\n"
 "Bu birkaç dakika sürebilir."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Bitti"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "hiçbiri"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "Seçili: %s. Birden fazla seçenek:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Seçenekler:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "Dosya yolu (Iptal etmek için girin):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "Dosya mevcut değil."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "Bu bir dizin."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "Devam etmek için, aşağıdaki URL'yi ziyaret etmelisiniz:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -641,15 +642,15 @@ msgstr ""
 "Şimdi tarayıcıda açabilirsiniz, ya da bu URL'yi başka bilgisayardaki bir "
 "tarayıcıya kopyalayabilirsiniz."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Tarayıcıyı aç"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr "Bekleyen çökme raporu yok. Daha fazla bilgi için --help 'i deneyin."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr "Raporda yeni işaretlemeler yapmak yerine bunları stdout'a yazın."
 
@@ -666,27 +667,27 @@ msgid ""
 "Write modified report to given file instead of changing the original report"
 msgstr "Asıl raporu değiştirmek yerine düzeltilmiş raporu verilen dosyaya yaz"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr "Kutup yığınını küme izleme düzeltmesinden sonra rapordan geri al"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "Raporun ÇekirdekDosyası'nı Geçersiz Kıl"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "Raporun çalıştırılabilir yolunu geçersiz kıl (ExecutablePath)"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "Raporun ProcMap'lerini Geçersiz Kıl"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "Raporların Yedek bilgisini onar"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -703,7 +704,7 @@ msgstr ""
 "bu durumda yalnızca şu anda çalışan dağıtımda meydana gelen çökmelerin "
 "kaynağına gidebilir."
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
@@ -713,24 +714,24 @@ msgstr ""
 "kullanarak gdb'yi ve bağımlılıklarını yüklemek için başka bir geçici sanal "
 "alan oluşturun."
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr "Paketler sandbox içine kurulurken indirme/yüklemeyi raporla"
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr "Yığın işlemi için kayıt iletilerinin başına zaman etiketleri ekle"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr "Raporlarda kaynağı tanımlanmış üçüncü parti depoları oluştur ve kullan"
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr "Sandbox içine indirilmiş paketler için önbellek dizini"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -738,13 +739,13 @@ msgstr ""
 "Açılmamış paketlerin dizini. Sonraki çalıştırmalar, daha önceden indirilmiş "
 "herhangi paketin de bu sandbox'a çıkartılacağını varsayacak."
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 "Fazladan bir paketi sandbox içine yükle (birden çok kez belirtilebilir)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -754,7 +755,7 @@ msgstr ""
 "çökme ID'si belirlenirken kaynağına ulaşılmış yığın izlerinini yüklemede "
 "kullanılır. (Eğer -g, -o veya -s belirtiymediyse)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -762,30 +763,30 @@ msgstr ""
 "Yeniden oluşturulmuş yığın izlerini göster ve bunları çökme veritabanına "
 "göndermeden önce onay al."
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr "Kopya sqlite veritabanının yolu (varsayılan: kopya kontrolü yok)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr "Rapora StacktraceSource ekleme."
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "-S olmaksızın -C kullanamazsınız. Durduruluyor."
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "Eklenti olarak gönderilsinler mi? [y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr "%(prog)s <report> <target directory>"
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr "Açılacak rapor dosyası"
 
@@ -793,19 +794,19 @@ msgstr "Açılacak rapor dosyası"
 msgid "directory to unpack report to"
 msgstr "raporun açılacağı dizin"
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "Hedef dizin zaten mevcut ve boş değil."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "Ayrıntılar için man sayfasına bakın."
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "valgrind tarafından oluşturulan günlük dosya adını belirtin"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
@@ -813,7 +814,7 @@ msgstr ""
 "önceden oluşturulmuş sanbox dizinini (SDIR) tekrar kullan veya bulunmuyorsa "
 "oluştur"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -821,7 +822,7 @@ msgstr ""
 "ek hata ayıklayıcı sembolleri için sandbox dizinini tekrar kullanma veya "
 "oluşturma ancak, sadece yüklü hata ayıklama sembollerini kullan."
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
@@ -829,11 +830,11 @@ msgstr ""
 "önceden oluşturulmuş önbellek dizinini (CDIR) tekrar kullan veya "
 "bulunmuyorsa oluştur"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr "paketleri sandbox içine kurarken indirme/yükleme sürecini bildir"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
@@ -841,12 +842,12 @@ msgstr ""
 "bellek sızıntısı tespiti için valgrind'in memcheck aracı altında "
 "çalıştırılan yürütülebilir dosya"
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Hata: %s yürütülebilir değil. Durduruluyor."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -854,7 +855,7 @@ msgstr ""
 "Bu durum bir önceki beklemeye almadan kaynaklamıştır ve sistemin düzenli "
 "devam etmesini engellemiştir."
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -862,7 +863,7 @@ msgstr ""
 "Bu durum bir önceki uykuya almadan kaynaklamıştır ve sistemin düzenli devam "
 "etmesini engellemiştir."
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -870,7 +871,7 @@ msgstr ""
 "Kalan işlem bitmesine çok yakın bir yerde takıldı ve normal bir biçimde "
 "tamamlanmış gibi görünecek."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 "Sisteminiz şimdi kararsız hale gelebilir ve yeniden başlatılması gerekebilir."
@@ -885,77 +886,77 @@ msgstr "Bir sorunu bildir..."
 msgid "Report a malfunction to the developers"
 msgstr "Geliştiricilere bir arıza bildir"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "Üzgünüz, %s uygulaması beklenmedik şekilde durdu."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "Üzgünüz, %s beklenmedik bir şekilde kapandı."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "Üzgünüz, %s içsel bir hatayla karşılaştı."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Gönder"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Ayrıntıları Göster"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Devam Et"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "%s uygulaması yanıt vermeyi durdurdu."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "\"%s\" programı yanıt vermeyi durdurdu."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Paket: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "Üzgünüz, yazılım yüklenirken bir hatayla karşılaşıldı."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "%s uygulaması bir iç hata ile karşılaştı."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "%s yazılımı beklenmedik bir şekilde kapandı."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr ""
 "Daha fazla sorunla karşılaşırsanız bilgisayarınız yeniden başlatmayı deneyin."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "İlerde oluşabilecek bu türden sorunları yok say"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Ayrıntıları Gizle"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -1011,7 +1012,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>Sorun bilgileri yükleniyor</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -1023,27 +1024,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Apport çökme dosyası"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "Kapalı Bırak"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Yeniden başlat"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Kullanıcı Adı:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Parola:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "Sorun Bilgileri Toplanıyor"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1051,6 +1052,6 @@ msgstr ""
 "Toplanan bilgi, uygulamanın geliştirilmesi için geliştiricilere "
 "gönderilebilir. Bu, birkaç dakika sürebilir."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "Sorun Bilgileri Gönderiliyor"

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2017-10-13 22:15+0000\n"
 "Last-Translator: Gheyret T.Kenji <Unknown>\n"
 "Language-Team: Uyghur Computer Science Association <UKIJ@yahoogroups.com>\n"
@@ -38,11 +38,11 @@ msgstr "سىستېما مەسىلە دوكلاتى"
 msgid "Please enter your password to access problem reports of system programs"
 msgstr "ئىمنى كىرگۈزۈپ سىستېما مەسىلە دوكلاتىنى كۆرۈڭ."
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "مەزكۇر بوغچا توغرا ئورنىتىلمىغاندەك قىلىدۇ"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -50,7 +50,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -63,21 +63,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "نامەلۇم پروگرامما"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "كەچۈرۈڭ، پروگرامما  «%s» ئويلىمىغان يەردىن تاقىلىپ قالدى"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "مەسىلە %s نىڭدا"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -85,62 +80,67 @@ msgstr ""
 "مەسىلىنى ئاپتوماتىك ئانالىز قىلىش ۋە ئىجادىيەتچىگە مەلۇمات يوللاشقا كېرەكلىك "
 "ئەسلەك يېتەرلىك ئەمەس ئىكەن."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "مەسىلە %s نىڭدا"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "مەلۇمات ئىناۋەتسىز"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "بۇ مەسىلىنى مەلۇم قىلىش ھوقۇقىڭىز يوق."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "خاتالىق"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "مەزكۇر مەلۇماتنى بىر تەرەپ قىلىشقا كېرەكلىك دىسكا بوشلۇقى يوق."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "ئىناۋەتسىز PID"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr "كۆرسىتىلگەن جەريان ID مەۋجۇت ئەمەس."
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr "سىزنىڭ PID ئەمەس"
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr "كۆرسىتىلگەن جەريان ID سىزگە تەۋە ئەمەس."
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "بوغچا كۆرسىتىلمىگەن."
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr "بوغچا ياكى بىر PID نى كۆرسىتىڭ. تەپسىلاتلار ئۈچۈن --help نى ئىشلىتىڭ."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "ھوقۇقىڭىز يەتمىدى"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -148,30 +148,30 @@ msgstr ""
 "بۇ سىزنىڭ پروگراممىڭىز ئەمەس. مەزكۇر پروگراممىنى ئۆزىڭىزنىڭ ياكى root نىڭ "
 "ھوقۇقىدا ئىجرا قىلدۇرۇڭ."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "كۆرسىتىلگەن PID مەزكۇر پروگراممىنىڭ PID ئەمەس."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "ئەھۋال قوليازما %s تەسىر كۆرسىتىدىغان بوغچىنى بەلگىلىمىگەن"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "بوغچا %s مەۋجۇت ئەمەس"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "مەلۇمات قۇرالمىدى"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "مەلۇماتىنى يېڭىلاۋاتىدۇ"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -183,7 +183,7 @@ msgstr ""
 "\n"
 "«apport-bug» نى ئىشلىتىپ يېڭىدىن مەلۇمات تەييارلاڭ."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -202,24 +202,24 @@ msgstr ""
 "\n"
 "راستلا داۋاملاشتۇرامسىز؟"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "قوشۇمچە ئۇچۇرلار توپلانمىدى."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "قانداق مەسىلىنى مەلۇم قىلماقچى؟"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "نامەلۇم ھادىسە"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "ھادىسە «%s» نامەلۇم."
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -230,37 +230,37 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 "ئۇچۇرنى ياپقاندىن كېيىن پروگرامما كۆزنىكىنى چېكىپ، بۇ مەسىلىنى مەلۇم قىلىڭ."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop كۆزنەكنىڭ ئىجرا ID سىنى تېپىشتا مەغلۇپ بولدى"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "بوغچا ئاتىنى كۆرسىتىپ بېرىڭ."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "دوكلاتقا يېڭىدىن خەتكۈش قوشۇڭ، كۆپ قېتىم بەلگىلەشكە بولىدۇ."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -271,17 +271,17 @@ msgstr ""
 "كۆرۈلگەن ئالامەتلەرنىڭ تىزىمىنى كۆرسىتىدۇ. (پەقەت يالغۇز ئارگۇمېنت "
 "بېرىلگەندىلا.)"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "خاتالىق دوكلاتىنى تولدۇرۇش ئۈچۈن كۆزنەكنى نىشان قىلىپ چېكىڭ"
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "كەمتۈك يېڭىلاش ھالىتىدە قوزغىتىش. --package دېگەن تاللانمىنى ئىشلىتىشكە "
 "بولىدۇ."
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -289,7 +289,7 @@ msgstr ""
 "ھادىسە ھەققىدە مەلۇمات تەييارلاڭ. (Implied if symptom name is given as only "
 "argument)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -297,7 +297,7 @@ msgstr ""
 "--file-bug ھالىتىدە بوغچا ئاتىنى كۆرسىتىڭ. ئەگەر --pid كۆرسىتىلگەن بولسا، "
 "بۇنى كۆرسەتمىسىمۇ بولىدۇ.(Implied if package name is given as only argument.)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -307,12 +307,12 @@ msgstr ""
 "كۆرسىتىلسە، كەمتۈك مەلۇماتىغا تېخىمۇ كۆپ ئۇچۇرلار قوشۇلىدۇ. (Implied if pid "
 "is given as only argument.)"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr ""
 "تەمىنلەنگەن pid بولسا بىر ئېسىلىپ قالغان(توختاپ قالغان) پروگرامما ئىكەن."
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -322,7 +322,7 @@ msgstr ""
 "apport ياكى .crash ھۆججىتىنى ئىشلىتىپ يوللاش(پەقەت ھۆججەت ئاتى ئارگۇمېنت "
 "شەكىلدە بېرىلگەندىلا.)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -331,126 +331,128 @@ msgstr ""
 "كەمتۈك يېزىش ھالىتىدە، توپلانغان ئۇچۇرلارنى مەلۇم قىلماي ھۆججەتكە ساقلاپ "
 "قويۇشقا، بۇ ھۆججەتنى كېيىن باشقا كومپيۇتېر ئارقىلىق يوللاشقىمۇ بولىدۇ."
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Apport نىڭ نەشر نومۇرىنى بېسىپ چىقىرىدۇ."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "crash نى تەكشۈرۈش ئۈچۈن apport-retrace تېرمىنال كۆزنىكىدە ئىجرا بولىدۇ."
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "gdb ئەڭگىمەسىنى ئىجرا قىلىش"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "سازلاش بەلگىلىرىنى چۈشۈرمەيلا gdb ئەڭگىمەسىنى ئىجرا قىلىش"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "%s نى تولۇق بەلگىلەر بىلەن يېڭىلاش"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr "دوكلات ھالىتى تەڭشىكىنى ئەۋەتىش ئۇنتۇلغان"
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 "ھادىسە مەلۇم قىلىش ھالىتىنى ساقلاش مەغلۇب بولدى. ئاپتوماتىك تەڭشىيەلمەيدۇ "
 "ياكى دوكلاتسىز قىلىش ھالىتىنى تەڭشىگىلى بولمايدۇ."
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr "دوكلات ھالىتى تەڭشىكىنى ئەۋەتىش ئۇنتۇلغان"
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr "بۇ دوكلات زادىلا ئورنىتىلىپ باقمىغان پروگراممىغا ئىشلىتىلىدۇ."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 msgstr "توقۇنۇشتا ئۆزگەرگەن پروگرامما %s تە خاتالىق كۆرۈلدى."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "بوغچا بۇزۇلغان بولغاچقا بىر تەرەپ قىلغىلى بولمىدى."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr "بۇ  قاچىلانمىغان ئورالما ھەققىدىكى دوكلات"
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr ""
 "بۇ مەسىلە ھەققىدىكى مەلۇماتنى بىر تەرەپ قىلاي دېگەندە  خاتالىق يۈز بەردى:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "بوغچا ياكى مەنبە كود بوغچىسىنىڭ نامىنى بېكىتكىلى بولمىدى."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "توركۆرگۈنى قوزغاتقىلى بولمىدى"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "%s نى كۆرىدىغان توركۆرگۈنى قوزغاتقىلى بولمىدى."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "توردىكى مەسىلە"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr "crash ساندىنىغا باغلىنالمىدى، ئىنتېرنېت باغلىنىشىنى تەكشۈرۈپ كۆرۈڭ."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "توردىكى مەسىلە"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "ئەسلەك يېتىشمىدى"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 "سىستېمىڭىزدا مەزكۇر crash مەلۇماتىنى بىر تەرەپ قىلىشقا يېتەرلىك ئەسلەك يوق."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -461,11 +463,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "مەسىلە ئاللىقاچان ئايدىڭلاشقان"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -475,38 +477,37 @@ msgstr ""
 "كۆرۈڭ، ئەگەر سىزنىڭ مەلۇماتىڭىزدا تېخىمۇ كۆپرەك ئۇچۇرلار بار بولسا "
 "ئىجادىيەتچىلەر ئۈچۈن تېخىمۇ پايدىلىق بولاتتى."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "مەسىلە ئىجادىيەتچىلەرگە مەلۇم قىلىندى. سىزگە تەشەككۈر!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "خالىغان كۇنۇپكىنى باسسىڭىز داۋاملىشىدۇ..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "نېمە قىلغۇڭىز بار؟ سىز تۆۋەندىكىلەرنى قىلالايسىز:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "تاللاڭ(%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i بايت)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(ئىككىلىك سانلىق-مەلۇمات)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "بۇ مەلۇماتنى ئىجادىيەتچىگە ئەۋەتسۇنمۇ؟"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -514,54 +515,54 @@ msgstr ""
 "مەلۇماتنى ئەۋەتىپ بولغاندىن كېيىن \n"
 "توركۆرگۈدە ئېچىلغان بەتتىكى جەدۋەلنى تولدۇرۇڭ."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "مەلۇمات (%s) نى ئەۋەت(&S)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "يەرلىكتە تەكشۈر(&E)"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "مەلۇمات كۆرسەت(&V)"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 "كېيىن يەنە باشقىلارغا ئەۋەتىش ياكى كۆچۈرۈپ بېرىش ئۈچۈن مەلۇمات ھۆججىتى "
 "ساقلاپ قوي(&K)"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr ""
 "پروگراممىنىڭ مەزكۇر نەشرىدە بۇنىڭدىن كېلىپ چىققان crashes نى ئەمەلدىن قالدۇر "
 "ياكى پىسەنت قىلما(&I)"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "ۋاز كەچ(&C)"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "مەلۇمات ھۆججىتى:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "جەزملە(&C)"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "خاتالىق: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "مەسىلىلەرگە ئائىت ئۇچۇرلارنى توپلاۋاتىدۇ"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -569,11 +570,11 @@ msgstr ""
 "ئىجادىيەتچىلەرنىڭ پروگراممىنى مۇكەممەللەشتۈرۈشى ئۈچۈن \n"
 "توپلانغان ئۇچۇرلارنى ئەۋەتىدۇ. بۇنىڭغا ئازراق ۋاقىت كېتىدۇ."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "مەسىلىلەر ھەققىدىكى ئۇچۇرلارنى يېڭىلاۋاتىدۇ"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -581,40 +582,40 @@ msgstr ""
 "توپلانغان ئۇچۇرلارنى كەمتۈك باشقۇرۇش سىستېمىسىغا ئەۋەتىدۇ.\n"
 "بۇنىڭغا ئازراق ۋاقىت كېتىدۇ."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "تامام(&D)"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "يوق"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "تاللانغىنى : %s. كوپنى تاللاش:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "تاللاشلار:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "ھۆججەتنىڭ يولى(بولدى قىلىش ئۈچۈن قايتۇرۇش كۇنۇپكىسىنى بېسىڭ):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "ھۆججەت مەۋجۇت ئەمەس."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "بۇ بىر مۇندەرىجە."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "داۋاملاشتۇرۇش ئۈچۈن تۆۋەندىكى URL نى كۆرۈشىڭىز كېرەك:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -622,17 +623,17 @@ msgstr ""
 "ئەمدى توركۆرگۈنى قوزغىتىڭ ياكى، URL نى باشقا كومپيۇتېردىكى توركۆرگۈگە "
 "كۆچۈرۈڭ."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "ھازىرلا توركۆرگۈنى قوزغىتىش"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 "تېخى بىر تەرەپ قىلىنمىغان crash ھەققىدىكى مەلۇمات يوق. --help نى ئىشلەتسىڭىز "
 "تېخىمۇ كوپ ئۇچۇرغا ئېرىشەلەيسىز."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr "بۇ يېڭى چىققانلىرىنى مەلۇماتقا يازماي stdout قا يازسۇن."
 
@@ -649,29 +650,29 @@ msgid ""
 "Write modified report to given file instead of changing the original report"
 msgstr "ئەسلىدىكى مەلۇماتقا يازماي كۆرسىتىلگەن ھۆججەتكە يازسۇن."
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 "stack ئىزلىشى قايتا ھاسىللانغاندىن كېيىن، غول تۆكمىنى(core dump) مەلۇماتتىن "
 "چىقىرىۋېتىش"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "دوكلاتنىڭ CoreFile نى قاپلاش"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "دوكلاتنىڭ ExecutablePath نى قاپلاش"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "دوكلاتنىڭ ProcMaps نى قاپلاش"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "دوكلاتنىڭ بوغچا ئۇچۇرىنى قايتا قۇرۇش"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -685,7 +686,7 @@ msgstr ""
 "سىستېما بەلگىلىمىسىڭىز، سىستېما سەپلىمىسىنى ئىشلىتىدۇ، شۇنىڭ بىلەن ئىجرا "
 "قىلىنىۋاتقان سىستېمىنى ھالاك قىلىدۇ."
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
@@ -695,30 +696,30 @@ msgstr ""
 "نەشىرىدىكى gdb ئارقىلىق gdb ۋە ئۇنىڭ بېقىنىشچانلىقىنى ئورنىتىش ئۈچۈن باشقا "
 "ۋاقىتلىق قۇم ساندۇقى ياساڭ."
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 "بوغچىلارنى قۇم خالتىسى ئىچىگە ئورناتقاندىكى چۈشۈرۈش/ئورنىتىش جەريانىنى مەلۇم "
 "قىلىش"
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr ""
 "ئۇچۇر خاتىرىلەشتىن بۇرۇن ۋاقىتنى خاتىرىلەڭ، بۇ قېتىملىق مەشغۇلاتنى "
 "تەمىنلەيدۇ."
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 "دوكلاتتا كۆرسىتىلگەن ئەسلى ئورۇندىن پايدىلىنىپ ئۈچىنچى تەرەپ خەزىنىسىنى "
 "ياسايدۇ ۋە ئىشلىتىدۇ."
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr "قۇم خالتىسى ئىچىگە چۈشۈرۈلگەن بوغچىلارنىڭ غەملەك مۇندەرىجىسى"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -726,14 +727,14 @@ msgstr ""
 "يېيىلمىغان بوغچىلارنىڭ مۇندەرىجىسى. كېيىن ئىجرا قىلىدىغان چاغدا، چۈشۈرۈلگەن "
 "بوغچىلار مۇشۇ يەرگە يېيىلىدۇ."
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 "قۇم خالتىسى ئىچىگە قوشۇمچە بوغچىنى ئورنىتىش(بىر قانچە قېتىم كۆرسىتىشكە "
 "بولىدۇ)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -744,7 +745,7 @@ msgstr ""
 "ئۇچۇرى ئۈچۈن ئىشلىتىلىدۇ. (ئىشلەتكۈچى -g, -o, ياكى -s نى بەلگىلىگەن "
 "بولمىسىلا)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -752,32 +753,32 @@ msgstr ""
 "قايتۇرغان ئىزلاش ئۇچۇرىنى كۆرسىتىدۇ ھەمدە يىمىرىلىش ساندىنىغا يوللاش "
 "يوللىماسلىقنى جەزملەشنى سورايدۇ."
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 "تەكرارلانغان sqlite ساندىنىنىڭ يولى.(كۆڭۈلدە تەكرارلىنىشنى تەكشۈرمەيدۇ)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr "دوكلاتقا StacktraceSource نى قوشماڭ."
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr ""
 "سىز -S نى بەلگىلىمەي تۇرۇپ -C تاللانمىنى ئىشلىتەلمەيسىز، توختىتىۋاتىدۇ."
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "بۇ قوشۇلما ھۆججەتلەرنى ئەۋەتسە بولامدۇ؟[y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -785,19 +786,19 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "نىشان مۇندەرىجە بار ھەم بوش ئەمەس."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "تېخىمۇ كۆپ تەپسىلاتنى man قوللانمىسىدىن كۆرۈڭ."
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "بۇ valgrind ھاسىل قىلىدىغان خاتىرە ھۆججىتىنىڭ ئىسمىنى بەلگىلەڭ."
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
@@ -805,7 +806,7 @@ msgstr ""
 "ئىلگىرى قۇرۇلغان sandbox مۇندەرىجىسى (SDIR) نى قايتا ئىشلىتىدۇ ياكى ئەگەر ئۇ "
 "مەۋجۇت بولمىسا، ئۇنى قۇرىدۇ"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -813,7 +814,7 @@ msgstr ""
 "قوشۇمچە سازلاش بەلگىسى ئۈچۈن sandbox مۇندەرىجىسىنى قۇرمايدۇ ياكى قايتا "
 "ئىشلەتمەيدۇ ئەمما پەقەت ئورنىتىلغان سازلاش بەلگىلىرىگە تايىنىدۇ."
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
@@ -821,23 +822,23 @@ msgstr ""
 "ئىلگىرى قۇرۇلغان غەملەك مۇندەرىجە (CDIR) نى قايتا ئىشلىتىدۇ ياكى ئەگەر "
 "مەۋجۇت بولمىسا ئۇنى قۇرىدۇ"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 "ئورنىتىش بوغچىسى sandbox قا كىرسە چۈشۈرۈش/ئورنىتىش جەريانىنى دوكلات قىلىدۇ"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "خاتالىق: %s نى ئىجرا قىلغىلى بولمايدۇ. توختىتىۋاتىدۇ."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -845,7 +846,7 @@ msgstr ""
 "بۇ ئالدىنقى قېتىملىق توڭدا(suspend) دە يۈز بەرگەن بولۇپ، سىستېمىنى نورمال "
 "داۋام قىلغىلى بولمىدى."
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -853,7 +854,7 @@ msgstr ""
 "بۇ ئالدىنقى قېتىملىق ئۈچەكتە(hibernation) دە يۈز بەرگەن بولۇپ، سىستېمىنى "
 "نورمال داۋام قىلغىلى بولمىدى."
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -861,7 +862,7 @@ msgstr ""
 "ئەسلىگە قايتۇرۇش باسقۇچى ئاخىرلىشاي دەپ قالدى، بۇنداق بولغاندا نورمال "
 "تاماملىنىدۇ."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 "سىستېمىڭىزنىڭ تۇراقسىز بولۇپ قېلىش ئېھتىماللىقى بار، قايتا قوزغىتىش "
@@ -877,77 +878,77 @@ msgstr "مەسىلىنى مەلۇم قىلىش..."
 msgid "Report a malfunction to the developers"
 msgstr "خاتالىقنى ئىجادىيەتچىگە مەلۇم قىلىدۇ"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "كەچۈرۈڭ، پروگرامما %s  تاسادىپىي توختاپ قالدى."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "كەچۈرۈڭ، %s تاسادىپىي تاقالدى."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "كەچۈرۈڭ، %s ئىچكى خاتالىققا يولۇقتى."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "يوللا"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "تەپسىلاتلارنى كۆرسەت"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "داۋاملاشتۇر"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "پروگرامما %s جاۋاب قايتۇرۇشتىن توختىدى."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "پروگرامما «%s» جاۋاب قايتۇرۇشتىن توختىدى."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "بوغچا: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "كەچۈرۈڭ، يۇمشاق دېتال ئورناتقاندا بىر خاتالىق كۆرۈلدى."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "پروگرامما %s نىڭدا بىر ئىچكى خاتالىق يۈز بەردى."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "بۇ %s ئەپ تاسادىپىي تاقالدى."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr ""
 "ئەگەر تېخىمۇ كۆپ مەسىلىنى بايقىسىڭىز، كومپيۇتېرنى قايتا قوزغىتىشنى سىناڭ."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "بۇ تۈردىكى كەلگۈسىدىكى مەسىلىگە سەل قاراش"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "تەپسىلاتلارنى يوشۇر"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -1003,7 +1004,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>مەسىلە ھەققىدىكى ئۇچۇرلارنى يۈكلەۋاتىدۇ</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -1015,27 +1016,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Apport چاتاق ھۆججىتى"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "تاقاق پېتى قالدۇر"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "قايتا ئىجرا قىل"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "ئىشلەتكۈچى ئاتى:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "ئىم:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "چاتاق ھەققىدىكى ئۇچۇرلارنى توپلاۋاتىدۇ"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1043,6 +1044,6 @@ msgstr ""
 "ئىجادىيەتچىنىڭ پروگرامما ئىقتىدارىنى ياخشىلىشىغا قۇلايلىق يارىتىش ئۈچۈن، "
 "توپلانغان ئۇچۇرلار ئىجادىيەتچىگە يوللىنىدۇ. بۇنىڭغا بىرقانچە مىنۇت كېتىدۇ."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "چاتاق ھەققىدىكى ئۇچۇرلارنى يۈكلەۋاتىدۇ"

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2023-02-21 12:31+0000\n"
 "Last-Translator: Volodymyr Shypovych <Unknown>\n"
 "Language-Team: Ukrainian <uk@li.org>\n"
@@ -40,11 +40,11 @@ msgstr ""
 "Будь ласка введіть свій пароль для отримання длступу до звіті системних "
 "програм"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "Здається, що цей пакунок встановлено невірно"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -55,7 +55,7 @@ msgstr ""
 "індексів доступних пакунків, якщо це не допоможе, вилучіть пов’язані "
 "сторонні пакунки та повторіть спробу."
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -68,21 +68,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "невідома програма"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "На жаль, програма \"%s\" несподівано закрилася"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Помилка у %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -90,65 +85,70 @@ msgstr ""
 "На вашому комп'ютері недостатньо вільної пам'яті для автоматичного аналізу "
 "проблеми та надсилання розробникам звіту."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Помилка у %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Неправильний звіт про помилку"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "Ви не маєте доступу до цього звіту."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Помилка"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "Недостатньо місця на диску для обробки цього звіту."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr "PID не вказано"
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 "Вам потрібно зазначити PID. Перегляньте --help для більш детальної інформації"
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "Неправильний PID"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr "Зазначеного ідентифікатора процесу не існує."
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr "Не ваш PID"
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr "Вказаний ідентифікатор процесу вам не належить."
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "Не вказано пакунок"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Необхідно вказати пакунок або PID. Наберіть --help для отримання додаткової "
 "інформації."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "У доступі відмовлено"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -156,30 +156,30 @@ msgstr ""
 "Зазначений процес Вам не належить. Будь ласка, запустіть програму як власник "
 "процесу або як root."
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "Зазначений процес ID не належить до програми."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "Симптоматичний скрипт %s не може визначити постраждалих пакунків"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Пакунку %s не існує"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "Неможливо створити звіт"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "Оновлення звіту про проблему"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -190,7 +190,7 @@ msgstr ""
 "існує, або вже закритий.\n"
 "Будь-ласка, створіть новий звіт за допомогою \"apport-bug\"."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -209,24 +209,24 @@ msgstr ""
 "\n"
 "Ви справді бажаєте продовжити?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "Не зібрано додаткової інформації."
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "Про яку проблему ви бажаєте повідомити?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Невідомий симптом"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Симптом «%s» не відомий"
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -245,7 +245,7 @@ msgstr ""
 "вкладці \"Процеси\" шукаєте потрібну Вам програму. ID процесу – це номер, "
 "вказаний у колонці ID."
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -253,30 +253,30 @@ msgstr ""
 "Після того, як сховаєте дане повідомлення, будь-ласка, клацніть на вікно "
 "програми для того, щоб відіслати звіт про помилку."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "Помилка xprop: не вдалося визначити ID процесу вікна"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "Вкажіть назву пакунку."
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "Додати додаткову мітку до звіту. Може бути задано декілька разів."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -286,16 +286,16 @@ msgstr ""
 "pid, або просто --pid. Якщо ні одного не вказано, показати список відомих "
 "симптомів. (Мається на увазі якщо задано один аргумент.)"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "Натисніть на цільове вікно для заповнення звіту про помилку."
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 "Запустити у режимі оновлення помилки. Може виконуватися з ключем --package."
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -303,7 +303,7 @@ msgstr ""
 "Відправити звіт про помилку з симптомом. (Мається на увазі, якщо ім'я "
 "симптому дано як єдиний аргумент.)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -311,7 +311,7 @@ msgstr ""
 "Вкажіть назву пакунку у режимі --file-bug. Необов’язково якщо вказано --pid. "
 "(Припустимо що назва пакунку вказана у якості єдиного аргументу)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -321,11 +321,11 @@ msgstr ""
 "про помилку міститиме більше інформації. (Мається на увазі, що вказано "
 "єдиний аргумент- pid.)"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "Вказаний ідентифікатор належить процесу, який не відповідає."
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -335,7 +335,7 @@ msgstr ""
 "замість файлів у черзі в %s. (За умови, що файл надано у якості єдиного "
 "параметру.)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -344,49 +344,49 @@ msgstr ""
 "У режимі збору помилок замість надсилати зібрану інформацію, збережіть її у "
 "файл. Цей файл можна буде відправити пізніше з іншого комп'ютера."
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "Надрукувати номер версії Apport ."
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 "Буде здійснено запуск «apport-retrace» у вікні терміналу для перевірки "
 "аварійного завершення роботи."
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "Запустити сеанс gdb"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "Запустити сеанс gdb, оминувши завантаження символів відлагодження"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "Оновити %s з повним відстеженням символьного стеку"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr "Неможливо запам'ятати параметри стану для надсилання звіту"
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 "Збереження стану звітування про аварію завершилося невдачею. Неможливо "
 "встановити режим звітування auto або never."
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr "Неможливо запам'ятати параметри стану для надсилання звіту"
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 "Цей звіт про помилку належить до програми, якої більше немає у системі."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
@@ -395,19 +395,21 @@ msgstr ""
 "Проблема у програмі %s, до якої були внесені зміни з моменту аварійного "
 "завершення її роботи."
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Цей звіт про помилку пошкоджено та не може бути оброблено."
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr "Цей звіт стосується пакунку, який не встановлено."
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "Сталася помилка при спробі обробки звіту:"
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
@@ -415,24 +417,24 @@ msgstr ""
 "У вас встановлено дві версії цього застосунку. Про помилку в якій з них ви "
 "волієте повідомити?"
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr "%s snap"
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr "%s пакунок deb"
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 "%s постачається в snap, оприлюднено від %s. Зв'яжіться через %s для "
 "отримання допомоги."
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -441,39 +443,39 @@ msgstr ""
 "%s постачається в snap, оприлюднено від %s. Контактної адреси не вказано; "
 "відвідайте форум https://forum.snapcraft.io/ для отримання допомоги."
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "Не вдалося визначити ім'я пакунку або ім'я пакунку з вихідним кодом."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "Неможливо запустити веб-переглядач"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Не вдається запустити веб-переглядач, щоб відкрити %s."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Проблема з мережею"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Не вдається під'єднатися до пошкодженої бази даних, будь ласка, перевірте "
 "з'єднання з мережею Інтернет."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Проблема з мережею"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Пам'ять вичерпано"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "У системі недостатньо пам'яті для обробки цього звіту про аварію."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -484,11 +486,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "Про помилку вже відомо"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -498,38 +500,37 @@ msgstr ""
 "ласка, перевірте, чи можете ви додати до нього іншу корисну інформацію, яка "
 "могла б допомогти розробникам."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "Про цю проблему розробникам вже відомо. Дякуємо!"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Натисніть будь-яку клавішу для продовження..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "Що ви бажаєте зробити? Варіанти вибору:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Будь ласка, виберіть (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i байт)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(двійкові дані)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Надіслати розробникам звіт про помилку?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -537,51 +538,51 @@ msgstr ""
 "Після того, як звіт буде відправлено, заповніть форму\n"
 "у вікні браузера, яке автоматично відкрилося."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "&Надіслати звіт (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "&Локальна перевірка"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "&Переглянути звіт"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 "&Зберегти файл звіту для подальшого відправлення або копіювання будь-куди"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "Скасувати та &ігнорувати майбутні аварії у цій версії програми"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Скасувати"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Файл звіту про помилку:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&Підтвердити"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Помилка: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "Збір інформації про помилку"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -589,11 +590,11 @@ msgstr ""
 "Зібрану інформацію може бути направлено розробникам\n"
 "для покращення програми. Це може зайняти декілька хвилин."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "Вивантаження даних щодо проблеми"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -601,40 +602,40 @@ msgstr ""
 "Зібрана інформація надсилається до системи відстежування помилок.\n"
 "Це може зайняти декілька хвилин."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "&Завершено"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "немає"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "Вибрано: %s. Декілька варіянтів:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Вибір:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "Шлях до файлу (Enter для скасування):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "Файлу не існує"
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "Це каталог."
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "Щоб продовжити, ви повинні пройти за адресою:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -642,17 +643,17 @@ msgstr ""
 "Ви можете запустити браузер зараз або скопіювати цю адресу у браузер на "
 "іншому комп'ютері."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Запустити браузер"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 "Немає звітів про аварії у очікуванні. Спробуйте --help для детальної "
 "інформації."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr "Не вкладайте нові записи у звіт, а долучайте їх до stdout."
 
@@ -670,27 +671,27 @@ msgid ""
 msgstr ""
 "Записати змінений звіт до вказаного файлу замість заміни оригінального звіту"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr "Зняти дамп зі звіту після трасування стеку регенерації"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "Перекрити звіти CoreFile"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "Перекрити звіти ExecutablePath"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "Перекрити звіти ProcMaps"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "Перебудувати звітовий пакунок інформації"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -707,7 +708,7 @@ msgstr ""
 "разі виявлення аварійних ситуацій, що виникли у випуску системи, яка працює "
 "на дану мить."
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
@@ -717,30 +718,30 @@ msgstr ""
 "використовуючи той же випуск, що і звіт, а не іншу версію gdb, яку ви "
 "встановили."
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 "Сповіщати про хід виконання завантаження/встановлення пакунків у тимчасовому "
 "середовищі"
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr ""
 "Додавати тимчасові мітки до повідомлень у журналі, для групових операцій"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 "Створення і використання сторонніх сховищ на основі початкових, вказаних у "
 "звітах"
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr ""
 "Тека для збереження пакунків, що заванатажуються у тимчасове середовище"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
@@ -748,14 +749,14 @@ msgstr ""
 "Каталог для розпакування пакунків. При наступних запусках усі вже "
 "завантажені пакунки будуть розпаковуватися у це ізольоване оточення."
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 "Встановити у тимчасове середовище додатковий пакунок (може встановлюватися "
 "декілька разів)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -765,7 +766,7 @@ msgstr ""
 "Використовується лише якщо вказано ID аварії для відсилання трасувань стеку "
 "(за умови, що ні -g, -o , ані -s не вказано)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -773,31 +774,31 @@ msgstr ""
 "Показати перетрасований стек та запитати підтвердження перед відправленням "
 "його у базу аварій."
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 "Шлях до дублікату бази даних sqlite (типово: немає дублікату для перевірки)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr "Не додавати StacktraceSource до звіту."
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "Неможна використовувати -C без -S. Зупинка."
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "Відіслати їх як вкладення? [так/ні]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr "%(prog)s <звіт> <цільова тека>"
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr "Файл звіту для розпакування"
 
@@ -805,19 +806,19 @@ msgstr "Файл звіту для розпакування"
 msgid "directory to unpack report to"
 msgstr "цільова тека для розпаковки звіту"
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "Каталог адресату існує і не є порожнім."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "Дивіться подробиці у man-сторінці."
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "вкажіть ім’я log-файлу для valgrind"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
@@ -825,7 +826,7 @@ msgstr ""
 "використовувати раніше створений каталог пісочниці (SDIR) або створити, якщо "
 "його не існує"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -834,7 +835,7 @@ msgstr ""
 "символів налагодження, а покладатися лише на встановлені символи "
 "налагодження."
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
@@ -842,24 +843,24 @@ msgstr ""
 "використовувати раніше створений каталог кешу (CDIR) або створити, якщо його "
 "не існує"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 "показувати поступ завантаження/встановлення під час встановлення пакунків у "
 "пісочницю"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "Помилка: %s — невиконуваний файл. Зупинка."
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
@@ -867,7 +868,7 @@ msgstr ""
 "Це сталося під час попереднього сеансу призупинення роботи і призвело до "
 "неможливості належного відновлення роботи системи."
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
@@ -875,7 +876,7 @@ msgstr ""
 "Це сталося під час попереднього сеансу присипляння і призвело до "
 "неможливості належного відновлення роботи системи."
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -883,7 +884,7 @@ msgstr ""
 "Обробка даних звіту зависла дуже близько до кінця і буде, як видається, "
 "завершена нормально."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 "Система може стати нестабільною, можливо буде потрібне перезавантаження."
@@ -898,76 +899,76 @@ msgstr "Повідомити про помилку..."
 msgid "Report a malfunction to the developers"
 msgstr "Звітувати про збій розробникам"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "Перепрошуємо, програма %s неочікувано зупинилася."
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "Вибачте, %s було несподівано завершено."
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "Вибачте, у %s сталася внутрішня помилка."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Надіслати"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "Показати подробиці"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Продовжити"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "Програма %s перестала відповідати."
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "Програма \"%s\" перестала відповідати."
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Пакунок: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "Вибачте, під час встановлення сталася помилка."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "У програмі %s сталася внутрішня помилка."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "Програма %s несподівано припинила роботу."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr "Якщо проблема з’явиться знову, спробуйте перезавантажити комп’ютер."
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "Ігнорувати такі проблеми у майбутньому"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "Сховати подробиці"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -1023,7 +1024,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>Передача інформації про помилку</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -1035,27 +1036,27 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Файл аварії Apport"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "Залишити закритим"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Перезапустити"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Ім'я користувача:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Пароль:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "Збір інформації про помилку"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
@@ -1063,6 +1064,6 @@ msgstr ""
 "Зібрані дані можна надіслати розробникам з метою покращення програми. Ви "
 "можете витратити на це декілька хвилин."
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "Вивантаження інформації про помилку"

--- a/po/uz.po
+++ b/po/uz.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2012-12-20 18:03+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Uzbek <uz@li.org>\n"
@@ -36,11 +36,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr ""
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -57,111 +57,111 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr ""
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr ""
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr ""
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
 msgstr ""
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr ""
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr ""
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr ""
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr ""
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr ""
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr ""
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr ""
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr ""
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 msgstr ""
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr ""
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr ""
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr ""
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr ""
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -169,7 +169,7 @@ msgid ""
 "Please create a new report using \"apport-bug\"."
 msgstr ""
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -181,24 +181,24 @@ msgid ""
 "Do you really want to proceed?"
 msgstr ""
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr ""
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr ""
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr ""
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr ""
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -209,202 +209,204 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr ""
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr ""
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr ""
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr ""
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
 "a single argument is given.)"
 msgstr ""
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr ""
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
 "ones in %s. (Implied if file is given as only argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr ""
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr ""
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr ""
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr ""
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr ""
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr ""
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr ""
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr ""
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr ""
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr ""
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr ""
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr ""
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr ""
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -412,161 +414,160 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr ""
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 msgstr ""
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr ""
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr ""
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr ""
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr ""
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr ""
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Тузувчиларга муаммо ҳақида хабар юборилсинми?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
 msgstr ""
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr ""
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr ""
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr ""
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr ""
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr ""
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr ""
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr ""
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr ""
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr ""
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr ""
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
 msgstr ""
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr ""
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
 msgstr ""
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr ""
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr ""
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr ""
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr ""
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr ""
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr ""
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr ""
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr ""
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
 msgstr ""
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr ""
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr ""
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr ""
 
@@ -581,27 +582,27 @@ msgid ""
 "Write modified report to given file instead of changing the original report"
 msgstr ""
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr ""
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr ""
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr ""
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr ""
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -611,78 +612,78 @@ msgid ""
 "be able to retrace crashes that happened on the currently running release."
 msgstr ""
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
 "have installed."
 msgstr ""
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr ""
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
 msgstr ""
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
 "neither -g, -o, nor -s are specified)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
 msgstr ""
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr ""
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr ""
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr ""
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -690,70 +691,70 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr ""
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
 msgstr ""
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 
@@ -767,76 +768,76 @@ msgstr ""
 msgid "Report a malfunction to the developers"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "%s'да ички хато рўй берди."
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "Юбориш"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "Давом этилсин"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "Пакет: %s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "Дастур ўрнатилганда муаммо рўй берди."
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "%s дастурида ички хато рўй берди."
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "%s дастури тўсатдан ёпилди."
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr ""
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr ""
 
@@ -890,7 +891,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr ""
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -900,32 +901,32 @@ msgstr ""
 msgid "Apport crash file"
 msgstr ""
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "Ёпилган қолдирилсин"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "Қайта ишга туширилсин"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr ""
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr ""
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr ""
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
 msgstr ""
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr ""

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2011-03-27 11:11+0000\n"
 "Last-Translator: Nguyễn Anh <Unknown>\n"
 "Language-Team: Vietnamese <vi@li.org>\n"
@@ -36,11 +36,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr ""
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -61,21 +61,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "chương trình không xác định"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "Xin lỗi, chương trình \"%s\" đã kết thúc bất ngờ"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "Vấn đề trong %s"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
@@ -83,63 +78,68 @@ msgstr ""
 "Máy tính của bạn không đủ bộ nhớ trống để tự động phân tích vấn đề và gửi "
 "báo cáo tới các nhà phát triển."
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "Vấn đề trong %s"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "Báo cáo vấn đề không hợp lệ"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "Bạn không được phép truy cập báo cáo vấn đề này."
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "Lỗi"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "Không đủ dung lượng đĩa để thực hiện báo cáo này."
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "PID không hợp lệ"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "Chưa gói nào được xác định"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr ""
 "Bạn cần xác định một gói hoặc một PID. Xem --help để biết thêm thông tin."
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "Không đủ quyền truy cập"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
@@ -147,31 +147,31 @@ msgstr ""
 "Tiến trình không phải của bạn. Vui lòng chạy chương trình với tài khoản của "
 "chủ tiến trình hoặc với tài khoản quản trị root"
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "ID của tiến trình không phải của một chương trình."
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr ""
 "Trình tìm triệu chứng %s không xác định được gói phần mềm đã bị ảnh hưởng"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "Gói %s không tồn tại"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "Không tạo được bản báo cáo"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "Cập nhật lại vấn đề đang báo cáo"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -182,7 +182,7 @@ msgstr ""
 "này đã bị báo trùng hoặc đã bị đóng.\n"
 "Hãy tạo một tạo một báo lỗi mới sử dụng \"apport-bug\"."
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -200,24 +200,24 @@ msgstr ""
 "lỗi\" và tạo một chú giải về vấn đề mà bạn báo.\n"
 "Bạn có thật sự muốn thực hiện?"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "Không có thêm thông tin đã được thu tập"
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "Bạn muốn báo cáo vấn đề loại nào?"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "Dấu hiệu không xác định"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "Không biết dấu hiệu \"%s\""
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -228,7 +228,7 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
@@ -236,30 +236,30 @@ msgstr ""
 "Sau khi đóng thông điệp này vui lòng nhấp vào một cửa sổ ứng dụng để báo cáo "
 "một vấn đề về nó."
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop không thể định số ID tiến trình của cửa sổ"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr ""
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "Thêm một thẻ cho báo cáo. Có thể thực hiện nhiều lần."
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -269,15 +269,15 @@ msgstr ""
 "chỉ là --pid. Nếu không cách nào trong hai cách trên được sử dụng, hiển thị "
 "danh sách những dấu hiệu đã biết. (Mặc định nếu một tham số được đưa ra.)"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr ""
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "Bắt đầu ở chế độ cập nhật lỗi. Có thể dùng tuỳ chọn --package."
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
@@ -285,7 +285,7 @@ msgstr ""
 "Đệ trình báo cáo lỗi về một triệu chứng. (Mặc định nếu tên triệu chứng là "
 "tham số duy nhất.)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -293,18 +293,18 @@ msgstr ""
 "Xác định tên gói trong chế độ --file-bug. Tùy chọn này nếu một --pid được "
 "xác định. (Mặc định nếu tên gói được đưa ra như là tham số duy nhất.)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
 "argument.)"
 msgstr ""
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr ""
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -313,129 +313,131 @@ msgstr ""
 "Báo cáo lỗi sử dụng các tệp .apport hoặc .crash thay vì sử dụng các tệp tạm "
 "trong %s. (Mặc định nếu tệp tin là tham số duy nhất.)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
 "machine."
 msgstr ""
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "In ra số phiên bản Trình báo lỗi"
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr ""
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr ""
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr ""
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr ""
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr "Báo cáo vấn đề này gắn với chương trình đã bị gỡ."
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 msgstr ""
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "Báo cáo vấn đề này bị hỏng và không thể được thực hiện"
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr ""
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr ""
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "Không thể xác định tên của gói hoặc gói nguồn."
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "Không thể bật trình duyệt web"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "Không thể bật trình duyệt web để mở %s."
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "Lỗi mạng"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr ""
 "Không thể kết nối tới cơ sở lỗi, vui lòng kiểm tra kết nối Internet của bạn."
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "Lỗi mạng"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "Hết bộ nhớ"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "Hệ thống của bạn không đủ bộ nhớ để thực hiện báo cáo lỗi này."
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -446,11 +448,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "Vấn đề đã biết"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -460,38 +462,37 @@ msgstr ""
 "lòng kiểm tra nếu bạn có thể thêm bất cứ thông tin gì có ích cho những người "
 "phát triển."
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr ""
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "Nhấn phím bất kì để tiếp tục..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "Bạn muốn làm gì? Các lựa chọn là:"
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "Vui lòng chọn (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i bytes)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(dữ liệu nhị phân)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "Gửi báo cáo vấn đề tới những người phát triển?"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -499,50 +500,50 @@ msgstr ""
 "Sau khi báo cáo về vấn đề được gửi, vui lòng điền vào mẫu trong trang\n"
 "web vừa tự động mở ra."
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "&Gửi báo cáo (%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr ""
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "&Xem báo cáo"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr "G&iữ tệp báo cáo để gửi sau hoặc sao chép"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "Hủy và bỏ &qua hỏng hóc của chương trình này những lần sau"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "&Thôi"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "Tệp báo cáo vấn đề:"
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "&Xác nhận"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "Lỗi: %s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "Thu thập thông tin về vấn đề"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -550,11 +551,11 @@ msgstr ""
 "Thông tin được thu thập có thể gửi tới những người phát triển để cải tiến\n"
 "ứng dụng. Công việc này có thể mất vài phút."
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "Tải lên thông tin về vấn đề"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -562,40 +563,40 @@ msgstr ""
 "Thông tin thu thập đang được gửi tới hệ thống kiểm duyệt lỗi.\n"
 "Côn việc này có thể mất vài phút."
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "Đã &xong"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "không"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "Đã chọn: %s. Nhiều lựa chọn:"
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "Các lựa chọn:"
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "Đường đẫn tới tệp (Enter để hủy):"
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "Tệp không tồn tại."
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "Nó là một thư mục"
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "Để tiếp tục, bạn phải vào địa chỉ URL sau:"
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
@@ -603,15 +604,15 @@ msgstr ""
 "Giờ bạn có thể chạy một trình duyệt, hoặc chép địa chỉ URL này vào một trình "
 "duyệt hoặc máy tính khác."
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "Chạy một trình duyệt"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr "Không có báo cáo lỗi nào đang chờ. Thử --help để biết thêm thông tin."
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr "Không đưa dấu vết mới vào báo cáo, nhưng in chúng ra stdout."
 
@@ -628,29 +629,29 @@ msgid ""
 "Write modified report to given file instead of changing the original report"
 msgstr "Ghi báo cáo đã sửa đổi tới tệp đưa ra thay vì thay đổi báo cáo gốc"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr ""
 "Xóa các thông tin lưu lại được khi chương trình gặp lỗi khỏi báo cáo sau khi "
 "đã ghi lại vết của ngăn xếp."
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "Ghi đè CoreFile của báo cáo"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "Ghi đè ExecutablePath của báo cáo"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "Ghi đè ProcMaps của báo cáo"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "Tạo lại thông tin gói của báo cáo"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -660,42 +661,42 @@ msgid ""
 "be able to retrace crashes that happened on the currently running release."
 msgstr ""
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
 "have installed."
 msgstr ""
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr ""
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr ""
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
 msgstr ""
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr ""
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -705,7 +706,7 @@ msgstr ""
 "Múc đích là tạo ra một ID để tải lên những dấu vết đã theo (chỉ khi nào "
 "không dùng -g, -o hoặc -s)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
@@ -713,31 +714,31 @@ msgstr ""
 "Hiển thị ngăn xếp dấu vết dò lại được và yêu cầu xác nhận trước khi gửi "
 "chúng tới cơ sở dữ liệu lỗi."
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr ""
 "Đường dẫn tới bản sao cơ sở dữ liệu sqlite (mặc định: không kiểm tra bản sao)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr ""
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr ""
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "Đồng ý gửi chúng như những đính kèm? [y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -745,64 +746,64 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "Thư mục đích tồn tại và không rỗng."
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr ""
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
@@ -810,7 +811,7 @@ msgstr ""
 "Quá trình khôi phục bị dừng khi sắp kết thúc và sẽ xuất hiện để hoàn thành "
 "bình thường."
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr ""
 "Hệ thống của bạn có thể trở nên không ổn định bây giờ và cần khởi động lại."
@@ -825,76 +826,76 @@ msgstr "Báo cáo một vấn đề..."
 msgid "Report a malfunction to the developers"
 msgstr "Báo cáo một trục trặc tới nhà phát triển"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr ""
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr ""
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr ""
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr ""
 
@@ -950,7 +951,7 @@ msgstr ""
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>Tải lên thông tin về vấn đề</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -962,32 +963,32 @@ msgstr ""
 msgid "Apport crash file"
 msgstr "Báo cáo tệp lỗi"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr ""
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr ""
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "Tài khoản:"
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "Mật khẩu:"
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr ""
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
 msgstr ""
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr ""

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2022-10-10 02:46+0000\n"
 "Last-Translator: Luke Luo <Unknown>\n"
 "Language-Team: Chinese (China) <zh_CN@li.org>\n"
@@ -36,11 +36,11 @@ msgstr "系统问题报告"
 msgid "Please enter your password to access problem reports of system programs"
 msgstr "请输入您的密码以查看系统程序问题报告。"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "该软件包似乎没有被正确安装"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -50,7 +50,7 @@ msgstr ""
 "%s 软件包似乎不是官方版本。请在更新可用包索引后重试，如果仍然不能工作，请移除"
 "这些第三方软件包后再试。"
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -62,111 +62,111 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "未知程序"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "对不起，%s 程序异常退出"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "%s 中的问题"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
 msgstr "您的计算机剩余空间不足，程序无法自动诊断问题并向开发者发送问题报告。"
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "%s 中的问题"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "无效的问题报告"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "您没有访问这个问题报告的权限。"
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "错误"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "没有足够的磁盘空间来处理报告。"
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr "没有指定 PID"
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr "你需要指定一个 PID。获取更多信息请使用 --help 参数。"
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "无效的 PID"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr "指定的进程ID不存在。"
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr "不是您的 PID"
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr "这个指定的进程 ID 不属于您。"
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "没有指定软件包"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr "您需要指定一个软件包或者 PID。使用 --help 选项来获取更多信息。"
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "拒绝访问"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 msgstr "指定的进程只能以进程的所有者或 root 身份运行。"
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "指定的进程 ID 不属于一个程序。"
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "症状脚本 %s 没有划定受影响的包"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "软件包 %s 不存在"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "无法创建报告"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "更新问题报告"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -176,7 +176,7 @@ msgstr ""
 "您不是该问题报告的报告者或订阅者，或者该报告被视为重复或已经关闭。\n"
 "请使用 apport-bug 新建一份报告。"
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -193,24 +193,24 @@ msgstr ""
 "的报告进行评论。\n"
 "您确定要继续么？"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "未收集更多信息。"
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "您想报告什么类型的问题？"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "未知症状"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "症状 %s 未知。"
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -227,36 +227,36 @@ msgstr ""
 "可以通过运行System Monitor应用程序找到进程ID。在Processes选项卡中，滚动直到找"
 "到正确的应用程序。进程ID是ID列中列出的编号。"
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr "在关闭这个消息只后，请点击要报告问题的程序窗口。"
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop 无法确定窗口的进程 ID"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "请指定包的名称。"
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "向报告中添加额外的标记，可多次指定。"
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -265,21 +265,21 @@ msgstr ""
 "以填写 bug 模式启动。需要 --package 和可选的 --pid 参数，或单独使用 --pid 参"
 "数。如果二者均未给出，将显示一系列症状供选择。"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "点击一个窗口作为提交问题报告的目标。"
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "启动错误更新模式。可以使用选项 --package 来指定软件包。"
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr "针对某个症状报告 bug。"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -287,7 +287,7 @@ msgstr ""
 "--file-bug 模式中指定软件包名。如果指定了 --pid，则是可选的。(如果只给定软件"
 "包名这一个参数则为必需。)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -296,11 +296,11 @@ msgstr ""
 "在 --file-bug 模式中指定运行的程序。如果指定，该问题报告将包含更多的信息。(默"
 "认指定 pid 作为唯一参数。)"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "此进程号的程序是挂起的。"
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -309,7 +309,7 @@ msgstr ""
 "从给定的 .apport 或者  .crash 文件，而不是从正在处理的 %s 中汇报崩溃。(如果文"
 "件只给定了参数时实现。)"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -318,84 +318,86 @@ msgstr ""
 "在提交报告过程中，将收集到的信息保存到要报告的文件中。该文件可用于稍后在另一"
 "台机器上提交。"
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "输出 Apport 版本号"
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr "这将在终端窗口中启动 apport-retrace，以检查此崩溃。"
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "运行 gdb 会话"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "不下载调试符号的情况下运行 gdb 会话"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "利用全符号的堆栈跟踪更新 %s"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr "无法记取发送报告的状态设置"
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr "保存崩溃报告状态失败， 无法设置自动或永不报告模式。"
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr "无法记取发送报告的状态设置"
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr "这一问题报告适用于不再安装的程序。"
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 msgstr "自崩溃发生起已更改的程序 %s 出现问题。"
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "该问题报告已损坏，无法处理。"
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr "这份报告是关于未安装软件包的信息。"
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "尝试处理此问题报告时出现错误："
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr "您安装了该应用程序的两个版本，您希望针对哪个版本报告错误？"
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr "%s snap"
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr "%s deb 软件包"
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr "%s是由snap提供%s发布的软件。通过%s联系他们以获得帮助。"
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -404,37 +406,37 @@ msgstr ""
 "%s 是 %s 提供的一个 Snap，但没有提供联系地址。请访问 https://forum.snapcraft."
 "io 以寻求帮助。"
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "无法检测包或者源码包的名称。"
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "无法打开浏览器"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "无法使用浏览器打开网页 %s"
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "网络问题"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr "无法连接到崩溃数据库，请检查您的 Internet 连接。"
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "网络问题"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "内存耗尽"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "您的系统没有足够的内存来处理此崩溃报告。"
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -445,49 +447,48 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "该问题为已知问题"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
 "helpful for the developers."
 msgstr "关于这个问题，之前已经有如网页所示的报告。您是否有所补充？"
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "已将此问题报告给开发人员。谢谢！"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "按任意键继续…"
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "您想做什么？您的选择是："
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "请选择(%s)："
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i 字节)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "(二进制数据)"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "要向开发者发送问题报告吗？"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -495,50 +496,50 @@ msgstr ""
 "当问题报告被发出之后，请填写\n"
 "自动弹出窗口的表格。"
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "发送报告(&S)(%s)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "本地检查(&E)"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "查看报告(&V)"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr "保存报告文件以便稍后发送或者复制到其他地方(&K)"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "终止并忽略这个版本软件以后出现的崩溃(&I)"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "取消(&C)"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "问题报告文件："
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "确认(&C)"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "错误：%s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "正在收集问题信息"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -546,11 +547,11 @@ msgstr ""
 "收集到的信息将会传送到开发人员处以改进软件。\n"
 "这可能会花费几分钟时间，"
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "上传问题信息"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -558,54 +559,54 @@ msgstr ""
 "收集到的信息正在被发送到错误跟踪系统。\n"
 "这可能要花费几分钟时间。"
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "完成(&D)"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "无"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "已选择：%s。 多重选择："
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "选择："
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "文件的路径(回车取消)："
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "文件不存在。"
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "这是一个目录。"
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "要继续，您必须访问下面这个网址："
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
 msgstr "您现在可以启动一个浏览器，或者复制这个网址到另外一个电脑的浏览器。"
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "现在启动一个浏览器"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr "没有已知的崩溃报告，尝试 --help 以获得更多信息。"
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr "不把新的痕迹写入到报告，但是把它们写入到标准输出。"
 
@@ -620,27 +621,27 @@ msgid ""
 "Write modified report to given file instead of changing the original report"
 msgstr "将更改过的报告写入指定文件而非改变原始报告"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr "生成栈回溯后将内核转储从报告中删除"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "覆盖报告核心文件"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "覆盖报告执行路径"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "覆盖报告的进程表"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "重建报告的包信息"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -654,7 +655,7 @@ msgstr ""
 "定 \"system\"，则其将使用系统配置文件，但之后，其将只能够追溯当前正在运行的版"
 "本上发生的崩溃。"
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
@@ -663,35 +664,35 @@ msgstr ""
 "生成另一个临时沙盒，在其中安装报告所述版本的 gdb 和它的依赖项，而不使用您现有"
 "版本的 gdb。"
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr "在将软件包安装到沙盒中时，报告下载和安装的进度"
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr "为进行批量操作，请预先设置时间戳，以记录消息"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr "根据报告中指定的来源创建并使用第三方软件仓库"
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr "下载到沙盒中软件包的缓存目录"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
 msgstr "用于解压包目录。以后运行将假设任何已下载的包被提取到这个沙盒。"
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr "将其他软件包安装到沙盒(可多次加以指定)中"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -700,36 +701,36 @@ msgstr ""
 "包含崩溃数据库访问信息文件之路径。此项将用于为特定崩溃代码上传堆栈的回溯调试"
 "信息(除非用户指定 -g, -o 或 -s)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
 msgstr "显示返回的堆栈信息，并询求确认是否将其发送至崩溃数据库。"
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr "SQLite 数据库路径重复(默认：不重复检查)"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr "不要将 StacktraceSource 附加到报告中。"
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "您不能在未指定 -S 选项的情况下使用 -C 选项，停止。"
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "确定以附件形式发送这些？[y/n]"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr "要解压的报告文件"
 
@@ -737,70 +738,70 @@ msgstr "要解压的报告文件"
 msgid "directory to unpack report to"
 msgstr "存放解压后报告的文件夹"
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "目标目录存在且不为空。"
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "更多细节请查看 man 手册。"
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "请指定 valgrind 生成的日志文件名"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
 msgstr "重复使用以前创建的缓存目录 (SDIR) ，或者，如果它不存在，则创建它"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
 msgstr "不创建或重用额外的调试符号的沙箱目录，仅依靠安装调试符号。"
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
 msgstr "重复使用以前创建的缓存目录(CDIR)，或者，如果它不存在，则创建它"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr "安装包进入沙盒时报告下载/安装进度"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "错误：%s 不是可执行文件，停止。"
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr "发生于之前的挂起时，并且使系统午饭正常恢复。"
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr "发生于之前的休眠时，并且使系统午饭正常恢复。"
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
 msgstr "这个恢复过程已经非常接近尾声，将正常结束。"
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr "您的系统现在可能变得不稳定，可能需要重新启动。"
 
@@ -814,76 +815,76 @@ msgstr "提交一份问题报告…"
 msgid "Report a malfunction to the developers"
 msgstr "向开发者报告一个故障"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "对不起，应用程序 %s 意外停止。"
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "对不起，%s 已意外关闭。"
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "对不起，%s 出现了内部错误。"
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "发送"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "显示详细信息"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "继续"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "应用程序 %s 停止响应。"
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "程序 %s 停止响应。"
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "软件包：%s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "对不起，安装软件时出现问题。"
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "应用程序 %s 发生内部错误。"
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "应用程序 %s 已意外关闭。"
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr "如果您注意到更多问题，请尝试重新启动计算机。"
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "以后忽略此类错误"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "隐藏详细信息"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -937,7 +938,7 @@ msgstr "正在收集信息，这些信息将会帮助开发人员修复您报告
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>正在上传问题信息</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -947,32 +948,32 @@ msgstr "所收集的信息正在发送到缺陷跟踪系统。这可能需要几
 msgid "Apport crash file"
 msgstr "Apport 崩溃文件"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "保持关闭状态"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "重新启动程序"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "用户名："
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "密码："
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "正在收集问题信息"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
 msgstr "收集到的信息可以发送给开发者来改进程序。这可能要花费几分钟的时间。"
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "上传问题信息"

--- a/po/zh_HK.po
+++ b/po/zh_HK.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2012-10-09 16:49+0000\n"
 "Last-Translator: Roy Chan <roy.chan@linux.org.hk>\n"
 "Language-Team: Chinese (Hong Kong) <zh_HK@li.org>\n"
@@ -36,11 +36,11 @@ msgstr ""
 msgid "Please enter your password to access problem reports of system programs"
 msgstr ""
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "這個套件似乎尚未正確安裝"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -60,111 +60,111 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "不明的程式"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "對不起，該程式 \"%s\" 不正常起關閉了"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "於 %s 中的問題"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
 msgstr "你的電腦沒有足夠的記憶體以自動分析問題並把問題回報至開發者。"
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "於 %s 中的問題"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "不存在的問題報告"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "你沒有權限去存取這個報告。"
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "錯誤"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "你沒有足夠的硬碟空間去處理這個報告。"
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr ""
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr ""
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "無效的進程ID"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr ""
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr ""
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr ""
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "沒有指定軟件包"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr "你必須指定一個軟件包或進程ID。請輸入 --help 獲得更多資訊。"
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "動作不被許可"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 msgstr "被指定的程序並不屬於你的。請以其擁有者身份或管理員身份運行。"
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "指定的進程ID並不屬於一個程式。"
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "問題判斷指令 %s 無法辨認受影響的套件"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "軟件包 %s 不存在"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "不能創建報告"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "正在更新問題報告"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -175,7 +175,7 @@ msgstr ""
 "\n"
 "請使用「apport-bug」來建立一份新的問題回報。"
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -194,24 +194,24 @@ msgstr ""
 "\n"
 "您真的想要繼續嗎？"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "沒有收集到額外的資訊。"
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "您想回報哪種問題？"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "未知的症狀"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "症狀 %s 未知。"
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -222,36 +222,36 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr "在關閉本訊息後，請點擊應用程式視窗來回報有關它的訊息。"
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop 無法得知該視窗的程序 ID"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "指定套件名稱"
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "加入額外標籤至回報中。可以多次分別指定。"
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -260,21 +260,21 @@ msgstr ""
 "啟動為錯誤歸檔模式。需要 --packages 和一個可選擇的 --pid，或是只需 --pid。若"
 "兩者都未給予，顯示一份已知症狀的列表。（暗示若只有給予單一參數。）"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "請點擊要作為問題報告目標發送的視窗。"
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "加上 --package 指令以啟動軟體錯誤更新模式。"
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr "建立一份關於症狀的錯誤報告。（暗示若症狀名稱是唯一給予的參數。）"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -282,7 +282,7 @@ msgstr ""
 "在 --file-bug 模式中指定套件名稱。若指定 --pid 則是可選擇的。（暗示若套件名稱"
 "是唯一給予的參數。）"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -291,11 +291,11 @@ msgstr ""
 "在 --file-bug 模式中指定一個正在執行中的程式。如果有指定，該臭蟲回報將包含更"
 "多資訊。(表示是否只要提供 pid 為引數。)"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "提供的 pid 是懸凍的應用程式。"
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -304,7 +304,7 @@ msgstr ""
 "從特定的 .apport 或 .crash 檔案來回報當機，代替等待中的 %s。（暗示若特定檔案"
 "是唯一給予的參數。）"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -313,121 +313,123 @@ msgstr ""
 "在臭蟲歸檔模式中，收集的資訊將儲存在檔案中而不是將它回報。這個檔案可以稍後從"
 "不同機器回報。"
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "列印 Apport 版本號。"
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr "這會在終端機視窗中啟動 apport-retrace 以檢查程式當掉原因。"
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "執行 gdb 作業階段"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "執行 gdb 作業階段而不下載除錯符號"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "以完整的符號堆疊追蹤來更新 %s"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr ""
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr ""
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr "此問題報告用於不再安裝的程式。"
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 msgstr "發生問題的程式 %s 自上次遭遇當掉之後已有變動。"
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "這個問題報告已損壞並不能繼續處理。"
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr ""
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "試圖處理問題回報時遭遇錯誤："
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr ""
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr ""
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "無法確定套件或原始碼套件名稱。"
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "無法啟動網頁瀏覽器"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "無法以網頁瀏覽器開啟 %s。"
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "網絡問題"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr "無法連線至系統崩潰資料庫，請檢查您的網絡連線。"
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "網絡問題"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "記憶體耗盡"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "您的系統沒有足夠的記憶體來處理此份當機報告。"
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -438,11 +440,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "問題已發現"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -451,38 +453,37 @@ msgstr ""
 "此問題在網頁瀏覽器上顯示的錯誤報告中已經回報，請檢查您是否能提供更多可能對開"
 "發者有用的進一步資訊。"
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "此問題已經回報給開發者。感謝您！"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "按下任何鍵繼續…"
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "你想做什麼？你的選擇是："
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "請選擇(%s)："
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i 位元組)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "（二進制數據）"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "是否要傳送問題報告給程式開發者？"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -490,50 +491,50 @@ msgstr ""
 "在報告送出之後，請填妥於\n"
 "自動開啟的瀏覽器中的表格。"
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "傳送報告（%s） (&S)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "於本地端檢查(&E)"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "檢視報告 (&V)"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr "保留回報檔稍候傳送或複製至其他地點 (&K)"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "取消及忽略未來此程式版本的當機 (&I)"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "取消 (&C)"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "問題回報檔："
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "確認 (&C)"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "錯誤：%s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "正在收集問題資訊"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -541,11 +542,11 @@ msgstr ""
 "已收集的資訊可傳送給程式開發者以改進此\n"
 "應用程式。這可能需要幾分鐘。"
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "正在上載問題資訊"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -553,54 +554,54 @@ msgstr ""
 "已收集的資訊將被傳送至錯誤追蹤系統。\n"
 "這可能需要數分鐘。"
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "完成 (&D)"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "無"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "已選擇：%s。多種選擇："
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "選項："
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "檔案路徑（按下 Enter 取消）："
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "檔案不存在。"
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "這是一個目錄。"
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "如要繼續，您必須造訪以下網址："
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
 msgstr "您現在可以啟動瀏覽器，或複製此網址到另一台電腦的瀏覽器中。"
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "現在啟動瀏覽器"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr "無等待中的當機報告。輸入 --help 以獲得更多資訊。"
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr "不要將新的錯誤追溯放在報告中，只把參數寫入。"
 
@@ -615,27 +616,27 @@ msgid ""
 "Write modified report to given file instead of changing the original report"
 msgstr "寫入經修改的報告到特定的檔案來替代改變原來的報告"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr "在堆疊追溯重新產生後從報告中移除核心傾印"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "蓋報告的核心檔案"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "覆蓋報告的可執行路徑"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "覆蓋報告的行程對映（ProcMaps）"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "重建報告的套件資訊"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -649,42 +650,42 @@ msgstr ""
 "您有指定「system」(系統) 的話，它會使用系統組態檔，但是接著只能回追發生於目前"
 "執行中發行版的當掉情形。"
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
 "have installed."
 msgstr ""
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr "當套件安裝至沙箱時回報下載/安裝進度"
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr "在記錄訊息前加上時間戳記，供批次操作"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr ""
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr "為下載於沙箱內的套件製作目錄快取"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
 msgstr "解包套件的目錄。未來執行時將假定任何已下載的套件也都抽出於此沙盒中。"
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr "安裝額外套件至沙箱內 (可以指定多次)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -693,36 +694,36 @@ msgstr ""
 "有當機資料庫認證資訊的檔案路徑。在指定某個當機 ID 來上傳重新追蹤的堆疊追蹤時"
 "可使用 (只有在 -g、-o 或 -s 都沒有被指定)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
 msgstr "顯示重新追蹤的堆疊追蹤，並在送出它們到當機資料庫之前先請求確認。"
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr "重複的 sqlite 資料庫路徑（預設：無重複檢查）"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr ""
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr ""
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "允許傳送這些附件？"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -730,70 +731,70 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "目的目錄存在且不是空的。"
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
 msgstr ""
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr ""
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr ""
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
 msgstr "回復行程在非常接近結束的時候停止回應，但系統仍將會繼續正常運行。"
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr "您的系統現在也許會不穩定且需要重新啟動。"
 
@@ -807,76 +808,76 @@ msgstr "報告問題..."
 msgid "Report a malfunction to the developers"
 msgstr "報告問題予開發者"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "很抱歉，應用程式 %s 已無預期停止。"
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "非常抱歉，%s 已無預警關閉。"
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "非常抱歉， %s 遭遇內部錯誤。"
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "傳送"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "顯示詳細資料"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "繼續"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "應用程式 %s 已停止回應。"
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "程式「%s」已停止回應。"
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "套件：%s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "非常抱歉，於安裝軟件時遭遇問題。"
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "應用程式 %s 已遭遇某內部錯誤。"
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "應用程式 %s 已無預警關閉。"
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr "若您之後仍發現問題，請嘗試重新啟動電腦。"
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "忽略未來發生的此類型問題"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "隱藏詳細資料"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -930,7 +931,7 @@ msgstr "正在收集資訊以幫助程式開發者修正在你報告中的問題
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>正在上傳問題資訊</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -940,32 +941,32 @@ msgstr "正在把收集到的資訊傳送至錯誤追蹤系統。可能會花上
 msgid "Apport crash file"
 msgstr "Apport 當機檔案"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "維持關閉"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "重新啟動"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "使用者名稱："
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "密碼："
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "正在收集問題資訊"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
 msgstr "收集之資訊會傳送給開發者以改善該應用程式。可能會花數分鐘。"
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "正在上傳問題資訊"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-12 17:42+0200\n"
+"POT-Creation-Date: 2023-07-21 16:31+0200\n"
 "PO-Revision-Date: 2019-08-13 14:40+0000\n"
 "Last-Translator: Cheng-Chia Tseng <pswo10680@gmail.com>\n"
 "Language-Team: Chinese (Taiwan) <zh_TW@li.org>\n"
@@ -36,11 +36,11 @@ msgstr "系統問題報告"
 msgid "Please enter your password to access problem reports of system programs"
 msgstr "請輸入密碼以存取系統程式的問題報告"
 
-#: ../apport/ui.py:263
+#: ../apport/ui.py:259
 msgid "This package does not seem to be installed correctly"
 msgstr "這個軟體包似乎尚未正確安裝"
 
-#: ../apport/ui.py:273
+#: ../apport/ui.py:269
 #, python-format
 msgid ""
 "This does not seem to be an official %s package. Please retry after updating "
@@ -48,7 +48,7 @@ msgid ""
 "third party packages and try again."
 msgstr ""
 
-#: ../apport/ui.py:303
+#: ../apport/ui.py:299
 #, python-format
 msgid ""
 "You have some obsolete package versions installed. Please upgrade the "
@@ -60,111 +60,111 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:466
+#: ../apport/ui.py:471
 msgid "unknown program"
 msgstr "未知程式"
 
-#: ../apport/ui.py:469
+#: ../apport/ui.py:473
 #, python-format
 msgid "Sorry, the program \"%s\" closed unexpectedly"
 msgstr "對不起，\"%s\" 程式已不正常關閉"
 
-#: ../apport/ui.py:472 ../apport/ui.py:1987
-#, python-format
-msgid "Problem in %s"
-msgstr "在 %s 中的問題"
-
-#: ../apport/ui.py:477
+#: ../apport/ui.py:475
 msgid ""
 "Your computer does not have enough free memory to automatically analyze the "
 "problem and send a report to the developers."
 msgstr "閣下電腦無足夠可用記憶體供自動分析問題並向開發者傳送報告。"
 
-#: ../apport/ui.py:537 ../apport/ui.py:555 ../apport/ui.py:728
-#: ../apport/ui.py:737 ../apport/ui.py:974 ../apport/ui.py:1783
-#: ../apport/ui.py:1948 ../apport/ui.py:1953
+#: ../apport/ui.py:480 ../apport/ui.py:1909
+#, python-format
+msgid "Problem in %s"
+msgstr "在 %s 中的問題"
+
+#: ../apport/ui.py:536 ../apport/ui.py:553 ../apport/ui.py:719
+#: ../apport/ui.py:725 ../apport/ui.py:955 ../apport/ui.py:1723
+#: ../apport/ui.py:1877 ../apport/ui.py:1883
 msgid "Invalid problem report"
 msgstr "無效的問題回報"
 
-#: ../apport/ui.py:538
+#: ../apport/ui.py:537
 msgid "You are not allowed to access this problem report."
 msgstr "您無權存取此問題報告。"
 
-#: ../apport/ui.py:546
+#: ../apport/ui.py:545
 msgid "Error"
 msgstr "錯誤"
 
-#: ../apport/ui.py:548
+#: ../apport/ui.py:547
 msgid "There is not enough disk space available to process this report."
 msgstr "無足夠磁碟空間處理此報告。"
 
-#: ../apport/ui.py:586
+#: ../apport/ui.py:583
 msgid "No PID specified"
 msgstr "沒有指定 PID"
 
-#: ../apport/ui.py:588
+#: ../apport/ui.py:584
 msgid "You need to specify a PID. See --help for more information."
 msgstr "您需要指定一個 PID。更多說明請見 --help。"
 
-#: ../apport/ui.py:599 ../apport/ui.py:704
+#: ../apport/ui.py:593 ../apport/ui.py:698
 msgid "Invalid PID"
 msgstr "PID 無效"
 
-#: ../apport/ui.py:600
+#: ../apport/ui.py:593
 msgid "The specified process ID does not exist."
 msgstr "指定的程序 ID 不存在。"
 
-#: ../apport/ui.py:605
+#: ../apport/ui.py:598
 msgid "Not your PID"
 msgstr "不是您的 PID"
 
-#: ../apport/ui.py:606
+#: ../apport/ui.py:599
 msgid "The specified process ID does not belong to you."
 msgstr "指定的程序 ID 不屬於您。"
 
-#: ../apport/ui.py:661
+#: ../apport/ui.py:656
 msgid "No package specified"
 msgstr "未指定軟體包"
 
-#: ../apport/ui.py:663
+#: ../apport/ui.py:658
 msgid ""
 "You need to specify a package or a PID. See --help for more information."
 msgstr "您要指定軟體包或 PID。更多資訊請見 --help。"
 
-#: ../apport/ui.py:691
+#: ../apport/ui.py:685
 msgid "Permission denied"
 msgstr "權限不足"
 
-#: ../apport/ui.py:693
+#: ../apport/ui.py:687
 msgid ""
 "The specified process does not belong to you. Please run this program as the "
 "process owner or as root."
 msgstr "指定的程序並不屬於您。請以程序擁有者或是 root 身份執行此程式。"
 
-#: ../apport/ui.py:706
+#: ../apport/ui.py:699
 msgid "The specified process ID does not belong to a program."
 msgstr "指定的程序 ID 並不屬於程式。"
 
-#: ../apport/ui.py:730
+#: ../apport/ui.py:720
 #, python-format
 msgid "Symptom script %s did not determine an affected package"
 msgstr "徵狀判斷指令稿 %s 無法判斷出受影響的軟體包"
 
-#: ../apport/ui.py:738
+#: ../apport/ui.py:726
 #, python-format
 msgid "Package %s does not exist"
 msgstr "%s 軟體包不存在"
 
-#: ../apport/ui.py:767 ../apport/ui.py:979 ../apport/ui.py:1012
-#: ../apport/ui.py:1022
+#: ../apport/ui.py:755 ../apport/ui.py:960 ../apport/ui.py:993
+#: ../apport/ui.py:1000
 msgid "Cannot create report"
 msgstr "無法建立報告"
 
-#: ../apport/ui.py:782 ../apport/ui.py:841 ../apport/ui.py:859
+#: ../apport/ui.py:770 ../apport/ui.py:826 ../apport/ui.py:843
 msgid "Updating problem report"
 msgstr "正在更新問題報告"
 
-#: ../apport/ui.py:784
+#: ../apport/ui.py:772
 msgid ""
 "You are not the reporter or subscriber of this problem report, or the report "
 "is a duplicate or already closed.\n"
@@ -175,7 +175,7 @@ msgstr ""
 "\n"
 "請使用「apport-bug」來建立一份新的問題回報。"
 
-#: ../apport/ui.py:796
+#: ../apport/ui.py:784
 msgid ""
 "You are not the reporter of this problem report. It is much easier to mark a "
 "bug as a duplicate of another than to move your comments and attachments to "
@@ -194,24 +194,24 @@ msgstr ""
 "\n"
 "您真的想要繼續嗎？"
 
-#: ../apport/ui.py:842 ../apport/ui.py:860
+#: ../apport/ui.py:826 ../apport/ui.py:843
 msgid "No additional information collected."
 msgstr "沒有收集到額外的資訊。"
 
-#: ../apport/ui.py:923
+#: ../apport/ui.py:904
 msgid "What kind of problem do you want to report?"
 msgstr "您想要回報何種問題？"
 
-#: ../apport/ui.py:944
+#: ../apport/ui.py:923
 msgid "Unknown symptom"
 msgstr "不知名徵狀"
 
-#: ../apport/ui.py:945
+#: ../apport/ui.py:924
 #, python-format
 msgid "The symptom \"%s\" is not known."
 msgstr "「%s」徵狀不為人所知。"
 
-#: ../apport/ui.py:981
+#: ../apport/ui.py:962
 msgid ""
 "The window option cannot be used on Wayland.\n"
 "\n"
@@ -222,36 +222,36 @@ msgid ""
 "process ID is the number listed in the ID column."
 msgstr ""
 
-#: ../apport/ui.py:997
+#: ../apport/ui.py:978
 msgid ""
 "After closing this message please click on an application window to report a "
 "problem about it."
 msgstr "在關閉本訊息後，請點擊應用程式視窗來回報有關它的訊息。"
 
-#: ../apport/ui.py:1014 ../apport/ui.py:1023
+#: ../apport/ui.py:994 ../apport/ui.py:1001
 msgid "xprop failed to determine process ID of the window"
 msgstr "xprop 無法得知該視窗的程序 ID"
 
-#: ../apport/ui.py:1038
+#: ../apport/ui.py:1016
 #, python-format
 msgid "%(prog)s <report number>"
 msgstr ""
 
-#: ../apport/ui.py:1039
+#: ../apport/ui.py:1017
 msgid "Specify package name."
 msgstr "指定軟體包名稱。"
 
-#: ../apport/ui.py:1046 ../apport/ui.py:1179
+#: ../apport/ui.py:1023 ../apport/ui.py:1153
 msgid "Add an extra tag to the report. Can be specified multiple times."
 msgstr "加入額外標籤至回報中。可以多次分別指定。"
 
-#: ../apport/ui.py:1084
+#: ../apport/ui.py:1061
 #, python-format
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
 
-#: ../apport/ui.py:1095
+#: ../apport/ui.py:1072
 msgid ""
 "Start in bug filing mode. Requires --package and an optional --pid, or just "
 "a --pid. If neither is given, display a list of known symptoms. (Implied if "
@@ -260,21 +260,21 @@ msgstr ""
 "啟動為臭蟲歸檔模式。需要 --package 或再加上 --pid，或是只需 --pid。若兩者都未"
 "給予，顯示已知徵狀列表。(暗示若只有給予單一參數。)"
 
-#: ../apport/ui.py:1104
+#: ../apport/ui.py:1081
 msgid "Click a window as a target for filing a problem report."
 msgstr "請點擊要作為問題報告目標發送的視窗。"
 
-#: ../apport/ui.py:1113
+#: ../apport/ui.py:1089
 msgid "Start in bug updating mode. Can take an optional --package."
 msgstr "以臭蟲更新模式啟動。可以加上選用的參數 --package。"
 
-#: ../apport/ui.py:1122
+#: ../apport/ui.py:1097
 msgid ""
 "File a bug report about a symptom. (Implied if symptom name is given as only "
 "argument.)"
 msgstr "建立關於症狀的錯誤報告。(暗示是否只要提供症狀名稱作為引數。)"
 
-#: ../apport/ui.py:1131
+#: ../apport/ui.py:1106
 msgid ""
 "Specify package name in --file-bug mode. This is optional if a --pid is "
 "specified. (Implied if package name is given as only argument.)"
@@ -282,7 +282,7 @@ msgstr ""
 "在 --file-bug 模式中指定軟體包名稱。若指定 --pid 則前者不加亦可。(表示是否只"
 "要提供 pid 為引數。)"
 
-#: ../apport/ui.py:1142
+#: ../apport/ui.py:1117
 msgid ""
 "Specify a running program in --file-bug mode. If this is specified, the bug "
 "report will contain more information.  (Implied if pid is given as only "
@@ -291,11 +291,11 @@ msgstr ""
 "在 --file-bug 模式中指定一個正在執行中的程式。如果有指定，該臭蟲回報將包含更"
 "多資訊。(表示是否只要提供 pid 為引數。)"
 
-#: ../apport/ui.py:1150
+#: ../apport/ui.py:1125
 msgid "The provided pid is a hanging application."
 msgstr "提供的 pid 是懸凍的應用程式。"
 
-#: ../apport/ui.py:1158
+#: ../apport/ui.py:1133
 #, python-format
 msgid ""
 "Report the crash from given .apport or .crash file instead of the pending "
@@ -304,7 +304,7 @@ msgstr ""
 "從特定的 .apport 或 .crash 檔案來回報當掉情形，代替等待中的 %s。（暗示若特定"
 "檔案是唯一給予的參數。）"
 
-#: ../apport/ui.py:1168
+#: ../apport/ui.py:1143
 msgid ""
 "In bug filing mode, save the collected information into a file instead of "
 "reporting it. This file can then be reported later on from a different "
@@ -313,84 +313,86 @@ msgstr ""
 "在臭蟲歸檔模式中，收集的資訊將儲存在檔案中而不是將它回報。這個檔案可以稍後從"
 "不同機器回報。"
 
-#: ../apport/ui.py:1187
+#: ../apport/ui.py:1159
 msgid "Print the Apport version number."
 msgstr "列印 Apport 版本號碼。"
 
-#: ../apport/ui.py:1349
+#: ../apport/ui.py:1321
 msgid ""
 "This will launch apport-retrace in a terminal window to examine the crash."
 msgstr "這會在終端機視窗中啟動 apport-retrace 以檢查程式當掉原因。"
 
-#: ../apport/ui.py:1353
+#: ../apport/ui.py:1325
 msgid "Run gdb session"
 msgstr "執行 gdb 作業階段"
 
-#: ../apport/ui.py:1354
+#: ../apport/ui.py:1326
 msgid "Run gdb session without downloading debug symbols"
 msgstr "執行 gdb 作業階段而不下載除錯符號"
 
 #. TRANSLATORS: %s contains the crash report file name
-#: ../apport/ui.py:1356
+#: ../apport/ui.py:1328
 #, python-format
 msgid "Update %s with fully symbolic stack trace"
 msgstr "以完整的符號堆疊追蹤來更新 %s"
 
-#: ../apport/ui.py:1418
-msgid "Can't remember send report status settings"
-msgstr "無法儲存「傳送回報狀態」設定"
-
-#: ../apport/ui.py:1422
+#: ../apport/ui.py:1386
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr "儲存回報當機狀態時發生錯誤，無法設定自動或永不回報模式。"
 
-#: ../apport/ui.py:1504 ../apport/ui.py:1517
+#: ../apport/ui.py:1390
+msgid "Can't remember send report status settings"
+msgstr "無法儲存「傳送回報狀態」設定"
+
+#: ../apport/ui.py:1467 ../apport/ui.py:1480
 msgid ""
 "This problem report applies to a program which is not installed any more."
 msgstr "此問題報告用於不再安裝的程式。"
 
-#: ../apport/ui.py:1541
+#: ../apport/ui.py:1500
 #, python-format
 msgid ""
 "The problem happened with the program %s which changed since the crash "
 "occurred."
 msgstr "發生問題的程式 %s 自上次遭遇當掉之後已有變動。"
 
-#: ../apport/ui.py:1602 ../apport/ui.py:1724 ../apport/ui.py:1957
+#. can happen with broken core dumps
+#. can happen with broken gz values
+#: ../apport/ui.py:1559 ../apport/ui.py:1671 ../apport/ui.py:1881
 msgid "This problem report is damaged and cannot be processed."
 msgstr "此問題報告已損壞故無法處理。"
 
-#: ../apport/ui.py:1611
+#: ../apport/ui.py:1565
 msgid "This report is about a package that is not installed."
 msgstr "這個是關於未安裝軟體包的回報。"
 
-#: ../apport/ui.py:1619
+#: ../apport/ui.py:1572
 msgid "An error occurred while attempting to process this problem report:"
 msgstr "試圖處理問題回報時遭遇錯誤："
 
-#: ../apport/ui.py:1636
+#: ../apport/ui.py:1589
 msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr "此應用程式您安裝了兩個版本，您想對哪一個版本回報臭蟲？"
 
-#: ../apport/ui.py:1641
+#: ../apport/ui.py:1594
 #, python-format
 msgid "%s snap"
 msgstr "%s snap"
 
-#: ../apport/ui.py:1642
+#: ../apport/ui.py:1595
 #, python-format
 msgid "%s deb package"
 msgstr "%s deb 套件包"
 
-#: ../apport/ui.py:1681
+#: ../apport/ui.py:1633
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
 
-#: ../apport/ui.py:1686
+#: ../apport/ui.py:1638
 #, python-format
 msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
@@ -399,37 +401,37 @@ msgstr ""
 "%s 是由 %s 所發布的 snap 。開發者沒有提供聯絡地址；請前往論壇 https://forum."
 "snapcraft.io/ 尋求協助。"
 
-#: ../apport/ui.py:1785
+#: ../apport/ui.py:1724
 msgid "Could not determine the package or source package name."
 msgstr "無法決定軟體包或原始碼軟體包名稱。"
 
-#: ../apport/ui.py:1810
+#: ../apport/ui.py:1747
 msgid "Unable to start web browser"
 msgstr "無法啟動網頁瀏覽器"
 
-#: ../apport/ui.py:1811
+#: ../apport/ui.py:1748
 #, python-format
 msgid "Unable to start web browser to open %s."
 msgstr "無法啟動網頁瀏覽器以開啟 %s。"
 
-#: ../apport/ui.py:1904
-msgid "Network problem"
-msgstr "網路問題"
-
-#: ../apport/ui.py:1908
+#: ../apport/ui.py:1839
 msgid ""
 "Cannot connect to crash database, please check your Internet connection."
 msgstr "無法連接到當機資料庫，請檢查您的網路連線。"
 
-#: ../apport/ui.py:1939
+#: ../apport/ui.py:1842
+msgid "Network problem"
+msgstr "網路問題"
+
+#: ../apport/ui.py:1868
 msgid "Memory exhaustion"
 msgstr "記憶體耗盡"
 
-#: ../apport/ui.py:1941
+#: ../apport/ui.py:1870
 msgid "Your system does not have enough memory to process this crash report."
 msgstr "您的系統沒有足夠的記憶體來處理此份當機報告。"
 
-#: ../apport/ui.py:1992
+#: ../apport/ui.py:1914
 #, python-format
 msgid ""
 "The problem cannot be reported:\n"
@@ -440,11 +442,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../apport/ui.py:2048 ../apport/ui.py:2060
+#: ../apport/ui.py:1966 ../apport/ui.py:1978
 msgid "Problem already known"
 msgstr "已知問題"
 
-#: ../apport/ui.py:2050
+#: ../apport/ui.py:1968
 msgid ""
 "This problem was already reported in the bug report displayed in the web "
 "browser. Please check if you can add any further information that might be "
@@ -453,38 +455,37 @@ msgstr ""
 "此問題在網路瀏覽器顯示之臭蟲報告中已回報。請檢查您是否能新增任何可能對開發者"
 "有幫助的進一步資訊。"
 
-#: ../apport/ui.py:2062
+#: ../apport/ui.py:1979
 msgid "This problem was already reported to developers. Thank you!"
 msgstr "此問題已經回報給開發者。感謝您！"
 
-#: ../bin/apport-cli.py:85
+#: ../bin/apport-cli.py:88
 msgid "Press any key to continue..."
 msgstr "按任意鍵繼續..."
 
-#: ../bin/apport-cli.py:92
+#: ../bin/apport-cli.py:95
 msgid "What would you like to do? Your options are:"
 msgstr "您要做什麼？選擇有："
 
-#: ../bin/apport-cli.py:105
+#: ../bin/apport-cli.py:108
 #, python-format
 msgid "Please choose (%s):"
 msgstr "請選擇 (%s):"
 
-#: ../bin/apport-cli.py:173
+#: ../bin/apport-cli.py:175
 #, python-format
 msgid "(%i bytes)"
 msgstr "(%i 位元組)"
 
-#: ../bin/apport-cli.py:175 ../gtk/apport-gtk.py:170 ../kde/apport-kde.py:405
+#: ../bin/apport-cli.py:177 ../gtk/apport-gtk.py:173 ../kde/apport-kde.py:397
 msgid "(binary data)"
 msgstr "（二進制資料）"
 
-#: ../bin/apport-cli.py:209 ../gtk/apport-gtk.py:209 ../gtk/apport-gtk.ui.h:6
-#: ../kde/apport-kde.py:198
+#: ../bin/apport-cli.py:219 ../gtk/apport-gtk.ui.h:6 ../kde/apport-kde.py:196
 msgid "Send problem report to the developers?"
 msgstr "是否傳送問題報告予開發者？"
 
-#: ../bin/apport-cli.py:211
+#: ../bin/apport-cli.py:221
 msgid ""
 "After the problem report has been sent, please fill out the form in the\n"
 "automatically opened web browser."
@@ -492,50 +493,50 @@ msgstr ""
 "在問題報告傳送後，請填寫自動開啟之\n"
 "網路瀏覽器中的表格。"
 
-#: ../bin/apport-cli.py:218
+#: ../bin/apport-cli.py:228
 #, python-format
 msgid "&Send report (%s)"
 msgstr "傳送報告 (%s)(&S)"
 
-#: ../bin/apport-cli.py:223
+#: ../bin/apport-cli.py:232
 msgid "&Examine locally"
 msgstr "於本地端檢查(&E)"
 
-#: ../bin/apport-cli.py:227
+#: ../bin/apport-cli.py:236
 msgid "&View report"
 msgstr "檢視報告(&V)"
 
-#: ../bin/apport-cli.py:230
+#: ../bin/apport-cli.py:238
 msgid "&Keep report file for sending later or copying to somewhere else"
 msgstr "保留回報檔，稍後傳送或複製至其他位置(&K)"
 
-#: ../bin/apport-cli.py:235
+#: ../bin/apport-cli.py:241
 msgid "Cancel and &ignore future crashes of this program version"
 msgstr "取消及忽略未來此程式版本的當機(&I)"
 
-#: ../bin/apport-cli.py:238 ../bin/apport-cli.py:326 ../bin/apport-cli.py:360
-#: ../bin/apport-cli.py:383
+#: ../bin/apport-cli.py:244 ../bin/apport-cli.py:324 ../bin/apport-cli.py:358
+#: ../bin/apport-cli.py:379
 msgid "&Cancel"
 msgstr "取消(&C)"
 
-#: ../bin/apport-cli.py:267
+#: ../bin/apport-cli.py:265
 msgid "Problem report file:"
 msgstr "問題回報檔："
 
-#: ../bin/apport-cli.py:273 ../bin/apport-cli.py:278
+#: ../bin/apport-cli.py:271 ../bin/apport-cli.py:276
 msgid "&Confirm"
 msgstr "確認(&C)"
 
-#: ../bin/apport-cli.py:277
+#: ../bin/apport-cli.py:275
 #, python-format
 msgid "Error: %s"
 msgstr "錯誤：%s"
 
-#: ../bin/apport-cli.py:283 ../kde/apport-kde.py:455
+#: ../bin/apport-cli.py:281 ../kde/apport-kde.py:445
 msgid "Collecting problem information"
 msgstr "正在收集問題資訊"
 
-#: ../bin/apport-cli.py:285
+#: ../bin/apport-cli.py:283
 msgid ""
 "The collected information can be sent to the developers to improve the\n"
 "application. This might take a few minutes."
@@ -543,11 +544,11 @@ msgstr ""
 "收集的資訊可傳送予開發者以改進此\n"
 "應用程式。這可能需要數分鐘。"
 
-#: ../bin/apport-cli.py:301 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:504
+#: ../bin/apport-cli.py:299 ../gtk/apport-gtk.ui.h:17 ../kde/apport-kde.py:494
 msgid "Uploading problem information"
 msgstr "正在上傳問題資訊"
 
-#: ../bin/apport-cli.py:303
+#: ../bin/apport-cli.py:301
 msgid ""
 "The collected information is being sent to the bug tracking system.\n"
 "This might take a few minutes."
@@ -555,54 +556,54 @@ msgstr ""
 "已收集的資訊將傳送至臭蟲追蹤系統。\n"
 "這可能需要數分鐘。"
 
-#: ../bin/apport-cli.py:359
+#: ../bin/apport-cli.py:357
 msgid "&Done"
 msgstr "完成(&D)"
 
-#: ../bin/apport-cli.py:365
+#: ../bin/apport-cli.py:363
 msgid "none"
 msgstr "無"
 
-#: ../bin/apport-cli.py:367
+#: ../bin/apport-cli.py:364
 #, python-format
 msgid "Selected: %s. Multiple choices:"
 msgstr "已選擇：%s。多種選擇："
 
-#: ../bin/apport-cli.py:384
+#: ../bin/apport-cli.py:380
 msgid "Choices:"
 msgstr "選項："
 
-#: ../bin/apport-cli.py:398
+#: ../bin/apport-cli.py:394
 msgid "Path to file (Enter to cancel):"
 msgstr "檔案路徑 (按 Enter 取消)："
 
-#: ../bin/apport-cli.py:404
+#: ../bin/apport-cli.py:400
 msgid "File does not exist."
 msgstr "檔案不存在。"
 
-#: ../bin/apport-cli.py:406
+#: ../bin/apport-cli.py:402
 msgid "This is a directory."
 msgstr "這是個目錄。"
 
-#: ../bin/apport-cli.py:412
+#: ../bin/apport-cli.py:407
 msgid "To continue, you must visit the following URL:"
 msgstr "欲繼續，您必須造訪以下網址："
 
-#: ../bin/apport-cli.py:415
+#: ../bin/apport-cli.py:409
 msgid ""
 "You can launch a browser now, or copy this URL into a browser on another "
 "computer."
 msgstr "您現在可以啟動瀏覽器，或複製此網址到另一臺電腦的瀏覽器中。"
 
-#: ../bin/apport-cli.py:421
+#: ../bin/apport-cli.py:414
 msgid "Launch a browser now"
 msgstr "現在啟動瀏覽器"
 
-#: ../bin/apport-cli.py:437
+#: ../bin/apport-cli.py:429
 msgid "No pending crash reports. Try --help for more information."
 msgstr "無待處理之當機報告。更多資訊請試試 --help。"
 
-#: ../bin/apport-retrace.py:44
+#: ../bin/apport-retrace.py:46
 msgid "Do not put the new traces into the report, but write them to stdout."
 msgstr "不要將新的錯誤追溯放在報告中，但輸出至標準輸出（stdout）。"
 
@@ -617,27 +618,27 @@ msgid ""
 "Write modified report to given file instead of changing the original report"
 msgstr "寫入已修改的報告至特定的檔案來替代改變原始報告"
 
-#: ../bin/apport-retrace.py:72
+#: ../bin/apport-retrace.py:71
 msgid "Remove the core dump from the report after stack trace regeneration"
 msgstr "在堆疊追溯重新產生後從報告中移除核心傾印"
 
-#: ../bin/apport-retrace.py:80
+#: ../bin/apport-retrace.py:74
 msgid "Override report's CoreFile"
 msgstr "覆蓋報告的核心檔案（CoreFile）"
 
-#: ../bin/apport-retrace.py:86
+#: ../bin/apport-retrace.py:77
 msgid "Override report's ExecutablePath"
 msgstr "覆蓋報告的可執行路徑（ExecutablePath）"
 
-#: ../bin/apport-retrace.py:92
+#: ../bin/apport-retrace.py:80
 msgid "Override report's ProcMaps"
 msgstr "覆蓋報告的行程對映（ProcMaps）"
 
-#: ../bin/apport-retrace.py:98
+#: ../bin/apport-retrace.py:86
 msgid "Rebuild report's Package information"
 msgstr "重建報告的軟體包資訊"
 
-#: ../bin/apport-retrace.py:105
+#: ../bin/apport-retrace.py:93
 msgid ""
 "Build a temporary sandbox and download/install the necessary packages and "
 "debug symbols in there; without this option it assumes that the necessary "
@@ -651,7 +652,7 @@ msgstr ""
 "如果您有指定「system」(系統) 的話，它會使用系統組態檔，但是接著只能回追發生於"
 "目前執行中發行版的當掉情形。"
 
-#: ../bin/apport-retrace.py:119
+#: ../bin/apport-retrace.py:107
 msgid ""
 "Build another temporary sandbox for installing gdb and its dependencies "
 "using the same release as the report rather than whatever version of gdb you "
@@ -660,36 +661,36 @@ msgstr ""
 "建置另一個暫時沙盒以安裝 gdb 和其相關依賴以使用相同發行版作回報，而不是採用您"
 "本機已安裝的 gdb 版本。"
 
-#: ../bin/apport-retrace.py:129
+#: ../bin/apport-retrace.py:117
 msgid "Report download/install progress when installing packages into sandbox"
 msgstr "當軟體包安裝至沙箱時回報下載/安裝進度"
 
-#: ../bin/apport-retrace.py:136
+#: ../bin/apport-retrace.py:123
 msgid "Prepend timestamps to log messages, for batch operation"
 msgstr "在記錄訊息前加上時間戳記，供批次操作"
 
-#: ../bin/apport-retrace.py:142
+#: ../bin/apport-retrace.py:129
 msgid ""
 "Create and use third-party repositories from origins specified in reports"
 msgstr "製作並使用指定的第三方軟體庫來源置於報告中"
 
-#: ../bin/apport-retrace.py:150
+#: ../bin/apport-retrace.py:137
 msgid "Cache directory for packages downloaded in the sandbox"
 msgstr "為下載於沙箱內的軟體包製作目錄快取"
 
-#: ../bin/apport-retrace.py:156
+#: ../bin/apport-retrace.py:143
 msgid ""
 "Directory for unpacked packages. Future runs will assume that any already "
 "downloaded package is also extracted to this sandbox."
 msgstr ""
 "解開軟體包的目錄。未來執行時將假定任何已下載的軟體包也都抽出於此沙盒中。"
 
-#: ../bin/apport-retrace.py:167 ../bin/apport-valgrind.py:97
+#: ../bin/apport-retrace.py:154 ../bin/apport-valgrind.py:99
 msgid ""
 "Install an extra package into the sandbox (can be specified multiple times)"
 msgstr "安裝額外軟體包至沙箱內 (可以指定多次)"
 
-#: ../bin/apport-retrace.py:174
+#: ../bin/apport-retrace.py:161
 msgid ""
 "Path to a file with the crash database authentication information. This is "
 "used when specifying a crash ID to upload the retraced stack traces (only if "
@@ -698,36 +699,36 @@ msgstr ""
 "有當機資料庫認證資訊的檔案路徑。在指定某個當機 ID 來上傳重新追蹤的堆疊追蹤時"
 "可使用 (只有在 -g、-o 或 -s 都沒有被指定)"
 
-#: ../bin/apport-retrace.py:184
+#: ../bin/apport-retrace.py:171
 msgid ""
 "Display retraced stack traces and ask for confirmation before sending them "
 "to the crash database."
 msgstr "顯示重新追蹤的堆疊追蹤，並在送出它們到當機資料庫之前先請求確認。"
 
-#: ../bin/apport-retrace.py:192
+#: ../bin/apport-retrace.py:179
 msgid "Path to the duplicate sqlite database (default: no duplicate checking)"
 msgstr "重複的 sqlite 資料庫路徑（預設：無重複檢查）"
 
-#: ../bin/apport-retrace.py:200
+#: ../bin/apport-retrace.py:186
 msgid "Do not add StacktraceSource to the report."
 msgstr "不要在回報中增加 StacktraceSource"
 
-#: ../bin/apport-retrace.py:213
+#: ../bin/apport-retrace.py:199
 msgid "You cannot use -C without -S. Stopping."
 msgstr "不能在沒有 -S 的情況下使用 -C。結束處理。"
 
 #. translators: don't translate y/n,
 #. apport currently only checks for "y"
-#: ../bin/apport-retrace.py:243
+#: ../bin/apport-retrace.py:229
 msgid "OK to send these as attachments? [y/n]"
 msgstr "允許傳送這些附件？"
 
-#: ../bin/apport-unpack.py:29
+#: ../bin/apport-unpack.py:31
 #, python-format
 msgid "%(prog)s <report> <target directory>"
 msgstr ""
 
-#: ../bin/apport-unpack.py:31
+#: ../bin/apport-unpack.py:32
 msgid "Report file to unpack"
 msgstr ""
 
@@ -735,25 +736,25 @@ msgstr ""
 msgid "directory to unpack report to"
 msgstr ""
 
-#: ../bin/apport-unpack.py:59
+#: ../bin/apport-unpack.py:60
 msgid "Destination directory exists and is not empty."
 msgstr "目的目錄存在且不是空的。"
 
-#: ../bin/apport-valgrind.py:37
+#: ../bin/apport-valgrind.py:40
 msgid "See man page for details."
 msgstr "詳情見 man page。"
 
-#: ../bin/apport-valgrind.py:46
+#: ../bin/apport-valgrind.py:49
 msgid "specify the log file name produced by valgrind"
 msgstr "提供由 valgrind 產生的日誌檔名"
 
-#: ../bin/apport-valgrind.py:52
+#: ../bin/apport-valgrind.py:55
 msgid ""
 "reuse a previously created sandbox dir (SDIR) or, if it does not exist, "
 "create it"
 msgstr "重新使用之前建立的沙箱資料夾 (SDIR) 若不存在則新增一個"
 
-#: ../bin/apport-valgrind.py:60
+#: ../bin/apport-valgrind.py:63
 msgid ""
 "do  not  create  or reuse a sandbox directory for additional debug symbols "
 "but rely only on installed debug symbols."
@@ -761,46 +762,46 @@ msgstr ""
 "不能新增或使用之前的沙盒給額外的Debug symbol 用途,但僅依靠安裝的 debug "
 "symbols"
 
-#: ../bin/apport-valgrind.py:69
+#: ../bin/apport-valgrind.py:72
 msgid ""
 "reuse a previously created cache dir (CDIR) or, if it does not exist, create "
 "it"
 msgstr "重新使用之前建立的暫存資料夾 (CDIR) 若不存在則新增一個"
 
-#: ../bin/apport-valgrind.py:78
+#: ../bin/apport-valgrind.py:81
 msgid "report download/install progress when installing packages into sandbox"
 msgstr "當軟體包安裝至沙箱時回報下載/安裝進度"
 
-#: ../bin/apport-valgrind.py:86
+#: ../bin/apport-valgrind.py:88
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
 
-#: ../bin/apport-valgrind.py:129
+#: ../bin/apport-valgrind.py:130
 #, python-format
 msgid "Error: %s is not an executable. Stopping."
 msgstr "錯誤：%s 並非可執行檔。結束處理。"
 
-#: ../data/apportcheckresume.py:67
+#: ../data/apportcheckresume.py:75
 msgid ""
 "This occurred during a previous suspend, and prevented the system from "
 "resuming properly."
 msgstr "在上次暫停時遭遇這個問題，並使系統無法正常恢復。"
 
-#: ../data/apportcheckresume.py:72
+#: ../data/apportcheckresume.py:80
 msgid ""
 "This occurred during a previous hibernation, and prevented the system from "
 "resuming properly."
 msgstr "在上次休眠時遭遇這個問題，並使系統無法正常恢復。"
 
-#: ../data/apportcheckresume.py:80
+#: ../data/apportcheckresume.py:88
 msgid ""
 "The resume processing hung very near the end and will have appeared to have "
 "completed normally."
 msgstr "回復行程在非常接近結束的時候停止回應，且將會表現出正常完成的情形。"
 
-#: ../data/kernel_oops.py:30
+#: ../data/kernel_oops.py:33
 msgid "Your system might become unstable now and might need to be restarted."
 msgstr "您的系統現在也許會不穩定且需要重新啟動。"
 
@@ -814,76 +815,76 @@ msgstr "報告問題..."
 msgid "Report a malfunction to the developers"
 msgstr "報告問題予開發者"
 
-#: ../gtk/apport-gtk.py:186
+#: ../gtk/apport-gtk.py:189
 #, python-format
 msgid "Sorry, the application %s has stopped unexpectedly."
 msgstr "很抱歉，應用程式 %s 已無預期停止。"
 
-#: ../gtk/apport-gtk.py:189
+#: ../gtk/apport-gtk.py:192
 #, python-format
 msgid "Sorry, %s has closed unexpectedly."
 msgstr "非常抱歉，%s 已無預警關閉。"
 
-#: ../gtk/apport-gtk.py:194 ../kde/apport-kde.py:213 ../kde/apport-kde.py:265
+#: ../gtk/apport-gtk.py:197 ../kde/apport-kde.py:211 ../kde/apport-kde.py:260
 #, python-format
 msgid "Sorry, %s has experienced an internal error."
 msgstr "非常抱歉， %s 遭遇內部錯誤。"
 
-#: ../gtk/apport-gtk.py:217 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:206
+#: ../gtk/apport-gtk.py:219 ../gtk/apport-gtk.ui.h:14 ../kde/apport-kde.py:204
 msgid "Send"
 msgstr "傳送"
 
-#: ../gtk/apport-gtk.py:235 ../gtk/apport-gtk.py:661 ../gtk/apport-gtk.ui.h:11
-#: ../kde/apport-kde.py:329
+#: ../gtk/apport-gtk.py:240 ../gtk/apport-gtk.py:646 ../gtk/apport-gtk.ui.h:11
+#: ../kde/apport-kde.py:321
 msgid "Show Details"
 msgstr "顯示詳細資料"
 
-#: ../gtk/apport-gtk.py:248 ../kde/apport-kde.py:257 ../kde/apport-kde.py:275
+#: ../gtk/apport-gtk.py:253 ../kde/apport-kde.py:252 ../kde/apport-kde.py:267
 msgid "Continue"
 msgstr "繼續"
 
-#: ../gtk/apport-gtk.py:272
+#: ../gtk/apport-gtk.py:277
 #, python-format
 msgid "The application %s has stopped responding."
 msgstr "應用程式 %s 已停止回應。"
 
-#: ../gtk/apport-gtk.py:276
+#: ../gtk/apport-gtk.py:281
 #, python-format
 msgid "The program \"%s\" has stopped responding."
 msgstr "程式「%s」已停止回應。"
 
-#: ../gtk/apport-gtk.py:293 ../kde/apport-kde.py:221
+#: ../gtk/apport-gtk.py:298 ../kde/apport-kde.py:219
 #, python-format
 msgid "Package: %s"
 msgstr "軟體包：%s"
 
-#: ../gtk/apport-gtk.py:299 ../kde/apport-kde.py:228
+#: ../gtk/apport-gtk.py:304 ../kde/apport-kde.py:226
 msgid "Sorry, a problem occurred while installing software."
 msgstr "非常抱歉，於安裝軟體時遭遇問題。"
 
-#: ../gtk/apport-gtk.py:311 ../gtk/apport-gtk.py:335 ../kde/apport-kde.py:237
+#: ../gtk/apport-gtk.py:314 ../gtk/apport-gtk.py:333 ../kde/apport-kde.py:234
 #, python-format
 msgid "The application %s has experienced an internal error."
 msgstr "應用程式 %s 已遭遇某內部錯誤。"
 
-#: ../gtk/apport-gtk.py:317 ../kde/apport-kde.py:244
+#: ../gtk/apport-gtk.py:316 ../kde/apport-kde.py:239
 #, python-format
 msgid "The application %s has closed unexpectedly."
 msgstr "應用程式 %s 已無預警關閉。"
 
-#: ../gtk/apport-gtk.py:348 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:270
+#: ../gtk/apport-gtk.py:341 ../gtk/apport-gtk.ui.h:7 ../kde/apport-kde.py:264
 msgid "If you notice further problems, try restarting the computer."
 msgstr "若您之後仍發現問題，請嘗試重新啟動電腦。"
 
-#: ../gtk/apport-gtk.py:353 ../kde/apport-kde.py:277
+#: ../gtk/apport-gtk.py:344 ../kde/apport-kde.py:269
 msgid "Ignore future problems of this type"
 msgstr "忽略未來發生的此類型問題"
 
-#: ../gtk/apport-gtk.py:665 ../kde/apport-kde.py:326
+#: ../gtk/apport-gtk.py:650 ../kde/apport-kde.py:318
 msgid "Hide Details"
 msgstr "隱藏詳細資料"
 
-#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:545 ../kde/apport-kde.py:588
+#: ../gtk/apport-gtk.ui.h:1 ../kde/apport-kde.py:533 ../kde/apport-kde.py:576
 msgid "Apport"
 msgstr "Apport"
 
@@ -937,7 +938,7 @@ msgstr "正在收集資訊以幫助開發者修正您報告的問題。"
 msgid "<big><b>Uploading problem information</b></big>"
 msgstr "<big><b>正在上傳問題資訊</b></big>"
 
-#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:506
+#: ../gtk/apport-gtk.ui.h:19 ../kde/apport-kde.py:496
 msgid ""
 "The collected information is being sent to the bug tracking system. This "
 "might take a few minutes."
@@ -947,32 +948,32 @@ msgstr "正將收集到的資訊傳送至臭蟲追蹤系統。這可能需要數
 msgid "Apport crash file"
 msgstr "Apport 當機檔案"
 
-#: ../kde/apport-kde.py:260
+#: ../kde/apport-kde.py:255
 msgid "Leave Closed"
 msgstr "維持關閉"
 
-#: ../kde/apport-kde.py:261 ../kde/apport-kde.py:425
+#: ../kde/apport-kde.py:256 ../kde/apport-kde.py:415
 msgid "Relaunch"
 msgstr "重新啟動"
 
-#: ../kde/apport-kde.py:354
+#: ../kde/apport-kde.py:346
 msgid "Username:"
 msgstr "使用者名稱："
 
-#: ../kde/apport-kde.py:355
+#: ../kde/apport-kde.py:347
 msgid "Password:"
 msgstr "密碼："
 
-#: ../kde/apport-kde.py:454
+#: ../kde/apport-kde.py:444
 msgid "Collecting Problem Information"
 msgstr "正收集問題資訊"
 
-#: ../kde/apport-kde.py:457
+#: ../kde/apport-kde.py:447
 msgid ""
 "The collected information can be sent to the developers to improve the "
 "application. This might take a few minutes."
 msgstr "收集之資訊會傳送予開發者以改善該應用程式。此舉或需數分鐘。"
 
-#: ../kde/apport-kde.py:503
+#: ../kde/apport-kde.py:493
 msgid "Uploading Problem Information"
 msgstr "正上傳問題資訊"


### PR DESCRIPTION
Import translation updates from https://translations.launchpad.net/ubuntu/mantic/+source/apport for languages that have updates. Do not update translations that have no changes except for updated metadata (POT-Creation-Date, X-Launchpad-Export-Date, and X-Generator). Do not import translation file that have zero translated messages.