### PR TITLE
Skip test_get_file_package_diversion if the system has no diversion

### DIFF
--- a/tests/integration/test_packaging_apt_dpkg.py
+++ b/tests/integration/test_packaging_apt_dpkg.py
@@ -426,7 +426,7 @@ usr/bin/frob                                            foo/frob
                 # pick first diversion we have
                 break
         else:  # pragma: no cover
-            self.fail(f"No non-local diversion found. dpkg-divert output: {output}")
+            self.skipTest(f"No non-local diversion found. dpkg-divert output: {output}")
 
         file = fields[2]
         pkg = fields[-1]


### PR DESCRIPTION
Ubuntu used to have a dpkg diversion for dash, but that changed in Ubuntu 23.10 (mantic). Skip the integration test
`test_get_file_package_diversion` if the system has no diversion.

Bug: https://launchpad.net/bugs/2028879