### PR TITLE
setup: replace deprecated distutils by setuptools

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -137,7 +137,7 @@ jobs:
           bash binutils default-jdk-headless dpkg-dev gcc gdb iputils-ping kmod
           libc6-dev pkg-config python3 python3-apt python3-distutils-extra
           python3-launchpadlib python3-psutil python3-pytest python3-pytest-cov
-          python3-requests python3-systemd valgrind
+          python3-requests python3-setuptools python3-systemd valgrind
       - name: Build Java subdir
         run: >
           python3 -m coverage run ./setup.py build_java_subdir
@@ -173,7 +173,7 @@ jobs:
           bash binutils default-jdk-headless dpkg-dev gcc gdb iputils-ping kmod
           libc6-dev pkg-config python3 python3-apt python3-distutils-extra
           python3-launchpadlib python3-psutil python3-pytest python3-pytest-cov
-          python3-systemd valgrind
+          python3-setuptools python3-systemd valgrind
       - name: Install
         run: >
           sudo python3 -m coverage run
@@ -296,8 +296,8 @@ jobs:
           dbus dbus-x11 dirmngr dpkg-dev gcc gdb gir1.2-gtk-3.0 gir1.2-wnck-3.0
           gnome-icon-theme gpg gvfs-daemons psmisc python3 python3-apt
           python3-dbus python3-distutils-extra python3-gi python3-launchpadlib
-          python3-pyqt5 python3-pytest python3-pytest-cov ubuntu-dbgsym-keyring
-          ubuntu-keyring valgrind xvfb
+          python3-pyqt5 python3-pytest python3-pytest-cov python3-setuptools
+          ubuntu-dbgsym-keyring ubuntu-keyring valgrind xvfb
       - name: Install
         run: >
           sudo python3 -m coverage run

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@
 import distutils.command.build
 import distutils.command.clean
 import distutils.core
-import distutils.version
 import glob
 import logging
 import os.path
@@ -23,10 +22,6 @@ except ImportError:
         "To build Apport you need https://launchpad.net/python-distutils-extra\n"
     )
     sys.exit(1)
-
-assert (
-    distutils.version.StrictVersion(DistUtilsExtra.auto.__version__) >= "2.24"
-), "needs DistUtilsExtra.auto >= 2.24"
 
 BASH_COMPLETIONS = "share/bash-completion/completions/"
 

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ import distutils.command.clean
 import distutils.core
 import distutils.version
 import glob
+import logging
 import os.path
 import subprocess
 import sys
@@ -75,6 +76,7 @@ class install_fix_hashbangs(DistUtilsExtra.auto.install_auto):
     """Fix hashbang lines in scripts in data dir."""
 
     def _fix_symlinks_in_bash_completion(self):
+        log = logging.getLogger(__name__)
         autoinstalled_completion_dir = os.path.join(
             self.install_data, "share", "apport", "bash-completion"
         )
@@ -89,7 +91,7 @@ class install_fix_hashbangs(DistUtilsExtra.auto.install_auto):
             if not os.path.exists(dest):
                 continue
 
-            distutils.log.info("Convert %s into a symlink to %s...", dest, source)
+            log.info("Convert %s into a symlink to %s...", dest, source)
             os.remove(dest)
             os.symlink(source, dest)
 
@@ -103,6 +105,7 @@ class install_fix_hashbangs(DistUtilsExtra.auto.install_auto):
             os.rmdir(autoinstalled_completion_dir)
 
     def run(self):
+        log = logging.getLogger(__name__)
         DistUtilsExtra.auto.install_auto.run(self)
         self._fix_symlinks_in_bash_completion()
         new_hashbang = f"#!{sys.executable.rsplit('.', 1)[0]}\n"
@@ -121,7 +124,7 @@ class install_fix_hashbangs(DistUtilsExtra.auto.install_auto):
                             # ignore data files like spinner.gif
                             continue
                     if lines[0].startswith("#!") and "python" in lines[0]:
-                        distutils.log.info("Updating hashbang of %s", f)
+                        log.info("Updating hashbang of %s", f)
                         lines[0] = new_hashbang
                         with open(f, "w", encoding="utf-8") as fd:
                             for line in lines:

--- a/setup.py
+++ b/setup.py
@@ -168,6 +168,7 @@ DistUtilsExtra.auto.setup(
     url="https://launchpad.net/apport",
     license="gpl",
     description="intercept, process, and report crashes and bug reports",
+    packages=["apport", "apport.crashdb_impl", "apport.packaging_impl"],
     version=__version__,
     data_files=[
         ("share/doc/apport/", glob.glob("doc/*.txt")),

--- a/setuptools_apport/java.py
+++ b/setuptools_apport/java.py
@@ -1,0 +1,98 @@
+"""Setuptools extension to build the Java subdirectory."""
+
+import functools
+import glob
+import logging
+import os
+import pathlib
+import subprocess
+import typing
+
+from setuptools import Command, Distribution
+
+
+# pylint: disable-next=invalid-name
+class build_java(Command):
+    """Compile Java components of Apport"""
+
+    description = __doc__
+    user_options: list[tuple[str, str, str]] = []
+
+    def initialize_options(self) -> None:
+        """Set or (reset) all options/attributes/caches to their default values"""
+
+    def finalize_options(self) -> None:
+        """Set final values for all options/attributes"""
+
+    # pylint: disable-next=no-self-use
+    def run(self) -> None:
+        """Build the Java .class and .jar files."""
+        oldwd = os.getcwd()
+        os.chdir("java")
+        release = "7"
+
+        javac = ["javac", "-source", release, "-target", release]
+        subprocess.check_call(javac + glob.glob("com/ubuntu/apport/*.java"))
+        subprocess.check_call(
+            ["jar", "cvf", "apport.jar"] + glob.glob("com/ubuntu/apport/*.class")
+        )
+        subprocess.check_call(javac + ["testsuite/crash.java"])
+        subprocess.check_call(
+            ["jar", "cvf", "crash.jar", "crash.class"], cwd="testsuite"
+        )
+
+        os.chdir(oldwd)
+
+
+# pylint: disable-next=invalid-name
+class install_java(Command):
+    """Install Java components of Apport."""
+
+    def __init__(self, dist: Distribution, **kwargs: dict[str, typing.Any]) -> None:
+        super().__init__(dist, **kwargs)
+        self.initialize_options()
+
+    def initialize_options(self) -> None:
+        """Set default values for all the options that this command supports."""
+        self.install_dir: typing.Optional[str] = None
+
+    def finalize_options(self) -> None:
+        """Set final values for all the options that this command supports."""
+        self.set_undefined_options("install_data", ("install_dir", "install_dir"))
+
+    def _install_data_files(self, dst_path: str, src_files: list[pathlib.Path]) -> None:
+        assert self.install_dir
+        for src_file in src_files:
+            target = pathlib.Path(self.install_dir) / dst_path / src_file.name
+            self.mkpath(str(target.parent))
+            self.copy_file(str(src_file), str(target), preserve_mode=False)
+
+    def run(self) -> None:
+        """Install the Java .jar files."""
+        self._install_data_files("share/java", [pathlib.Path("java/apport.jar")])
+
+
+@functools.cache
+def has_java(unused_command: Command) -> bool:
+    """Check if the Java compiler is available."""
+    try:
+        subprocess.run(["javac", "-version"], capture_output=True, check=True)
+    except (OSError, subprocess.CalledProcessError):
+        logging.getLogger(__name__).warning(
+            "Java support: Java not available, not building Java crash handler"
+        )
+        return False
+    return True
+
+
+def register_java_sub_commands(
+    build: type[Command], install: type[Command]
+) -> dict[str, type[Command]]:
+    """Plug the Java extension into setuptools.
+
+    Return a dictionary with the added command classes which needs to
+    be passed to the `setup` call as `cmdclass` parameter.
+    """
+    build.sub_commands.append(("build_java_subdir", has_java))
+    install.sub_commands.append(("install_java", has_java))
+    return {"build_java_subdir": build_java, "install_java": install_java}

--- a/tests/run-linters
+++ b/tests/run-linters
@@ -14,7 +14,7 @@
 
 set -eu
 
-PYTHON_FILES="apport apport_python_hook.py data problem_report.py setup.py tests"
+PYTHON_FILES="apport apport_python_hook.py data problem_report.py setup.py setuptools_apport tests"
 PYTHON_SCRIPTS=$(find bin data gtk kde -type f -executable ! -name apport-bug ! -name apport-collect ! -name is-enabled ! -name root_info_wrapper)
 
 check_hardcoded_names() {


### PR DESCRIPTION
Replace deprecated distutils by setuptools:

* replace distutils.log by logging library
* drop DistUtilsExtra version check
* port build_java to setuptools

See also https://setuptools.pypa.io/en/latest/deprecated/distutils-legacy.html