### PR TITLE
problem_report: add CompressedValue.get_on_disk_size

### DIFF
--- a/apport/ui.py
+++ b/apport/ui.py
@@ -1265,9 +1265,7 @@ class UserInterface:
         for k in self.report:
             if self.report[k]:
                 try:
-                    # if we have a compressed value, take its size, but take
-                    # base64 overhead into account
-                    size += len(self.report[k].gzipvalue) * 8 / 6
+                    size += self.report[k].get_on_disk_size()
                 except AttributeError:
                     size += len(self.report[k])
         return size
@@ -1280,9 +1278,7 @@ class UserInterface:
             if k != "CoreDump":
                 if self.report[k]:
                     try:
-                        # if we have a compressed value, take its size,
-                        # but take base64 overhead into account
-                        size += len(self.report[k].gzipvalue) * 8 / 6
+                        size += self.report[k].get_on_disk_size()
                     except AttributeError:
                         size += len(self.report[k])
 

--- a/problem_report.py
+++ b/problem_report.py
@@ -73,6 +73,15 @@ class CompressedValue:
         self.gzipvalue = out.getvalue()
         self.legacy_zlib = False
 
+    def get_on_disk_size(self) -> int:
+        """Return the size needed on disk to store the compressed value.
+
+        The compressed value will be base64 encoded when written to disk
+        which adds an overhead of 1/3 plus up to 2 bytes of padding. Additional
+        spaces and newlines are ignored in this calculation.
+        """
+        return ((len(self.gzipvalue) + 2) // 3) * 4
+
     def get_value(self):
         """Return uncompressed value."""
         if not self.gzipvalue:

--- a/tests/unit/test_problem_report.py
+++ b/tests/unit/test_problem_report.py
@@ -3,6 +3,7 @@
 # TODO: Address following pylint complaints
 # pylint: disable=invalid-name
 
+import base64
 import email
 import io
 import locale
@@ -671,3 +672,10 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
         self.assertEqual(pr["DataYes"], "yesyes")
         self.assertEqual(pr["GoodFile"], bin_data)
         self.assertEqual(sorted(pr.keys()), ["DataYes", "GoodFile"])
+
+    def test_get_on_disk_size(self) -> None:
+        """Test CompressedValue.get_on_disk_size()."""
+        compressed_value = problem_report.CompressedValue(b"somedata")
+        self.assertEqual(len(compressed_value.gzipvalue), 28)
+        base64_encoded = base64.b64encode(compressed_value.gzipvalue)
+        self.assertEqual(compressed_value.get_on_disk_size(), len(base64_encoded))


### PR DESCRIPTION
Avoid accessing `CompressedValue.gzipvalue` directly. So move the on-disk size calculation into a `get_on_disk_size` method.