### PR TITLE
test: support running tests directly with pytest

### DIFF
--- a/tests/integration/test_report.py
+++ b/tests/integration/test_report.py
@@ -8,6 +8,7 @@ import atexit
 import grp
 import io
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -143,7 +144,7 @@ class T(unittest.TestCase):
             self.assertNotIn("LANG=", pr["ProcEnviron"])
         self.assertNotIn("USER", pr["ProcEnviron"])
         self.assertNotIn("PWD", pr["ProcEnviron"])
-        self.assertRegex(pr["ExecutablePath"], r".*\.py$")
+        self.assertRegex(pr["ExecutablePath"], rf"^({re.escape(sys.argv[0])}|.*\.py)$")
         self.assertEqual(
             int(pr["ExecutableTimestamp"]), int(os.stat(pr["ExecutablePath"]).st_mtime)
         )


### PR DESCRIPTION
```
$ pytest tests/integration/test_report.py
[...]
=================================== FAILURES ===================================
_____________________________ T.test_add_proc_info _____________________________

self = <tests.integration.test_report.T testMethod=test_add_proc_info>

    def test_add_proc_info(self):
        # TODO: Split into separate test cases
        # pylint: disable=too-many-statements
        """add_proc_info()."""
        # check without additional safe environment variables
        pr = apport.report.Report()
        self.assertIsNone(pr.pid)
        pr.add_proc_info()
        self.assertEqual(pr.pid, os.getpid())
        self.assertTrue(
            set(["ProcEnviron", "ProcMaps", "ProcCmdline", "ProcMaps"]).issubset(
                set(pr.keys())
            ),
            "report has required fields",
        )
        if "LANG" in os.environ:
            self.assertIn("LANG=" + os.environ["LANG"], pr["ProcEnviron"])
        else:
            self.assertNotIn("LANG=", pr["ProcEnviron"])
        self.assertNotIn("USER", pr["ProcEnviron"])
        self.assertNotIn("PWD", pr["ProcEnviron"])
>       self.assertRegex(pr["ExecutablePath"], r".*\.py$")
E       AssertionError: Regex didn't match: '.*\\.py$' not found in '/usr/bin/pytest'

tests/integration/test_report.py:146: AssertionError
=========================== short test summary info ============================
FAILED tests/integration/test_report.py::T::test_add_proc_info - AssertionError: Regex didn't match: '.*\\.py$' not found in '/usr/bin/pytest'
=================== 1 failed, 33 passed, 1 skipped in 9.05s ====================
```