### PR TITLE
feat: assert that a problem report exists where needed

### DIFF
--- a/apport/ui.py
+++ b/apport/ui.py
@@ -406,6 +406,7 @@ class UserInterface:
         for f in reports:
             if not self.load_report(f):
                 continue
+            assert self.report
 
             # Skip crashes that happened during logout, which are uninteresting
             # and confusing to see at the next login. A crash happened and gets
@@ -456,6 +457,7 @@ class UserInterface:
                 pass
             if not self.report and not self.load_report(report_file):
                 return
+            assert self.report
 
             if "Ignore" in self.report:
                 return
@@ -1257,6 +1259,7 @@ class UserInterface:
 
     def get_complete_size(self):
         """Return the size of the complete report."""
+        assert self.report
         # report wasn't loaded, so count manually
         size = 0
         for k in self.report:
@@ -1271,6 +1274,7 @@ class UserInterface:
 
     def get_reduced_size(self):
         """Return the size of the reduced report."""
+        assert self.report
         size = 0
         for k in self.report:
             if k != "CoreDump":
@@ -1300,7 +1304,7 @@ class UserInterface:
 
     def restart(self):
         """Reopen the crashed application."""
-        assert "ProcCmdline" in self.report
+        assert self.report and "ProcCmdline" in self.report
 
         if os.fork() == 0:
             os.setsid()
@@ -1314,6 +1318,7 @@ class UserInterface:
 
     def examine(self):
         """Locally examine crash report."""
+        assert self.report_file
         response = self.ui_question_choice(
             _(
                 "This will launch apport-retrace in a terminal window"
@@ -1391,7 +1396,7 @@ class UserInterface:
 
     def check_report_crashdb(self):
         """Process reports' CrashDB field, if present."""
-        if "CrashDB" not in self.report:
+        if self.report is None or "CrashDB" not in self.report:
             return True
 
         # specification?
@@ -1445,6 +1450,7 @@ class UserInterface:
         If a symptom script is given, this will be run first (used by
         run_symptom()).
         """
+        assert self.report
         self.report["_MarkForUpload"] = "True"
 
         # skip if we already ran (we might load a processed report)
@@ -1730,6 +1736,7 @@ class UserInterface:
             on_finished()
 
     def _is_snap(self):
+        assert self.report
         return "SnapSource" in self.report or "Snap" in self.report
 
     def open_url(self, url):
@@ -1772,6 +1779,7 @@ class UserInterface:
     def file_report(self):
         """Upload the current report and guide the user to the reporting
         web page."""
+        assert self.report
         # FIXME: This behaviour is not really correct, but necessary as
         # long as we only support a single crashdb and have whoopsie
         # hardcoded. Once we have multiple crash dbs, we need to check
@@ -1896,6 +1904,7 @@ class UserInterface:
 
         If so, display an info message and return True.
         """
+        assert self.report
         if not self.crashdb.accepts(self.report):
             return False
         if "UnreportableReason" in self.report:
@@ -1920,6 +1929,7 @@ class UserInterface:
 
         Return None if report cannot be associated to a .desktop file.
         """
+        assert self.report
         if "DesktopFile" in self.report and os.path.exists(self.report["DesktopFile"]):
             desktop_file = self.report["DesktopFile"]
         else:
@@ -1952,6 +1962,7 @@ class UserInterface:
         If so, tell the user about it, open the existing bug in a browser, and
         return True.
         """
+        assert self.report
         if not self.crashdb.accepts(self.report):
             return False
         if "_KnownReport" not in self.report:

--- a/bin/apport-cli
+++ b/bin/apport-cli
@@ -154,6 +154,7 @@ class CLIUserInterface(apport.ui.UserInterface):
 
     def _get_details(self):
         """Build report string for display."""
+        assert self.report
 
         details = ""
         max_show = 1000000

--- a/gtk/apport-gtk
+++ b/gtk/apport-gtk
@@ -115,6 +115,7 @@ class GTKUserInterface(apport.ui.UserInterface):
     def ui_update_view(self, shown_keys=None):
         # TODO: Split into smaller functions/methods
         # pylint: disable=too-many-branches
+        assert self.report
 
         # do nothing if the dialog is already destroyed when the data
         # collection finishes
@@ -180,6 +181,7 @@ class GTKUserInterface(apport.ui.UserInterface):
         prominent placement. Otherwise, provide a simple explanation for
         more novice users.
         """
+        assert self.report
         env = self.report.get("ProcEnviron", "")
         from_console = "TERM=" in env and "SHELL=" in env
 
@@ -202,6 +204,7 @@ class GTKUserInterface(apport.ui.UserInterface):
     def setup_bug_report(self):
         # This is a bug generated through `apport-bug $package`, or
         # `apport-collect $id`.
+        assert self.report
 
         # avoid collecting information again, in this mode we already have it
         if "DistroRelease" in self.report:

--- a/kde/apport-kde
+++ b/kde/apport-kde
@@ -367,6 +367,7 @@ class MainUserInterface(apport.ui.UserInterface):
     #
 
     def ui_update_view(self, dialog, shown_keys=None):
+        assert self.report
         # report contents
         details = dialog.findChild(QTreeWidget, "details")
         if shown_keys:

--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -328,6 +328,7 @@ class T(unittest.TestCase):
         self.assertTrue(rs < 10000)
 
         # now add some information (e. g. from package hooks)
+        assert self.ui.report
         self.ui.report["ExtraInfo"] = "A" * 50000
         s = self.ui.get_complete_size()
         self.assertTrue(s >= fsize + 49900)
@@ -352,6 +353,7 @@ class T(unittest.TestCase):
         """load_report()"""
         # valid report
         self.ui.load_report(self.report_file.name)
+        assert self.ui.report
         self.assertEqual(set(self.ui.report.keys()), set(self.report.keys()))
         self.assertEqual(self.ui.report["Package"], self.report["Package"])
         self.assertEqual(
@@ -438,6 +440,7 @@ class T(unittest.TestCase):
         self.ui.load_report(self.report_file.name)
         # add some tuple values, for robustness testing (might be added by
         # apport hooks)
+        assert self.ui.report
         self.ui.report["Fstab"] = ("/etc/fstab", True)
         self.ui.report["CompressedValue"] = problem_report.CompressedValue(b"Test")
         self.ui.collect_info()
@@ -476,6 +479,7 @@ class T(unittest.TestCase):
             # wait for ui_pulse_info_collection_progress() call
             while self.ui.ic_progress_pulses == progress_pulses:
                 time.sleep(0.01)
+            assert self.ui.report
             return apport.report.Report.search_bug_patterns(self.ui.report, url)
 
         with unittest.mock.patch.object(
@@ -709,6 +713,7 @@ class T(unittest.TestCase):
             f"http://bash.bugs.example.com/{self.ui.crashdb.latest_id()}",
         )
 
+        assert self.ui.report
         self.assertTrue(self.ui.ic_progress_pulses > 0)
         self.assertEqual(self.ui.report["SourcePackage"], "bash")
         self.assertIn("Dependencies", self.ui.report)
@@ -734,6 +739,7 @@ class T(unittest.TestCase):
             self.ui.present_details_response = apport.ui.Action(report=True)
             self.assertEqual(self.ui.run_argv(), True)
 
+        assert self.ui.report
         self.assertIn("SourcePackage", self.ui.report)
         self.assertIn("Dependencies", self.ui.report)
         self.assertIn("ProcMaps", self.ui.report)
@@ -826,6 +832,7 @@ class T(unittest.TestCase):
         self.ui = UserInterfaceMock(["ui-test", "-f", "-P", str(pid)])
         self.ui.present_details_response = apport.ui.Action(report=True)
         self.ui.run_argv()
+        assert self.ui.report
 
         kernel_package = apport.packaging.get_kernel_package()
         self.assertEqual(
@@ -954,6 +961,7 @@ class T(unittest.TestCase):
         self.assertNotEqual(self.ui.ic_progress_pulses, 0)
         self.assertTrue(self.ui.present_details_shown)
 
+        assert self.ui.report
         self.assertIn("SourcePackage", self.ui.report)
         self.assertIn("Dependencies", self.ui.report)
         self.assertIn("Stacktrace", self.ui.report)
@@ -982,6 +990,7 @@ class T(unittest.TestCase):
         self.assertEqual(self.ui.opened_url, None)
         self.assertEqual(self.ui.ic_progress_pulses, 0)
 
+        assert self.ui.report
         self.assertTrue(self.ui.report.check_ignored())
         self.assertEqual(self.ui.offer_restart, False)
 
@@ -997,6 +1006,7 @@ class T(unittest.TestCase):
         self.ui.run_crash(report_file)
         self.assertEqual(self.ui.msg_severity, None, self.ui.msg_text)
 
+        assert self.ui.report
         self.assertIn("SourcePackage", self.ui.report)
         self.assertIn("Dependencies", self.ui.report)
         self.assertIn("Stacktrace", self.ui.report)
@@ -1304,6 +1314,7 @@ class T(unittest.TestCase):
         self.ui.present_details_response = apport.ui.Action(report=True)
         self.ui.run_crash(report_file)
 
+        assert self.ui.report
         self.assertNotIn("ExecutableTimestamp", self.ui.report)
         self.assertIn(
             self.ui.report["ExecutablePath"],
@@ -1354,6 +1365,7 @@ class T(unittest.TestCase):
         )
         self.assertTrue(self.ui.present_details_shown)
 
+        assert self.ui.report
         self.assertIn("SourcePackage", self.ui.report)
         self.assertIn("Package", self.ui.report)
         self.assertEqual(self.ui.report["ProblemType"], "Package")
@@ -1427,6 +1439,7 @@ class T(unittest.TestCase):
         )
         self.assertTrue(self.ui.present_details_shown)
 
+        assert self.ui.report
         self.assertIn("SourcePackage", self.ui.report)
         # did we run the hooks properly?
         self.assertIn("KernelDebug", self.ui.report)
@@ -1458,6 +1471,7 @@ class T(unittest.TestCase):
         self.ui.run_crash(report_file)
         self.assertEqual(self.ui.msg_severity, None, self.ui.msg_text)
 
+        assert self.ui.report
         self.assertNotIn("ProcCwd", self.ui.report)
 
         dump = io.BytesIO()
@@ -1517,6 +1531,7 @@ class T(unittest.TestCase):
             self.ui.run_crash(report_file)
             self.assertEqual(self.ui.msg_severity, None, self.ui.msg_text)
 
+            assert self.ui.report
             self.assertEqual(self.ui.report["ProcAuxInfo"], "my hostname")
             # after anonymization this should mess up Stacktrace; this mostly
             # confirms that our test logic works
@@ -1547,6 +1562,7 @@ class T(unittest.TestCase):
             self.ui.run_crash(report_file)
             self.assertEqual(self.ui.msg_severity, None, self.ui.msg_text)
 
+            assert self.ui.report
             self.assertTrue(
                 self.ui.report["Title"].startswith(
                     f"{os.path.basename(self.TEST_EXECUTABLE)} crashed with SIGSEGV"
@@ -1587,6 +1603,7 @@ class T(unittest.TestCase):
             self.ui.run_crash(report_file)
             self.assertEqual(self.ui.msg_severity, None, self.ui.msg_text)
 
+            assert self.ui.report
             self.assertEqual(
                 self.ui.report["ProcInfo1"], "That was User Name and friends"
             )
@@ -1608,6 +1625,7 @@ class T(unittest.TestCase):
             r.write(f)
         self.ui.crashdb.known = lambda r: True
         self.ui.run_crash(report_file)
+        assert self.ui.report
         self.assertEqual(self.ui.report["_KnownReport"], "1")
         self.assertEqual(self.ui.msg_severity, "info")
         self.assertEqual(self.ui.opened_url, None)
@@ -1619,6 +1637,7 @@ class T(unittest.TestCase):
             r.write(f)
         self.ui.crashdb.known = lambda r: "http://myreport/1"
         self.ui.run_crash(report_file)
+        assert self.ui.report
         self.assertEqual(self.ui.report["_KnownReport"], "http://myreport/1")
         self.assertEqual(self.ui.msg_severity, "info")
         self.assertEqual(self.ui.opened_url, "http://myreport/1")
@@ -1724,6 +1743,7 @@ class T(unittest.TestCase):
         self.assertTrue(self.ui.present_details_shown)
 
         self.assertTrue(self.ui.ic_progress_pulses > 0)
+        assert self.ui.report
         self.assertTrue(self.ui.report["Package"].startswith("bash "))
         self.assertIn("Dependencies", self.ui.report)
         self.assertIn("ProcEnviron", self.ui.report)
@@ -1742,6 +1762,7 @@ class T(unittest.TestCase):
         self.assertTrue(self.ui.present_details_shown)
 
         self.assertTrue(self.ui.ic_progress_pulses > 0)
+        assert self.ui.report
         self.assertTrue(self.ui.report["Package"].startswith("bash "))
         self.assertIn("Dependencies", self.ui.report)
         self.assertIn("ProcEnviron", self.ui.report)
@@ -1759,6 +1780,7 @@ class T(unittest.TestCase):
         self.assertTrue(self.ui.present_details_shown)
 
         self.assertTrue(self.ui.ic_progress_pulses > 0)
+        assert self.ui.report
         self.assertTrue(self.ui.report["Package"].startswith("bash "))
         self.assertIn("Dependencies", self.ui.report)
         self.assertIn("ProcEnviron", self.ui.report)
@@ -1780,6 +1802,7 @@ class T(unittest.TestCase):
         self.assertTrue(self.ui.present_details_shown)
 
         self.assertTrue(self.ui.ic_progress_pulses > 0)
+        assert self.ui.report
         self.assertEqual(self.ui.report["Package"], "foo (not installed)")
         self.assertEqual(self.ui.report["MachineType"], "Laptop")
         self.assertIn("ProcEnviron", self.ui.report)
@@ -1808,6 +1831,7 @@ class T(unittest.TestCase):
         self.assertTrue(self.ui.present_details_shown)
 
         self.assertTrue(self.ui.ic_progress_pulses > 0)
+        assert self.ui.report
         self.assertEqual(self.ui.report["Package"], f"{source_pkg} (not installed)")
         self.assertEqual(self.ui.report["MachineType"], "Laptop")
         self.assertIn("ProcEnviron", self.ui.report)
@@ -1835,6 +1859,7 @@ class T(unittest.TestCase):
                 """
             )
         )
+        assert self.ui.report
         self.assertEqual(self.ui.report["begin"], "1")
         self.assertEqual(self.ui.report["end"], "1")
         self.assertEqual(self.ui.msg_text, "InfoText")
@@ -1852,6 +1877,7 @@ class T(unittest.TestCase):
                 """
             )
         )
+        assert self.ui.report
         self.assertEqual(self.ui.report["begin"], "1")
         self.assertEqual(self.ui.report["end"], "1")
         self.assertEqual(self.ui.msg_text, "YesNo?")
@@ -1880,6 +1906,7 @@ class T(unittest.TestCase):
                 """
             )
         )
+        assert self.ui.report
         self.assertEqual(self.ui.report["begin"], "1")
         self.assertEqual(self.ui.report["end"], "1")
         self.assertEqual(self.ui.msg_text, "YourFile?")
@@ -1904,6 +1931,7 @@ class T(unittest.TestCase):
                 """
             )
         )
+        assert self.ui.report
         self.assertEqual(self.ui.report["begin"], "1")
         self.assertEqual(self.ui.report["end"], "1")
         self.assertEqual(self.ui.msg_text, "YourChoice?")
@@ -1929,6 +1957,7 @@ class T(unittest.TestCase):
                 """
             )
         )
+        assert self.ui.report
         self.assertEqual(self.ui.report["answer"], "None")
 
     def test_interactive_hooks_cancel(self):
@@ -1997,6 +2026,7 @@ class T(unittest.TestCase):
         self.assertEqual(self.ui.msg_severity, None)
         self.assertTrue(self.ui.present_details_shown)
 
+        assert self.ui.report
         self.assertEqual(self.ui.report["itch"], "scratch")
         self.assertIn("DistroRelease", self.ui.report)
         self.assertEqual(self.ui.report["SourcePackage"], "bash")
@@ -2012,6 +2042,7 @@ class T(unittest.TestCase):
         self.assertEqual(self.ui.msg_severity, None)
         self.assertTrue(self.ui.present_details_shown)
 
+        assert self.ui.report
         self.assertEqual(self.ui.report["itch"], "scratch")
         self.assertIn("foo", self.ui.report.get_tags())
 
@@ -2034,6 +2065,7 @@ class T(unittest.TestCase):
         self.assertTrue(self.ui.present_details_shown)
         self.assertEqual(self.ui.msg_text, "do you?")
 
+        assert self.ui.report
         self.assertEqual(self.ui.report["itch"], "slap")
         self.assertIn("DistroRelease", self.ui.report)
         self.assertEqual(self.ui.report["SourcePackage"], "bash")
@@ -2082,6 +2114,7 @@ class T(unittest.TestCase):
         self.assertEqual(self.ui.msg_severity, None)
         self.assertTrue(self.ui.ic_progress_pulses > 0)
         self.assertTrue(self.ui.present_details_shown)
+        assert self.ui.report
         self.assertTrue(self.ui.report["Package"].startswith("bash"))
 
     @unittest.mock.patch("sys.stderr", new_callable=io.StringIO)
@@ -2474,6 +2507,7 @@ class T(unittest.TestCase):
     def test_can_examine_locally_nocrash(self):
         """can_examine_locally() for a non-crash report"""
         self.ui.load_report(self.report_file.name)
+        assert self.ui.report
         del self.ui.report["CoreDump"]
 
         orig_fn = self.ui.ui_has_terminal
@@ -2503,6 +2537,7 @@ class T(unittest.TestCase):
         self.assertTrue(self.ui.present_details_shown)
 
         # data was collected for whoopsie
+        assert self.ui.report
         self.assertEqual(self.ui.report["SourcePackage"], "bash")
         self.assertIn("Dependencies", self.ui.report)
         self.assertIn("ProcEnviron", self.ui.report)


### PR DESCRIPTION
Some UI methods rely on an existing problem report. Assert that they are present instead of trying to access the report.