### PR TITLE
ci: upgrade to codecov/codecov-action@v4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,9 @@ on:  # yamllint disable-line rule:truthy
 env:
   DEBIAN_FRONTEND: noninteractive
 
+# Note: ca-certificates and git are needed for actions/checkout to use git
+# which is needed for codecov/codecov-action.
+
 jobs:
   linter:
     runs-on: ubuntu-latest
@@ -53,20 +56,21 @@ jobs:
       image: ${{ matrix.container }}
       options: --cap-add=SYS_PTRACE --security-opt seccomp=unconfined
     steps:
-      - uses: actions/checkout@v4
       - name: Install dependencies
         run: >
           apt-get update
           && apt-get install --no-install-recommends --yes
-          bash binutils default-jdk-headless dpkg-dev gcc gdb iputils-ping kmod
-          libc6-dev locales procps python3 python3-apt python3-distutils-extra
-          python3-launchpadlib python3-psutil python3-pytest python3-pytest-cov
-          python3-requests python3-setuptools python3-systemd valgrind
+          bash binutils ca-certificates default-jdk-headless dpkg-dev gcc gdb
+          git iputils-ping kmod libc6-dev locales procps python3 python3-apt
+          python3-distutils-extra python3-launchpadlib python3-psutil
+          python3-pytest python3-pytest-cov python3-requests python3-setuptools
+          python3-systemd valgrind
       # python3-zstandard is not available on ubuntu:jammy
       - name: Install optional dependencies
         run: >
           apt-get install --no-install-recommends --yes python3-zstandard
           || true
+      - uses: actions/checkout@v4
       - name: Enable German locale
         run: sed -i 's/^# de_DE/de_DE/g' /etc/locale.gen && locale-gen
       - name: Build Java subdir
@@ -77,12 +81,10 @@ jobs:
         run: >
           python3 -m pytest -ra --cov=$(pwd) --cov-branch --cov-report=xml
           tests/unit/ tests/integration/
-      - name: Install dependencies for Codecov
-        run: >
-          apt-get install --no-install-recommends --yes
-          ca-certificates curl git
+      - name: Install additional dependencies for Codecov
+        run: apt-get install --no-install-recommends --yes curl gpg gpg-agent
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
@@ -93,7 +95,6 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
       - name: Remove system installed Apport
         run: >
           sudo apt-get remove --purge --yes
@@ -102,11 +103,12 @@ jobs:
         run: >
           sudo apt-get update
           && sudo apt-get install --no-install-recommends --yes
-          bash binutils default-jdk-headless dpkg-dev gcc gdb iputils-ping kmod
-          libc6-dev locales pkg-config python3 python3-apt
+          bash binutils ca-certificates default-jdk-headless dpkg-dev gcc gdb
+          git iputils-ping kmod libc6-dev locales pkg-config python3 python3-apt
           python3-distutils-extra python3-launchpadlib python3-psutil
           python3-pytest python3-pytest-cov python3-setuptools python3-systemd
           valgrind
+      - uses: actions/checkout@v4
       - name: Enable German locale
         run: sudo sed -i 's/^# de_DE/de_DE/g' /etc/locale.gen && sudo locale-gen
       - name: Install
@@ -124,12 +126,11 @@ jobs:
           tests/unit/ tests/integration/
           && cd -
           && cp "$WORKDIR/coverage.xml" .
-      - name: Install dependencies for Codecov
+      - name: Install additional dependencies for Codecov
         run: >
-          sudo apt-get install --no-install-recommends --yes
-          ca-certificates curl git
+          sudo apt-get install --no-install-recommends --yes curl gpg gpg-agent
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
@@ -146,22 +147,21 @@ jobs:
     container:
       image: ${{ matrix.container }}
     steps:
-      - uses: actions/checkout@v4
       - name: Install dependencies
         run: >
           apt-get update
           && apt-get install --no-install-recommends --yes
-          python3 python3-apt python3-psutil python3-pytest python3-pytest-cov
+          ca-certificates git python3 python3-apt python3-psutil python3-pytest
+          python3-pytest-cov
+      - uses: actions/checkout@v4
       - name: Run all tests (to check if they are skipped or succeed)
         run: >
-          python3 -m pytest -ra --cov=$(pwd) --cov-branch --cov-report=xml
-          tests/
-      - name: Install dependencies for Codecov
-        run: >
-          apt-get install --no-install-recommends --yes
-          ca-certificates curl git
+          SKIP_ONLINE_TESTS=1 python3 -m pytest -ra --cov=$(pwd) --cov-branch
+          --cov-report=xml tests/
+      - name: Install additional dependencies for Codecov
+        run: apt-get install --no-install-recommends --yes curl gpg gpg-agent
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
@@ -179,18 +179,18 @@ jobs:
       image: ${{ matrix.container }}
       options: --cap-add=SYS_PTRACE --security-opt seccomp=unconfined
     steps:
-      - uses: actions/checkout@v4
       - name: Enable 'deb-src' URIs in /etc/apt/sources.list
         run: sed -i '/^#\sdeb-src /s/^#\s//' /etc/apt/sources.list
       - name: Install dependencies
         run: >
           apt-get update
           && apt-get install --no-install-recommends --yes
-          dbus dbus-x11 dirmngr dpkg-dev gcc gdb gir1.2-gtk-3.0 gir1.2-wnck-3.0
-          gnome-icon-theme gpg gvfs-daemons psmisc python3 python3-apt
-          python3-dbus python3-gi python3-launchpadlib python3-pyqt5
+          ca-certificates dbus dbus-x11 dirmngr dpkg-dev gcc gdb gir1.2-gtk-3.0
+          gir1.2-wnck-3.0 git gnome-icon-theme gpg gvfs-daemons psmisc python3
+          python3-apt python3-dbus python3-gi python3-launchpadlib python3-pyqt5
           python3-pytest python3-pytest-cov python3-requests
           ubuntu-dbgsym-keyring ubuntu-keyring valgrind xterm xvfb
+      - uses: actions/checkout@v4
       - name: Start D-Bus daemon
         run: mkdir -p /run/dbus && dbus-daemon --system --fork
       - name: Run system tests
@@ -201,12 +201,10 @@ jobs:
           --cov-report=xml tests/system/
       - name: Stop D-Bus daemon
         run: kill $(cat /run/dbus/pid)
-      - name: Install dependencies for Codecov
-        run: >
-          apt-get install --no-install-recommends --yes
-          ca-certificates curl git
+      - name: Install additional dependencies for Codecov
+        run: apt-get install --no-install-recommends --yes curl gpg gpg-agent
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
@@ -217,7 +215,6 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
       - name: Remove system installed Apport
         run: >
           sudo apt-get remove --purge --yes
@@ -228,11 +225,12 @@ jobs:
         run: >
           sudo apt-get update
           && sudo apt-get install --no-install-recommends --yes
-          dbus dbus-x11 dirmngr dpkg-dev gcc gdb gir1.2-gtk-3.0 gir1.2-wnck-3.0
-          gnome-icon-theme gpg gvfs-daemons psmisc python3 python3-apt
-          python3-dbus python3-distutils-extra python3-gi python3-launchpadlib
-          python3-pyqt5 python3-pytest python3-pytest-cov python3-setuptools
-          ubuntu-dbgsym-keyring ubuntu-keyring valgrind xvfb
+          ca-certificates dbus dbus-x11 dirmngr dpkg-dev gcc gdb gir1.2-gtk-3.0
+          gir1.2-wnck-3.0 git gnome-icon-theme gpg gvfs-daemons psmisc python3
+          python3-apt python3-dbus python3-distutils-extra python3-gi
+          python3-launchpadlib python3-pyqt5 python3-pytest python3-pytest-cov
+          python3-setuptools ubuntu-dbgsym-keyring ubuntu-keyring valgrind xvfb
+      - uses: actions/checkout@v4
       - name: Install
         run: >
           sudo python3 -m coverage run
@@ -254,12 +252,11 @@ jobs:
           --cov-report=xml tests/system/
           && cd -
           && cp "$WORKDIR/coverage.xml" .
-      - name: Install dependencies for Codecov
+      - name: Install additional dependencies for Codecov
         run: >
-          sudo apt-get install --no-install-recommends --yes
-          ca-certificates curl git
+          sudo apt-get install --no-install-recommends --yes curl gpg gpg-agent
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true


### PR DESCRIPTION
GitHub CI warns: "Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, codecov/codecov-action@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/."

So upgrade codecov/codecov-action@v3 to codecov/codecov-action@v4. Explicitly set `SKIP_ONLINE_TESTS=1` for the skip tests, because installing ca-certificates causes the skip tests to have their Internet check succeed.