### PR TITLE
replace deprecated typing.Tuple by tuple

### DIFF
--- a/data/apport
+++ b/data/apport
@@ -121,7 +121,7 @@ def get_core_path(
     )[1]
 
 
-def get_pid_info(proc_pid: ProcPid) -> typing.Tuple[UserGroupID, os.stat_result]:
+def get_pid_info(proc_pid: ProcPid) -> tuple[UserGroupID, os.stat_result]:
     """Read /proc information about pid"""
     # unhandled exceptions on missing or invalidly formatted files are okay
     # here -- we want to know in the log file

--- a/problem_report.py
+++ b/problem_report.py
@@ -385,7 +385,7 @@ class ProblemReport(collections.UserDict):
         for k in binkeys:
             self._write_key_and_binary_value_compressed_and_encoded_to_file(file, k)
 
-    def _get_sorted_keys(self, only_new: bool) -> typing.Tuple[list[str], list[str]]:
+    def _get_sorted_keys(self, only_new: bool) -> tuple[list[str], list[str]]:
         """Sort keys into ASCII non-ASCII/binary attachment ones, so that
         the base64 ones appear last in the report
         """

--- a/tests/integration/test_dupdb_admin.py
+++ b/tests/integration/test_dupdb_admin.py
@@ -13,7 +13,6 @@ import os
 import shutil
 import subprocess
 import tempfile
-import typing
 import unittest
 from typing import Optional
 
@@ -43,7 +42,7 @@ class TestDupdbAdmin(unittest.TestCase):
         args: list,
         expected_returncode: int = 0,
         expected_stdout: Optional[str] = "",
-    ) -> typing.Tuple[str, str]:
+    ) -> tuple[str, str]:
         cmd = ["dupdb-admin", "-f", self.db_file] + args
         process = subprocess.run(
             cmd,
@@ -61,9 +60,7 @@ class TestDupdbAdmin(unittest.TestCase):
         return (process.stdout, process.stderr)
 
     @staticmethod
-    def _find_files_and_directories(
-        base_dir: str,
-    ) -> typing.Tuple[list[str], list[str]]:
+    def _find_files_and_directories(base_dir: str) -> tuple[list[str], list[str]]:
         found_directories = []
         found_files = []
         for root, dirs, files in os.walk(base_dir):


### PR DESCRIPTION
`typing.Tuple` is a deprecated alias for `tuple` starting with Python 3.9.