### PR TITLE
test: fix date in test_crash_apport_from_systemd_coredump

### DIFF
--- a/tests/integration/test_signal_crashes.py
+++ b/tests/integration/test_signal_crashes.py
@@ -821,7 +821,7 @@ class T(unittest.TestCase):
 
             now = datetime.datetime.now(tz=datetime.timezone.utc)
             expected_report = apport.report.Report(
-                date=now.strftime("%a %b %d %H:%M:%S %Y")
+                date=now.strftime("%a %b %e %H:%M:%S %Y")
             )
             expected_report.pid = pid
             expected_report.add_proc_info()


### PR DESCRIPTION
test_crash_apport_from_systemd_coredump fails if the current day of the month contains only one digit:

```
>       self.assertEqual(dict(report), dict(expected_report))
E       AssertionError: {'Pro[16 chars]h', 'Architecture': 'amd64', 'Date': 'Wed Apr [4740 chars]'no'} != {'Pro[16 chars]h', 'Date': 'Wed Apr 03 15:32:15 2024', 'ProcC[4740 chars]'no'}
E         {'Architecture': 'amd64',
E       -  'Date': 'Wed Apr  3 15:32:15 2024',
E       ?                   ^
E
E       +  'Date': 'Wed Apr 03 15:32:15 2024',
E       ?                   ^
E
```