### PR TITLE
test: make branch coverage report stable

### DIFF
--- a/tests/integration/test_hooks.py
+++ b/tests/integration/test_hooks.py
@@ -234,6 +234,10 @@ class T(unittest.TestCase):
         dmesgfile = os.path.join(vmcore_dir, f"dmesg.{timedir}")
         with open(dmesgfile, "wt", encoding="utf-8") as dmesg:
             dmesg.write("1" * 100)
+        vmcore_dir2 = pathlib.Path(apport.fileutils.report_dir) / "20240110211337"
+        vmcore_dir2.mkdir()
+        wrongly_named = vmcore_dir2 / "dmesg.wrongly-named"
+        wrongly_named.write_bytes(b"2" * 80)
 
         self.assertEqual(
             subprocess.call(self.data_dir / "kernel_crashdump", env=self.env),

--- a/tests/integration/test_signal_crashes.py
+++ b/tests/integration/test_signal_crashes.py
@@ -1199,17 +1199,25 @@ class T(unittest.TestCase):
     def test_wait_for_gdb_child_process(self, sleep_mock):
         """Test wait_for_gdb_child_process() helper method."""
         child = MagicMock(spec=psutil.Process)
-        child.status.side_effect = ["tracing-stop", "sleeping"]
-        child.cmdline.return_value = [self.TEST_EXECUTABLE] + self.TEST_ARGS
+        child.status.side_effect = ["tracing-stop", "running", "sleeping"]
+        child.cmdline.side_effect = [
+            ["/bin/sh", "-c", f"exec {self.TEST_EXECUTABLE}"],
+            [self.TEST_EXECUTABLE] + self.TEST_ARGS,
+        ]
         with unittest.mock.patch("psutil.Process", spec=psutil.Process) as process_mock:
             process_mock.return_value.children.side_effect = [
                 [],
                 [child],  # child not started (tracing-stop)
+                [child],  # shell wrapper running
                 [child],  # child ready
             ]
+
             self.wait_for_gdb_child_process(123456789, self.TEST_EXECUTABLE)
+
         sleep_mock.assert_called_with(0.1)
-        self.assertEqual(sleep_mock.call_count, 2)
+        self.assertEqual(sleep_mock.call_count, 3)
+        self.assertEqual(child.status.call_count, 3)
+        self.assertEqual(child.cmdline.call_count, 2)
 
     @unittest.mock.patch("psutil.Process", spec=psutil.Process)
     @unittest.mock.patch("time.sleep")

--- a/tests/unit/test_parse_segv.py
+++ b/tests/unit/test_parse_segv.py
@@ -2,6 +2,7 @@
 
 import unittest
 
+from problem_report import ProblemReport
 from tests.helper import import_module_from_file
 from tests.paths import get_data_directory
 
@@ -135,6 +136,27 @@ DISASM = """\
 
 class TestHookParseSegv(unittest.TestCase):
     """Test Segfault Parser."""
+
+    def test_add_info_without_segv_reason(self) -> None:
+        """Test add_info() with no SegvReason in result."""
+        report = ProblemReport()
+        report["Signal"] = "11"
+        report["Architecture"] = "amd64"
+        report["Disassembly"] = DISASM
+        report["ProcMaps"] = MAPS
+        report["Registers"] = REGS64
+
+        parse_segv.add_info(report)
+
+        self.assertEqual(
+            report.get("SegvAnalysis"),
+            "Segfault happened at: 0x08083540 <main+0>:    lea    0x4(%esp),%ecx\n"
+            "PC (0x08083540) ok\n"
+            "insn (lea) does not access VMA\n"
+            "SP (0xbfc6af24) ok\n"
+            "Reason could not be automatically determined.",
+        )
+        self.assertNotIn("SegvReason", report)
 
     def test_invalid_00_registers(self):
         """Require valid registers."""


### PR DESCRIPTION
There are three cases where the branch coverage report is not stable between runs.