### PR TITLE
ci: run integration tests also on Debian

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Run linter tests
         run: tests/run-linters
 
-  unit:
+  unit-and-integration:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -47,39 +47,6 @@ jobs:
         container:
           - debian:bookworm-slim
           - debian:testing-slim
-    container:
-      image: ${{ matrix.container }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install dependencies
-        run: >
-          apt-get update
-          && apt-get install --no-install-recommends --yes
-          locales python3 python3-apt python3-pytest python3-pytest-cov
-          python3-systemd python3-zstandard
-      - name: Enable German locale
-        run: sed -i 's/^# de_DE/de_DE/g' /etc/locale.gen && locale-gen
-      - name: Run unit tests
-        run: >
-          python3 -m pytest -ra --cov=$(pwd) --cov-branch --cov-report=xml
-          tests/unit/
-      - name: Install dependencies for Codecov
-        run: >
-          apt-get install --no-install-recommends --yes
-          ca-certificates curl git
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
-          files: ./coverage.xml
-
-  unit-and-integration:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        container:
           - ubuntu:jammy
           - ubuntu:mantic
     container:
@@ -92,7 +59,7 @@ jobs:
           apt-get update
           && apt-get install --no-install-recommends --yes
           bash binutils default-jdk-headless dpkg-dev gcc gdb iputils-ping kmod
-          libc6-dev locales python3 python3-apt python3-distutils-extra
+          libc6-dev locales procps python3 python3-apt python3-distutils-extra
           python3-launchpadlib python3-psutil python3-pytest python3-pytest-cov
           python3-requests python3-setuptools python3-systemd valgrind
       # python3-zstandard is not available on ubuntu:jammy

--- a/tests/integration/test_packaging_apt_dpkg.py
+++ b/tests/integration/test_packaging_apt_dpkg.py
@@ -108,8 +108,8 @@ class T(unittest.TestCase):
 
     def test_get_dependencies_depends_only(self):
         """get_dependencies() on package with Depends only."""
-        d = impl.get_dependencies("libc-bin")
-        self.assertGreaterEqual(len(d), 1)
+        d = impl.get_dependencies("sysvinit-utils")
+        self.assertIn("libc6", d)
         for dep in d:
             self.assertTrue(impl.get_version(dep))
 

--- a/tests/integration/test_packaging_apt_dpkg.py
+++ b/tests/integration/test_packaging_apt_dpkg.py
@@ -19,7 +19,7 @@ from tests.helper import skip_if_command_is_missing
 @skip_if_command_is_missing("dpkg")
 class T(unittest.TestCase):
     # pylint: disable=missing-class-docstring,missing-function-docstring
-    # pylint: disable=protected-access
+    # pylint: disable=protected-access,too-many-public-methods
 
     def setUp(self):
         # save and restore configuration file
@@ -87,9 +87,8 @@ class T(unittest.TestCase):
         self.assertTrue(impl.get_available_version("libc6").startswith("2"))
         self.assertRaises(ValueError, impl.get_available_version, "nonexisting")
 
-    def test_get_dependencies(self):
-        """get_dependencies()."""
-        # package with both Depends: and Pre-Depends:
+    def test_get_dependencies_depends_and_pre_depends(self):
+        """get_dependencies() on package with both Depends and Pre-Depends."""
         d = impl.get_dependencies("bash")
         self.assertGreater(len(d), 2)
         self.assertIn("libc6", d)
@@ -99,14 +98,16 @@ class T(unittest.TestCase):
                 continue
             self.assertTrue(impl.get_version(dep))
 
-        # Pre-Depends: only
+    def test_get_dependencies_pre_depends_only(self):
+        """get_dependencies() on package with Pre-Depends only."""
         d = impl.get_dependencies("coreutils")
         self.assertGreaterEqual(len(d), 1)
         self.assertIn("libc6", d)
         for dep in d:
             self.assertTrue(impl.get_version(dep))
 
-        # Depends: only
+    def test_get_dependencies_depends_only(self):
+        """get_dependencies() on package with Depends only."""
         d = impl.get_dependencies("libc-bin")
         self.assertGreaterEqual(len(d), 1)
         for dep in d:


### PR DESCRIPTION
The libc-bin package suggests `manpages` on Ubuntu, but recommends it on Debian. If the recommended packages are not installed, the test `test_get_dependencies_depends_only` will fail on Debian:

```
_____________________ T.test_get_dependencies_depends_only _____________________

self = <tests.integration.test_packaging_apt_dpkg.T testMethod=test_get_dependencies_depends_only>

    def test_get_dependencies_depends_only(self):
        """get_dependencies() on package with Depends only."""
        d = impl.get_dependencies("libc-bin")
        self.assertGreaterEqual(len(d), 1)
        for dep in d:
>           self.assertTrue(impl.get_version(dep))

tests/integration/test_packaging_apt_dpkg.py:114:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <apport.packaging_impl.apt_dpkg.__AptDpkgPackageInfo object at 0x7f659f504fd0>
package = 'manpages'

    def get_version(self, package):
        """Return the installed version of a package."""
        pkg = self._apt_pkg(package)
        inst = pkg.installed
        if not inst:
>           raise ValueError(f"package {package} does not exist")
E           ValueError: package manpages does not exist

apport/packaging_impl/apt_dpkg.py:266: ValueError
```

Use the essential package `sysvinit-utils` which only depends on `libc6` in Debian and Ubuntu. This package does not recommend/suggest anything.

With this fix, the integration tests can also be run on Debian.