### PR TITLE
apt_dpkg: Drop rootdir="/" from apt.Cache

### DIFF
--- a/apport/packaging_impl/apt_dpkg.py
+++ b/apport/packaging_impl/apt_dpkg.py
@@ -198,7 +198,7 @@ class __AptDpkgPackageInfo(PackageInfo):
             self._clear_apt_cache()
             # avoid spewage on stdout
             progress = apt.progress.base.OpProgress()
-            self._apt_cache = apt.Cache(progress=progress, rootdir="/")
+            self._apt_cache = apt.Cache(progress=progress)
         return self._apt_cache
 
     def _sandbox_cache(

--- a/tests/system/test_packaging_apt_dpkg.py
+++ b/tests/system/test_packaging_apt_dpkg.py
@@ -365,7 +365,7 @@ def test_install_packages_error(configdir, cachedir, rootdir, apt_style):
         impl.install_packages(
             rootdir, configdir, release, [("tzdata", None)], False, cachedir
         )
-    exc_info.match("^E:Type 'bogus' is not known .* sources could not be read.$")
+    exc_info.match("E:Type 'bogus' is not known .* sources could not be read.$")
 
     # sources.list with wrong server
     with open(
@@ -378,7 +378,7 @@ def test_install_packages_error(configdir, cachedir, rootdir, apt_style):
             rootdir, configdir, release, [("tzdata", None)], False, cachedir
         )
     exc_info.match(
-        "^E:The repository 'http://archive.ubuntu.com/nosuchdistro"
+        "E:The repository 'http://archive.ubuntu.com/nosuchdistro"
         " jammy.*' does not have a Release file.$"
     )
 


### PR DESCRIPTION
When instantiating `apt.Cache` with `rootdir` set to something else than `None`, it tries to create the required directories. When running not as root and `/etc/apt/sources.list` not being present, it will fail with `PermissionError` (see https://launchpad.net/bugs/1974015).

So leave `rootdir` unset to let the cache use the system sources.list and system lists/files without trying to create `/etc/apt/sources.list`.