### PR TITLE
fix: MachineType f-string

### DIFF
--- a/apport/hookutils.py
+++ b/apport/hookutils.py
@@ -219,6 +219,12 @@ def attach_dmi(report):
             if value:
                 report[f"dmi.{f.replace('_', '.')}"] = value
 
+    # Use the hardware information to create a machine type.
+    if "dmi.sys.vendor" in report and "dmi.product.name" in report:
+        report[
+            "MachineType"
+        ] = f"{report['dmi.sys.vendor']} {report['dmi.product.name']}"
+
 
 def attach_hardware(report):
     """Attach a standard set of hardware-related data to the report, including:
@@ -265,12 +271,6 @@ def attach_hardware(report):
     report["UdevDb"] = labels
 
     attach_dmi(report)
-
-    # Use the hardware information to create a machine type.
-    if "dmi.sys.vendor" in report and "dmi.product.name" in report:
-        report[
-            "MachineType"
-        ] = "{report['dmi.sys.vendor']} {report['dmi.product.name']}"
 
     if command_available("prtconf"):
         report["Prtconf"] = command_output(["prtconf"])

--- a/tests/unit/test_hookutils.py
+++ b/tests/unit/test_hookutils.py
@@ -83,6 +83,7 @@ class TestHookutils(unittest.TestCase):
                 "dmi.product.family": "B550 MB",
                 "dmi.product.name": "B550I AORUS PRO AX",
                 "dmi.sys.vendor": "Gigabyte Technology Co., Ltd.",
+                "MachineType": "Gigabyte Technology Co., Ltd. B550I AORUS PRO AX",
             },
         )
 


### PR DESCRIPTION
Fixes MachineType key to be an f-string instead of a regular string

It looks like when things were changed over to f-strings this one line missed the "f". I did some basic searches through the rest of the code to find other instances of this but couldn't find any.