### PR TITLE
test: fix deletion of the tmpdir in test_run_report_bug_noperm_pid

### DIFF
--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -765,6 +765,7 @@ class T(unittest.TestCase):
 
     def test_run_report_bug_noperm_pid(self):
         """run_report_bug() for a pid which runs as a different user"""
+        self.ui = None
         restore_root = False
         if os.getuid() == 0:
             # temporarily drop to normal user "mail"


### PR DESCRIPTION
pytest shows following warning when run as root:

```
tests/integration/test_ui.py::T::test_run_report_bug_noperm_pid
  /usr/lib/python3/dist-packages/_pytest/unraisableexception.py:78: PytestUnraisableExceptionWarning: Exception ignored in: <function UserInterfaceMock.__del__ at 0x7f15bed0d4e0>

  Traceback (most recent call last):
    File "/__w/apport/apport/tests/integration/test_ui.py", line 111, in __del__
      self.crashdb_conf.close()
    File "/usr/lib/python3.11/tempfile.py", line 648, in close
      self._closer.close()
    File "/usr/lib/python3.11/tempfile.py", line 585, in close
      unlink(self.name)
  PermissionError: [Errno 1] Operation not permitted: '/tmp/tmpunnl4xag'

    warnings.warn(pytest.PytestUnraisableExceptionWarning(msg))
```

This failure is caused by `setUp` calling `self.ui = UserInterfaceMock()` as root. Then this object cannot be cleaned after switching to user with `os.setresuid`.