### PR TITLE
feat: remove support for Upstart

### DIFF
--- a/apport/hookutils.py
+++ b/apport/hookutils.py
@@ -27,6 +27,7 @@ import stat
 import subprocess
 import sys
 import tempfile
+import warnings
 
 import apport.fileutils
 from apport.packaging_impl import impl as packaging
@@ -167,56 +168,26 @@ def attach_conffiles(report, package, conffiles=None, ui=None):
         report[f"mtime.conffile.{path_to_key(path)}"] = mtime.isoformat()
 
 
+# pylint: disable-next=unused-argument
 def attach_upstart_overrides(report, package):
     """Attach information about any Upstart override files."""
-    try:
-        files = packaging.get_files(package)
-    except ValueError:
-        return
-
-    for file in files:
-        if os.path.exists(file) and file.startswith("/etc/init/"):
-            override = file.replace(".conf", ".override")
-            key = f"upstart.{override.replace('/etc/init/', '')}"
-            attach_file_if_exists(report, override, key)
+    warnings.warn(
+        "apport.hookutils.attach_upstart_overrides() is obsolete."
+        " Upstart is dead. Please drop this call.",
+        PendingDeprecationWarning,
+        stacklevel=2,
+    )
 
 
+# pylint: disable-next=unused-argument
 def attach_upstart_logs(report, package):
     """Attach information about a package's session upstart logs."""
-    try:
-        files = packaging.get_files(package)
-    except ValueError:
-        return
-
-    for f in files:
-        if not os.path.exists(f):
-            continue
-        if f.startswith("/usr/share/upstart/sessions/"):
-            log = os.path.basename(f).replace(".conf", ".log")
-            key = f"upstart.{log}"
-            try:
-                log = os.path.join(os.environ["XDG_CACHE_HOME"], "upstart", log)
-            except KeyError:
-                try:
-                    log = os.path.join(os.environ["HOME"], ".cache", "upstart", log)
-                except KeyError:
-                    continue
-
-            attach_file_if_exists(report, log, key)
-
-        if f.startswith("/usr/share/applications/") and f.endswith(".desktop"):
-            desktopname = os.path.splitext(os.path.basename(f))[0]
-            key = f"upstart.application.{desktopname}"
-            log = f"application-{desktopname}.log"
-            try:
-                log = os.path.join(os.environ["XDG_CACHE_HOME"], "upstart", log)
-            except KeyError:
-                try:
-                    log = os.path.join(os.environ["HOME"], ".cache", "upstart", log)
-                except KeyError:
-                    continue
-
-            attach_file_if_exists(report, log, key)
+    warnings.warn(
+        "apport.hookutils.attach_upstart_logs() is obsolete."
+        " Upstart is dead. Please drop this call.",
+        PendingDeprecationWarning,
+        stacklevel=2,
+    )
 
 
 def attach_dmesg(report):

--- a/tests/integration/test_hookutils.py
+++ b/tests/integration/test_hookutils.py
@@ -487,10 +487,6 @@ GdkPixbuf-CRITICAL **: gdk_pixbuf_scale_simple: another standard glib assertion
         apport.hookutils.attach_conffiles(report, "bash")
         apport.hookutils.attach_conffiles(report, "apport")
         apport.hookutils.attach_conffiles(report, "nonexisting")
-        apport.hookutils.attach_upstart_overrides(report, "apport")
-        apport.hookutils.attach_upstart_overrides(report, "nonexisting")
-        apport.hookutils.attach_upstart_logs(report, "apport")
-        apport.hookutils.attach_upstart_logs(report, "nonexisting")
         apport.hookutils.attach_default_grub(report)
 
     def test_command_output(self):

--- a/tests/system/test_ui_gtk.py
+++ b/tests/system/test_ui_gtk.py
@@ -195,7 +195,7 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
         +-----------------------------------------------------------------+
         """
         self.app.report["ProblemType"] = "Crash"
-        self.app.report["ProcStatus"] = "Name:\tupstart\nPid:\t1"
+        self.app.report["ProcStatus"] = "Name:\tsystemd\nPid:\t1"
         GLib.idle_add(Gtk.main_quit)
         self.app.ui_present_report_details(True)
         self.assertTrue(self.app.w("dont_send_button").get_property("visible"))

--- a/tests/system/test_ui_kde.py
+++ b/tests/system/test_ui_kde.py
@@ -191,7 +191,7 @@ class T(unittest.TestCase):
     def test_regular_crash_thread_layout(self):
         """A thread of execution has failed, but the application persists."""
         self.app.report["ProblemType"] = "Crash"
-        self.app.report["ProcStatus"] = "Name:\tupstart\nPid:\t1"
+        self.app.report["ProcStatus"] = "Name:\tsystemd\nPid:\t1"
         QTimer.singleShot(0, QCoreApplication.quit)
         self.app.ui_present_report_details(True)
         self.assertFalse(self.app.dialog.closed_button.isVisible())

--- a/tests/unit/test_hookutils.py
+++ b/tests/unit/test_hookutils.py
@@ -106,3 +106,10 @@ class TestHookutils(unittest.TestCase):
         with self.assertRaises(_SkipPopen):
             apport.hookutils.recent_syslog(re.compile("."), journald_only_system=False)
         popen_mock.assert_called_once_with(cmd, stdout=unittest.mock.ANY)
+
+    def test_deprecated_upstart_functions(self) -> None:
+        """attach_upstart_*() throw deprecation warnings."""
+        with self.assertWarns(PendingDeprecationWarning):
+            apport.hookutils.attach_upstart_logs({}, "apport")
+        with self.assertWarns(PendingDeprecationWarning):
+            apport.hookutils.attach_upstart_overrides({}, "nonexisting")


### PR DESCRIPTION
Upstart is dead and not used any more. Remove the code for supporting Upstart. For backward compatibility do not remove the function but throw deprecation warnings instead.