### PR TITLE
test/launchpad: Some refactorings

### DIFF
--- a/tests/integration/test_crashdb_launchpad.py
+++ b/tests/integration/test_crashdb_launchpad.py
@@ -127,15 +127,6 @@ class T(unittest.TestCase):
         Return the ID.
         """
         r = self._generate_sigsegv_report()
-        r.add_package_info(self.test_package)
-        r.add_os_info()
-        r.add_gdb_info()
-        r.add_user_info()
-        self.assertEqual(r.standard_title(), "crash crashed with SIGSEGV in f()")
-
-        # add some binary gibberish which isn't UTF-8
-        r["ShortGibberish"] = ' "]\xb6"\n'
-        r["LongGibberish"] = "a\nb\nc\ne\nf\n\xff\xff\xff\n\f"
 
         return self._create_bug_from_report("SEGV", r)
 
@@ -981,8 +972,7 @@ NameError: global name 'weird' is not defined"""
         # should not confuse get_fixed_version()
         self.assertEqual(self.crashdb.get_fixed_version(self.get_python_report()), None)
 
-    @staticmethod
-    def _generate_sigsegv_report(signal: int = 11) -> Report:
+    def _generate_sigsegv_report(self, signal: int = 11) -> Report:
         """Create a test executable which will die with a SIGSEGV, generate
         a core dump for it, create a problem report with those two
         arguments (ExecutablePath and CoreDump) and call add_gdb_info().
@@ -1037,5 +1027,15 @@ int main() { return f(42); }
             pr.add_gdb_info()
         finally:
             os.chdir(orig_cwd)
+
+        pr.add_package_info(self.test_package)
+        pr.add_os_info()
+        pr.add_gdb_info()
+        pr.add_user_info()
+        self.assertEqual(pr.standard_title(), "crash crashed with SIGSEGV in f()")
+
+        # add some binary gibberish which isn't UTF-8
+        pr["ShortGibberish"] = ' "]\xb6"\n'
+        pr["LongGibberish"] = "a\nb\nc\ne\nf\n\xff\xff\xff\n\f"
 
         return pr

--- a/tests/integration/test_crashdb_launchpad.py
+++ b/tests/integration/test_crashdb_launchpad.py
@@ -743,7 +743,9 @@ and more
             return db.launchpad.projects[project]
         return None
 
-    def _file_bug(self, bug_target, report, description=None):
+    def _file_bug(
+        self, bug_target: object, report: Report, description: str = "some description"
+    ) -> int:
         """File a bug report for a report.
 
         Return the bug ID.
@@ -752,10 +754,6 @@ and more
         # must avoid using it. Fake it by manually doing the comments and
         # attachments that +filebug would ordinarily do itself when given a
         # blob handle.
-
-        if description is None:
-            description = "some description"
-
         mime = self.crashdb._generate_upload_blob(report)
         msg = email.message_from_binary_file(mime)
         mime.close()

--- a/tests/integration/test_crashdb_launchpad.py
+++ b/tests/integration/test_crashdb_launchpad.py
@@ -31,9 +31,9 @@ try:
 except ImportError as error:
     IMPORT_ERROR = error
 
-import apport.report
 from apport.crashdb_impl.launchpad import CrashDatabase
 from apport.packaging_impl import impl as packaging
+from apport.report import Report
 
 _CACHE = {}
 
@@ -77,7 +77,7 @@ class T(unittest.TestCase):
 
         # create a local reference report so that we can compare
         # DistroRelease, Architecture, etc.
-        self.ref_report = apport.report.Report()
+        self.ref_report = Report()
         self.ref_report.add_os_info()
         self.ref_report.add_user_info()
         self.ref_report["SourcePackage"] = "coreutils"
@@ -141,7 +141,7 @@ class T(unittest.TestCase):
 
         Return the ID.
         """
-        r = apport.report.Report("Crash")
+        r = Report("Crash")
         r["ExecutablePath"] = "/bin/foo"
         r[
             "Traceback"
@@ -354,7 +354,7 @@ and more
         title = b"1\xc3\xa4\xe2\x99\xa52"
 
         # distro, UTF-8 bytestring
-        r = apport.report.Report("Bug")
+        r = Report("Bug")
         r["Title"] = title
         url = self.crashdb.get_comment_url(r, 42)
         self.assertTrue(
@@ -389,7 +389,7 @@ and more
         self.assertTrue(crash_id > 0)
         sys.stderr.write(f"(https://{self.hostname}/bugs/{crash_id}) ")
 
-        r = apport.report.Report("Bug")
+        r = Report("Bug")
 
         r["OneLiner"] = b"bogus\xe2\x86\x92".decode("UTF-8")
         r["StacktraceTop"] = "f()\ng()\nh(1)"
@@ -424,7 +424,7 @@ and more
         self.assertTrue(crash_id > 0)
         sys.stderr.write(f"(https://{self.hostname}/bugs/{crash_id}) ")
 
-        r = apport.report.Report("Bug")
+        r = Report("Bug")
 
         r["OneLiner"] = "bogus→"
         r["StacktraceTop"] = "f()\ng()\nh(1)"
@@ -458,7 +458,7 @@ and more
         self.assertTrue(crash_id > 0)
         sys.stderr.write(f"(https://{self.hostname}/bugs/{crash_id}) ")
 
-        r = apport.report.Report("Bug")
+        r = Report("Bug")
 
         r["OneLiner"] = "bogus→"
         r["StacktraceTop"] = "f()\ng()\nh(1)"
@@ -544,18 +544,16 @@ and more
 
         # now try duplicating to a duplicate bug; this should automatically
         # transition to the master bug
-        self.crashdb.close_duplicate(
-            apport.report.Report(), known_test_id, known_test_id2
-        )
+        self.crashdb.close_duplicate(Report(), known_test_id, known_test_id2)
         self.crashdb.close_duplicate(r, segv_id, known_test_id)
         self.assertEqual(self.crashdb.duplicate_of(segv_id), known_test_id2)
 
-        self.crashdb.close_duplicate(apport.report.Report(), known_test_id, None)
-        self.crashdb.close_duplicate(apport.report.Report(), known_test_id2, None)
+        self.crashdb.close_duplicate(Report(), known_test_id, None)
+        self.crashdb.close_duplicate(Report(), known_test_id2, None)
         self.crashdb.close_duplicate(r, segv_id, None)
 
         # this should be a no-op
-        self.crashdb.close_duplicate(apport.report.Report(), known_test_id, None)
+        self.crashdb.close_duplicate(Report(), known_test_id, None)
         self.assertEqual(self.crashdb.duplicate_of(known_test_id), None)
 
         self.crashdb.mark_regression(segv_id, known_test_id)
@@ -855,7 +853,7 @@ and more
         self.assertEqual(crashdb.distro, None)
 
         # create Python crash report
-        r = apport.report.Report("Crash")
+        r = Report("Crash")
         r["ExecutablePath"] = "/bin/foo"
         r[
             "Traceback"
@@ -929,7 +927,7 @@ NameError: global name 'weird' is not defined"""
             for b in range(first_dup, first_dup + 13):
                 count += 1
                 sys.stderr.write(f"{b} ")
-                db.close_duplicate(apport.report.Report(), b, self.get_segv_report())
+                db.close_duplicate(Report(), b, self.get_segv_report())
                 b = db.launchpad.bugs[self.get_segv_report()]
                 has_escalation_tag = db.options["escalation_tag"] in b.tags
                 has_escalation_subscription = any(
@@ -944,7 +942,7 @@ NameError: global name 'weird' is not defined"""
         finally:
             for b in range(first_dup, first_dup + count):
                 sys.stderr.write(f"R{b} ")
-                db.close_duplicate(apport.report.Report(), b, None)
+                db.close_duplicate(Report(), b, None)
         sys.stderr.write("\n")
 
     def test_marking_python_task_mangle(self):
@@ -999,7 +997,7 @@ NameError: global name 'weird' is not defined"""
         """
         workdir = None
         orig_cwd = os.getcwd()
-        pr = apport.report.Report()
+        pr = Report()
         try:
             workdir = tempfile.mkdtemp()
             atexit.register(shutil.rmtree, workdir)

--- a/tests/integration/test_crashdb_launchpad.py
+++ b/tests/integration/test_crashdb_launchpad.py
@@ -93,12 +93,10 @@ class T(unittest.TestCase):
         bug_target = self._get_bug_target(self.crashdb, report)
         self.assertTrue(bug_target)
 
-        crash_id = self._file_bug(bug_target, report)
+        crash_id, web_link = self._file_bug(bug_target, report)
         self.assertTrue(crash_id > 0)
 
-        sys.stderr.write(
-            f"(Created {name} report: https://{self.hostname}/bugs/{crash_id}) "
-        )
+        sys.stderr.write(f"(Created {name} report: {web_link}) ")
         return crash_id
 
     def _create_project(self, name):
@@ -745,7 +743,7 @@ and more
 
     def _file_bug(
         self, bug_target: object, report: Report, description: str = "some description"
-    ) -> int:
+    ) -> tuple[int, str]:
         """File a bug report for a report.
 
         Return the bug ID.
@@ -798,7 +796,7 @@ and more
             if sub:
                 bug.subscribe(person=sub)
 
-        return bug.id
+        return bug.id, bug.web_link
 
     def _mark_needs_retrace(self, crash_id):
         """Mark a report ID as needing retrace."""
@@ -869,9 +867,9 @@ NameError: global name 'weird' is not defined"""
         bug_target = self._get_bug_target(crashdb, r)
         self.assertEqual(bug_target.name, "langpack-o-matic")
 
-        crash_id = self._file_bug(bug_target, r)
+        crash_id, web_link = self._file_bug(bug_target, r)
         self.assertTrue(crash_id > 0)
-        sys.stderr.write(f"(https://{self.hostname}/bugs/{crash_id}) ")
+        sys.stderr.write(f"({web_link}) ")
 
         # update
         r = crashdb.download(crash_id)

--- a/tests/integration/test_crashdb_launchpad.py
+++ b/tests/integration/test_crashdb_launchpad.py
@@ -982,7 +982,7 @@ NameError: global name 'weird' is not defined"""
         self.assertEqual(self.crashdb.get_fixed_version(self.get_python_report()), None)
 
     @staticmethod
-    def _generate_sigsegv_report(signal="11"):
+    def _generate_sigsegv_report(signal: int = 11) -> Report:
         """Create a test executable which will die with a SIGSEGV, generate
         a core dump for it, create a problem report with those two
         arguments (ExecutablePath and CoreDump) and call add_gdb_info().
@@ -1032,7 +1032,7 @@ int main() { return f(42); }
 
             pr["ExecutablePath"] = os.path.join(workdir, "crash")
             pr["CoreDump"] = (os.path.join(workdir, "core"),)
-            pr["Signal"] = signal
+            pr["Signal"] = str(signal)
 
             pr.add_gdb_info()
         finally:

--- a/tests/integration/test_crashdb_launchpad.py
+++ b/tests/integration/test_crashdb_launchpad.py
@@ -85,6 +85,22 @@ class T(unittest.TestCase):
         # Objects tests rely on.
         self._create_project("langpack-o-matic")
 
+    def _create_bug_from_report(self, name: str, report: Report) -> int:
+        """Create a Launchpad bug report from a crash report.
+
+        Return the bug ID.
+        """
+        bug_target = self._get_bug_target(self.crashdb, report)
+        self.assertTrue(bug_target)
+
+        crash_id = self._file_bug(bug_target, report)
+        self.assertTrue(crash_id > 0)
+
+        sys.stderr.write(
+            f"(Created {name} report: https://{self.hostname}/bugs/{crash_id}) "
+        )
+        return crash_id
+
     def _create_project(self, name):
         """Create a project using launchpadlib to be used by tests."""
         project = self.crashdb.launchpad.projects[name]
@@ -123,17 +139,7 @@ class T(unittest.TestCase):
         r["ShortGibberish"] = ' "]\xb6"\n'
         r["LongGibberish"] = "a\nb\nc\ne\nf\n\xff\xff\xff\n\f"
 
-        # create a bug for the report
-        bug_target = self._get_bug_target(self.crashdb, r)
-        self.assertTrue(bug_target)
-
-        crash_id = self._file_bug(bug_target, r)
-        self.assertTrue(crash_id > 0)
-
-        sys.stderr.write(
-            f"(Created SEGV report: https://{self.hostname}/bugs/{crash_id}) "
-        )
-        return crash_id
+        return self._create_bug_from_report("SEGV", r)
 
     @cache
     def get_python_report(self):
@@ -159,15 +165,7 @@ NameError: global name 'weird' is not defined"""
             " global name 'weird' is not defined",
         )
 
-        bug_target = self._get_bug_target(self.crashdb, r)
-        self.assertTrue(bug_target)
-
-        crash_id = self._file_bug(bug_target, r)
-        self.assertTrue(crash_id > 0)
-        sys.stderr.write(
-            f"(Created Python report: https://{self.hostname}/bugs/{crash_id}) "
-        )
-        return crash_id
+        return self._create_bug_from_report("Python", r)
 
     @cache
     def get_uncommon_description_report(self, force_fresh=False):


### PR DESCRIPTION
* Import Report from `apport.report`
* Introduce `_create_bug_from_report()`
* set default description in `_file_bug`
* Also return web_link in `_file_bug`
* pass signal as int to `_generate_sigsegv_report`
* Move more parts into `_generate_sigsegv_report()`

Successfully tested Launchpad tests locally:
```
TEST_LAUNCHPAD=1 python3 -m unittest tests/integration/test_crashdb_launchpad.py
```

So the failing codecov/patch can be ignored.