### PR TITLE
problem_report: document multiple key extraction support

### DIFF
--- a/problem_report.py
+++ b/problem_report.py
@@ -235,7 +235,7 @@ class ProblemReport(collections.UserDict):
     def extract_keys(self, file, bin_keys, directory):
         # TODO: Split into smaller functions/methods
         # pylint: disable=too-many-branches
-        """Extract only one binary element from the problem report.
+        """Extract only given binary elements from the problem report.
 
         Binary elements like kernel crash dumps can be very big. This method
         extracts directly files without loading the report into memory.


### PR DESCRIPTION
Commit ed9101f3d87fc15068ac34c5a9d3ca11082236ee ("Implement multiple key extract : rename to extract_keys") implemened multiple key extract support but forgot to update the docstring for `extract_keys`.