### PR TITLE
ui: Drop forking in open_url and show error message if webbrowser.open() fails

### DIFF
--- a/apport/ui.py
+++ b/apport/ui.py
@@ -1733,7 +1733,7 @@ class UserInterface:
                 run_as_real_user(["xdg-open", url], get_user_env=True)
             except OSError:
                 # fall back to webbrowser
-                webbrowser.open(url, new=True, autoraise=True)
+                webbrowser.open(url, new=1, autoraise=True)
                 sys.exit(0)
         except Exception as error:  # pylint: disable=broad-except
             os.write(w, str(error))

--- a/apport/ui.py
+++ b/apport/ui.py
@@ -1711,13 +1711,18 @@ class UserInterface:
         try:
             try:
                 run_as_real_user(["xdg-open", url], get_user_env=True)
+                return
             except OSError:
                 # fall back to webbrowser
-                webbrowser.open(url, new=1, autoraise=True)
+                if webbrowser.open(url, new=1, autoraise=True):
+                    return
+                error_details = ""
         except Exception as error:  # pylint: disable=broad-except
-            title = _("Unable to start web browser")
-            message = _("Unable to start web browser to open %s.") % url
-            self.ui_error_message(title, message + f"\n{error}")
+            error_details = f"\n{error}"
+
+        title = _("Unable to start web browser")
+        message = _("Unable to start web browser to open %s.") % url
+        self.ui_error_message(title, message + error_details)
 
     def file_report(self):
         """Upload the current report and guide the user to the reporting

--- a/apport/ui.py
+++ b/apport/ui.py
@@ -1708,37 +1708,16 @@ class UserInterface:
 
         Display an error dialog if everything fails.
         """
-        (r, w) = os.pipe()
-        if os.fork() > 0:
-            os.close(w)
-            status = os.wait()[1]
-            if status:
-                title = _("Unable to start web browser")
-                error = _("Unable to start web browser to open %s.") % url
-                message = os.fdopen(r).readline()
-                if message:
-                    error += "\n" + message
-                self.ui_error_message(title, error)
-            try:
-                os.close(r)
-            except OSError:
-                pass
-            return
-
-        os.setsid()
-        os.close(r)
-
         try:
             try:
                 run_as_real_user(["xdg-open", url], get_user_env=True)
             except OSError:
                 # fall back to webbrowser
                 webbrowser.open(url, new=1, autoraise=True)
-                sys.exit(0)
         except Exception as error:  # pylint: disable=broad-except
-            os.write(w, str(error))
-            sys.exit(1)
-        os._exit(0)  # pylint: disable=protected-access
+            title = _("Unable to start web browser")
+            message = _("Unable to start web browser to open %s.") % url
+            self.ui_error_message(title, message + f"\n{error}")
 
     def file_report(self):
         """Upload the current report and guide the user to the reporting

--- a/tests/unit/test_ui.py
+++ b/tests/unit/test_ui.py
@@ -1,0 +1,81 @@
+"""Unit tests for the apport.ui module."""
+
+import os
+import tempfile
+import textwrap
+import unittest
+import unittest.mock
+from unittest.mock import MagicMock
+
+import apport.ui
+
+
+class TestUI(unittest.TestCase):
+    """Unit tests for apport.ui."""
+
+    crashdb_conf: str
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        # pylint: disable-next=consider-using-with
+        crashdb_conf_file = tempfile.NamedTemporaryFile("w+")
+        cls.addClassCleanup(crashdb_conf_file.close)
+        crashdb_conf_file.write(
+            textwrap.dedent(
+                """\
+            default = 'testsuite'
+            databases = {
+                'testsuite': {
+                    'impl': 'memory',
+                    'bug_pattern_url': None,
+                },
+                'debug': {
+                    'impl': 'memory',
+                    'distro': 'debug',
+                },
+            }
+            """
+            )
+        )
+        crashdb_conf_file.flush()
+        cls.crashdb_conf = crashdb_conf_file.name
+
+    def setUp(self) -> None:
+        self.orig_environ = os.environ.copy()
+        os.environ["APPORT_CRASHDB_CONF"] = self.crashdb_conf
+        self.ui = apport.ui.UserInterface([])
+
+        # Mock environment for run_as_real_user() to not being called via sudo/pkexec
+        os.environ.pop("SUDO_UID", None)
+        os.environ.pop("PKEXEC_UID", None)
+
+    def tearDown(self) -> None:
+        os.environ.clear()
+        os.environ.update(self.orig_environ)
+
+    @unittest.mock.patch("subprocess.run")
+    @unittest.mock.patch("webbrowser.open")
+    def test_open_url(self, open_mock: MagicMock, run_mock: MagicMock) -> None:
+        """Test successful UserInterface.open_url() without pkexec/sudo."""
+        self.ui.open_url("https://example.com")
+
+        run_mock.assert_called_once_with(
+            ["xdg-open", "https://example.com"], check=False
+        )
+        open_mock.assert_not_called()
+
+    @unittest.mock.patch("subprocess.run")
+    @unittest.mock.patch("webbrowser.open")
+    def test_open_url_webbrowser_fallback(
+        self, open_mock: MagicMock, run_mock: MagicMock
+    ) -> None:
+        """Test UserInterface.open_url() to fall back to webbrowser.open()."""
+        run_mock.side_effect = FileNotFoundError
+        open_mock.return_value = True
+
+        self.ui.open_url("https://example.net")
+
+        run_mock.assert_called_once_with(
+            ["xdg-open", "https://example.net"], check=False
+        )
+        open_mock.assert_called_once_with("https://example.net", new=1, autoraise=True)


### PR DESCRIPTION
The `new` parameter in `webbrowser.open` takes an integer and not a boolean: "If `new` is 0, the url is opened in the same browser window if possible. If `new` is 1, a new browser window is opened if possible. If `new` is 2, a new browser page (“tab”) is opened if possible."

run_as_real_user uses `subprocess.run` and `webbrowser.open` which are non-blocking. So forking can be dropped.

`webbrowser.open` returns a boolean. If openining a browser fails (e. g. in a minimal chroot), `webbrowser.open` will return `False`. In this case `UserInterface.open_url` silently does nothing. Print/show an error message in case `webbrowser.open` returns `False`.