### PR TITLE
problem_report: separate base64 encoding and gzip compression

### DIFF
--- a/problem_report.py
+++ b/problem_report.py
@@ -461,7 +461,7 @@ class ProblemReport(collections.UserDict):
         """Write the binary keys with gzip compression and base64 encoding"""
         # TODO: Split into smaller functions/methods
         # pylint: disable=too-many-branches,too-many-statements
-        v = self.data[key]
+        value = self.data[key]
         limit = None
         size = 0
 
@@ -470,8 +470,8 @@ class ProblemReport(collections.UserDict):
         file.write(b": base64\n ")
 
         # CompressedValue
-        if isinstance(v, CompressedValue):
-            file.write(base64.b64encode(v.gzipvalue))
+        if isinstance(value, CompressedValue):
+            file.write(base64.b64encode(value.gzipvalue))
             file.write(b"\n")
             return
 
@@ -489,23 +489,23 @@ class ProblemReport(collections.UserDict):
 
         bc = zlib.compressobj(6, zlib.DEFLATED, -zlib.MAX_WBITS, zlib.DEF_MEM_LEVEL, 0)
         # direct value
-        if hasattr(v, "find"):
-            size += len(v)
-            crc = zlib.crc32(v, crc)
-            outblock = bc.compress(v)
+        if hasattr(value, "find"):
+            size += len(value)
+            crc = zlib.crc32(value, crc)
+            outblock = bc.compress(value)
             if outblock:
                 file.write(base64.b64encode(outblock))
                 file.write(b"\n ")
         # file reference
         else:
-            if len(v) >= 3 and v[2] is not None:
-                limit = v[2]
+            if len(value) >= 3 and value[2] is not None:
+                limit = value[2]
 
-            if hasattr(v[0], "read"):
-                f = v[0]  # file-like object
+            if hasattr(value[0], "read"):
+                f = value[0]  # file-like object
             else:
                 # hard to change, pylint: disable=consider-using-with
-                f = open(v[0], "rb")  # file name
+                f = open(value[0], "rb")  # file name
             while True:
                 block = f.read(1048576)
                 size += len(block)
@@ -525,13 +525,13 @@ class ProblemReport(collections.UserDict):
                         file.write(b"\n ")
                 else:
                     break
-            if not hasattr(v[0], "read"):
+            if not hasattr(value[0], "read"):
                 f.close()
 
-            if len(v) >= 4 and v[3]:
+            if len(value) >= 4 and value[3]:
                 if size == 0:
                     raise OSError(
-                        f"did not get any data for field {key} from {str(v[0])}"
+                        f"did not get any data for field {key} from {str(value[0])}"
                     )
 
         # flush compressor and write the rest


### PR DESCRIPTION
Refactor _write_key_and_binary_value_compressed_and_encoded_to_file into a generator taking in all sorts of data and compressing and splitting it into byte chunks, and a function encoding an iterable of binary chunks into an RFC822 base64 field.

The compression generator is still in need of further refactoring, but it's still a step in the right direction.