### PR TITLE
report: use isinstance check for CompressedValue

### DIFF
--- a/apport/report.py
+++ b/apport/report.py
@@ -1920,7 +1920,7 @@ class Report(problem_report.ProblemReport):
                 atexit.register(os.unlink, core)
                 os.write(fd, self["CoreDump"])
                 os.close(fd)
-            elif hasattr(self["CoreDump"], "gzipvalue"):
+            elif isinstance(self["CoreDump"], problem_report.CompressedValue):
                 (fd, core) = tempfile.mkstemp(prefix="apport_core_")
                 atexit.register(os.unlink, core)
                 os.close(fd)


### PR DESCRIPTION
The property `gzipvalue` from `CompressedValue` should not be used directly.