### PR TITLE
style: Import MagicMock from unittest.mock

### DIFF
--- a/tests/helper.py
+++ b/tests/helper.py
@@ -13,6 +13,7 @@ import unittest.mock
 import urllib.error
 import urllib.request
 from typing import Any, Optional
+from unittest.mock import MagicMock
 
 
 def get_init_system() -> str:
@@ -93,7 +94,7 @@ def skip_if_command_is_missing(cmd: str) -> typing.Callable:
 @contextlib.contextmanager
 def wrap_object(
     target: object, attribute: str, include_instance: bool = False
-) -> typing.Generator[unittest.mock.MagicMock, None, None]:
+) -> typing.Generator[MagicMock, None, None]:
     """Wrap the named member on an object with a mock object.
 
     wrap_object() can be used as a context manager. Inside the
@@ -109,7 +110,7 @@ def wrap_object(
     See also https://stackoverflow.com/questions/44768483 for
     the use case.
     """
-    mock = unittest.mock.MagicMock()
+    mock = MagicMock()
     real_attribute = getattr(target, attribute)
 
     def mocked_attribute(self, *args, **kwargs):

--- a/tests/integration/test_crashdb_launchpad.py
+++ b/tests/integration/test_crashdb_launchpad.py
@@ -23,6 +23,7 @@ import sys
 import tempfile
 import unittest
 import unittest.mock
+from unittest.mock import MagicMock
 
 try:
     from launchpadlib.errors import HTTPError
@@ -689,9 +690,7 @@ and more
         r = self.crashdb.download(crash_id)
         self.assertNotIn("CoreDump", r)
 
-    @unittest.mock.patch.object(
-        CrashDatabase, "_get_source_version", unittest.mock.MagicMock()
-    )
+    @unittest.mock.patch.object(CrashDatabase, "_get_source_version", MagicMock())
     def test_get_fixed_version(self):
         """get_fixed_version() for fixed bugs
 

--- a/tests/integration/test_hookutils.py
+++ b/tests/integration/test_hookutils.py
@@ -12,6 +12,7 @@ import sys
 import tempfile
 import unittest
 import unittest.mock
+from unittest.mock import MagicMock
 
 import apport.hookutils
 import apport.report
@@ -207,8 +208,7 @@ class T(unittest.TestCase):
             self.assertNotEqual(len(apport.hookutils.recent_syslog(re.compile("."))), 0)
 
     @unittest.mock.patch(
-        "apport.hookutils._root_command_prefix",
-        unittest.mock.MagicMock(return_value=[]),
+        "apport.hookutils._root_command_prefix", MagicMock(return_value=[])
     )
     def test_attach_mac_events(self):
         # TODO: Split into separate test cases
@@ -473,8 +473,7 @@ GdkPixbuf-CRITICAL **: gdk_pixbuf_scale_simple: another standard glib assertion
 
     @staticmethod
     @unittest.mock.patch(
-        "apport.hookutils._root_command_prefix",
-        unittest.mock.MagicMock(return_value=[]),
+        "apport.hookutils._root_command_prefix", MagicMock(return_value=[])
     )
     def test_no_crashes():
         """Functions do not crash (very shallow)."""

--- a/tests/integration/test_report.py
+++ b/tests/integration/test_report.py
@@ -16,6 +16,7 @@ import textwrap
 import time
 import unittest
 import unittest.mock
+from unittest.mock import MagicMock
 
 import apport.packaging
 import apport.report
@@ -824,8 +825,7 @@ int main() { return f(42); }
         self.assertRaises(FileNotFoundError, pr.add_gdb_info)
 
     @unittest.mock.patch(
-        "apport.hookutils._root_command_prefix",
-        unittest.mock.MagicMock(return_value=[]),
+        "apport.hookutils._root_command_prefix", MagicMock(return_value=[])
     )
     def test_add_zz_parse_segv_details(self):
         """parse-segv produces sensible results"""

--- a/tests/integration/test_signal_crashes.py
+++ b/tests/integration/test_signal_crashes.py
@@ -30,6 +30,7 @@ import time
 import typing
 import unittest
 from typing import Optional
+from unittest.mock import MagicMock
 
 import psutil
 
@@ -759,7 +760,7 @@ class T(unittest.TestCase):
         self.assertEqual(report["ExecutablePath"], os.path.realpath("/bin/ping"))
 
     @unittest.mock.patch("os.readlink")
-    def test_is_not_same_ns(self, readlink_mock: unittest.mock.MagicMock) -> None:
+    def test_is_not_same_ns(self, readlink_mock: MagicMock) -> None:
         readlink_mock.side_effect = ["mnt:[1]", "mnt:[2]"]
         open_mock = unittest.mock.mock_open(read_data="0::/user.slice\n")
         command = [self.TEST_EXECUTABLE] + self.TEST_ARGS
@@ -1200,7 +1201,7 @@ class T(unittest.TestCase):
     @unittest.mock.patch("time.sleep")
     def test_wait_for_gdb_child_process(self, sleep_mock):
         """Test wait_for_gdb_child_process() helper method."""
-        child = unittest.mock.MagicMock(spec=psutil.Process)
+        child = MagicMock(spec=psutil.Process)
         child.status.side_effect = ["tracing-stop", "sleeping"]
         child.cmdline.return_value = [self.TEST_EXECUTABLE] + self.TEST_ARGS
         with unittest.mock.patch("psutil.Process", spec=psutil.Process) as process_mock:

--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -24,6 +24,7 @@ import unittest
 import unittest.mock
 import urllib.error
 from typing import Any, Optional
+from unittest.mock import MagicMock
 
 import apport.crashdb_impl.memory
 import apport.packaging
@@ -184,7 +185,7 @@ class UserInterfaceMock(apport.ui.UserInterface):
 
 
 @unittest.mock.patch(
-    "apport.hookutils._root_command_prefix", unittest.mock.MagicMock(return_value=[])
+    "apport.hookutils._root_command_prefix", MagicMock(return_value=[])
 )
 class T(unittest.TestCase):
     # pylint: disable=missing-function-docstring,too-many-instance-attributes
@@ -1032,8 +1033,8 @@ class T(unittest.TestCase):
         self.assertIn("decompress", self.ui.msg_text)
         self.assertTrue(self.ui.present_details_shown)
 
-    @unittest.mock.patch("apport.report.Report.add_gdb_info", unittest.mock.MagicMock())
-    @unittest.mock.patch("apport.hookutils.attach_conffiles", unittest.mock.MagicMock())
+    @unittest.mock.patch("apport.report.Report.add_gdb_info", MagicMock())
+    @unittest.mock.patch("apport.hookutils.attach_conffiles", MagicMock())
     def test_run_crash_argv_file(self):
         """run_crash() through a file specified on the command line"""
         # valid
@@ -1071,7 +1072,7 @@ class T(unittest.TestCase):
         self.assertEqual(self.ui.run_argv(), True)
         self.assertEqual(self.ui.msg_severity, "error")
 
-    @unittest.mock.patch("apport.report.Report.add_gdb_info", unittest.mock.MagicMock())
+    @unittest.mock.patch("apport.report.Report.add_gdb_info", MagicMock())
     def test_run_crash_unreportable(self):
         """run_crash() on a crash with the UnreportableReason field"""
         self.report["UnreportableReason"] = "It stinks."
@@ -1087,7 +1088,7 @@ class T(unittest.TestCase):
         )
         self.assertEqual(self.ui.msg_severity, "info")
 
-    @unittest.mock.patch("apport.report.Report.add_gdb_info", unittest.mock.MagicMock())
+    @unittest.mock.patch("apport.report.Report.add_gdb_info", MagicMock())
     def test_run_crash_malicious_crashdb(self):
         """run_crash() on a crash with malicious CrashDB"""
         self.report["ExecutablePath"] = "/bin/bash"
@@ -1103,7 +1104,7 @@ class T(unittest.TestCase):
         self.assertFalse(os.path.exists("/tmp/pwned"))
         self.assertIn("invalid crash database definition", self.ui.msg_text)
 
-    @unittest.mock.patch("apport.report.Report.add_gdb_info", unittest.mock.MagicMock())
+    @unittest.mock.patch("apport.report.Report.add_gdb_info", MagicMock())
     def test_run_crash_malicious_package(self):
         """Package: path traversal"""
         with tempfile.NamedTemporaryFile(suffix=".py") as bad_hook:
@@ -1945,7 +1946,7 @@ class T(unittest.TestCase):
             ),
         )
 
-    @unittest.mock.patch("apport.hookutils.attach_conffiles", unittest.mock.MagicMock())
+    @unittest.mock.patch("apport.hookutils.attach_conffiles", MagicMock())
     @unittest.mock.patch("sys.stderr", new_callable=io.StringIO)
     def test_run_symptom(self, stderr_mock):
         # TODO: Split into separate test cases
@@ -2617,8 +2618,8 @@ class T(unittest.TestCase):
             pass
         self.ui.wait_for_pid(pid)
 
-    @unittest.mock.patch("os.getgid", unittest.mock.MagicMock(return_value=0))
-    @unittest.mock.patch("os.getuid", unittest.mock.MagicMock(return_value=0))
+    @unittest.mock.patch("os.getgid", MagicMock(return_value=0))
+    @unittest.mock.patch("os.getuid", MagicMock(return_value=0))
     @unittest.mock.patch.dict("os.environ", {"SUDO_UID": str(os.getuid())}, clear=True)
     def test_run_as_real_user(self) -> None:
         """Test run_as_real_user() with SUDO_UID set."""
@@ -2651,13 +2652,11 @@ class T(unittest.TestCase):
         )
         self.assertEqual(run_mock.call_count, 2)
 
-    @unittest.mock.patch("os.getgid", unittest.mock.MagicMock(return_value=0))
-    @unittest.mock.patch("os.getuid", unittest.mock.MagicMock(return_value=0))
+    @unittest.mock.patch("os.getgid", MagicMock(return_value=0))
+    @unittest.mock.patch("os.getuid", MagicMock(return_value=0))
     @unittest.mock.patch.dict("os.environ", {"SUDO_UID": "1337"}, clear=True)
     @unittest.mock.patch("pwd.getpwuid")
-    def test_run_as_real_user_no_gvfsd(
-        self, getpwuid_mock: unittest.mock.MagicMock
-    ) -> None:
+    def test_run_as_real_user_no_gvfsd(self, getpwuid_mock: MagicMock) -> None:
         """Test run_as_real_user() without no gvfsd process."""
         getpwuid_mock.return_value = pwd.struct_passwd(
             ("testuser", "x", 1337, 42, "Test user,,,", "/home/testuser", "/bin/bash")
@@ -2688,8 +2687,8 @@ class T(unittest.TestCase):
 
         run_mock.assert_called_once_with(["/bin/true"], check=False)
 
-    @unittest.mock.patch("os.getgid", unittest.mock.MagicMock(return_value=37))
-    @unittest.mock.patch("os.getuid", unittest.mock.MagicMock(return_value=37))
+    @unittest.mock.patch("os.getgid", MagicMock(return_value=37))
+    @unittest.mock.patch("os.getuid", MagicMock(return_value=37))
     @unittest.mock.patch.dict("os.environ", {"SUDO_UID": "0"})
     def test_run_as_real_user_non_root(self) -> None:
         # pylint: disable=no-self-use

--- a/tests/system/test_ui_gtk.py
+++ b/tests/system/test_ui_gtk.py
@@ -21,6 +21,7 @@ import textwrap
 import unittest
 import unittest.mock
 from gettext import gettext as _
+from unittest.mock import MagicMock
 
 import apport.crashdb_impl.memory
 import apport.report
@@ -510,9 +511,7 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
         # no crash counter
         self.assertFalse(self.app.w("ignore_future_problems").get_property("visible"))
 
-    @unittest.mock.patch.object(
-        GTKUserInterface, "can_examine_locally", unittest.mock.MagicMock()
-    )
+    @unittest.mock.patch.object(GTKUserInterface, "can_examine_locally", MagicMock())
     def test_examine_button(self):
         """Crash dialog showing or not showing "Examine locally".
 
@@ -656,16 +655,16 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
         self.assertFalse(remember_send_error_report.get_property("visible"))
         self.assertFalse(remember_send_error_report.get_active())
 
-    @unittest.mock.patch.object(GTKUserInterface, "open_url", unittest.mock.MagicMock())
+    @unittest.mock.patch.object(GTKUserInterface, "open_url", MagicMock())
     @unittest.mock.patch.object(
-        GTKUserInterface, "ui_start_upload_progress", unittest.mock.MagicMock()
+        GTKUserInterface, "ui_start_upload_progress", MagicMock()
     )
     @unittest.mock.patch.object(
-        GTKUserInterface, "ui_stop_upload_progress", unittest.mock.MagicMock()
+        GTKUserInterface, "ui_stop_upload_progress", MagicMock()
     )
-    @unittest.mock.patch("apport.report.Report.add_gdb_info", unittest.mock.MagicMock())
+    @unittest.mock.patch("apport.report.Report.add_gdb_info", MagicMock())
     @unittest.mock.patch(
-        "apport.fileutils.allowed_to_report", unittest.mock.MagicMock(return_value=True)
+        "apport.fileutils.allowed_to_report", MagicMock(return_value=True)
     )
     def test_crash_nodetails(self):
         """Crash report without showing details"""
@@ -705,16 +704,16 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
         # URL was opened
         self.assertEqual(self.app.open_url.call_count, 1)
 
-    @unittest.mock.patch.object(GTKUserInterface, "open_url", unittest.mock.MagicMock())
+    @unittest.mock.patch.object(GTKUserInterface, "open_url", MagicMock())
     @unittest.mock.patch.object(
-        GTKUserInterface, "ui_start_upload_progress", unittest.mock.MagicMock()
+        GTKUserInterface, "ui_start_upload_progress", MagicMock()
     )
     @unittest.mock.patch.object(
-        GTKUserInterface, "ui_stop_upload_progress", unittest.mock.MagicMock()
+        GTKUserInterface, "ui_stop_upload_progress", MagicMock()
     )
-    @unittest.mock.patch("apport.report.Report.add_gdb_info", unittest.mock.MagicMock())
+    @unittest.mock.patch("apport.report.Report.add_gdb_info", MagicMock())
     @unittest.mock.patch(
-        "apport.fileutils.allowed_to_report", unittest.mock.MagicMock(return_value=True)
+        "apport.fileutils.allowed_to_report", MagicMock(return_value=True)
     )
     def test_crash_details(self):
         """Crash report with showing details"""
@@ -766,15 +765,15 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
         # URL was opened
         self.assertEqual(self.app.open_url.call_count, 1)
 
-    @unittest.mock.patch.object(GTKUserInterface, "open_url", unittest.mock.MagicMock())
+    @unittest.mock.patch.object(GTKUserInterface, "open_url", MagicMock())
     @unittest.mock.patch.object(
-        GTKUserInterface, "ui_start_upload_progress", unittest.mock.MagicMock()
+        GTKUserInterface, "ui_start_upload_progress", MagicMock()
     )
     @unittest.mock.patch.object(
-        GTKUserInterface, "ui_stop_upload_progress", unittest.mock.MagicMock()
+        GTKUserInterface, "ui_stop_upload_progress", MagicMock()
     )
     @unittest.mock.patch(
-        "apport.fileutils.allowed_to_report", unittest.mock.MagicMock(return_value=True)
+        "apport.fileutils.allowed_to_report", MagicMock(return_value=True)
     )
     def test_broken_crash_details(self):
         """Broken crash report with showing details."""
@@ -839,9 +838,9 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
         self.assertIn("cannot be reported", self.error_text)
         self.assertIn("decompressing", self.error_text)
 
-    @unittest.mock.patch.object(GTKUserInterface, "open_url", unittest.mock.MagicMock())
+    @unittest.mock.patch.object(GTKUserInterface, "open_url", MagicMock())
     @unittest.mock.patch(
-        "apport.fileutils.allowed_to_report", unittest.mock.MagicMock(return_value=True)
+        "apport.fileutils.allowed_to_report", MagicMock(return_value=True)
     )
     def test_crash_noaccept(self):
         """Crash report with non-accepting crash DB"""
@@ -876,9 +875,9 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
         self.assertTrue(r["Package"].startswith("bash "))
         self.assertIn("libc", r["Dependencies"])
 
-    @unittest.mock.patch.object(GTKUserInterface, "open_url", unittest.mock.MagicMock())
+    @unittest.mock.patch.object(GTKUserInterface, "open_url", MagicMock())
     @unittest.mock.patch(
-        "apport.fileutils.allowed_to_report", unittest.mock.MagicMock(return_value=True)
+        "apport.fileutils.allowed_to_report", MagicMock(return_value=True)
     )
     def test_kerneloops_nodetails(self):
         """Kernel oops report without showing details"""
@@ -963,7 +962,7 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
         )
         self.assertEqual(self.app.report["Package"], f"{pkg} (not installed)")
 
-    @unittest.mock.patch.object(GTKUserInterface, "open_url", unittest.mock.MagicMock())
+    @unittest.mock.patch.object(GTKUserInterface, "open_url", MagicMock())
     def test_update_report(self):
         """Updating an existing report."""
         self.app.report_file = None
@@ -997,7 +996,7 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
         # No URL in this mode
         self.assertEqual(self.app.open_url.call_count, 0)
 
-    @unittest.mock.patch.object(GTKUserInterface, "open_url", unittest.mock.MagicMock())
+    @unittest.mock.patch.object(GTKUserInterface, "open_url", MagicMock())
     def test_update_report_different_binary_source(self):
         """Updating an existing report on a source package which does not have
         a binary of the same name"""
@@ -1048,9 +1047,7 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
         # No URL in this mode
         self.assertEqual(self.app.open_url.call_count, 0)
 
-    @unittest.mock.patch.object(
-        GTKUserInterface, "get_desktop_entry", unittest.mock.MagicMock()
-    )
+    @unittest.mock.patch.object(GTKUserInterface, "get_desktop_entry", MagicMock())
     def test_missing_icon(self):
         # LP: 937354
         self.app.report["ProblemType"] = "Crash"
@@ -1142,7 +1139,7 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
         self.app.run_crash(self.app.report_file)
 
     @unittest.mock.patch.object(
-        GTKUserInterface, "ui_start_upload_progress", unittest.mock.MagicMock()
+        GTKUserInterface, "ui_start_upload_progress", MagicMock()
     )
     def test_close_during_collect(self):
         """Close details window during information collection"""

--- a/tests/system/test_ui_kde.py
+++ b/tests/system/test_ui_kde.py
@@ -20,6 +20,7 @@ import textwrap
 import unittest
 import unittest.mock
 from gettext import gettext as _
+from unittest.mock import MagicMock
 
 try:
     from PyQt5.QtCore import QCoreApplication, QTimer
@@ -492,12 +493,10 @@ class T(unittest.TestCase):
             )
         self.assertEqual(answer, None)
 
-    @unittest.mock.patch.object(
-        MainUserInterface, "open_url", unittest.mock.MagicMock()
-    )
-    @unittest.mock.patch("apport.report.Report.add_gdb_info", unittest.mock.MagicMock())
+    @unittest.mock.patch.object(MainUserInterface, "open_url", MagicMock())
+    @unittest.mock.patch("apport.report.Report.add_gdb_info", MagicMock())
     @unittest.mock.patch(
-        "apport.fileutils.allowed_to_report", unittest.mock.MagicMock(return_value=True)
+        "apport.fileutils.allowed_to_report", MagicMock(return_value=True)
     )
     def test_1_crash_nodetails(self):
         """Crash report without showing details"""
@@ -531,12 +530,10 @@ class T(unittest.TestCase):
         # URL was opened
         self.assertEqual(self.app.open_url.call_count, 1)
 
-    @unittest.mock.patch.object(
-        MainUserInterface, "open_url", unittest.mock.MagicMock()
-    )
-    @unittest.mock.patch("apport.report.Report.add_gdb_info", unittest.mock.MagicMock())
+    @unittest.mock.patch.object(MainUserInterface, "open_url", MagicMock())
+    @unittest.mock.patch("apport.report.Report.add_gdb_info", MagicMock())
     @unittest.mock.patch(
-        "apport.fileutils.allowed_to_report", unittest.mock.MagicMock(return_value=True)
+        "apport.fileutils.allowed_to_report", MagicMock(return_value=True)
     )
     def test_1_crash_details(self):
         """Crash report with showing details"""
@@ -583,12 +580,10 @@ class T(unittest.TestCase):
         # URL was opened
         self.assertEqual(self.app.open_url.call_count, 1)
 
-    @unittest.mock.patch.object(
-        MainUserInterface, "open_url", unittest.mock.MagicMock()
-    )
-    @unittest.mock.patch("apport.report.Report.add_gdb_info", unittest.mock.MagicMock())
+    @unittest.mock.patch.object(MainUserInterface, "open_url", MagicMock())
+    @unittest.mock.patch("apport.report.Report.add_gdb_info", MagicMock())
     @unittest.mock.patch(
-        "apport.fileutils.allowed_to_report", unittest.mock.MagicMock(return_value=True)
+        "apport.fileutils.allowed_to_report", MagicMock(return_value=True)
     )
     def test_1_crash_noaccept(self):
         """Crash report with non-accepting crash DB"""
@@ -662,9 +657,7 @@ class T(unittest.TestCase):
         )
         self.assertEqual(self.app.report["Package"], f"{pkg} (not installed)")
 
-    @unittest.mock.patch.object(
-        MainUserInterface, "open_url", unittest.mock.MagicMock()
-    )
+    @unittest.mock.patch.object(MainUserInterface, "open_url", MagicMock())
     def test_1_update_report(self):
         """Updating an existing report"""
         self.app.report_file = None
@@ -697,9 +690,7 @@ class T(unittest.TestCase):
         # No URL in this mode
         self.assertEqual(self.app.open_url.call_count, 0)
 
-    @unittest.mock.patch.object(
-        MainUserInterface, "open_url", unittest.mock.MagicMock()
-    )
+    @unittest.mock.patch.object(MainUserInterface, "open_url", MagicMock())
     def test_1_update_report_different_binary_source(self):
         """Updating an existing report on a source package which does not have
         a binary of the same name"""

--- a/tests/unit/test_fileutils.py
+++ b/tests/unit/test_fileutils.py
@@ -7,6 +7,7 @@ import io
 import time
 import unittest
 import unittest.mock
+from unittest.mock import MagicMock
 
 import apport.fileutils
 import apport.packaging
@@ -54,7 +55,7 @@ class T(unittest.TestCase):
     def test_get_login_defs_missing(self) -> None:
         """Test get_login_defs() with /etc/login.defs not present."""
         apport.fileutils.get_login_defs.cache_clear()
-        open_mock = unittest.mock.MagicMock(side_effect=FileNotFoundError)
+        open_mock = MagicMock(side_effect=FileNotFoundError)
         with unittest.mock.patch("builtins.open", open_mock):
             login_defs = apport.fileutils.get_login_defs()
         open_mock.assert_called_once()
@@ -72,7 +73,7 @@ class T(unittest.TestCase):
     def test_get_sys_gid_max_default(self) -> None:
         """Test get_sys_gid_max() returning the default."""
         apport.fileutils.get_login_defs.cache_clear()
-        open_mock = unittest.mock.MagicMock(side_effect=FileNotFoundError)
+        open_mock = MagicMock(side_effect=FileNotFoundError)
         with unittest.mock.patch("builtins.open", open_mock):
             sys_gid_max = apport.fileutils.get_sys_gid_max()
         open_mock.assert_called_once()

--- a/tests/unit/test_hooks_image.py
+++ b/tests/unit/test_hooks_image.py
@@ -10,6 +10,7 @@
 """Unit tests for data/general-hooks/image.py."""
 
 import unittest
+from unittest.mock import MagicMock
 
 import problem_report
 from tests.helper import import_module_from_file
@@ -21,7 +22,7 @@ image = import_module_from_file(get_data_directory() / "general-hooks" / "image.
 class TestGeneralHookImage(unittest.TestCase):
     """Unit tests for data/general-hooks/image.py."""
 
-    @unittest.mock.patch("os.path.isfile", unittest.mock.MagicMock(return_value=True))
+    @unittest.mock.patch("os.path.isfile", MagicMock(return_value=True))
     def test_add_info(self):
         """Test add_info() for Ubuntu 22.04 server cloud image."""
         report = problem_report.ProblemReport()
@@ -39,7 +40,7 @@ class TestGeneralHookImage(unittest.TestCase):
         self.assertEqual(report["Tags"], "cloud-image")
         open_mock.assert_called_with("/etc/cloud/build.info", encoding="utf-8")
 
-    @unittest.mock.patch("os.path.isfile", unittest.mock.MagicMock(return_value=True))
+    @unittest.mock.patch("os.path.isfile", MagicMock(return_value=True))
     def test_add_info_empty_build_info(self):
         """Test add_info() with empty /etc/cloud/build.info."""
         report = problem_report.ProblemReport()
@@ -50,7 +51,7 @@ class TestGeneralHookImage(unittest.TestCase):
         self.assertEqual(report["Tags"], "cloud-image")
         open_mock.assert_called_with("/etc/cloud/build.info", encoding="utf-8")
 
-    @unittest.mock.patch("os.path.isfile", unittest.mock.MagicMock(return_value=True))
+    @unittest.mock.patch("os.path.isfile", MagicMock(return_value=True))
     def test_add_info_unknown_field(self):
         """Test add_info() with unknown field in /etc/cloud/build.info."""
         report = problem_report.ProblemReport()

--- a/tests/unit/test_hookutils.py
+++ b/tests/unit/test_hookutils.py
@@ -6,6 +6,7 @@ import subprocess
 import time
 import unittest
 import unittest.mock
+from unittest.mock import MagicMock
 
 import apport.hookutils
 
@@ -16,15 +17,12 @@ class TestHookutils(unittest.TestCase):
 
     maxDiff = None
 
-    @unittest.mock.patch("os.path.isdir", unittest.mock.MagicMock(return_value=True))
+    @unittest.mock.patch("os.path.isdir", MagicMock(return_value=True))
     @unittest.mock.patch("os.listdir")
     @unittest.mock.patch("os.stat")
     @unittest.mock.patch("apport.hookutils.read_file")
     def test_attach_dmi(
-        self,
-        read_file_mock: unittest.mock.MagicMock,
-        stat_mock: unittest.mock.MagicMock,
-        listdir_mock: unittest.mock.MagicMock,
+        self, read_file_mock: MagicMock, stat_mock: MagicMock, listdir_mock: MagicMock
     ) -> None:
         """attach_dmi()"""
 
@@ -106,7 +104,7 @@ class TestHookutils(unittest.TestCase):
         self.assertEqual(report["CurrentDmesg"], "existingcurrent")
 
     @unittest.mock.patch("subprocess.run")
-    @unittest.mock.patch("os.path.exists", unittest.mock.MagicMock(return_value=True))
+    @unittest.mock.patch("os.path.exists", MagicMock(return_value=True))
     def test_attach_journal_errors_with_date(self, run_mock):
         run_mock.return_value = subprocess.CompletedProcess(
             args=None, returncode=0, stdout=b"journalctl output", stderr=b""
@@ -128,7 +126,7 @@ class TestHookutils(unittest.TestCase):
         )
 
     @unittest.mock.patch("subprocess.run")
-    @unittest.mock.patch("os.path.exists", unittest.mock.MagicMock(return_value=True))
+    @unittest.mock.patch("os.path.exists", MagicMock(return_value=True))
     def test_attach_journal_errors_without_date(self, run_mock):
         run_mock.return_value = subprocess.CompletedProcess(
             args=None, returncode=0, stdout=b"journalctl output", stderr=b""
@@ -157,7 +155,7 @@ class TestHookutils(unittest.TestCase):
         )
 
     @unittest.mock.patch("subprocess.Popen")
-    @unittest.mock.patch("os.path.exists", unittest.mock.MagicMock(return_value=True))
+    @unittest.mock.patch("os.path.exists", MagicMock(return_value=True))
     def test_recent_syslog_journald_cmd(self, popen_mock):
         class _SkipPopen(Exception):
             pass

--- a/tests/unit/test_packaging_apt_dpkg.py
+++ b/tests/unit/test_packaging_apt_dpkg.py
@@ -12,6 +12,7 @@
 import tempfile
 import unittest
 import unittest.mock
+from unittest.mock import MagicMock
 
 import apt
 
@@ -25,7 +26,7 @@ from apport.packaging_impl.apt_dpkg import (
 
 @unittest.mock.patch(
     "apport.packaging_impl.apt_dpkg.__AptDpkgPackageInfo.get_os_version",
-    unittest.mock.MagicMock(return_value=("Ubuntu", "22.04")),
+    MagicMock(return_value=("Ubuntu", "22.04")),
 )
 class TestPackagingAptDpkg(unittest.TestCase):
     """Unit tests for apport.packaging_impl.apt_dpkg."""
@@ -34,7 +35,7 @@ class TestPackagingAptDpkg(unittest.TestCase):
     def test_is_distro_package_no_candidate(self, apt_cache_mock):
         """is_distro_package() for package that has no candidate."""
         getitem_mock = apt_cache_mock.return_value.__getitem__
-        getitem_mock.return_value = unittest.mock.MagicMock(
+        getitem_mock.return_value = MagicMock(
             spec=apt.Package, installed=None, candidate=None
         )
         self.assertEqual(impl.is_distro_package("adduser"), False)
@@ -44,9 +45,9 @@ class TestPackagingAptDpkg(unittest.TestCase):
     def test_is_distro_package_no_installed_version(self, apt_cache_mock):
         """is_distro_package() for not installed package."""
         getitem_mock = apt_cache_mock.return_value.__getitem__
-        getitem_mock.return_value = unittest.mock.MagicMock(
+        getitem_mock.return_value = MagicMock(
             spec=apt.Package,
-            installed=unittest.mock.MagicMock(spec=apt.package.Version, version=None),
+            installed=MagicMock(spec=apt.package.Version, version=None),
         )
         self.assertEqual(impl.is_distro_package("7zip"), False)
         getitem_mock.assert_called_once_with("7zip")
@@ -54,13 +55,13 @@ class TestPackagingAptDpkg(unittest.TestCase):
     @unittest.mock.patch("apt.Cache", spec=apt.Cache)
     def test_is_distro_package_ppa(self, apt_cache_mock):
         """is_distro_package() for a PPA package."""
-        version = unittest.mock.MagicMock(
+        version = MagicMock(
             spec=apt.package.Version,
-            origins=[unittest.mock.MagicMock(spec=apt.package.Origin, origin="LP-PPA")],
+            origins=[MagicMock(spec=apt.package.Origin, origin="LP-PPA")],
             version="0.5.0-0ppa1",
         )
         getitem_mock = apt_cache_mock.return_value.__getitem__
-        getitem_mock.return_value = unittest.mock.MagicMock(
+        getitem_mock.return_value = MagicMock(
             spec=apt.Package, candidate=version, installed=version
         )
         self.assertEqual(impl.is_distro_package("bdebstrap"), False)
@@ -70,13 +71,13 @@ class TestPackagingAptDpkg(unittest.TestCase):
     @unittest.mock.patch("apt.Cache", spec=apt.Cache)
     def test_is_distro_package_system_image(self, apt_cache_mock, exists_mock):
         """is_distro_package() for a system image without cache."""
-        version = unittest.mock.MagicMock(
+        version = MagicMock(
             spec=apt.package.Version,
-            origins=[unittest.mock.MagicMock(spec=apt.package.Origin, origin="")],
+            origins=[MagicMock(spec=apt.package.Origin, origin="")],
             version="2.23.1-0ubuntu4",
         )
         getitem_mock = apt_cache_mock.return_value.__getitem__
-        getitem_mock.return_value = unittest.mock.MagicMock(
+        getitem_mock.return_value = MagicMock(
             spec=apt.Package, candidate=version, installed=version
         )
         exists_mock.return_value = True

--- a/tests/unit/test_report.py
+++ b/tests/unit/test_report.py
@@ -8,6 +8,7 @@ import os
 import textwrap
 import unittest
 import unittest.mock
+from unittest.mock import MagicMock
 
 import apport.packaging
 import apport.report
@@ -597,7 +598,7 @@ dispatch_queue () at canberra-gtk-module.c:815""",
             ),
         )
 
-    @unittest.mock.patch("shutil.which", unittest.mock.MagicMock(return_value=None))
+    @unittest.mock.patch("shutil.which", MagicMock(return_value=None))
     def test_gdb_add_info_no_gdb(self):
         r = apport.report.Report()
         r["Signal"] = "6"

--- a/tests/unit/test_sandboxutils.py
+++ b/tests/unit/test_sandboxutils.py
@@ -13,6 +13,7 @@ import os
 import tempfile
 import unittest
 import unittest.mock
+from unittest.mock import MagicMock
 
 from apport.packaging import PackageInfo
 from apport.report import Report
@@ -32,7 +33,7 @@ class TestSandboxutils(unittest.TestCase):
         return report
 
     @unittest.mock.patch("apport.sandboxutils.packaging", spec=PackageInfo)
-    def test_make_sandbox(self, packaging_mock: unittest.mock.MagicMock) -> None:
+    def test_make_sandbox(self, packaging_mock: MagicMock) -> None:
         """make_sandbox() for a sample report."""
         packaging_mock.install_packages.return_value = "obsolete\n"
         report = self._get_sample_report()
@@ -44,7 +45,7 @@ class TestSandboxutils(unittest.TestCase):
 
     @unittest.mock.patch("apport.sandboxutils.packaging", spec=PackageInfo)
     def test_make_sandbox_install_packages_failure(
-        self, packaging_mock: unittest.mock.MagicMock
+        self, packaging_mock: MagicMock
     ) -> None:
         """make_sandbox() where packaging.install_packages fails."""
         packaging_mock.install_packages.side_effect = SystemError("100% fail")
@@ -53,9 +54,7 @@ class TestSandboxutils(unittest.TestCase):
         packaging_mock.install_packages.assert_called_once()
 
     @unittest.mock.patch("apport.sandboxutils.packaging", spec=PackageInfo)
-    def test_make_sandbox_with_sandbox_dir(
-        self, packaging_mock: unittest.mock.MagicMock
-    ) -> None:
+    def test_make_sandbox_with_sandbox_dir(self, packaging_mock: MagicMock) -> None:
         """make_sandbox() with sandbox_dir set."""
         packaging_mock.install_packages.return_value = "obsolete\n"
         with tempfile.TemporaryDirectory(dir="/var/tmp") as tmpdir:

--- a/tests/unit/test_signal_crashes.py
+++ b/tests/unit/test_signal_crashes.py
@@ -18,6 +18,7 @@ import sys
 import tempfile
 import time
 import unittest
+from unittest.mock import MagicMock
 
 import apport.fileutils
 import apport.user_group
@@ -65,7 +66,7 @@ class TestApport(unittest.TestCase):
             del os.environ["APPORT_LOCK_FILE"]
 
     @unittest.mock.patch("fcntl.lockf")
-    def test_check_lock_taken(self, lockf_mock: unittest.mock.MagicMock) -> None:
+    def test_check_lock_taken(self, lockf_mock: MagicMock) -> None:
         """Test check_lock() with lock file taken by other process."""
         # Since this is a unit test, let the mock raise an exception instead
         # of letting the fcntl.lockf call run into the timeout signal.
@@ -86,7 +87,7 @@ class TestApport(unittest.TestCase):
         self.assertEqual(apport_binary.refine_core_ulimit(options), -1)
 
     @unittest.mock.patch("os.isatty")
-    def test_init_error_log_is_tty(self, isatty_mock: unittest.mock.MagicMock) -> None:
+    def test_init_error_log_is_tty(self, isatty_mock: MagicMock) -> None:
         """Test init_error_log() doing nothing on a TTY."""
         isatty_mock.return_value = True
         stderr = sys.stderr
@@ -114,11 +115,9 @@ class TestApport(unittest.TestCase):
         with self.assertRaisesRegex(SystemExit, "^1$"):
             apport_binary.receive_arguments_via_socket()
 
+    @unittest.mock.patch.object(apport_binary, "init_error_log", MagicMock())
     @unittest.mock.patch.object(
-        apport_binary, "init_error_log", unittest.mock.MagicMock()
-    )
-    @unittest.mock.patch.object(
-        apport_binary, "is_same_ns", unittest.mock.MagicMock(return_value=False)
+        apport_binary, "is_same_ns", MagicMock(return_value=False)
     )
     @unittest.mock.patch.object(apport_binary, "forward_crash_to_container")
     def test_main_forward_crash_to_container(self, forward_mock):
@@ -127,18 +126,14 @@ class TestApport(unittest.TestCase):
         self.assertEqual(apport_binary.main(args), 0)
         forward_mock.assert_called_once()
 
-    @unittest.mock.patch.object(
-        apport_binary, "init_error_log", unittest.mock.MagicMock()
-    )
+    @unittest.mock.patch.object(apport_binary, "init_error_log", MagicMock())
     @unittest.mock.patch.object(apport_binary, "start_apport")
     def test_main_start(self, start_mock):
         """Test calling apport with --start."""
         self.assertEqual(apport_binary.main(["--start"]), 0)
         start_mock.assert_called_once_with()
 
-    @unittest.mock.patch.object(
-        apport_binary, "init_error_log", unittest.mock.MagicMock()
-    )
+    @unittest.mock.patch.object(apport_binary, "init_error_log", MagicMock())
     @unittest.mock.patch.object(apport_binary, "stop_apport")
     def test_main_stop(self, stop_mock):
         """Test calling apport with --stop."""
@@ -195,14 +190,12 @@ class TestApport(unittest.TestCase):
         )
         self.assertEqual(open_mock.call_count, 3)
 
-    @unittest.mock.patch("os.setresgid", unittest.mock.MagicMock())
-    @unittest.mock.patch("os.setresuid", unittest.mock.MagicMock())
+    @unittest.mock.patch("os.setresgid", MagicMock())
+    @unittest.mock.patch("os.setresuid", MagicMock())
     @unittest.mock.patch.object(apport_binary, "_run_with_output_limit_and_timeout")
     @unittest.mock.patch("os.path.exists")
     def test_is_closing_session(
-        self,
-        path_exist_mock: unittest.mock.MagicMock,
-        run_mock: unittest.mock.MagicMock,
+        self, path_exist_mock: MagicMock, run_mock: MagicMock
     ) -> None:
         """Test is_closing_session()."""
         path_exist_mock.return_value = True
@@ -252,14 +245,12 @@ class TestApport(unittest.TestCase):
                     apport_binary.is_closing_session(proc_pid, crash_user), False
                 )
 
-    @unittest.mock.patch("os.setresgid", unittest.mock.MagicMock())
-    @unittest.mock.patch("os.setresuid", unittest.mock.MagicMock())
+    @unittest.mock.patch("os.setresgid", MagicMock())
+    @unittest.mock.patch("os.setresuid", MagicMock())
     @unittest.mock.patch.object(apport_binary, "_run_with_output_limit_and_timeout")
     @unittest.mock.patch("os.path.exists")
     def test_is_closing_session_gdbus_failure(
-        self,
-        path_exist_mock: unittest.mock.MagicMock,
-        run_mock: unittest.mock.MagicMock,
+        self, path_exist_mock: MagicMock, run_mock: MagicMock
     ) -> None:
         """Test is_closing_session() with OSError from gdbus."""
         path_exist_mock.return_value = True
@@ -277,10 +268,8 @@ class TestApport(unittest.TestCase):
         path_exist_mock.assert_called_once_with("/run/user/1337/bus")
         run_mock.assert_called_once()
 
-    @unittest.mock.patch.object(apport_binary, "check_lock", unittest.mock.MagicMock())
-    @unittest.mock.patch.object(
-        apport_binary, "init_error_log", unittest.mock.MagicMock()
-    )
+    @unittest.mock.patch.object(apport_binary, "check_lock", MagicMock())
+    @unittest.mock.patch.object(apport_binary, "init_error_log", MagicMock())
     def test_missing_proc_pid(self) -> None:
         """Test /proc/<pid> is already gone."""
         fake_pid = 2147483647


### PR DESCRIPTION
Importing `MagicMock` from `unittest.mock` makes the code shorter by reducing the need to wrap long lines.