### PR TITLE
problem_report: support reading zstd compressed values

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,11 @@ jobs:
           python3-distutils-extra python3-gi python3-launchpadlib
           python3-psutil python3-pytest python3-rpm python3-typeshed
           python3-yaml python3-requests
+      # python3-zstandard is not available on ubuntu:jammy
+      - name: Install optional dependencies
+        run: >
+          apt-get install --no-install-recommends --yes python3-zstandard
+          || true
       - name: Run linter tests
         run: tests/run-linters
 
@@ -56,6 +61,11 @@ jobs:
           && apt-get install --no-install-recommends --yes
           locales python3 python3-apt python3-pytest python3-pytest-cov
           python3-systemd
+      # python3-zstandard is not available on ubuntu:jammy
+      - name: Install optional dependencies
+        run: >
+          apt-get install --no-install-recommends --yes python3-zstandard
+          || true
       - name: Enable German locale
         run: sed -i 's/^# de_DE/de_DE/g' /etc/locale.gen && locale-gen
       - name: Run unit tests

--- a/doc/data-format.tex
+++ b/doc/data-format.tex
@@ -81,7 +81,10 @@ should be compressed.
 
 A binary value is introduced by the text ``\verb!base64!'' and a line break
 following the key name, colon, and space. After that, the binary data is
-encoded as follows:
+compressed (either gzip or zstandard) and then base64-encoded. Each line
+should contain at most 1 MiB of binary data when decoded and uncompressed.
+
+For gzip compression, the binary data is encoded as follows:
 
 \begin{itemize}
     \item Write a gzip header


### PR DESCRIPTION
`systemd-coredump` compresses the coredump with Zstandard. To support copying the coredump into a `ProblemReport` add support for reading Zstandard compressed values.

This merge request contains:
* https://github.com/canonical/apport/pull/255
* https://github.com/canonical/apport/pull/258
* https://github.com/canonical/apport/pull/259
* https://github.com/canonical/apport/pull/260
* https://github.com/canonical/apport/pull/261
* https://github.com/canonical/apport/pull/262
* https://github.com/canonical/apport/pull/269
* https://github.com/canonical/apport/pull/270