### PR TITLE
test: let fake_getpwuid return pwd.struct_passwd

### DIFF
--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -1565,10 +1565,10 @@ class T(unittest.TestCase):
         orig_getpwuid = pwd.getpwuid
         orig_getuid = os.getuid
 
-        def fake_getpwuid(_unused_uid):
+        def fake_getpwuid(_unused_uid: int) -> pwd.struct_passwd:
             r = list(orig_getpwuid(orig_getuid()))
             r[4] = "Joe (Hacker,+1 234,,"
-            return r
+            return pwd.struct_passwd(r)
 
         pwd.getpwuid = fake_getpwuid
         os.getuid = lambda: 1234


### PR DESCRIPTION
`pwd.getpwuid` returns a `pwd.struct_passwd`. So let `fake_getpwuid` return the same type.