### PR TITLE
hookutils: skip checking stat for skipped DMI files and  add unit test for apport.hookutils.attach_dmi

### DIFF
--- a/apport/hookutils.py
+++ b/apport/hookutils.py
@@ -233,12 +233,12 @@ def attach_dmi(report):
     dmi_dir = "/sys/class/dmi/id"
     if os.path.isdir(dmi_dir):
         for f in os.listdir(dmi_dir):
+            if f in ("subsystem", "uevent"):
+                continue
             p = os.path.realpath(f"{dmi_dir}/{f}")
             st = os.stat(p)
             # ignore the root-only ones, since they have serial numbers
             if not stat.S_ISREG(st.st_mode) or (st.st_mode & 4 == 0):
-                continue
-            if f in ("subsystem", "uevent"):
                 continue
 
             try:


### PR DESCRIPTION
The DMI files `subsystem` and `uevent` will be always skipped. So checking their status with `os.stat` is not needed.

Add a unit test for `apport.hookutils.attach_dmi` that uses real data. This can be used as basis for fixing issues in `attach_hardware` (see https://github.com/canonical/apport/pull/226).