### PR TITLE
fix: raise "gdb not found" as soon as detected (LP: #2031919)

### DIFF
--- a/apport/report.py
+++ b/apport/report.py
@@ -902,13 +902,6 @@ class Report(problem_report.ProblemReport):
         }
         gdb_cmd, environ = self.gdb_command(rootdir, gdb_sandbox)
         environ["HOME"] = "/nonexistent"
-        if not gdb_cmd:
-            raise FileNotFoundError(
-                errno.ENOENT,
-                os.strerror(errno.ENOENT),
-                "gdb not found in retracing env",
-            )
-
         gdb_cmd += [
             "--batch",
             # limit maximum backtrace depth (to avoid looped stacks)
@@ -1811,7 +1804,7 @@ class Report(problem_report.ProblemReport):
                     else:
                         self[k] = pattern.sub(repl, self[k])
 
-    def gdb_command(self, sandbox, gdb_sandbox=None):
+    def gdb_command(self, sandbox: Optional[str], gdb_sandbox: Optional[str] = None) -> tuple[list[str], dict]:
         # TODO: Split into smaller functions/methods
         # pylint: disable=too-many-branches,too-many-locals
         """Build gdb command for this report.
@@ -1841,7 +1834,12 @@ class Report(problem_report.ProblemReport):
         )
         gdb_path = _which_extrapath("gdb", gdb_sandbox_bin)
         if not gdb_path:
-            return "", ""
+            raise FileNotFoundError(
+                errno.ENOENT,
+                os.strerror(errno.ENOENT),
+                "gdb not found in retracing env",
+            )
+
         command = [gdb_path]
         environ = {}
 

--- a/apport/report.py
+++ b/apport/report.py
@@ -1804,7 +1804,9 @@ class Report(problem_report.ProblemReport):
                     else:
                         self[k] = pattern.sub(repl, self[k])
 
-    def gdb_command(self, sandbox: Optional[str], gdb_sandbox: Optional[str] = None) -> tuple[list[str], dict]:
+    def gdb_command(
+        self, sandbox: Optional[str], gdb_sandbox: Optional[str] = None
+    ) -> tuple[list[str], dict[str, str]]:
         # TODO: Split into smaller functions/methods
         # pylint: disable=too-many-branches,too-many-locals
         """Build gdb command for this report.
@@ -1841,7 +1843,7 @@ class Report(problem_report.ProblemReport):
             )
 
         command = [gdb_path]
-        environ = {}
+        environ: dict[str, str] = {}
 
         if not same_arch:
             # check if we have gdb-multiarch

--- a/apport/report.py
+++ b/apport/report.py
@@ -1884,7 +1884,7 @@ class Report(problem_report.ProblemReport):
                 environ |= {
                     "LD_LIBRARY_PATH": ld_lib_path,
                     "PYTHONHOME": pyhome,
-                    "GCONV_PATH": (f"{gdb_sandbox}/usr/lib/{native_multiarch}/gconv"),
+                    "GCONV_PATH": f"{gdb_sandbox}/usr/lib/{native_multiarch}/gconv",
                 }
                 command.insert(
                     0, f"{gdb_sandbox}" f"/lib/{native_multiarch}/ld-linux-x86-64.so.2"

--- a/tests/unit/test_report.py
+++ b/tests/unit/test_report.py
@@ -593,6 +593,16 @@ dispatch_queue () at canberra-gtk-module.c:815""",
             ),
         )
 
+    @unittest.mock.patch("shutil.which", unittest.mock.MagicMock(return_value=None))
+    def test_gdb_add_info_no_gdb(self):
+        r = apport.report.Report()
+        r["Signal"] = "6"
+        r["ExecutablePath"] = "/bin/bash"
+        r["CoreDump"] = "/var/lib/apport/coredump/core.bash"
+        r["AssertionMessage"] = "foo.c:42 main: i > 0"
+        with self.assertRaises(FileNotFoundError):
+            r.add_gdb_info()
+
     def test_crash_signature(self):
         """crash_signature()."""
         r = apport.report.Report()


### PR DESCRIPTION
The previous version would actually simply return invalid values instead
of raising, and the code that would raise would first *use* said values,
leading to crashes, despair, and bug reports.

In addition, this PR contains some more type hints (that would have caught this!!) and a small drive-by cosmetic fix.