### PR TITLE
setup: Do not fail when pkg-config is missing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -135,7 +135,7 @@ jobs:
           apt-get update
           && apt-get install --no-install-recommends --yes
           bash binutils default-jdk-headless dpkg-dev gcc gdb iputils-ping kmod
-          libc6-dev pkg-config python3 python3-apt python3-distutils-extra
+          libc6-dev python3 python3-apt python3-distutils-extra
           python3-launchpadlib python3-psutil python3-pytest python3-pytest-cov
           python3-requests python3-setuptools python3-systemd valgrind
       - name: Build Java subdir

--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,7 @@ try:
     systemd_tmpfiles_dir = subprocess.check_output(
         ["pkg-config", "--variable=tmpfilesdir", "systemd"], universal_newlines=True
     ).strip()
-except subprocess.CalledProcessError:
+except (FileNotFoundError, subprocess.CalledProcessError):
     # hardcoded fallback path
     systemd_unit_dir = "/lib/systemd/system"
     systemd_tmpfiles_dir = "/usr/lib/tmpfiles.d"


### PR DESCRIPTION
```
$ ./setup.py --help
Traceback (most recent call last):
  File "./setup.py", line 106, in <module>
    systemd_unit_dir = subprocess.check_output(
  File "/usr/lib/python3.10/subprocess.py", line 421, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/lib/python3.10/subprocess.py", line 503, in run
    with Popen(*popenargs, **kwargs) as process:
  File "/usr/lib/python3.10/subprocess.py", line 971, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib/python3.10/subprocess.py", line 1863, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'pkg-config'
```