### PR TITLE
apport-unpack: fix reading from stdin

### DIFF
--- a/bin/apport-unpack
+++ b/bin/apport-unpack
@@ -19,9 +19,12 @@ import argparse
 import contextlib
 import gettext
 import gzip
+import io
 import os
 import sys
+from collections.abc import Iterator
 from gettext import gettext as _
+from typing import BinaryIO
 
 import problem_report
 from apport import fatal
@@ -36,10 +39,13 @@ def parse_args() -> argparse.Namespace:
 
 
 @contextlib.contextmanager
-def open_report(report_filename):
+def open_report(report_filename: str) -> Iterator[(BinaryIO | gzip.GzipFile)]:
     """Open a problem report from given filename."""
     if report_filename == "-":
-        yield sys.stdin
+        # sys.stdin has type io.TextIOWrapper, not the claimed io.TextIO.
+        # See https://github.com/python/typeshed/issues/10093
+        assert isinstance(sys.stdin, io.TextIOWrapper)
+        yield sys.stdin.detach()
     elif report_filename.endswith(".gz"):
         with gzip.open(report_filename, "rb") as report_file:
             yield report_file
@@ -67,7 +73,10 @@ def main() -> None:
     bin_keys = []
     try:
         with open_report(args.report) as report_file:
-            report.load(report_file, binary=False)
+            # In case of passing the report to stdin,
+            # the report needs to be loaded in one go.
+            # The current implementation loads the whole report into memory.
+            report.load(report_file, binary=args.report == "-")
     except (OSError, problem_report.MalformedProblemReport) as error:
         fatal("%s", str(error))
     for key, value in report.items():

--- a/bin/apport-unpack
+++ b/bin/apport-unpack
@@ -79,11 +79,12 @@ def main() -> None:
                 key_file.write(value.encode("UTF-8"))
             else:
                 key_file.write(value)
-    try:
-        with open_report(args.report) as report_file:
-            report.extract_keys(report_file, bin_keys, args.target_directory)
-    except (OSError, problem_report.MalformedProblemReport) as error:
-        fatal("%s", str(error))
+    if bin_keys:
+        try:
+            with open_report(args.report) as report_file:
+                report.extract_keys(report_file, bin_keys, args.target_directory)
+        except (OSError, problem_report.MalformedProblemReport) as error:
+            fatal("%s", str(error))
 
 
 if __name__ == "__main__":

--- a/bin/apport-unpack
+++ b/bin/apport-unpack
@@ -16,6 +16,7 @@ empty directory."""
 # pylint: enable=invalid-name
 
 import argparse
+import contextlib
 import gettext
 import gzip
 import os
@@ -34,18 +35,17 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def load_report(report_filename: str) -> problem_report.ProblemReport:
-    """Load problem report from given filename."""
-    report = problem_report.ProblemReport()
+@contextlib.contextmanager
+def open_report(report_filename):
+    """Open a problem report from given filename."""
     if report_filename == "-":
-        report.load(sys.stdin, binary=False)
+        yield sys.stdin
     elif report_filename.endswith(".gz"):
         with gzip.open(report_filename, "rb") as report_file:
-            report.load(report_file, binary=False)
+            yield report_file
     else:
         with open(report_filename, "rb") as report_file:
-            report.load(report_file, binary=False)
-    return report
+            yield report_file
 
 
 # pylint: disable-next=missing-function-docstring
@@ -63,9 +63,11 @@ def main() -> None:
     except OSError as error:
         fatal("%s", str(error))
 
+    report = problem_report.ProblemReport()
     bin_keys = []
     try:
-        report = load_report(args.report)
+        with open_report(args.report) as report_file:
+            report.load(report_file, binary=False)
     except (OSError, problem_report.MalformedProblemReport) as error:
         fatal("%s", str(error))
     for key, value in report.items():
@@ -78,12 +80,8 @@ def main() -> None:
             else:
                 key_file.write(value)
     try:
-        if args.report.endswith(".gz"):
-            with gzip.open(args.report, "rb") as key_file:
-                report.extract_keys(key_file, bin_keys, args.target_directory)
-        else:
-            with open(args.report, "rb") as key_file:
-                report.extract_keys(key_file, bin_keys, args.target_directory)
+        with open_report(args.report) as report_file:
+            report.extract_keys(report_file, bin_keys, args.target_directory)
     except (OSError, problem_report.MalformedProblemReport) as error:
         fatal("%s", str(error))
 

--- a/bin/apport-unpack
+++ b/bin/apport-unpack
@@ -26,7 +26,7 @@ import problem_report
 from apport import fatal
 
 
-def parse_args():
+def parse_args() -> argparse.Namespace:
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(usage=_("%(prog)s <report> <target directory>"))
     parser.add_argument("report", help=_("Report file to unpack"))
@@ -49,7 +49,7 @@ def load_report(report_filename: str) -> problem_report.ProblemReport:
 
 
 # pylint: disable-next=missing-function-docstring
-def main():
+def main() -> None:
     gettext.textdomain("apport")
     args = parse_args()
 

--- a/tests/integration/test_apport_unpack.py
+++ b/tests/integration/test_apport_unpack.py
@@ -64,6 +64,27 @@ class TestApportUnpack(unittest.TestCase):
         self.assertEqual(self._get_unpack("binary"), self.bindata)
         self.assertEqual(self._get_unpack("compressed"), b"FooFoo!")
 
+    def test_unpack_stdin(self):
+        """apport-unpack unpacks report from stdin"""
+        with open(self.report_file, "rb") as report_file:
+            process = subprocess.run(
+                ["apport-unpack", "-", self.unpack_dir],
+                check=False,
+                env=self.env,
+                stdin=report_file,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+
+        self.assertEqual(process.stderr, b"", process.stderr.decode())
+        self.assertEqual(process.stdout, b"", process.stdout.decode())
+        self.assertEqual(process.returncode, 0)
+
+        self.assertEqual(self._get_unpack("utf8"), self.utf8_str)
+        self.assertEqual(self._get_unpack("unicode"), self.utf8_str)
+        self.assertEqual(self._get_unpack("binary"), self.bindata)
+        self.assertEqual(self._get_unpack("compressed"), b"FooFoo!")
+
     def test_help(self):
         """Call apport-unpack with --help."""
         process = self._call_apport_unpack(["--help"])


### PR DESCRIPTION
Reading a report from stdin fails:

```
Traceback (most recent call last):
  File "bin/apport-unpack", line 91, in <module>
    main()
  File "bin/apport-unpack", line 70, in main
    report.load(report_file, binary=False)
  File "problem_report.py", line 155, in load
    self._assert_bin_mode(file)
  File "problem_report.py", line 792, in _assert_bin_mode
    assert not hasattr(file, "encoding"), "file stream must be in binary mode"
AssertionError: file stream must be in binary mode
```

This failure has been found by mypy after adding type hints to `ProblemReport.load`.