### PR TITLE
test: do not use hardcoded dates in tests

### DIFF
--- a/tests/unit/test_hookutils.py
+++ b/tests/unit/test_hookutils.py
@@ -1,9 +1,9 @@
 """Unit tests for the apport.hookutils module."""
 
+import datetime
 import os
 import re
 import subprocess
-import time
 import unittest
 import unittest.mock
 from unittest.mock import MagicMock
@@ -109,8 +109,9 @@ class TestHookutils(unittest.TestCase):
         run_mock.return_value = subprocess.CompletedProcess(
             args=None, returncode=0, stdout=b"journalctl output", stderr=b""
         )
+        now = datetime.datetime.now()
 
-        report = apport.Report(date="Wed May 18 18:31:08 2022")
+        report = apport.Report(date=now.strftime("%a %b %d %H:%M:%S %Y"))
         apport.hookutils.attach_journal_errors(report)
 
         self.assertEqual(run_mock.call_count, 1)
@@ -120,8 +121,8 @@ class TestHookutils(unittest.TestCase):
             [
                 "journalctl",
                 "--priority=warning",
-                f"--since=@{1652898658 + time.altzone}",
-                f"--until=@{1652898678 + time.altzone}",
+                f"--since=@{int(now.timestamp()) - 10}",
+                f"--until=@{int(now.timestamp()) + 10}",
             ],
         )
 

--- a/tests/unit/test_problem_report.py
+++ b/tests/unit/test_problem_report.py
@@ -5,6 +5,7 @@
 
 import base64
 import contextlib
+import datetime
 import email
 import io
 import locale
@@ -84,13 +85,15 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
 
     def test_get_timestamp_locale_german(self):
         """get_timestamp() returns date when LC_TIME is set."""
-        pr = problem_report.ProblemReport(date="Wed May 18 09:49:57 2022")
+        now = datetime.datetime.now()
+
+        pr = problem_report.ProblemReport(date=now.strftime("%a %b %d %H:%M:%S %Y"))
         orig_ctime = locale.getlocale(locale.LC_TIME)
         try:
             locale.setlocale(locale.LC_TIME, "de_DE.UTF-8")
         except locale.Error:
             self.skipTest("Missing German locale support")
-        self.assertEqual(pr.get_timestamp(), 1652867397 + time.altzone)
+        self.assertEqual(pr.get_timestamp(), int(now.timestamp()))
         locale.setlocale(locale.LC_TIME, orig_ctime)
 
     def test_get_timestamp_returns_none(self):


### PR DESCRIPTION
This MR addresses the following test failures caused by the daylight savings:

```
=================================== FAILURES ===================================
______________ TestHookutils.test_attach_journal_errors_with_date ______________

self = <tests.unit.test_hookutils.TestHookutils testMethod=test_attach_journal_errors_with_date>
run_mock = <MagicMock name='run' id='140704711544272'>

    @unittest.mock.patch("subprocess.run")
    @unittest.mock.patch("os.path.exists", unittest.mock.MagicMock(return_value=True))
    def test_attach_journal_errors_with_date(self, run_mock):
        run_mock.return_value = subprocess.CompletedProcess(
            args=None, returncode=0, stdout=b"journalctl output", stderr=b""
        )
    
        report = apport.Report(date="Wed May 18 18:31:08 2022")
        apport.hookutils.attach_journal_errors(report)
    
        self.assertEqual(run_mock.call_count, 1)
        self.assertEqual(report.get("JournalErrors"), "journalctl output")
>       self.assertEqual(
            run_mock.call_args[0][0],
            [
                "journalctl",
                "--priority=warning",
                f"--since=@{1652898658 + time.altzone}",
                f"--until=@{1652898678 + time.altzone}",
            ],
        )
E       AssertionError: Lists differ: ['jou[14 chars]riority=warning', '--since=@1652855458', '--until=@1652855478'] != ['jou[14 chars]riority=warning', '--since=@1652851858', '--until=@1652851878']
E       
E       First differing element 2:
E       '--since=@1652855458'
E       '--since=@1652851858'
E       
E         ['journalctl',
E          '--priority=warning',
E       -  '--since=@1652855458',
E       ?                  ^^
E       
E       +  '--since=@1652851858',
E       ?                  ^^
E       
E       -  '--until=@1652855478']
E       ?                  ^^
E       
E       +  '--until=@1652851878']
E       ?                  ^^

tests/unit/test_hookutils.py:46: AssertionError
______________________ T.test_get_timestamp_locale_german ______________________

self = <tests.unit.test_problem_report.T testMethod=test_get_timestamp_locale_german>

    def test_get_timestamp_locale_german(self):
        """get_timestamp() returns date when LC_TIME is set."""
        pr = problem_report.ProblemReport(date="Wed May 18 09:49:57 2022")
        orig_ctime = locale.getlocale(locale.LC_TIME)
        try:
            locale.setlocale(locale.LC_TIME, "de_DE.UTF-8")
        except locale.Error:
            self.skipTest("Missing German locale support")
>       self.assertEqual(pr.get_timestamp(), 1652867397 + time.altzone)
E       AssertionError: 1652824197 != 1652820597

tests/unit/test_problem_report.py:83: AssertionError
=========================== short test summary info ============================
```

Refactor tests to use the current timestamp instead of the hardcoded value. This allows to avoid timezone conversion that depended on the date when the test is run.