### PR TITLE
fix: use context manager when manipulating GzipFiles (LP: #2051512)

### DIFF
--- a/apport/crashdb_impl/launchpad.py
+++ b/apport/crashdb_impl/launchpad.py
@@ -364,7 +364,8 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
                     pass
             elif ext == ".gz":
                 try:
-                    report[key] = gzip.GzipFile(fileobj=attachment).read()
+                    with gzip.GzipFile(fileobj=attachment) as gz:
+                        report[key] = gz.read()
                 except OSError as error:
                     # some attachments are only called .gz, but are
                     # uncompressed (LP #574360)

--- a/tests/integration/test_problem_report.py
+++ b/tests/integration/test_problem_report.py
@@ -538,4 +538,5 @@ class T(unittest.TestCase):
         with tempfile.TemporaryFile() as payload:
             payload.write(message.get_payload(decode=True))
             payload.seek(0)
-            return gzip.GzipFile(mode="rb", fileobj=payload).read()
+            with gzip.GzipFile(mode="rb", fileobj=payload) as gz:
+                return gz.read()


### PR DESCRIPTION
Those objects are technically file-like objects, with the associated semantics. In particular, starting with Python 3.12 the class using internal buffering, which means write() calls won't necessarily directly be reflected in the underlying storage object.

For the sake of consistency, the context manager approach has been generalized to read() calls as well, except when we could get away with removing the use of GzipFile altogether.