### PR TITLE
apport-kde: fix AttributeError in ui_question_file()

### DIFF
--- a/kde/apport-kde
+++ b/kde/apport-kde
@@ -362,6 +362,17 @@ class MainUserInterface(apport.ui.UserInterface):
         self.dialog: Optional[ReportDialog] = None
         self.progress: Optional[ProgressDialog] = None
 
+        self.app = QApplication(argv)
+        self.app.setApplicationName("apport-kde")
+        self.app.setApplicationDisplayName(_("Apport"))
+        self.app.setWindowIcon(QIcon.fromTheme("apport"))
+        translator = QTranslator()
+        translator.load(
+            f"qtbase_{QLocale.system().name()}",
+            QLibraryInfo.location(QLibraryInfo.TranslationsPath),
+        )
+        self.app.installTranslator(translator)
+
     #
     # ui_* implementation of abstract UserInterface classes
     #
@@ -571,17 +582,6 @@ if __name__ == "__main__":
             "This program needs a running X session. Please see"
             ' "man apport-cli" for a command line version of Apport.'
         )
-
-    app = QApplication(sys.argv)
-    app.setApplicationName("apport-kde")
-    app.setApplicationDisplayName(_("Apport"))
-    app.setWindowIcon(QIcon.fromTheme("apport"))
-    translator = QTranslator()
-    translator.load(
-        f"qtbase_{QLocale.system().name()}",
-        QLibraryInfo.location(QLibraryInfo.TranslationsPath),
-    )
-    app.installTranslator(translator)
 
     UserInterface = MainUserInterface(sys.argv)
     sys.exit(UserInterface.run_argv())

--- a/kde/apport-kde
+++ b/kde/apport-kde
@@ -565,15 +565,14 @@ class MainUserInterface(apport.ui.UserInterface):
 
         return response
 
-    def ui_question_file(self, text):
+    def ui_question_file(self, text: str) -> str | None:
         """Show a file selector dialog.
 
         Return path if the user selected a file, or None if cancelled.
         """
-        response = QFileDialog.getOpenFileName(None, str(text))
-        if response.length() == 0:
-            return None
-        return str(response)
+        filename = QFileDialog.getOpenFileName(None, str(text))[0]
+        # filename will be an empty string when cancelled
+        return filename or None
 
 
 if __name__ == "__main__":

--- a/tests/system/test_ui_kde.py
+++ b/tests/system/test_ui_kde.py
@@ -24,8 +24,7 @@ from unittest.mock import MagicMock
 
 try:
     from PyQt5.QtCore import QCoreApplication, QTimer
-    from PyQt5.QtGui import QIcon
-    from PyQt5.QtWidgets import QApplication, QProgressBar, QTreeWidget
+    from PyQt5.QtWidgets import QProgressBar, QTreeWidget
 
     PYQT5_IMPORT_ERROR = None
 except ImportError as error:
@@ -69,11 +68,6 @@ class T(unittest.TestCase):
         os.environ["LANGUAGE"] = "C"
 
         cls.argv = [str(apport_kde_path)]
-        cls.app = QApplication(cls.argv)
-        cls.app.applicationName = "apport-kde"
-        cls.app.applicationDisplayName = _("Apport")
-        cls.app.windowIcon = QIcon.fromTheme("apport")
-
         r = apport.report.Report()
         r.add_os_info()
         cls.distro = r["DistroRelease"]
@@ -116,6 +110,8 @@ class T(unittest.TestCase):
             QCoreApplication.processEvents()
             self.ui.dialog.done(0)
             QCoreApplication.processEvents()
+        self.ui.app.exit()
+        del self.ui.app
 
         shutil.rmtree(self.report_dir)
         shutil.rmtree(self.hook_dir)

--- a/tests/system/test_ui_kde.py
+++ b/tests/system/test_ui_kde.py
@@ -24,7 +24,7 @@ from unittest.mock import MagicMock
 
 try:
     from PyQt5.QtCore import QCoreApplication, QTimer
-    from PyQt5.QtWidgets import QProgressBar, QTreeWidget
+    from PyQt5.QtWidgets import QFileDialog, QProgressBar, QTreeWidget
 
     PYQT5_IMPORT_ERROR = None
 except ImportError as error:
@@ -750,3 +750,16 @@ class T(unittest.TestCase):
             self.assertEqual(progress.value(), 500)
         finally:
             self.ui.ui_stop_upload_progress()
+
+    def test_ui_question_file_close(self) -> None:
+        def cont() -> None:
+            for widget in self.ui.app.allWidgets():
+                if isinstance(widget, QFileDialog):
+                    widget.close()
+                    return
+
+            # try again
+            QTimer.singleShot(10, cont)  # pragma: no cover
+
+        QTimer.singleShot(10, cont)
+        self.assertIsNone(self.ui.ui_question_file("Please select a file"))


### PR DESCRIPTION
Move setting up `app` from the top-level into `MainUserInterface`. This moves the `app` code to a place where it is tested as well.

`MainUserInterface.ui_question_file` fails:

```python
ERROR: test_ui_question_file_close (tests.system.test_ui_kde.T.test_ui_question_file_close)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/system/test_ui_kde.py", line 765, in test_ui_question_file_close
    self.assertIsNone(self.ui.ui_question_file("Please select a file"))
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "kde/apport-kde", line 574, in ui_question_file
    if response.length() == 0:
       ^^^^^^^^^^^^^^^
AttributeError: 'tuple' object has no attribute 'length'
```

`QFileDialog.getOpenFileName` returns a tuple of the file name and selected filter.