### PR TITLE
feat: set signal name during crash collection

### DIFF
--- a/apport/report.py
+++ b/apport/report.py
@@ -1251,6 +1251,20 @@ class Report(problem_report.ProblemReport):
 
         return dom
 
+    def _get_signal_name(self) -> str:
+        signal_names = {
+            4: "SIGILL",
+            6: "SIGABRT",
+            8: "SIGFPE",
+            11: "SIGSEGV",
+            13: "SIGPIPE",
+        }
+        signal_number = int(self["Signal"])
+        try:
+            return signal_names[signal_number]
+        except KeyError:
+            return f"signal {signal_number}"
+
     def check_ignored(self) -> bool:
         """Check if current report should not be presented.
 
@@ -1403,14 +1417,6 @@ class Report(problem_report.ProblemReport):
 
         # signal crash
         if "Signal" in self and "ExecutablePath" in self and "StacktraceTop" in self:
-            signal_names = {
-                "4": "SIGILL",
-                "6": "SIGABRT",
-                "8": "SIGFPE",
-                "11": "SIGSEGV",
-                "13": "SIGPIPE",
-            }
-
             fn = self.stacktrace_top_function()
             if fn:
                 fn = f" in {fn}()"
@@ -1426,12 +1432,9 @@ class Report(problem_report.ProblemReport):
             ):
                 arch_mismatch = f" [non-native {self['PackageArchitecture']} package]"
 
-            signal_name = signal_names.get(
-                self.get("Signal"), "signal " + self.get("Signal")
-            )
             return (
                 f"{os.path.basename(self['ExecutablePath'])}"
-                f" crashed with {signal_name}{fn}{arch_mismatch}"
+                f" crashed with {self._get_signal_name()}{fn}{arch_mismatch}"
             )
 
         # Python exception

--- a/apport/report.py
+++ b/apport/report.py
@@ -1254,6 +1254,9 @@ class Report(problem_report.ProblemReport):
 
     def _get_signal_name(self) -> str:
         signal_number = int(self["Signal"])
+        signal_name = self.get("SignalName")
+        if signal_name:
+            return signal_name
         try:
             return signal.Signals(signal_number).name
         except ValueError:

--- a/apport/report.py
+++ b/apport/report.py
@@ -25,6 +25,7 @@ import pathlib
 import pwd
 import re
 import shutil
+import signal
 import stat
 import subprocess
 import sys
@@ -1252,17 +1253,10 @@ class Report(problem_report.ProblemReport):
         return dom
 
     def _get_signal_name(self) -> str:
-        signal_names = {
-            4: "SIGILL",
-            6: "SIGABRT",
-            8: "SIGFPE",
-            11: "SIGSEGV",
-            13: "SIGPIPE",
-        }
         signal_number = int(self["Signal"])
         try:
-            return signal_names[signal_number]
-        except KeyError:
+            return signal.Signals(signal_number).name
+        except ValueError:
             return f"signal {signal_number}"
 
     def check_ignored(self) -> bool:

--- a/data/apport
+++ b/data/apport
@@ -905,6 +905,12 @@ def process_crash(options: argparse.Namespace) -> int:
         return 1
 
 
+def _set_signal(report: apport.report.Report, signal_number: int) -> None:
+    report["Signal"] = str(signal_number)
+    with contextlib.suppress(ValueError):
+        report["SignalName"] = signal.Signals(signal_number).name
+
+
 def process_crash_with_proc_pid(options: argparse.Namespace, proc_pid: ProcPid) -> int:
     # TODO: Split into smaller functions/methods
     # pylint: disable=too-many-branches,too-many-locals
@@ -939,7 +945,7 @@ def process_crash_with_proc_pid(options: argparse.Namespace, proc_pid: ProcPid) 
         return 0
 
     info = apport.report.Report("Crash")
-    info["Signal"] = str(options.signal_number)
+    _set_signal(info, options.signal_number)
     core_size_limit = usable_ram() * 3 / 4
     # sys.stdin has type io.TextIOWrapper, not the claimed io.TextIO.
     # See https://github.com/python/typeshed/issues/10093

--- a/tests/unit/test_report.py
+++ b/tests/unit/test_report.py
@@ -70,6 +70,7 @@ class T(unittest.TestCase):
 
         # named signal crash
         report["Signal"] = "11"
+        report["SignalName"] = "SIGSEGV"
         report["ExecutablePath"] = "/bin/bash"
         report["StacktraceTop"] = textwrap.dedent(
             """\
@@ -82,6 +83,7 @@ class T(unittest.TestCase):
 
         # unnamed signal crash
         report["Signal"] = "42"
+        del report["SignalName"]
         self.assertEqual(
             report.standard_title(), "bash crashed with signal 42 in foo()"
         )
@@ -102,6 +104,7 @@ class T(unittest.TestCase):
 
         # assertion message
         report["Signal"] = "6"
+        report["SignalName"] = "SIGABRT"
         report["ExecutablePath"] = "/bin/bash"
         report["AssertionMessage"] = "foo.c:42 main: i > 0"
         self.assertEqual(
@@ -240,6 +243,7 @@ ImportError: No module named nonexistent
 
         # matching package/system architectures
         report["Signal"] = "11"
+        report["SignalName"] = "SIGSEGV"
         report["ExecutablePath"] = "/bin/bash"
         report["StacktraceTop"] = textwrap.dedent(
             """\
@@ -597,6 +601,7 @@ dispatch_queue () at canberra-gtk-module.c:815""",
     def test_gdb_add_info_no_gdb(self):
         r = apport.report.Report()
         r["Signal"] = "6"
+        r["SignalName"] = "SIGABRT"
         r["ExecutablePath"] = "/bin/bash"
         r["CoreDump"] = "/var/lib/apport/coredump/core.bash"
         r["AssertionMessage"] = "foo.c:42 main: i > 0"
@@ -769,6 +774,7 @@ RUNQUEUES[0]: c6002320
         # assertion failures
         r = apport.report.Report()
         r["Signal"] = "6"
+        r["SignalName"] = "SIGABRT"
         r["ExecutablePath"] = "/bin/bash"
         r["AssertionMessage"] = "foo.c:42 main: i > 0"
         self.assertEqual(r.crash_signature(), "/bin/bash:foo.c:42 main: i > 0")


### PR DESCRIPTION
Instead of hard-coding only five signal names, determine the signal name using the Python `signal` standard library.

Signal numbers vary by architecture. So include the signal name during crash collection to avoid getting the wrong name when reprocessing on a different architecture.