### PR TITLE
ci: Add Ubuntu 24.04 LTS "Noble Numbat"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -151,8 +151,8 @@ jobs:
         run: >
           apt-get update
           && apt-get install --no-install-recommends --yes
-          ca-certificates git python3 python3-apt python3-psutil python3-pytest
-          python3-pytest-cov
+          bash ca-certificates git python3 python3-apt python3-psutil
+          python3-pytest python3-pytest-cov
       - uses: actions/checkout@v4
       - name: Run all tests (to check if they are skipped or succeed)
         run: >

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,7 @@ jobs:
           - debian:testing-slim
           - ubuntu:jammy
           - ubuntu:mantic
+          - ubuntu:noble
     container:
       image: ${{ matrix.container }}
     steps:
@@ -52,6 +53,7 @@ jobs:
           - debian:testing-slim
           - ubuntu:jammy
           - ubuntu:mantic
+          - ubuntu:noble
     container:
       image: ${{ matrix.container }}
       options: --cap-add=SYS_PTRACE --security-opt seccomp=unconfined
@@ -144,6 +146,7 @@ jobs:
         container:
           - ubuntu:jammy
           - ubuntu:mantic
+          - ubuntu:noble
     container:
       image: ${{ matrix.container }}
     steps:
@@ -175,12 +178,17 @@ jobs:
         container:
           - ubuntu:jammy
           - ubuntu:mantic
+          - ubuntu:noble
     container:
       image: ${{ matrix.container }}
       options: --cap-add=SYS_PTRACE --security-opt seccomp=unconfined
     steps:
       - name: Enable 'deb-src' URIs in /etc/apt/sources.list
-        run: sed -i '/^#\sdeb-src /s/^#\s//' /etc/apt/sources.list
+        run: >
+          sed -i '/^#\sdeb-src /s/^#\s//' /etc/apt/sources.list
+          && ! test -e /etc/apt/sources.list.d/ubuntu.sources
+          || sed -i 's/^Types:.*/Types: deb deb-src/g'
+          /etc/apt/sources.list.d/ubuntu.sources
       - name: Install dependencies
         run: >
           apt-get update


### PR DESCRIPTION
Add Ubuntu 24.04 LTS "Noble Numbat" to the CI. Ubuntu 24.04 is using deb822 sources in `/etc/apt/sources.list.d/ubuntu.sources`.