### PR TITLE
fix: Critical fix apport module error when imported "TypeError: 'type' object is not subscriptable"

### DIFF
--- a/apport/fileutils.py
+++ b/apport/fileutils.py
@@ -569,7 +569,7 @@ def get_boot_id():
     return boot_id
 
 
-def get_process_environ(proc_pid_fd: int) -> dict[str, str]:
+def get_process_environ(proc_pid_fd: int) -> typing.Dict[str, str]:
     """Get the process environ from a proc directory file descriptor.
 
     Raises an OSError in case the environ file could not been read.


### PR DESCRIPTION
Critical fix
A test should be made to resolve further similar issues

```
>>> import apport
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3/dist-packages/apport/__init__.py", line 5, in <module>
    from apport.report import Report
  File "/usr/lib/python3/dist-packages/apport/report.py", line 32, in <module>
    import apport.fileutils
  File "/usr/lib/python3/dist-packages/apport/fileutils.py", line 495, in <module>
    def get_process_environ(proc_pid_fd: int) -> dict[str, str]:
TypeError: 'type' object is not subscriptable
Error in sys.excepthook:
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/apport_python_hook.py", line 72, in apport_excepthook
    from apport.fileutils import likely_packaged, get_recent_crashes
  File "/usr/lib/python3/dist-packages/apport/__init__.py", line 5, in <module>
    from apport.report import Report
  File "/usr/lib/python3/dist-packages/apport/report.py", line 32, in <module>
    import apport.fileutils
  File "/usr/lib/python3/dist-packages/apport/fileutils.py", line 495, in <module>
    def get_process_environ(proc_pid_fd: int) -> dict[str, str]:
TypeError: 'type' object is not subscriptable

Original exception was:
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3/dist-packages/apport/__init__.py", line 5, in <module>
    from apport.report import Report
  File "/usr/lib/python3/dist-packages/apport/report.py", line 32, in <module>
    import apport.fileutils
  File "/usr/lib/python3/dist-packages/apport/fileutils.py", line 495, in <module>
    def get_process_environ(proc_pid_fd: int) -> dict[str, str]:
TypeError: 'type' object is not subscriptable

```