### PR TITLE
coverage: automatically exclude skipTest lines

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,11 @@
 [tool.black]
 line-length = 88
 
+[tool.coverage.report]
+exclude_also = [
+    "skipTest\\(",
+]
+
 [tool.codespell]
 skip = ".git,*.click,*.gif,*.po,*.png"
 ignore-words-list = "buildd"


### PR DESCRIPTION
Since we're aiming at enabling as many tests as possible on CI, it makes sense to remove those lines from coverage since they would fall out of the covered paths as our CI gets better.