### PR TITLE
test: add test_crash_suid_dumpable_debug

### DIFF
--- a/tests/integration/test_signal_crashes.py
+++ b/tests/integration/test_signal_crashes.py
@@ -41,6 +41,7 @@ from tests.paths import get_data_directory, local_test_environment
 APPORT_PATH = get_data_directory() / "apport"
 apport_binary = import_module_from_file(APPORT_PATH)
 
+MAIL_UID = 8
 test_package = "coreutils"
 test_source = "coreutils"
 
@@ -671,23 +672,23 @@ class T(unittest.TestCase):
         # run test program in /run (which should only be writable to root)
         os.chdir("/run")
 
-        # run test program as user "mail"
         resource.setrlimit(resource.RLIMIT_CORE, (-1, -1))
 
         # if a user can crash a suid root binary, it should not create
         # core files
-        self.do_crash(command=myexe, uid=8, suid_dumpable=2)
+        self.do_crash(command=myexe, uid=MAIL_UID, suid_dumpable=2)
 
     @unittest.skipUnless(os.path.exists("/bin/ping"), "this test needs /bin/ping")
     @unittest.skipIf(os.geteuid() != 0, "this test needs to be run as root")
     def test_crash_setuid_drop(self):
         """Report generation for setuid program which drops root."""
-        # run ping as user "mail"
         resource.setrlimit(resource.RLIMIT_CORE, (-1, -1))
 
         # if a user can crash a suid root binary, it should not create
         # core files
-        self.do_crash(command="/bin/ping", args=["127.0.0.1"], uid=8, suid_dumpable=2)
+        self.do_crash(
+            command="/bin/ping", args=["127.0.0.1"], uid=MAIL_UID, suid_dumpable=2
+        )
 
     @unittest.skipIf(os.geteuid() != 0, "this test needs to be run as root")
     def test_crash_setuid_unpackaged(self):
@@ -701,7 +702,6 @@ class T(unittest.TestCase):
         os.close(fd)
         os.chmod(myexe, 0o4755)
 
-        # run test program as user "mail"
         resource.setrlimit(resource.RLIMIT_CORE, (-1, -1))
 
         # if a user can crash a suid root binary, it should not create
@@ -710,7 +710,7 @@ class T(unittest.TestCase):
             command=myexe,
             expect_corefile=False,
             expect_report=False,
-            uid=8,
+            uid=MAIL_UID,
             suid_dumpable=2,
         )
 
@@ -743,11 +743,10 @@ class T(unittest.TestCase):
     def test_crash_setuid_drop_via_socket(self):
         """Report generation via socket for setuid program which drops root."""
         resource.setrlimit(resource.RLIMIT_CORE, (-1, -1))
-        # run ping as user "mail"
         self.do_crash(
             command="/bin/ping",
             args=["127.0.0.1"],
-            uid=8,
+            uid=MAIL_UID,
             suid_dumpable=2,
             via_socket=True,
         )

--- a/tests/integration/test_signal_crashes.py
+++ b/tests/integration/test_signal_crashes.py
@@ -963,6 +963,10 @@ class T(unittest.TestCase):
         The socket is being used in a container via systemd activation,
         where the core dump gets read from /run/apport.socket.
 
+        If the specified program has file capability or is a
+        set‐user‐ID/set-group-ID program, this method needs to be called
+        as root to allow GDB to call the program.
+
         Note: The arguments for the test program must not contain spaces.
         Since there was no need for it, the support was not implemented.
         """

--- a/tests/integration/test_signal_crashes.py
+++ b/tests/integration/test_signal_crashes.py
@@ -680,6 +680,21 @@ class T(unittest.TestCase):
 
     @unittest.skipUnless(os.path.exists("/bin/ping"), "this test needs /bin/ping")
     @unittest.skipIf(os.geteuid() != 0, "this test needs to be run as root")
+    def test_crash_suid_dumpable_debug(self):
+        """Report generation for setuid program with suid_dumpable set to 1.
+
+        ping has cap_net_raw=ep and therefore do_crash needs root.
+        """
+        resource.setrlimit(resource.RLIMIT_CORE, (-1, -1))
+
+        # if a user can crash a suid root binary, it should not create
+        # core files if /proc/sys/fs/suid_dumpable is set to 1 ("debug")
+        self.do_crash(
+            command="/bin/ping", args=["127.0.0.1"], uid=MAIL_UID, suid_dumpable=1
+        )
+
+    @unittest.skipUnless(os.path.exists("/bin/ping"), "this test needs /bin/ping")
+    @unittest.skipIf(os.geteuid() != 0, "this test needs to be run as root")
     def test_crash_setuid_drop(self):
         """Report generation for setuid program which drops root."""
         resource.setrlimit(resource.RLIMIT_CORE, (-1, -1))


### PR DESCRIPTION
To increase the code coverage add a test for
`/proc/sys/fs/suid_dumpable` set to 1 ("debug") and crashing a set-user-ID (suid) program.