### PR TITLE
apport-gtk: make have_display a boolean

### DIFF
--- a/gtk/apport-gtk
+++ b/gtk/apport-gtk
@@ -36,7 +36,7 @@ except (AssertionError, ImportError, RuntimeError) as error:
     sys.stderr.write(f"Cannot start: {str(error)}\n")
     sys.exit(1)
 
-have_display = os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY")
+have_display = bool(os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"))
 
 
 def find_xid_for_pid(pid: int) -> int | None:


### PR DESCRIPTION
The variable `have_display` should be a boolean and not a string.