### PR TITLE
Expect to pass pid as int to Report.add_proc_environ

### DIFF
--- a/apport/ui.py
+++ b/apport/ui.py
@@ -635,7 +635,7 @@ class UserInterface:
         """Kill process with signal SIGSEGV."""
         os.kill(int(pid), signal.SIGSEGV)
 
-    def run_report_bug(self, symptom_script=None):
+    def run_report_bug(self, symptom_script: Optional[str] = None) -> bool:
         # TODO: Split into smaller functions/methods
         # pylint: disable=too-many-branches,too-many-return-statements
         # pylint: disable=too-many-statements
@@ -762,7 +762,7 @@ class UserInterface:
 
         return True
 
-    def run_update_report(self):
+    def run_update_report(self) -> bool:
         """Update an existing bug with locally collected information."""
         # avoid irrelevant noise
         if not self.crashdb.can_update(self.args.update_report):

--- a/tests/integration/test_report.py
+++ b/tests/integration/test_report.py
@@ -253,7 +253,7 @@ class T(unittest.TestCase):
         # test process is gone, should complain about nonexisting PID
         self.assertRaises(ValueError, pr.add_proc_info, process.pid)
 
-    def test_add_proc_info_nonascii(self):
+    def test_add_proc_info_nonascii(self) -> None:
         """add_proc_info() for non-ASCII values"""
         lang = b"n\xc3\xb6_v\xc3\xb8lid"
 
@@ -298,7 +298,7 @@ class T(unittest.TestCase):
         self.assertEqual(r["ProcEnviron"], "LANG=xx_YY.UTF-8")
         self.assertEqual(r["CurrentDesktop"], "Pixel Pusher")
 
-    def test_add_path_classification(self):
+    def test_add_path_classification(self) -> None:
         """Classification of $PATH."""
         # system default
         with subprocess.Popen(


### PR DESCRIPTION
Expect to pass `pid` as `int` to `Report.add_proc_environ`. Add type hints to all callers. Also use `int` in `Report.add_proc_info`, but keep supporting `str` for backward compatibility.