### PR TITLE
test/apport-valgrind: do not limit diff size

### DIFF
--- a/tests/integration/test_apport_valgrind.py
+++ b/tests/integration/test_apport_valgrind.py
@@ -23,6 +23,8 @@ from tests.paths import local_test_environment
 class TestApportValgrind(unittest.TestCase):
     """Integration tests for bin/apport-valgrind."""
 
+    maxDiff = None
+
     @classmethod
     def setUpClass(cls):
         cls.env = os.environ | local_test_environment()


### PR DESCRIPTION
Set `maxDiff` to `None` to see full diff output for better debugging bugs like https://launchpad.net/bugs/2043713