### PR TITLE
ci: Add check for Contributor Licence Agreement (CLA)

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -1,0 +1,12 @@
+---
+name: CLA
+
+on:  # yamllint disable-line rule:truthy
+  - pull_request_target
+
+jobs:
+  cla-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if CLA signed
+        uses: canonical/has-signed-canonical-cla@v1


### PR DESCRIPTION
Apport requires to have the Canonical Contributor Licence Agreement (CLA) to be signed.