### PR TITLE
apport-gtk: assert that widgets are found

### DIFF
--- a/gtk/apport-gtk
+++ b/gtk/apport-gtk
@@ -57,10 +57,11 @@ class GTKUserInterface(apport.ui.UserInterface):
     # pylint: disable=invalid-name,missing-function-docstring
     """GTK UserInterface."""
 
-    def w(self, widget):
+    def w(self, widget: str) -> Gtk.Widget:
         """Shortcut for getting a widget."""
-
-        return self.widgets.get_object(widget)
+        widget = self.widgets.get_object(widget)
+        assert widget is not None
+        return widget
 
     def __init__(self, argv: list[str]):
         apport.ui.UserInterface.__init__(self, argv)


### PR DESCRIPTION
`Gtk.Builder.get_object` might return `None`. This should only happen in case `apport-gtk.ui` is broken or not matching. Assert that the widgets are found to detect this kind of issue sooner and to make mypy happy.