### PR TITLE
ui: only show string values in details view

### DIFF
--- a/bin/apport-cli
+++ b/bin/apport-cli
@@ -151,7 +151,7 @@ class CLIUserInterface(apport.ui.UserInterface):
         self.in_update_view = False
         self.progress = None
 
-    def _get_details(self):
+    def _get_details(self) -> str:
         """Build report string for display."""
         assert self.report
 
@@ -161,20 +161,13 @@ class CLIUserInterface(apport.ui.UserInterface):
             details += f"== {key} =================================\n"
             # string value
             keylen = len(value)
-            if (
-                not hasattr(value, "gzipvalue")
-                and hasattr(value, "isspace")
-                and not self.report.is_binary(value)
-                and keylen < max_show
-            ):
+            if isinstance(value, str) and keylen < max_show:
                 s = value
             elif keylen >= max_show:
                 s = _("(%i bytes)") % keylen
             else:
                 s = _("(binary data)")
 
-            if isinstance(s, bytes):
-                s = s.decode("UTF-8", errors="ignore")
             details += s
             details += "\n\n"
 

--- a/gtk/apport-gtk
+++ b/gtk/apport-gtk
@@ -110,7 +110,7 @@ class GTKUserInterface(apport.ui.UserInterface):
         spinner.hide()
         return spinner
 
-    def ui_update_view(self, shown_keys=None):
+    def ui_update_view(self, shown_keys: (list[str] | None) = None) -> None:
         assert self.report
 
         # do nothing if the dialog is already destroyed when the data
@@ -124,20 +124,10 @@ class GTKUserInterface(apport.ui.UserInterface):
             self.tree_model.set_value(keyiter, 0, key)
 
             valiter = self.tree_model.insert_before(keyiter, None)
-            if (
-                not hasattr(value, "gzipvalue")
-                and hasattr(value, "isspace")
-                and not self.report.is_binary(value)
-            ):
+            if isinstance(value, str):
                 v = value
                 if len(v) > 4000:
-                    v = v[:4000]
-                    if isinstance(v, bytes):
-                        v += b"\n[...]"
-                    else:
-                        v += "\n[...]"
-                if isinstance(v, bytes):
-                    v = v.decode("UTF-8", errors="replace")
+                    v = v[:4000] + "\n[...]"
                 self.tree_model.set_value(valiter, 0, v)
                 # expand the row if the value has less than 5 lines
                 if len(list(filter(lambda c: c == "\n", value))) < 4:

--- a/kde/apport-kde
+++ b/kde/apport-kde
@@ -393,7 +393,9 @@ class MainUserInterface(apport.ui.UserInterface):
     # ui_* implementation of abstract UserInterface classes
     #
 
-    def ui_update_view(self, dialog, shown_keys=None):
+    def ui_update_view(
+        self, dialog: ReportDialog, shown_keys: (list[str] | None) = None
+    ) -> None:
         assert self.report
         # report contents
         details = dialog.findChild(QTreeWidget, "details")
@@ -404,11 +406,7 @@ class MainUserInterface(apport.ui.UserInterface):
             details.addTopLevelItem(keyitem)
 
             # string value
-            if (
-                not hasattr(value, "gzipvalue")
-                and hasattr(value, "isspace")
-                and not self.report.is_binary(value)
-            ):
+            if isinstance(value, str):
                 lines = value.splitlines()
                 for line in lines:
                     QTreeWidgetItem(keyitem, [str(line)])


### PR DESCRIPTION
`ProblemReport` tries to convert the values to `str` when reading the report. Only show those string values in the details view instead of converting binary data.