### PR TITLE
chore: Format Python code with black 24.2

### DIFF
--- a/apport/crashdb_impl/debian.py
+++ b/apport/crashdb_impl/debian.py
@@ -45,15 +45,15 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
         Checks for the proper settings of apport.
         """
         if not self.options.get("sender") and "UnreportableReason" not in report:
-            report[
-                "UnreportableReason"
-            ] = "Please configure sender settings in /etc/apport/crashdb.conf"
+            report["UnreportableReason"] = (
+                "Please configure sender settings in /etc/apport/crashdb.conf"
+            )
 
         # At this time, we are not ready to take CrashDumps
         if "Stacktrace" in report and not report.has_useful_stacktrace():
-            report[
-                "UnreportableReason"
-            ] = "Incomplete backtrace. Please install the debug symbol packages"
+            report["UnreportableReason"] = (
+                "Incomplete backtrace. Please install the debug symbol packages"
+            )
 
         return apport.crashdb.CrashDatabase.accepts(self, report)
 

--- a/apport/crashdb_impl/github.py
+++ b/apport/crashdb_impl/github.py
@@ -184,8 +184,8 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
     def upload(
         self,
         report: apport.Report,
-        progress_callback: (Callable | None) = None,
-        user_message_callback: (Callable | None) = None,
+        progress_callback: Callable | None = None,
+        user_message_callback: Callable | None = None,
     ) -> IssueHandle:
         """Upload given problem report return a handle for it.
         In Github, we open an issue.

--- a/apport/fileutils.py
+++ b/apport/fileutils.py
@@ -573,7 +573,7 @@ def get_process_environ(proc_pid_fd: int) -> dict[str, str]:
     Raises an OSError in case the environ file could not been read.
     """
 
-    def opener(path: (str | os.PathLike[str]), flags: int) -> int:
+    def opener(path: str | os.PathLike[str], flags: int) -> int:
         return os.open(path, flags, dir_fd=proc_pid_fd)
 
     with open(

--- a/apport/hookutils.py
+++ b/apport/hookutils.py
@@ -221,9 +221,9 @@ def attach_dmi(report):
 
     # Use the hardware information to create a machine type.
     if "dmi.sys.vendor" in report and "dmi.product.name" in report:
-        report[
-            "MachineType"
-        ] = f"{report['dmi.sys.vendor']} {report['dmi.product.name']}"
+        report["MachineType"] = (
+            f"{report['dmi.sys.vendor']} {report['dmi.product.name']}"
+        )
 
 
 def attach_hardware(report):
@@ -1075,9 +1075,11 @@ def attach_default_grub(report, key=None):
     if os.path.exists(path):
         with open(path, "r", encoding="utf-8") as f:
             filtered = [
-                line
-                if not line.startswith("password")
-                else "### PASSWORD LINE REMOVED ###"
+                (
+                    line
+                    if not line.startswith("password")
+                    else "### PASSWORD LINE REMOVED ###"
+                )
                 for line in f.readlines()
             ]
             report[key] = "".join(filtered)

--- a/apport/report.py
+++ b/apport/report.py
@@ -109,7 +109,7 @@ def _read_list_files_in_directory(directory: str) -> Iterator[str]:
 
 
 def _read_proc_link(
-    path: str, pid: (int | None) = None, dir_fd: (int | None) = None
+    path: str, pid: int | None = None, dir_fd: int | None = None
 ) -> str:
     """Use readlink() to resolve link.
 
@@ -122,7 +122,7 @@ def _read_proc_link(
 
 
 def _read_proc_file(
-    path: str, pid: (int | None) = None, dir_fd: (int | None) = None
+    path: str, pid: int | None = None, dir_fd: int | None = None
 ) -> str:
     """Read file content.
 
@@ -130,7 +130,7 @@ def _read_proc_file(
     """
     try:
         if dir_fd is None:
-            proc_file: (int | str) = f"/proc/{pid}/{path}"
+            proc_file: int | str = f"/proc/{pid}/{path}"
         else:
             proc_file = os.open(path, os.O_RDONLY | os.O_CLOEXEC, dir_fd=dir_fd)
 
@@ -161,7 +161,7 @@ def _read_maps(proc_pid_fd):
 
 
 def _command_output(
-    command: list[str], env: (dict[str, str] | None) = None, timeout: float = 1800
+    command: list[str], env: dict[str, str] | None = None, timeout: float = 1800
 ) -> str:
     """Run command and capture its output.
 
@@ -343,7 +343,7 @@ class Report(problem_report.ProblemReport):
     standard debugging data.
     """
 
-    def __init__(self, problem_type: str = "Crash", date: (str | None) = None) -> None:
+    def __init__(self, problem_type: str = "Crash", date: str | None = None) -> None:
         """Initialize a fresh problem report.
 
         date is the desired date/time string; if None (default), the current
@@ -353,8 +353,8 @@ class Report(problem_report.ProblemReport):
         self.pid, so that e. g. hooks can use it to collect additional data.
         """
         problem_report.ProblemReport.__init__(self, problem_type, date)
-        self.pid: (int | None) = None
-        self._proc_maps_cache: (list[tuple[int, int, str]] | None) = None
+        self.pid: int | None = None
+        self._proc_maps_cache: list[tuple[int, int, str]] | None = None
 
     @staticmethod
     def _customized_package_suffix(package: str) -> str:
@@ -420,7 +420,7 @@ class Report(problem_report.ProblemReport):
             dependencies += f"{dep} {v}{self._customized_package_suffix(dep)}"
         return dependencies
 
-    def add_package_info(self, package: (str | None) = None) -> None:
+    def add_package_info(self, package: str | None = None) -> None:
         """Add packaging information.
 
         If package is not given, the report must have ExecutablePath.
@@ -611,9 +611,9 @@ class Report(problem_report.ProblemReport):
                     self["InterpreterPath"] = self["ExecutablePath"]
                     self["ExecutablePath"] = path
                 else:
-                    self[
-                        "UnreportableReason"
-                    ] = f"Cannot determine path of python module {cmdargs[2]}"
+                    self["UnreportableReason"] = (
+                        f"Cannot determine path of python module {cmdargs[2]}"
+                    )
                 return
 
             del cmdargs[1]
@@ -687,9 +687,9 @@ class Report(problem_report.ProblemReport):
 
     def add_proc_info(
         self,
-        pid: (int | str | None) = None,
-        proc_pid_fd: (int | None) = None,
-        extraenv: (Iterable[str] | None) = None,
+        pid: int | str | None = None,
+        proc_pid_fd: int | None = None,
+        extraenv: Iterable[str] | None = None,
     ) -> None:
         # TODO: Split into smaller functions/methods
         # pylint: disable=too-many-branches
@@ -786,9 +786,9 @@ class Report(problem_report.ProblemReport):
 
     def add_proc_environ(
         self,
-        pid: (int | None) = None,
-        extraenv: (Iterable[str] | None) = None,
-        proc_pid_fd: (int | None) = None,
+        pid: int | None = None,
+        extraenv: Iterable[str] | None = None,
+        proc_pid_fd: int | None = None,
     ) -> None:
         """Add environment information.
 
@@ -815,7 +815,7 @@ class Report(problem_report.ProblemReport):
         self._add_environ(environ, extraenv)
 
     def _add_environ(
-        self, environ: _Environment, extraenv: (Iterable[str] | None) = None
+        self, environ: _Environment, extraenv: Iterable[str] | None = None
     ) -> None:
         anonymize_vars = {"LD_LIBRARY_PATH", "LD_PRELOAD", "XDG_RUNTIME_DIR"}
         safe_vars = anonymize_vars | {
@@ -891,7 +891,7 @@ class Report(problem_report.ProblemReport):
         return ret
 
     def add_gdb_info(
-        self, rootdir: (str | None) = None, gdb_sandbox: (str | None) = None
+        self, rootdir: str | None = None, gdb_sandbox: str | None = None
     ) -> None:
         # TODO: Split into smaller functions/methods
         # pylint: disable=too-many-branches,too-many-locals,too-many-statements
@@ -1099,9 +1099,9 @@ class Report(problem_report.ProblemReport):
 
     def add_hooks_info(
         self,
-        ui: (HookUI | None) = None,
-        package: (str | None) = None,
-        srcpackage: (str | None) = None,
+        ui: HookUI | None = None,
+        package: str | None = None,
+        srcpackage: str | None = None,
     ) -> bool:
         """Run hook script for collecting package specific data.
 
@@ -1121,7 +1121,7 @@ class Report(problem_report.ProblemReport):
         return ret
 
     def _add_hooks_info(
-        self, ui: HookUI, package: (str | None), srcpackage: (str | None)
+        self, ui: HookUI, package: str | None, srcpackage: str | None
     ) -> bool:
         # TODO: Split into smaller functions/methods
         # pylint: disable=too-many-branches
@@ -1188,7 +1188,7 @@ class Report(problem_report.ProblemReport):
 
         return False
 
-    def search_bug_patterns(self, url: (str | None)) -> str | None:
+    def search_bug_patterns(self, url: str | None) -> str | None:
         r"""Check bug patterns loaded from the specified url.
 
         Return bug URL on match, or None otherwise.
@@ -1835,7 +1835,7 @@ class Report(problem_report.ProblemReport):
                         self[k] = pattern.sub(repl, self[k])
 
     def gdb_command(
-        self, sandbox: (str | None), gdb_sandbox: (str | None) = None
+        self, sandbox: str | None, gdb_sandbox: str | None = None
     ) -> tuple[list[str], dict[str, str]]:
         # TODO: Split into smaller functions/methods
         # pylint: disable=too-many-branches,too-many-locals

--- a/apport/ui.py
+++ b/apport/ui.py
@@ -69,7 +69,7 @@ def get_pid(report):
         return None
 
 
-def _get_env_int(key: str, default: (int | None) = None) -> int | None:
+def _get_env_int(key: str, default: int | None = None) -> int | None:
     """Get an environment variable as integer.
 
     Return None if it doesn't exist or failed to convert to integer.
@@ -347,8 +347,8 @@ class UserInterface:
     def __init__(self, argv: list[str]):
         """Initialize program state and parse command line options."""
         self.gettext_domain = "apport"
-        self.report: (apport.report.Report | None) = None
-        self.report_file: (str | None) = None
+        self.report: apport.report.Report | None = None
+        self.report_file: str | None = None
         self.cur_package = None
         self.offer_restart = False
         self.specified_a_pkg = False
@@ -614,7 +614,7 @@ class UserInterface:
         """Kill process with signal SIGSEGV."""
         os.kill(int(pid), signal.SIGSEGV)
 
-    def run_report_bug(self, symptom_script: (str | None) = None) -> bool:
+    def run_report_bug(self, symptom_script: str | None = None) -> bool:
         # TODO: Split into smaller functions/methods
         # pylint: disable=too-many-branches,too-many-return-statements
         # pylint: disable=too-many-statements
@@ -1448,9 +1448,9 @@ class UserInterface:
                         "This problem report applies to a program"
                         " which is not installed any more."
                     )
-                    self.report[
-                        "UnreportableReason"
-                    ] = f"{msg} ({self.report['InterpreterPath']})"
+                    self.report["UnreportableReason"] = (
+                        f"{msg} ({self.report['InterpreterPath']})"
+                    )
                     if on_finished:
                         on_finished()
                     return
@@ -1949,7 +1949,7 @@ class UserInterface:
     #
 
     def ui_present_report_details(
-        self, allowed_to_report: bool = True, modal_for: (int | None) = None
+        self, allowed_to_report: bool = True, modal_for: int | None = None
     ) -> Action:
         """Show details of the bug report.
 
@@ -1995,7 +1995,7 @@ class UserInterface:
         """
         raise NotImplementedError("this function must be overridden by subclasses")
 
-    def ui_set_upload_progress(self, progress: (float | None)) -> None:
+    def ui_set_upload_progress(self, progress: float | None) -> None:
         """Update data upload progress bar.
 
         Set the progress bar in the debug data upload progress window to the

--- a/bin/apport-cli
+++ b/bin/apport-cli
@@ -203,7 +203,7 @@ class CLIUserInterface(apport.ui.UserInterface):
         return report_file
 
     def ui_present_report_details(
-        self, allowed_to_report: bool = True, modal_for: (int | None) = None
+        self, allowed_to_report: bool = True, modal_for: int | None = None
     ) -> apport.ui.Action:
         dialog = CLIDialog(
             _("Send problem report to the developers?"),
@@ -295,7 +295,7 @@ class CLIUserInterface(apport.ui.UserInterface):
         )
         self.progress.show()
 
-    def ui_set_upload_progress(self, progress: (float | None)) -> None:
+    def ui_set_upload_progress(self, progress: float | None) -> None:
         assert self.progress is not None
         self.progress.set(progress)
 
@@ -340,9 +340,9 @@ class CLIUserInterface(apport.ui.UserInterface):
                 choice_index_map = {}
                 for option in options:
                     if index not in result:
-                        choice_index_map[
-                            dialog.addbutton(option, str(index + 1))
-                        ] = index
+                        choice_index_map[dialog.addbutton(option, str(index + 1))] = (
+                            index
+                        )
                     index += 1
                 done = dialog.addbutton(_("&Done"))
                 cancel = dialog.addbutton(_("&Cancel"))

--- a/data/apport
+++ b/data/apport
@@ -55,9 +55,9 @@ LOG_FORMAT = "%(levelname)s: apport (pid %(process)s) %(asctime)s: %(message)s"
 class ProcPid(contextlib.ContextDecorator):
     """Context manager to access /proc/<pid>."""
 
-    def __init__(self, pid: int, path: (str | None) = None) -> None:
+    def __init__(self, pid: int, path: str | None = None) -> None:
         self.path = path or f"/proc/{pid}"
-        self.fd: (int | None) = None
+        self.fd: int | None = None
 
     def __enter__(self):
         self.fd = os.open(self.path, os.O_RDONLY | os.O_PATH | os.O_DIRECTORY)
@@ -68,7 +68,7 @@ class ProcPid(contextlib.ContextDecorator):
             os.close(self.fd)
         return False
 
-    def _opener(self, path: (str | os.PathLike[str]), flags: int) -> int:
+    def _opener(self, path: str | os.PathLike[str], flags: int) -> int:
         return os.open(path, flags, dir_fd=self.fd)
 
     def open(self, file: str) -> io.TextIOWrapper:
@@ -114,7 +114,7 @@ def get_core_path(
     options: argparse.Namespace,
     real_user: UserGroupID,
     proc_pid: ProcPid,
-    timestamp: (int | None) = None,
+    timestamp: int | None = None,
 ) -> str:
     """Get the path to the core file."""
     return apport.fileutils.get_core_path(
@@ -233,8 +233,8 @@ def write_user_coredump(
     proc_pid: ProcPid,
     real_user: UserGroupID,
     pidstat: os.stat_result,
-    coredump_fd: (int | None) = None,
-    from_report: (typing.BinaryIO | None) = None,
+    coredump_fd: int | None = None,
+    from_report: typing.BinaryIO | None = None,
 ) -> None:
     # pylint: disable=too-many-arguments
     """Write the core into a directory if ulimit requests it."""
@@ -1009,7 +1009,7 @@ def process_crash_from_kernel_with_proc_pid(
         logger.error("could not determine ExecutablePath, aborting")
         return 1
 
-    def _write_coredump_callback(from_report: (typing.BinaryIO | None) = None) -> None:
+    def _write_coredump_callback(from_report: typing.BinaryIO | None = None) -> None:
         write_user_coredump(
             core_path,
             core_ulimit,

--- a/data/unkillable_shutdown
+++ b/data/unkillable_shutdown
@@ -93,9 +93,9 @@ def do_report(pid, omit_pids):
     report["Tags"] = "shutdown-hang"
     report["Title"] = "does not terminate at computer shutdown"
     if "ExecutablePath" in report:
-        report[
-            "Title"
-        ] = f"{os.path.basename(report['ExecutablePath'])} {report['Title']}"
+        report["Title"] = (
+            f"{os.path.basename(report['ExecutablePath'])} {report['Title']}"
+        )
     report["Processes"] = apport.hookutils.command_output(["ps", "aux"])
     report["InitctlList"] = apport.hookutils.command_output(["initctl", "list"])
     if omit_pids:

--- a/gtk/apport-gtk
+++ b/gtk/apport-gtk
@@ -110,7 +110,7 @@ class GTKUserInterface(apport.ui.UserInterface):
         spinner.hide()
         return spinner
 
-    def ui_update_view(self, shown_keys: (list[str] | None) = None) -> None:
+    def ui_update_view(self, shown_keys: list[str] | None = None) -> None:
         assert self.report
 
         # do nothing if the dialog is already destroyed when the data
@@ -195,7 +195,7 @@ class GTKUserInterface(apport.ui.UserInterface):
         gdk_window.set_modal_hint(True)
 
     def ui_present_report_details(
-        self, allowed_to_report: bool = True, modal_for: (int | None) = None
+        self, allowed_to_report: bool = True, modal_for: int | None = None
     ) -> apport.ui.Action:
         # TODO: Split into smaller functions/methods
         # pylint: disable=too-many-branches,too-many-locals,too-many-statements
@@ -443,7 +443,7 @@ class GTKUserInterface(apport.ui.UserInterface):
         while Gtk.events_pending():
             Gtk.main_iteration_do(False)
 
-    def ui_set_upload_progress(self, progress: (float | None)) -> None:
+    def ui_set_upload_progress(self, progress: float | None) -> None:
         """Set the progress bar in the debug data upload progress
         window to the given ratio (between 0 and 1, or None for indefinite
         progress).

--- a/kde/apport-kde
+++ b/kde/apport-kde
@@ -123,7 +123,7 @@ class ProgressDialog(Dialog):
         if self.sender().buttonRole(button) == QDialogButtonBox.RejectRole:
             sys.exit(0)
 
-    def set(self, value: (float | None) = None) -> None:
+    def set(self, value: float | None = None) -> None:
         progress = self.findChild(QProgressBar, "progress")
         assert isinstance(progress, QProgressBar)
         if not value:
@@ -375,8 +375,8 @@ class MainUserInterface(apport.ui.UserInterface):
         apport.ui.UserInterface.__init__(self, argv)
         self.ui_data_path = os.path.dirname(argv[0])
         # Help unit tests get at the dialog.
-        self.dialog: (ReportDialog | None) = None
-        self.progress: (ProgressDialog | None) = None
+        self.dialog: ReportDialog | None = None
+        self.progress: ProgressDialog | None = None
 
         self.app = QApplication(argv)
         self.app.setApplicationName("apport-kde")
@@ -394,7 +394,7 @@ class MainUserInterface(apport.ui.UserInterface):
     #
 
     def ui_update_view(
-        self, dialog: ReportDialog, shown_keys: (list[str] | None) = None
+        self, dialog: ReportDialog, shown_keys: list[str] | None = None
     ) -> None:
         assert self.report
         # report contents
@@ -416,7 +416,7 @@ class MainUserInterface(apport.ui.UserInterface):
                 QTreeWidgetItem(keyitem, [_("(binary data)")])
 
     def ui_present_report_details(
-        self, allowed_to_report: bool = True, modal_for: (int | None) = None
+        self, allowed_to_report: bool = True, modal_for: int | None = None
     ) -> apport.ui.Action:
         desktop_info = self.get_desktop_entry()
         self.dialog = ReportDialog(self.report, allowed_to_report, self, desktop_info)
@@ -519,7 +519,7 @@ class MainUserInterface(apport.ui.UserInterface):
         )
         self.progress.show()
 
-    def ui_set_upload_progress(self, progress: (float | None)) -> None:
+    def ui_set_upload_progress(self, progress: float | None) -> None:
         assert self.progress
         if progress:
             self.progress.set(progress)

--- a/problem_report.py
+++ b/problem_report.py
@@ -62,7 +62,7 @@ class _EntryParser(Iterator):
 
     def __init__(self, iterator: Iterator[bytes]) -> None:
         self.iterator = iterator
-        self.next_line: (bytes | None) = None
+        self.next_line: bytes | None = None
         self.entry_read = True
 
     def entry_iterator(self) -> Iterator[bytes]:
@@ -212,9 +212,9 @@ class CompressedValue:
 
     def __init__(
         self,
-        value: (bytes | None) = None,
-        name: (str | None) = None,
-        compressed_value: (bytes | None) = None,
+        value: bytes | None = None,
+        name: str | None = None,
+        compressed_value: bytes | None = None,
     ) -> None:
         """Initialize an empty CompressedValue object with an optional name."""
         self.compressed_value = compressed_value
@@ -313,7 +313,7 @@ class CompressedValue:
 class ProblemReport(collections.UserDict):
     """Class to store, load, and handle problem reports."""
 
-    def __init__(self, problem_type: str = "Crash", date: (str | None) = None) -> None:
+    def __init__(self, problem_type: str = "Crash", date: str | None = None) -> None:
         """Initialize a fresh problem report.
 
         problem_type can be 'Crash', 'Packaging', 'KernelCrash' or
@@ -335,9 +335,9 @@ class ProblemReport(collections.UserDict):
 
     def load(
         self,
-        file: (gzip.GzipFile | typing.BinaryIO),
-        binary: (bool | typing.Literal["compressed"]) = True,
-        key_filter: (Iterable[str] | None) = None,
+        file: gzip.GzipFile | typing.BinaryIO,
+        binary: bool | typing.Literal["compressed"] = True,
+        key_filter: Iterable[str] | None = None,
     ) -> None:
         """Initialize problem report from a file-like object.
 
@@ -391,8 +391,8 @@ class ProblemReport(collections.UserDict):
 
     def extract_keys(
         self,
-        file: (gzip.GzipFile | typing.BinaryIO),
-        bin_keys: (Iterable[str] | str),
+        file: gzip.GzipFile | typing.BinaryIO,
+        bin_keys: Iterable[str] | str,
         directory: str,
     ) -> None:
         """Extract only given binary elements from the problem report.
@@ -463,7 +463,7 @@ class ProblemReport(collections.UserDict):
         return None in self.values()
 
     @staticmethod
-    def is_binary(string: (bytes | str)) -> bool:
+    def is_binary(string: bytes | str) -> bool:
         """Check if the given strings contains binary data."""
         if isinstance(string, bytes):
             for c in string:
@@ -472,7 +472,7 @@ class ProblemReport(collections.UserDict):
         return False
 
     @classmethod
-    def _try_unicode(cls, value: (bytes | str)) -> bytes | str:
+    def _try_unicode(cls, value: bytes | str) -> bytes | str:
         """Try to convert bytearray value to Unicode."""
         if isinstance(value, bytes) and not cls.is_binary(value):
             try:
@@ -482,7 +482,7 @@ class ProblemReport(collections.UserDict):
         return value
 
     def sorted_items(
-        self, keys: (Iterable[str] | None) = None
+        self, keys: Iterable[str] | None = None
     ) -> Iterator[tuple[str, (bytes | CompressedValue | str | tuple)]]:
         """Iterate over all non-internal items sorted.
 
@@ -893,7 +893,7 @@ class ProblemReport(collections.UserDict):
         file.write(b"\n")
 
     def __setitem__(
-        self, k: str, v: (bytes | CompressedFile | CompressedValue | str | tuple)
+        self, k: str, v: bytes | CompressedFile | CompressedValue | str | tuple
     ) -> None:
         assert hasattr(k, "isalnum")
         if not k.replace(".", "").replace("-", "").replace("_", "").isalnum():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,13 @@
+[project]
+authors = [
+    {name = "Martin Pitt", email = "martin.pitt@ubuntu.com"},
+]
+description = "intercept, process, and report crashes and bug reports"
+dynamic = ["version"]
+license = {text = "GPLv2+"}
+name = "apport"
+requires-python = ">=3.10"
+
 [tool.black]
 line-length = 88
 

--- a/setuptools_apport/java.py
+++ b/setuptools_apport/java.py
@@ -63,7 +63,7 @@ class install_java(Command):
 
     def initialize_options(self) -> None:
         """Set default values for all the options that this command supports."""
-        self.install_dir: (str | None) = None
+        self.install_dir: str | None = None
 
     def finalize_options(self) -> None:
         """Set final values for all the options that this command supports."""

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -83,7 +83,7 @@ def read_shebang(command: str) -> str | None:
 @contextlib.contextmanager
 def run_test_executable(
     args: Sequence[str] = (os.path.realpath("/bin/sleep"), "86400"),
-    env: (dict[str, str] | None) = None,
+    env: dict[str, str] | None = None,
 ) -> Iterator[int]:
     """Run test executable and yield the process ID. Kill process afterwards."""
     with subprocess.Popen(args, env=env) as test_process:

--- a/tests/integration/test_apport_checkreports.py
+++ b/tests/integration/test_apport_checkreports.py
@@ -35,7 +35,7 @@ class TestApportCheckreports(unittest.TestCase):
 
     def _call(
         self,
-        args: (list | None) = None,
+        args: list | None = None,
         expected_returncode: int = 0,
         expected_stdout: str = "",
     ) -> None:

--- a/tests/integration/test_crashdb_launchpad.py
+++ b/tests/integration/test_crashdb_launchpad.py
@@ -279,9 +279,9 @@ and more
         self.assertNotIn("apport-collected", tags)
 
         # updating with a useful stack trace removes core dump
-        r[
-            "StacktraceTop"
-        ] = "read () from /lib/libc.6.so\nfoo (i=1) from /usr/lib/libfoo.so"
+        r["StacktraceTop"] = (
+            "read () from /lib/libc.6.so\nfoo (i=1) from /usr/lib/libfoo.so"
+        )
         r["Stacktrace"] = "long\ntrace"
         r["ThreadStacktrace"] = "thread\neven longer\ntrace"
         self.crashdb.update_traces(self.get_segv_report(), r, "good retrace!")
@@ -305,9 +305,9 @@ and more
             bug.lp_save()
         except HTTPError:
             pass  # LP#336866 workaround
-        r[
-            "StacktraceTop"
-        ] = "read () from /lib/libc.6.so\nfoo (i=1) from /usr/lib/libfoo.so"
+        r["StacktraceTop"] = (
+            "read () from /lib/libc.6.so\nfoo (i=1) from /usr/lib/libfoo.so"
+        )
         self.crashdb.update_traces(
             self.get_segv_report(), r, "good retrace with title amendment"
         )
@@ -322,9 +322,9 @@ and more
         except HTTPError:
             pass  # LP#336866 workaround
 
-        r[
-            "StacktraceTop"
-        ] = "read () from /lib/libc.6.so\nfoo (i=1) from /usr/lib/libfoo.so"
+        r["StacktraceTop"] = (
+            "read () from /lib/libc.6.so\nfoo (i=1) from /usr/lib/libfoo.so"
+        )
         self.crashdb.update_traces(
             self.get_segv_report(), r, "good retrace with custom title"
         )
@@ -680,9 +680,9 @@ and more
         self.crashdb.close_duplicate(r, crash_id, self.get_segv_report())
 
         # updating with a useful stack trace removes core dump
-        r[
-            "StacktraceTop"
-        ] = "read () from /lib/libc.6.so\nfoo (i=1) from /usr/lib/libfoo.so"
+        r["StacktraceTop"] = (
+            "read () from /lib/libc.6.so\nfoo (i=1) from /usr/lib/libfoo.so"
+        )
         r["Stacktrace"] = "long\ntrace"
         r["ThreadStacktrace"] = "thread\neven longer\ntrace"
         self.crashdb.update_traces(crash_id, r, "good retrace!")
@@ -863,9 +863,9 @@ NameError: global name 'weird' is not defined"""
 
         # update
         r = crashdb.download(crash_id)
-        r[
-            "StacktraceTop"
-        ] = "read () from /lib/libc.6.so\nfoo (i=1) from /usr/lib/libfoo.so"
+        r["StacktraceTop"] = (
+            "read () from /lib/libc.6.so\nfoo (i=1) from /usr/lib/libfoo.so"
+        )
         r["Stacktrace"] = "long\ntrace"
         r["ThreadStacktrace"] = "thread\neven longer\ntrace"
         crashdb.update_traces(crash_id, r, "good retrace!")

--- a/tests/integration/test_dupdb_admin.py
+++ b/tests/integration/test_dupdb_admin.py
@@ -37,10 +37,7 @@ class TestDupdbAdmin(unittest.TestCase):
         shutil.rmtree(self.workdir)
 
     def _call(
-        self,
-        args: list,
-        expected_returncode: int = 0,
-        expected_stdout: (str | None) = "",
+        self, args: list, expected_returncode: int = 0, expected_stdout: str | None = ""
     ) -> tuple[str, str]:
         cmd = ["dupdb-admin", "-f", self.db_file] + args
         process = subprocess.run(

--- a/tests/integration/test_python_crashes.py
+++ b/tests/integration/test_python_crashes.py
@@ -374,8 +374,9 @@ func(42)
         # hook
         (fd, script) = tempfile.mkstemp(dir="/var/tmp")
         try:
-            with tempfile.NamedTemporaryFile() as i_file, unittest.mock.patch(
-                "apport.report._ignore_file", i_file.name
+            with (
+                tempfile.NamedTemporaryFile() as i_file,
+                unittest.mock.patch("apport.report._ignore_file", i_file.name),
             ):
                 os.write(
                     fd,

--- a/tests/integration/test_report.py
+++ b/tests/integration/test_report.py
@@ -1530,9 +1530,9 @@ int main() { return f(42); }
             r = apport.report.Report()
             r["Package"] = "foo-bin 0.2"
             r["SourcePackage"] = "foo"
-            r[
-                "ExecutablePath"
-            ] = f"{apport.report._opt_dir}/foolabs.example.com/foo/bin/frob"
+            r["ExecutablePath"] = (
+                f"{apport.report._opt_dir}/foolabs.example.com/foo/bin/frob"
+            )
 
             self.assertEqual(r.add_hooks_info(), False)
             self.assertEqual(r["SourceHook"], "1")

--- a/tests/integration/test_signal_crashes.py
+++ b/tests/integration/test_signal_crashes.py
@@ -789,8 +789,9 @@ class T(unittest.TestCase):
         readlink_mock.side_effect = ["mnt:[1]", "mnt:[2]"]
         open_mock = unittest.mock.mock_open(read_data="0::/user.slice\n")
         command = [self.TEST_EXECUTABLE] + self.TEST_ARGS
-        with subprocess.Popen(command) as test_process, unittest.mock.patch(
-            "builtins.open", open_mock
+        with (
+            subprocess.Popen(command) as test_process,
+            unittest.mock.patch("builtins.open", open_mock),
         ):
             try:
                 same_ns = apport_binary.is_same_ns(test_process.pid, "mnt")
@@ -911,7 +912,7 @@ class T(unittest.TestCase):
         orig_os_open = os.open
 
         def _mocked_os_open(
-            path: (str | os.PathLike[str]), flags: int, dir_fd: (int | None) = None
+            path: str | os.PathLike[str], flags: int, dir_fd: int | None = None
         ) -> int:
             if path == "root/run/apport.socket":
                 return orig_os_open(socket_path, flags)
@@ -981,7 +982,7 @@ class T(unittest.TestCase):
         self.assertNotEqual(gdb.stdout.strip(), "")
 
     def _check_report(
-        self, expect_report: bool = True, expected_owner: (int | None) = None
+        self, expect_report: bool = True, expected_owner: int | None = None
     ) -> None:
         if not expect_report:
             self.assertEqual(apport.fileutils.get_all_reports(), [])
@@ -1040,13 +1041,13 @@ class T(unittest.TestCase):
         self,
         expect_corefile: bool = False,
         sig: int = signal.SIGSEGV,
-        command: (str | None) = None,
-        expected_command: (str | None) = None,
-        uid: (int | None) = None,
-        expect_corefile_owner: (str | None) = None,
-        args: (list[str] | None) = None,
+        command: str | None = None,
+        expected_command: str | None = None,
+        uid: int | None = None,
+        expect_corefile_owner: str | None = None,
+        args: list[str] | None = None,
         suid_dumpable: int = 1,
-        hook_before_apport: (Callable | None) = None,
+        hook_before_apport: Callable | None = None,
         expect_report: bool = True,
         via_socket: bool = False,
     ) -> None:
@@ -1196,7 +1197,7 @@ class T(unittest.TestCase):
         return gdb_args
 
     @staticmethod
-    def _get_report_filename(command: str, uid: (int | None) = None) -> str:
+    def _get_report_filename(command: str, uid: int | None = None) -> str:
         if uid is None:
             uid = os.getuid()
         return os.path.join(

--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -49,7 +49,7 @@ class UserInterfaceMock(apport.ui.UserInterface):
     # pylint: disable=too-many-instance-attributes
     """Concrete apport.ui.UserInterface suitable for automatic testing"""
 
-    def __init__(self, argv: (list[str] | None) = None) -> None:
+    def __init__(self, argv: list[str] | None = None) -> None:
         # use our memory crashdb which is designed for testing
         # closed in __del__, pylint: disable=consider-using-with
         self.crashdb_conf = tempfile.NamedTemporaryFile()
@@ -89,20 +89,20 @@ class UserInterfaceMock(apport.ui.UserInterface):
         self.upload_progress_pulses = 0
 
         # store last message box
-        self.msg_title: (str | None) = None
-        self.msg_text: (str | None) = None
-        self.msg_severity: (str | None) = None
-        self.msg_choices: (list[str] | None) = None
+        self.msg_title: str | None = None
+        self.msg_text: str | None = None
+        self.msg_severity: str | None = None
+        self.msg_choices: list[str] | None = None
 
         # these store the choices the ui_present_* calls do
         self.present_package_error_response = None
         self.present_kernel_error_response = None
-        self.present_details_response: (apport.ui.Action | None) = None
-        self.question_yesno_response: (bool | None) = None
-        self.question_choice_response: (list[int] | None) = None
-        self.question_file_response: (str | None) = None
+        self.present_details_response: apport.ui.Action | None = None
+        self.question_yesno_response: bool | None = None
+        self.question_choice_response: list[int] | None = None
+        self.question_file_response: str | None = None
 
-        self.opened_url: (str | None) = None
+        self.opened_url: str | None = None
         self.present_details_shown = False
 
         self.clear_msg()
@@ -119,7 +119,7 @@ class UserInterfaceMock(apport.ui.UserInterface):
         self.msg_choices = None
 
     def ui_present_report_details(
-        self, allowed_to_report: bool = True, modal_for: (int | None) = None
+        self, allowed_to_report: bool = True, modal_for: int | None = None
     ) -> apport.ui.Action:
         self.present_details_shown = True
         assert modal_for is None or isinstance(modal_for, int)
@@ -151,7 +151,7 @@ class UserInterfaceMock(apport.ui.UserInterface):
         self.upload_progress_pulses = 0
         self.upload_progress_active = True
 
-    def ui_set_upload_progress(self, progress: (float | None)) -> None:
+    def ui_set_upload_progress(self, progress: float | None) -> None:
         assert self.upload_progress_active
         self.upload_progress_pulses += 1
 
@@ -504,7 +504,7 @@ class T(unittest.TestCase):
         self.assertTrue(os.stat(self.report_file.name).st_mode & stat.S_IRGRP)
 
     def _write_crashdb_config_hook(
-        self, crashdb: str, bash_hook: (str | None) = None
+        self, crashdb: str, bash_hook: str | None = None
     ) -> None:
         """Write source_bash.py hook that sets CrashDB"""
         with open(
@@ -1104,9 +1104,9 @@ class T(unittest.TestCase):
         """run_crash() on a crash with malicious CrashDB"""
         self.report["ExecutablePath"] = "/bin/bash"
         self.report["Package"] = "bash 1"
-        self.report[
-            "CrashDB"
-        ] = "{'impl': 'memory', 'crash_config': open('/tmp/pwned', 'w').close()}"
+        self.report["CrashDB"] = (
+            "{'impl': 'memory', 'crash_config': open('/tmp/pwned', 'w').close()}"
+        )
         self.update_report_file()
         self.ui.present_details_response = apport.ui.Action(report=True)
 
@@ -1513,9 +1513,9 @@ class T(unittest.TestCase):
                 #1  0x10000001 in main () at crash.c:40
                 """
             )
-            self[
-                "ProcMaps"
-            ] = "10000000-DEADBEF0 r-xp 00000000 08:02 100000           /bin/crash\n"
+            self["ProcMaps"] = (
+                "10000000-DEADBEF0 r-xp 00000000 08:02 100000           /bin/crash\n"
+            )
             assert self.crash_signature_addresses() is not None
 
         try:

--- a/tests/integration/test_unkillable_shutdown.py
+++ b/tests/integration/test_unkillable_shutdown.py
@@ -39,7 +39,7 @@ class TestUnkillableShutdown(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.report_dir)
 
-    def _call(self, omit: (list | None) = None) -> None:
+    def _call(self, omit: list | None = None) -> None:
         cmd = [self.data_dir / "unkillable_shutdown"]
         if omit:
             cmd += [arg for pid in omit for arg in ("-o", str(pid))]

--- a/tests/paths.py
+++ b/tests/paths.py
@@ -11,7 +11,7 @@ _CRASHDB_CONF = _SRCDIR / "etc" / "apport" / "crashdb.conf"
 _DATADIR = _SRCDIR / "data"
 
 
-def get_data_directory(local_path: (str | None) = None) -> pathlib.Path:
+def get_data_directory(local_path: str | None = None) -> pathlib.Path:
     """Return absolute path for apport's data directory.
 
     If the tests are executed in the local source code directory,
@@ -70,7 +70,7 @@ def patch_data_dir(report: Any) -> Mapping[str, str] | None:
     return orig
 
 
-def restore_data_dir(report: Any, orig: (Mapping[str, str] | None)) -> None:
+def restore_data_dir(report: Any, orig: Mapping[str, str] | None) -> None:
     """Restore APPORT_DATA_DIR in apport.report from local tests.
 
     The parameter orig is the result from the patch_data_dir() call.

--- a/tests/run-linters
+++ b/tests/run-linters
@@ -32,6 +32,11 @@ run_black() {
         echo "Skipping black tests, black is not installed"
         return
     fi
+    black_version=$(black --version | head -n1 | cut -d' ' -f 2)
+    if test "${black_version%%.*}" -lt 24; then
+        echo "Skipping black tests, black $black_version is installed but version >= 24 is needed"
+        return
+    fi
     echo "Running black..."
     black -C --check --diff ${PYTHON_FILES} ${PYTHON_SCRIPTS}
 }

--- a/tests/unit/test_report.py
+++ b/tests/unit/test_report.py
@@ -296,14 +296,14 @@ class T(unittest.TestCase):
         r["StacktraceTop"] = "read () from /lib/libc.6.so\n?? ()\n?? ()\n?? ()"
         self.assertFalse(r.has_useful_stacktrace())
 
-        r[
-            "StacktraceTop"
-        ] = "read () from /lib/libc.6.so\nfoo (i=1) from /usr/lib/libfoo.so"
+        r["StacktraceTop"] = (
+            "read () from /lib/libc.6.so\nfoo (i=1) from /usr/lib/libfoo.so"
+        )
         self.assertTrue(r.has_useful_stacktrace())
 
-        r[
-            "StacktraceTop"
-        ] = "read () from /lib/libc.6.so\nfoo (i=1) from /usr/lib/libfoo.so\n?? ()"
+        r["StacktraceTop"] = (
+            "read () from /lib/libc.6.so\nfoo (i=1) from /usr/lib/libfoo.so\n?? ()"
+        )
         self.assertTrue(r.has_useful_stacktrace())
 
         r["StacktraceTop"] = (


### PR DESCRIPTION
Debian testing ships black 24.2.0-1. Modify `tests/run-linters` to skip the black check if black < 24 is installed.