### PR TITLE
report: Fix crash if the user is a dynamic user

### DIFF
--- a/apport/report.py
+++ b/apport/report.py
@@ -551,7 +551,11 @@ class Report(problem_report.ProblemReport):
         - UserGroups: system groups the user is in
         """
         # Use effective uid in case privileges were dropped
-        user = pwd.getpwuid(os.geteuid())[0]
+        try:
+            user = pwd.getpwuid(os.geteuid())[0]
+        except KeyError:
+            # User not found (e.g. dynamic user in container)
+            return
         sys_gid_max = apport.fileutils.get_sys_gid_max()
         groups = [
             name

--- a/tests/integration/test_report.py
+++ b/tests/integration/test_report.py
@@ -123,6 +123,17 @@ class T(unittest.TestCase):
             self.assertLess(grp.getgrnam(g).gr_gid, 1000)
         self.assertNotIn(grp.getgrgid(os.getgid()).gr_name, pr["UserGroups"])
 
+    @unittest.mock.patch("os.geteuid")
+    def test_add_user_info_missing_user(self, geteuid_mock: MagicMock) -> None:
+        """Test add_user_info() with the effective user set to an dynamic user."""
+        geteuid_mock.return_value = 1000042
+        report = apport.report.Report()
+
+        report.add_user_info()
+
+        self.assertNotIn("UserGroups", report)
+        geteuid_mock.assert_called_once_with()
+
     def test_add_proc_info(self):
         # TODO: Split into separate test cases
         # pylint: disable=too-many-statements


### PR DESCRIPTION
Apport 2.28.0 failed to create a crash report from an crash inside a lxc container:

```
Traceback (most recent call last):
  File "/usr/share/apport/apport", line 1244, in <module>
    sys.exit(main(sys.argv[1:]))
             ^^^^^^^^^^^^^^^^^^
  File "/usr/share/apport/apport", line 761, in main
    return process_crash_from_systemd_coredump(options.systemd_coredump_instance)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/apport/apport", line 1240, in process_crash_from_systemd_coredump
    return process_crash(report, real_user, report_owner)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/apport/apport", line 1135, in process_crash
    info.add_user_info()
  File "/usr/lib/python3/dist-packages/apport/report.py", line 554, in add_user_info
    user = pwd.getpwuid(os.geteuid())[0]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'getpwuid(): uid not found: 1000000'
Error in sys.excepthook:
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/apport_python_hook.py", line 228, in partial_apport_excepthook
    return apport_excepthook(binary, exc_type, exc_obj, exc_tb)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/apport_python_hook.py", line 110, in apport_excepthook
    report.add_user_info()
  File "/usr/lib/python3/dist-packages/apport/report.py", line 554, in add_user_info
    user = pwd.getpwuid(os.geteuid())[0]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'getpwuid(): uid not found: 1000000'

Original exception was:
Traceback (most recent call last):
  File "/usr/share/apport/apport", line 1244, in <module>
    sys.exit(main(sys.argv[1:]))
             ^^^^^^^^^^^^^^^^^^
  File "/usr/share/apport/apport", line 761, in main
    return process_crash_from_systemd_coredump(options.systemd_coredump_instance)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/apport/apport", line 1240, in process_crash_from_systemd_coredump
    return process_crash(report, real_user, report_owner)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/apport/apport", line 1135, in process_crash
    info.add_user_info()
  File "/usr/lib/python3/dist-packages/apport/report.py", line 554, in add_user_info
    user = pwd.getpwuid(os.geteuid())[0]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'getpwuid(): uid not found: 1000000'
```

This stack trace is lengthy because `apport_python_hook` tries to create a Python crash report but crashes with the same reason.