### PR TITLE
ui: remove skipping crashes that happened during logout

### DIFF
--- a/tests/integration/test_report.py
+++ b/tests/integration/test_report.py
@@ -1822,50 +1822,6 @@ int main() { return f(42); }
         self.assertEqual(res.split("+", 1)[1], "5")
         self.assertIn("python", res.split("+", 1)[0])
 
-    def test_get_logind_session(self):
-        ret = apport.Report.get_logind_session(os.getpid())
-        if ret is None:
-            # ensure that we don't run under logind, and thus the None is
-            # justified
-            with open("/proc/self/cgroup", encoding="utf-8") as f:
-                contents = f.read()
-            sys.stdout.write("[not running under logind] ")
-            sys.stdout.flush()
-            self.assertNotIn("name=systemd:/user", contents)
-            return
-
-        (session, timestamp) = ret
-        self.assertNotEqual(session, "")
-        # session start must be >= 2014-01-01 and <= "now"
-        self.assertLess(timestamp, time.time())
-        self.assertGreater(
-            timestamp, time.mktime(time.strptime("2014-01-01", "%Y-%m-%d"))
-        )
-
-    def test_get_logind_session_fd(self):
-        proc_pid_fd = os.open(
-            f"/proc/{os.getpid()}", os.O_RDONLY | os.O_PATH | os.O_DIRECTORY
-        )
-        self.addCleanup(os.close, proc_pid_fd)
-        ret = apport.Report.get_logind_session(proc_pid_fd=proc_pid_fd)
-        if ret is None:
-            # ensure that we don't run under logind, and thus the None is
-            # justified
-            with open("/proc/self/cgroup", encoding="utf-8") as f:
-                contents = f.read()
-            sys.stdout.write("[not running under logind] ")
-            sys.stdout.flush()
-            self.assertNotIn("name=systemd:/user", contents)
-            return
-
-        (session, timestamp) = ret
-        self.assertNotEqual(session, "")
-        # session start must be >= 2014-01-01 and <= "now"
-        self.assertLess(timestamp, time.time())
-        self.assertGreater(
-            timestamp, time.mktime(time.strptime("2014-01-01", "%Y-%m-%d"))
-        )
-
     def test_command_output(self):
         out = apport.report._command_output(["echo", "hello"])
         self.assertEqual(out, "hello")


### PR DESCRIPTION
Ubuntu >= 22.04 uses only cgroup2 (Ubuntu 20.04 used both and Ubuntu 18.04 only cgroup version 1). `Report.get_logind_session` will fail to determine the logind session and always return `None` if only cgroup2 is used.

`get_logind_session` searches for cgroup lines with "name=systemd:" and then extracts the session from "/session-". This worked in Ubuntu 16.04 but started to fail in Ubuntu 18.04.

Content of `/proc/self/cgroup` on Ubuntu 16.04 (xenial):

```
12:cpuset:/
11:perf_event:/
10:pids:/user.slice/user-1000.slice
9:blkio:/
8:hugetlb:/
7:net_cls,net_prio:/
6:cpu,cpuacct:/
5:devices:/user.slice
4:freezer:/
3:rdma:/
2:memory:/
1:name=systemd:/user.slice/user-1000.slice/session-c1.scope
```

Content of `/proc/self/cgroup` on Ubuntu 18.04 (bionic):

```
12:freezer:/
11:net_cls,net_prio:/
10:memory:/
9:rdma:/
8:cpu,cpuacct:/
7:devices:/user.slice
6:perf_event:/
5:cpuset:/
4:pids:/user.slice/user-1000.slice/user@1000.service
3:hugetlb:/
2:blkio:/
1:name=systemd:/user.slice/user-1000.slice/user@1000.service/gnome-terminal-server.service
0::/user.slice/user-1000.slice/user@1000.service/gnome-terminal-server.service
```

Content of `/proc/self/cgroup` on Ubuntu 22.04 (jammy):

```
0::/user.slice/user-1000.slice/user@1000.service/app.slice/app-org.gnome.Terminal.slice/vte-spawn-0c3f8b02-b112-4cab-accc-764cbb223bac.scope
```

So crashes that happened during logout haven't been skipped for over five years and no one filed a bug report for it. So just remove the broken code.

Bug: https://launchpad.net/bugs/2043393