### PR TITLE
apport-gtk/apport-kde: assert that terminal was found

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -255,7 +255,7 @@ jobs:
           gnome-icon-theme gpg gvfs-daemons psmisc python3 python3-apt
           python3-dbus python3-gi python3-launchpadlib python3-pyqt5
           python3-pytest python3-pytest-cov python3-requests
-          ubuntu-dbgsym-keyring ubuntu-keyring valgrind xvfb
+          ubuntu-dbgsym-keyring ubuntu-keyring valgrind xterm xvfb
       - name: Start D-Bus daemon
         run: mkdir -p /run/dbus && dbus-daemon --system --fork
       - name: Run system tests

--- a/gtk/apport-gtk
+++ b/gtk/apport-gtk
@@ -598,6 +598,7 @@ class GTKUserInterface(apport.ui.UserInterface):
 
     def ui_run_terminal(self, command):
         program = self._get_terminal()
+        assert program is not None
         subprocess.call([program, "-e", command])
 
     #

--- a/kde/apport-kde
+++ b/kde/apport-kde
@@ -494,6 +494,7 @@ class MainUserInterface(apport.ui.UserInterface):
 
     def ui_run_terminal(self, command):
         program = self._get_terminal()
+        assert program is not None
         subprocess.call([program, "-e", command])
 
     def ui_stop_info_collection_progress(self):

--- a/tests/system/test_ui_gtk.py
+++ b/tests/system/test_ui_gtk.py
@@ -1182,6 +1182,12 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
             f'Für Hilfe gehen Sie über <a href="{url}">{url}</a>.',
         )
 
+    def test_ui_run_terminal(self) -> None:
+        """Test ui_run_terminal."""
+        if not self.app.ui_has_terminal():
+            self.skipTest("installed terminal application needed")
+        self.app.ui_run_terminal("true")
+
     def test_ui_update_view_destroyed(self):
         """Test ui_update_view if the dialog is already destroyed."""
         self.app.w("details_treeview").destroy()

--- a/tests/system/test_ui_kde.py
+++ b/tests/system/test_ui_kde.py
@@ -46,6 +46,7 @@ else:
 @unittest.skipIf(PYQT5_IMPORT_ERROR, f"PyQt/PyKDE not available: {PYQT5_IMPORT_ERROR}")
 class T(unittest.TestCase):
     # pylint: disable=missing-class-docstring,missing-function-docstring
+    # pylint: disable=too-many-public-methods
     COLLECTING_DIALOG = unittest.mock.call(
         str(apport_kde_path.parent),
         "Collecting Problem Information",
@@ -742,6 +743,12 @@ class T(unittest.TestCase):
         self.ui.ui_present_report_details(False)
         self.assertFalse(self.ui.dialog.send_error_report.isVisible())
         self.assertFalse(self.ui.dialog.send_error_report.isChecked())
+
+    def test_ui_run_terminal(self) -> None:
+        """Test ui_run_terminal."""
+        if not self.ui.ui_has_terminal():
+            self.skipTest("installed terminal application needed")
+        self.ui.ui_run_terminal("true")
 
     def test_ui_set_upload_progress(self) -> None:
         self.ui.ui_start_upload_progress()


### PR DESCRIPTION
`UserInterface.ui_run_terminal` should only be called after checking that `UserInterface.ui_has_terminal` returns `True`. So assert that `UserInterface.ui_run_terminal` finds a terminal to make mypy happy.

Install `xterm` as terminal application in system-tests, but do not install any terminal application in system-tests-installed to cover not having a terminal application.