### PR TITLE
test: improve debugging failed test_recent_syslog_overflow

### DIFF
--- a/tests/integration/test_hookutils.py
+++ b/tests/integration/test_hookutils.py
@@ -369,9 +369,7 @@ class T(unittest.TestCase):
         sys.stderr.write(f"[Δ {delta_kb} kB] ")
         self.assertLess(delta_kb, 5000)
 
-        self.assertTrue(
-            data.startswith("Apr 20 11:30:00 komputer kernel: bogus message\n")
-        )
+        self.assertRegex(data, "^Apr 20 11:30:00 komputer kernel: bogus message\n")
         self.assertGreater(len(data), 100000)
         self.assertLess(len(data), 1000000)
 


### PR DESCRIPTION
The test case `test_recent_syslog_overflow` fails on Ubuntu 24.04 (noble) ppc64el on 2024-01-07:

```
=================================== FAILURES ===================================
________________________ T.test_recent_syslog_overflow _________________________

self = <tests.integration.test_hookutils.T testMethod=test_recent_syslog_overflow>

    def test_recent_syslog_overflow(self):
        """recent_syslog on a huge file"""
        log = os.path.join(self.workdir, "syslog")
        with open(log, "w", encoding="utf-8") as f:
            lines = 1000000
            while lines >= 0:
                f.write("Apr 20 11:30:00 komputer kernel: bogus message\n")
                lines -= 1

        mem_before = self._get_mem_usage()
        data = apport.hookutils.recent_syslog(re.compile("kernel"), path=log)
        mem_after = self._get_mem_usage()
        delta_kb = mem_after - mem_before
        sys.stderr.write(f"[Δ {delta_kb} kB] ")
        self.assertLess(delta_kb, 5000)

>       self.assertTrue(
            data.startswith("Apr 20 11:30:00 komputer kernel: bogus message\n")
        )
E       AssertionError: False is not true

tests/integration/test_hookutils.py:372: AssertionError
----------------------------- Captured stderr call -----------------------------
[Δ 0 kB]
=============================== warnings summary ===============================
```

`assertTrue` does not help debugging the test failure. Replace it by `assertRegex` to log the data in case of a failure.