### PR TITLE
test: Silence false inconsistent-return-statements

### DIFF
--- a/tests/integration/test_recoverable_problem.py
+++ b/tests/integration/test_recoverable_problem.py
@@ -31,6 +31,9 @@ class TestRecoverableProblem(unittest.TestCase):
         self.env["APPORT_REPORT_DIR"] = self.report_dir
         self.datadir = get_data_directory()
 
+    # False positive return statement for unittest.TestCase.fail
+    # See https://github.com/pylint-dev/pylint/issues/4167
+    # pylint: disable-next=inconsistent-return-statements
     def _wait_for_report(self):
         seconds = 0
         while seconds < 10:

--- a/tests/integration/test_signal_crashes.py
+++ b/tests/integration/test_signal_crashes.py
@@ -1172,6 +1172,9 @@ class T(unittest.TestCase):
         sleep_mock.assert_called_with(0.1)
         self.assertEqual(sleep_mock.call_count, 600)
 
+    # False positive return statement for unittest.TestCase.fail
+    # See https://github.com/pylint-dev/pylint/issues/4167
+    # pylint: disable-next=inconsistent-return-statements
     def wait_for_gdb_child_process(self, gdb_pid: int, command: str) -> psutil.Process:
         """Wait until GDB execv()ed the child process."""
         gdb_process = psutil.Process(gdb_pid)


### PR DESCRIPTION
pylint 2.17.4 complains:

```
************* Module tests.integration.test_recoverable_problem
tests/integration/test_recoverable_problem.py:34:4: R1710: Either all return statements in a function should return an expression, or none of them should. (inconsistent-return-statements)
************* Module tests.integration.test_signal_crashes
tests/integration/test_signal_crashes.py:1175:4: R1710: Either all return statements in a function should return an expression, or none of them should. (inconsistent-return-statements)
```

Silence those false positives.