### PR TITLE
bash-completion: Do not use ls in completion

### DIFF
--- a/data/bash-completion/apport-bug
+++ b/data/bash-completion/apport-bug
@@ -3,17 +3,16 @@
 # get available symptoms
 _apport_symptoms ()
 {
-    local syms
-    if [ -r /usr/share/apport/symptoms ]; then 
-        for FILE in $(ls /usr/share/apport/symptoms); do
-            # hide utility files and symptoms that don't have a run() function
-            if [[ ! "$FILE" =~ ^_.* && -n $(egrep "^def run\s*\(.*\):" /usr/share/apport/symptoms/$FILE) ]]; then
-                syms="$syms ${FILE%.py}"
-            fi
-        done
-    fi
-    echo $syms
-
+    local filename path symptoms
+    for path in /usr/share/apport/symptoms/*; do
+        [[ -e "$path" ]] || continue
+        filename="${path##*/}"
+        # hide utility files and symptoms that don't have a run() function
+        [[ ! "$filename" =~ ^_.* ]] || continue
+        grep -Eq "^def run\s*\(.*\):" "$path" || continue
+        symptoms+=("${filename%.py}")
+    done
+    echo "${symptoms[*]}"
 }
 
 # completion when used without parameters


### PR DESCRIPTION
Users might set aliases for ls breaking the bash completion:

```
alias ls='ls -N --color=yes --time-style=long-iso'
apport-bug <tab>
```

Shellcheck also complains about it:

```
shellcheck -S error -s bash data/bash-completion/{apport-bug,apport-collect,apport-unpack}

In data/bash-completion/apport-bug line 8:
        for FILE in $(ls /usr/share/apport/symptoms); do
                    ^-- SC2045 (error): Iterating over ls output is fragile. Use globs.

For more information:
  https://www.shellcheck.net/wiki/SC2045 -- Iterating over ls output is fragi...
```

Ubuntu-Bug: https://launchpad.net/bugs/1850804