### PR TITLE
ui: don't rely on Dependencies to know if collect_info() has been run

### DIFF
--- a/apport/ui.py
+++ b/apport/ui.py
@@ -484,7 +484,7 @@ class UserInterface:
             allowed_to_report = apport.fileutils.allowed_to_report()
             response = self.ui_present_report_details(allowed_to_report)
             if response.report or response.examine:
-                if "Dependencies" not in self.report:
+                if "_MarkForUpload" not in self.report:
                     self.collect_info()
 
             if self.report is None:

--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -907,6 +907,7 @@ class T(unittest.TestCase):
                 r.add_proc_info(pid)
                 r.add_user_info()
                 r.add_os_info()
+                r.add_package_info()
 
                 # generate a core dump
                 os.kill(pid, signal.SIGSEGV)


### PR DESCRIPTION
Ever since we've started collecting deps info at crash file creation, that code path was essentially dead, and that resulted in the _MarkForUpload field never touched in some circumstances.

This quick workaround is to actually check for that internal field instead, as it's *only* written in collect_info(), but I think we'll need a better solution in the long term.

Fixes: ea64857890ac6cb8ad056af255cf7b706850bea7 ("feat: Already add package info during crash")
Bug-Ubuntu: https://bugs.launchpad.net/ubuntu/+source/apport/+bug/2038650