### PR TITLE
apt_dpkg: Add basic support for mirror+file: URIs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,6 @@ jobs:
         container:
           - debian:testing-slim
           - ubuntu:jammy
-          - ubuntu:kinetic
           - ubuntu:lunar
     container:
       image: ${{ matrix.container }}
@@ -44,7 +43,6 @@ jobs:
           - debian:bookworm-slim
           - debian:testing-slim
           - ubuntu:jammy
-          - ubuntu:kinetic
           - ubuntu:lunar
     container:
       image: ${{ matrix.container }}
@@ -123,7 +121,6 @@ jobs:
       matrix:
         container:
           - ubuntu:jammy
-          - ubuntu:kinetic
           - ubuntu:lunar
     container:
       image: ${{ matrix.container }}
@@ -207,7 +204,6 @@ jobs:
       matrix:
         container:
           - ubuntu:jammy
-          - ubuntu:kinetic
           - ubuntu:lunar
     container:
       image: ${{ matrix.container }}
@@ -238,7 +234,6 @@ jobs:
       matrix:
         container:
           - ubuntu:jammy
-          - ubuntu:kinetic
           - ubuntu:lunar
     container:
       image: ${{ matrix.container }}

--- a/apport/packaging_impl/apt_dpkg.py
+++ b/apport/packaging_impl/apt_dpkg.py
@@ -1299,6 +1299,8 @@ class __AptDpkgPackageInfo(PackageInfo):
             print("Extracting downloaded debs...")
         # False positive, see https://github.com/PyCQA/pylint/issues/7122
         for i in fetcher.items:  # pylint: disable=not-an-iterable
+            if not i.destfile.endswith("deb"):
+                continue
             out = subprocess.check_output(["dpkg-deb", "--show", i.destfile]).decode()
             (p, v) = out.strip().split()
             if (


### PR DESCRIPTION
The test case `TestApportValgrind.test_sandbox_cache_options` started to fail on the system-tests-installed CI run:

```
dpkg-deb: error: '/tmp/tmp4wlfuaxh/test-cache/system/apt/var/lib/apt/lists/auxfiles/_etc_apt_apt-mirrors.txt' is not a Debian format archive
Traceback (most recent call last):
  File "/usr/bin/apport-valgrind", line 159, in <module>
    sandbox, cache, outdated_msg = apport.sandboxutils.make_sandbox(
  File "/usr/lib/python3/dist-packages/apport/sandboxutils.py", line 226, in make_sandbox
    outdated_msg = packaging.install_packages(
  File "/usr/lib/python3/dist-packages/apport/packaging_impl/apt_dpkg.py", line 1302, in install_packages
    out = subprocess.check_output(["dpkg-deb", "--show", i.destfile]).decode()
  File "/usr/lib/python3.10/subprocess.py", line 421, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/lib/python3.10/subprocess.py", line 526, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['dpkg-deb', '--show', '/tmp/tmp4wlfuaxh/test-cache/system/apt/var/lib/apt/lists/auxfiles/_etc_apt_apt-mirrors.txt']' returned non-zero exit status 2.
```

Judging from the file name `_etc_apt_apt-mirrors.txt`, this file is not a Debian package. Therefore skip files not ending with `deb` (`ddeb` and `udeb` will be covered).

The GitHub CI uses `mirror+file:` URIs in `/etc/apt/sources.list`:

```
deb mirror+file:/etc/apt/apt-mirrors.txt jammy main restricted
deb-src mirror+file:/etc/apt/apt-mirrors.txt jammy main restricted
[...]
```

Parse the referenced mirror files and use the first mirror mentioned there.