### PR TITLE
test: fix integration tests for bash >= 5.2.21-2ubuntu2 and coreutils >= 9.4-3ubuntu1

### DIFF
--- a/tests/integration/test_packaging_apt_dpkg.py
+++ b/tests/integration/test_packaging_apt_dpkg.py
@@ -152,12 +152,12 @@ class T(unittest.TestCase):
     def test_get_files(self):
         """get_files()."""
         self.assertRaises(ValueError, impl.get_files, "nonexisting")
-        self.assertIn("/bin/bash", impl.get_files("bash"))
+        self.assertIn("/usr/share/man/man1/bash.1.gz", impl.get_files("bash"))
 
     def test_get_file_package(self):
         """get_file_package() on installed files."""
-        self.assertEqual(impl.get_file_package("/bin/bash"), "bash")
-        self.assertEqual(impl.get_file_package("/bin/cat"), "coreutils")
+        self.assertEqual(impl.get_file_package("/usr/bin/bash"), "bash")
+        self.assertEqual(impl.get_file_package("/usr/bin/cat"), "coreutils")
         self.assertEqual(impl.get_file_package("/etc/pam.conf"), "libpam-runtime")
         self.assertIsNone(impl.get_file_package("/nonexisting"))
 

--- a/tests/system/test_apport_valgrind.py
+++ b/tests/system/test_apport_valgrind.py
@@ -53,7 +53,7 @@ class TestApportValgrind(unittest.TestCase):
             sandbox,
             "--cache",
             cache,
-            "/bin/true",
+            "/usr/bin/true",
         ]
         subprocess.check_call(cmd, env=self.env)
 


### PR DESCRIPTION
bash 5.2.21-2ubuntu2 in Ubuntu 24.04 (noble) moves the files to /usr. This causes `test_get_file_package` and `test_get_files` to fail:

```
=================================== FAILURES ===================================
___________________________ T.test_get_file_package ____________________________

self = <tests.integration.test_packaging_apt_dpkg.T testMethod=test_get_file_package>

def test_get_file_package(self):
"""get_file_package() on installed files."""
> self.assertEqual(impl.get_file_package("/bin/bash"), "bash")
E AssertionError: None != 'bash'

tests/integration/test_packaging_apt_dpkg.py:158: AssertionError
_______________________________ T.test_get_files _______________________________

self = <tests.integration.test_packaging_apt_dpkg.T testMethod=test_get_files>

def test_get_files(self):
"""get_files()."""
self.assertRaises(ValueError, impl.get_files, "nonexisting")
> self.assertIn("/bin/bash", impl.get_files("bash"))
E AssertionError: '/bin/bash' not found in [...]

```

Use `/usr/bin` for `test_get_file_package`. `get_file_package` will fall back to search in `/bin` if the file is not in `/usr/bin`. Change `test_get_files` to look for a file that hasn't changed the location.

coreutils 9.4-3ubuntu1 in Ubuntu 24.04 (noble) moves files to /usr. This causes `TestApportValgrind.test_sandbox_cache_options` to fail:

```
ERROR: Cannot find package which ships ExecutablePath /bin/true
```

Use `/usr/bin/true` for `test_sandbox_cache_options` since that is the new location. Apport already will fall back to look for `/bin/true` in case `/usr/bin/true` cannot be found.

Bug-Ubuntu: https://launchpad.net/bugs/2054902