### PR TITLE
apport-cli/apport-kde: show the most interesting fields first in the details view

### DIFF
--- a/bin/apport-cli
+++ b/bin/apport-cli
@@ -157,20 +157,17 @@ class CLIUserInterface(apport.ui.UserInterface):
 
         details = ""
         max_show = 1000000
-        for key in sorted(self.report):
-            # ignore internal keys
-            if key.startswith("_"):
-                continue
+        for key, value in self.report.sorted_items():
             details += f"== {key} =================================\n"
             # string value
-            keylen = len(self.report[key])
+            keylen = len(value)
             if (
-                not hasattr(self.report[key], "gzipvalue")
-                and hasattr(self.report[key], "isspace")
-                and not self.report.is_binary(self.report[key])
+                not hasattr(value, "gzipvalue")
+                and hasattr(value, "isspace")
+                and not self.report.is_binary(value)
                 and keylen < max_show
             ):
-                s = self.report[key]
+                s = value
             elif keylen >= max_show:
                 s = _("(%i bytes)") % keylen
             else:

--- a/gtk/apport-gtk
+++ b/gtk/apport-gtk
@@ -112,8 +112,6 @@ class GTKUserInterface(apport.ui.UserInterface):
         return spinner
 
     def ui_update_view(self, shown_keys=None):
-        # TODO: Split into smaller functions/methods
-        # pylint: disable=too-many-branches
         assert self.report
 
         # do nothing if the dialog is already destroyed when the data
@@ -121,40 +119,18 @@ class GTKUserInterface(apport.ui.UserInterface):
         if not self.w("details_treeview").get_property("visible"):
             return
 
-        if shown_keys:
-            keys = set(self.report.keys()) & set(shown_keys)
-        else:
-            keys = self.report.keys()
-        # show the most interesting items on top
-        keys = sorted(keys)
-        for k in (
-            "Traceback",
-            "StackTrace",
-            "Title",
-            "ProblemType",
-            "Package",
-            "ExecutablePath",
-        ):
-            if k in keys:
-                keys.remove(k)
-                keys.insert(0, k)
-
         self.tree_model.clear()
-        for key in keys:
-            # ignore internal keys
-            if key.startswith("_"):
-                continue
-
+        for key, value in self.report.sorted_items(shown_keys):
             keyiter = self.tree_model.insert_before(None, None)
             self.tree_model.set_value(keyiter, 0, key)
 
             valiter = self.tree_model.insert_before(keyiter, None)
             if (
-                not hasattr(self.report[key], "gzipvalue")
-                and hasattr(self.report[key], "isspace")
-                and not self.report.is_binary(self.report[key])
+                not hasattr(value, "gzipvalue")
+                and hasattr(value, "isspace")
+                and not self.report.is_binary(value)
             ):
-                v = self.report[key]
+                v = value
                 if len(v) > 4000:
                     v = v[:4000]
                     if isinstance(v, bytes):
@@ -165,7 +141,7 @@ class GTKUserInterface(apport.ui.UserInterface):
                     v = v.decode("UTF-8", errors="replace")
                 self.tree_model.set_value(valiter, 0, v)
                 # expand the row if the value has less than 5 lines
-                if len(list(filter(lambda c: c == "\n", self.report[key]))) < 4:
+                if len(list(filter(lambda c: c == "\n", value))) < 4:
                     self.w("details_treeview").expand_row(
                         self.tree_model.get_path(keyiter), False
                     )

--- a/kde/apport-kde
+++ b/kde/apport-kde
@@ -369,26 +369,18 @@ class MainUserInterface(apport.ui.UserInterface):
         assert self.report
         # report contents
         details = dialog.findChild(QTreeWidget, "details")
-        if shown_keys:
-            keys = set(self.report.keys()) & set(shown_keys)
-        else:
-            keys = self.report.keys()
         details.clear()
-        for key in sorted(keys):
-            # ignore internal keys
-            if key.startswith("_"):
-                continue
-
+        for key, value in self.report.sorted_items(shown_keys):
             keyitem = QTreeWidgetItem([key])
             details.addTopLevelItem(keyitem)
 
             # string value
             if (
-                not hasattr(self.report[key], "gzipvalue")
-                and hasattr(self.report[key], "isspace")
-                and not self.report.is_binary(self.report[key])
+                not hasattr(value, "gzipvalue")
+                and hasattr(value, "isspace")
+                and not self.report.is_binary(value)
             ):
-                lines = self.report[key].splitlines()
+                lines = value.splitlines()
                 for line in lines:
                     QTreeWidgetItem(keyitem, [str(line)])
                 if len(lines) < 4:

--- a/tests/integration/test_ui_cli.py
+++ b/tests/integration/test_ui_cli.py
@@ -49,20 +49,30 @@ class TestApportCli(unittest.TestCase):
         self.app.report["CoreDump"] = b"\x01\x02"
 
     @skip_if_command_is_missing("/usr/bin/sensible-pager")
-    def test_ui_update_view(self):
+    def test_ui_update_view(self) -> None:
         read_fd, write_fd = os.pipe()
         with os.fdopen(write_fd, "w", buffering=1) as stdout:
             self.app.ui_update_view(stdout=stdout)
         with os.fdopen(read_fd, "r") as pipe:
             report = pipe.read()
-        self.assertIn(
-            "== ExecutablePath =================================\n"
+        self.assertRegex(
+            report,
+            "^== ExecutablePath =================================\n"
             "/bin/bash\n\n"
             "== ProblemType =================================\n"
             "Crash\n\n"
+            "== Architecture =================================\n"
+            "[^\n]+\n\n"
+            "== CoreDump =================================\n"
+            "[^\n]+\n\n"
+            "== Date =================================\n"
+            "[^\n]+\n\n"
+            "== DistroRelease =================================\n"
+            "[^\n]+\n\n"
             "== Signal =================================\n"
-            "11\n\n",
-            report,
+            "11\n\n"
+            "== Uname =================================\n"
+            "[^\n]+\n\n$",
         )
 
     @unittest.mock.patch("sys.stdout", new_callable=io.StringIO)

--- a/tests/unit/test_problem_report.py
+++ b/tests/unit/test_problem_report.py
@@ -434,6 +434,35 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
             ).encode(),
         )
 
+    def test_sorted_items(self) -> None:
+        """Test ProblemReport.sorted_items()."""
+        bin_report = textwrap.dedent(
+            """\
+            ProblemType: Crash
+            Date: now!
+            File: base64
+             eJw=
+             c3RyxIAMcBAFAG55BXk=
+            _MarkForUpload: False
+            Architecture: amd64
+            ExecutablePath: /usr/bin/python3
+            Package: python3.12-minimal
+            """
+        ).encode()
+
+        report = problem_report.ProblemReport()
+        report.load(io.BytesIO(bin_report), binary=False)
+        self.assertEqual(
+            list(report.sorted_items()),
+            [
+                ("ExecutablePath", "/usr/bin/python3"),
+                ("Package", "python3.12-minimal"),
+                ("ProblemType", "Crash"),
+                ("Architecture", "amd64"),
+                ("Date", "now!"),
+            ],
+        )
+
     def test_write_mime_text(self):
         """write_mime() for text values."""
         pr = problem_report.ProblemReport(date="now!")


### PR DESCRIPTION
Commit d452b6123689a90433c54cfc96b0bdd07e1c4a83 ("apport-gtk: Show the most interesting fields first in the details view.") implemented showing the most interesting fields only for apport-gtk but ignored apport-cli and apport-kde.

Move the sorting logic into `ProblemReport.sorted_items` and use it in all UI implementations.