### PR TITLE
Correct get_id_url() for testing Launchpad instances and use launchpadlib.uris.lookup_web_root

### DIFF
--- a/apport/crashdb_impl/launchpad.py
+++ b/apport/crashdb_impl/launchpad.py
@@ -274,7 +274,7 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
             f"?{urllib.parse.urlencode(args)}"
         )
 
-    def get_id_url(self, report, crash_id):
+    def get_id_url(self, report: apport.report.Report, crash_id: int) -> str:
         """Return URL for a given report ID.
 
         The report is passed in case building the URL needs additional
@@ -282,7 +282,7 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
 
         Return None if URL is not available or cannot be determined.
         """
-        return f"https://bugs.launchpad.net/bugs/{str(crash_id)}"
+        return f"https://bugs.{self.get_hostname()}/bugs/{crash_id}"
 
     def download(self, crash_id):
         # TODO: Split into smaller functions/methods


### PR DESCRIPTION
The method `get_id_url` hard-codes the URL to the production Launchpad instance. Use the same logic from `get_comment_url` to correct it.

There are more Launchpad instances besides production, qastaging, and staging. Rely on `launchpadlib.uris.lookup_web_root` to map the short instance names to web root URLs.

Successfully run the Launchpad tests locally:
```
TEST_LAUNCHPAD=1 python3 -m unittest tests/integration/test_crashdb_launchpad.py
```
So the failing codecov/patch can be ignored.