### PR TITLE
ui: pass PID as int to modal_for in ui_present_report_details

### DIFF
--- a/apport/ui.py
+++ b/apport/ui.py
@@ -606,7 +606,7 @@ class UserInterface:
         self.cur_package = apport.fileutils.find_file_package(path)
         self.report.add_os_info()
         allowed_to_report = apport.fileutils.allowed_to_report()
-        response = self.ui_present_report_details(allowed_to_report, modal_for=pid)
+        response = self.ui_present_report_details(allowed_to_report, modal_for=int(pid))
         if response.report:
             apport.fileutils.mark_hanging_process(self.report, pid)
             os.kill(int(pid), signal.SIGABRT)
@@ -1993,7 +1993,7 @@ class UserInterface:
     #
 
     def ui_present_report_details(
-        self, allowed_to_report: bool = True, modal_for: (str | None) = None
+        self, allowed_to_report: bool = True, modal_for: (int | None) = None
     ) -> Action:
         """Show details of the bug report.
 

--- a/bin/apport-cli
+++ b/bin/apport-cli
@@ -213,7 +213,7 @@ class CLIUserInterface(apport.ui.UserInterface):
         return report_file
 
     def ui_present_report_details(
-        self, allowed_to_report: bool = True, modal_for: (str | None) = None
+        self, allowed_to_report: bool = True, modal_for: (int | None) = None
     ) -> apport.ui.Action:
         dialog = CLIDialog(
             _("Send problem report to the developers?"),

--- a/gtk/apport-gtk
+++ b/gtk/apport-gtk
@@ -39,10 +39,8 @@ except (AssertionError, ImportError, RuntimeError) as error:
 have_display = os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY")
 
 
-def find_xid_for_pid(pid):
+def find_xid_for_pid(pid: int) -> int | None:
     """Return the X11 Window (xid) for the supplied process ID."""
-
-    pid = int(pid)
     screen = Wnck.Screen.get_default()
     screen.force_update()
     for window in screen.get_windows():
@@ -231,7 +229,7 @@ class GTKUserInterface(apport.ui.UserInterface):
         gdk_window.set_modal_hint(True)
 
     def ui_present_report_details(
-        self, allowed_to_report: bool = True, modal_for: (str | None) = None
+        self, allowed_to_report: bool = True, modal_for: (int | None) = None
     ) -> apport.ui.Action:
         # TODO: Split into smaller functions/methods
         # pylint: disable=too-many-branches,too-many-locals,too-many-statements

--- a/kde/apport-kde
+++ b/kde/apport-kde
@@ -397,7 +397,7 @@ class MainUserInterface(apport.ui.UserInterface):
                 QTreeWidgetItem(keyitem, [_("(binary data)")])
 
     def ui_present_report_details(
-        self, allowed_to_report: bool = True, modal_for: (str | None) = None
+        self, allowed_to_report: bool = True, modal_for: (int | None) = None
     ) -> apport.ui.Action:
         desktop_info = self.get_desktop_entry()
         self.dialog = ReportDialog(self.report, allowed_to_report, self, desktop_info)

--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -52,7 +52,7 @@ class UserInterfaceMock(apport.ui.UserInterface):
     # pylint: disable=too-many-instance-attributes
     """Concrete apport.ui.UserInterface suitable for automatic testing"""
 
-    def __init__(self, argv: (list[str] | None) = None):
+    def __init__(self, argv: (list[str] | None) = None) -> None:
         # use our memory crashdb which is designed for testing
         # closed in __del__, pylint: disable=consider-using-with
         self.crashdb_conf = tempfile.NamedTemporaryFile()
@@ -92,20 +92,20 @@ class UserInterfaceMock(apport.ui.UserInterface):
         self.upload_progress_pulses = 0
 
         # store last message box
-        self.msg_title = None
-        self.msg_text = None
-        self.msg_severity = None
-        self.msg_choices = None
+        self.msg_title: (str | None) = None
+        self.msg_text: (str | None) = None
+        self.msg_severity: (str | None) = None
+        self.msg_choices: (list[str] | None) = None
 
         # these store the choices the ui_present_* calls do
         self.present_package_error_response = None
         self.present_kernel_error_response = None
-        self.present_details_response = None
-        self.question_yesno_response = None
-        self.question_choice_response = None
-        self.question_file_response = None
+        self.present_details_response: (apport.ui.Action | None) = None
+        self.question_yesno_response: (bool | None) = None
+        self.question_choice_response: (list[int] | None) = None
+        self.question_file_response: (str | None) = None
 
-        self.opened_url = None
+        self.opened_url: (str | None) = None
         self.present_details_shown = False
 
         self.clear_msg()


### PR DESCRIPTION
The parameter `modal_for` in `UserInterface.ui_present_report_details` takes a process ID. Pass the process ID as `int` to it instead of `str` to avoid needing to convert it later.