### PR TITLE
problem_report: support compressed value on CompressedValue init

### DIFF
--- a/problem_report.py
+++ b/problem_report.py
@@ -58,9 +58,9 @@ class CompressedValue:
     problem_report used zlib format (without gzip header).
     """
 
-    def __init__(self, value=None, name=None):
+    def __init__(self, value=None, name=None, compressed_value=None):
         """Initialize an empty CompressedValue object with an optional name."""
-        self.gzipvalue = None
+        self.gzipvalue = compressed_value
         self.name = name
         if value:
             self.set_value(value)
@@ -222,8 +222,7 @@ class ProblemReport(collections.UserDict):
                 value = value.strip()
                 if value == b"base64":
                     if binary == "compressed":
-                        value = CompressedValue(name=key)
-                        value.gzipvalue = b""
+                        value = CompressedValue(name=key, compressed_value=b"")
                     else:
                         value = b""
                     b64_block = True

--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -1049,8 +1049,7 @@ class T(unittest.TestCase):
         r = apport.Report()
         r["ExecutablePath"] = self.TEST_EXECUTABLE
         r["Signal"] = "11"
-        r["CoreDump"] = problem_report.CompressedValue()
-        r["CoreDump"].gzipvalue = b"AAAAAAAA"
+        r["CoreDump"] = problem_report.CompressedValue(compressed_value=b"AAAAAAAA")
         r.add_user_info()
 
         report_file = os.path.join(apport.fileutils.report_dir, "test.crash")


### PR DESCRIPTION
Avoid accessing the `CompressedValue.gzipvalue` property by allowing to set the compressed value on initialization.

This merge request depends on https://github.com/canonical/apport/pull/262.