### PR TITLE
dpkg: memoize the get_system_architecture method

### DIFF
--- a/apport/packaging_impl/apt_dpkg.py
+++ b/apport/packaging_impl/apt_dpkg.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import contextlib
 import datetime
+import functools
 import glob
 import gzip
 import hashlib
@@ -651,6 +652,7 @@ class __AptDpkgPackageInfo(PackageInfo):
         return None
 
     @staticmethod
+    @functools.cache
     def get_system_architecture():
         """Return the architecture of the system, in the notation used by the
         particular distribution."""


### PR DESCRIPTION
It's rather costly, shelling out to dpkg and all.

This had the consequence of having to rename the `cache` variable into `apt_cache`, but it might be for the better anyway as there are already other caches around.