### PR TITLE
apt_dpkg: fix reading comment only entries in APT deb822 sources

### DIFF
--- a/apport/packaging_impl/apt_dpkg.py
+++ b/apport/packaging_impl/apt_dpkg.py
@@ -68,7 +68,8 @@ def _parse_deb822_sources(source: str) -> list[apt_sl.Deb822SourceEntry]:
         for line in f.read().split("\n"):
             line = line.rstrip()
             if line:
-                current.append(line)
+                if not line.lstrip().startswith("#"):
+                    current.append(line)
             else:
                 if not current:
                     continue

--- a/tests/unit/test_packaging_apt_dpkg.py
+++ b/tests/unit/test_packaging_apt_dpkg.py
@@ -90,6 +90,8 @@ class TestPackagingAptDpkg(unittest.TestCase):
         "builtins.open",
         new_callable=unittest.mock.mock_open,
         read_data="""
+# Some documentation in the beginning
+
 Types: deb deb-src
 URIs: http://example.com
 Suites: foo foo-bar


### PR DESCRIPTION
The default `/etc/apt/sources.list.d/ubuntu.sources` in Ubuntu 24.04 starts with a comment section:

```
# See http://help.ubuntu.com/community/UpgradeNotes for how to upgrade to
# newer versions of the distribution.

## Ubuntu distribution repository
## [...]
## See the sources.list(5) manual page for further settings.
Types: deb
URIs: http://archive.ubuntu.com/ubuntu/
Suites: noble noble-updates noble-backports
Components: main universe restricted multiverse
Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg

## Ubuntu security updates. Aside from URIs and Suites,
## this should mirror your choices in the previous section.
Types: deb
URIs: http://security.ubuntu.com/ubuntu/
Suites: noble-security
Components: main universe restricted multiverse
Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
```

This causes `TestApportValgrind.test_sandbox_cache_options` to fail:

```
Traceback (most recent call last):
  File "/__w/apport/apport/bin/apport-valgrind", line 159, in <module>
    sandbox, cache, outdated_msg = apport.sandboxutils.make_sandbox(
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/__w/apport/apport/apport/sandboxutils.py", line 261, in make_sandbox
    pkgs = needed_runtime_packages(report, pkgmap_cache_dir, pkg_versions, verbose)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/__w/apport/apport/apport/sandboxutils.py", line 102, in needed_runtime_packages
    pkg = packaging.get_file_package(
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/__w/apport/apport/apport/packaging_impl/apt_dpkg.py", line 627, in get_file_package
    return self._search_contents(file, map_cachedir, release, arch)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/__w/apport/apport/apport/packaging_impl/apt_dpkg.py", line 1523, in _search_contents
    f"{self._get_mirror()}/dists"
       ^^^^^^^^^^^^^^^^^^
  File "/__w/apport/apport/apport/packaging_impl/apt_dpkg.py", line 1471, in _get_mirror
    self._mirror = self._get_primary_mirror_from_apt_sources("/etc/apt")
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/__w/apport/apport/apport/packaging_impl/apt_dpkg.py", line 1439, in _get_primary_mirror_from_apt_sources
    sources = _load_all_sources(apt_dir)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/__w/apport/apport/apport/packaging_impl/apt_dpkg.py", line 121, in _load_all_sources
    sources.extend(_parse_deb822_sources(path))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/__w/apport/apport/apport/packaging_impl/apt_dpkg.py", line 76, in _parse_deb822_sources
    sections.append(apt_sl.Deb822SourceEntry("\n".join(current), source))
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/aptsources/sourceslist.py", line 168, in __init__
    self.section = _deb822.Section(section)
                   ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/aptsources/_deb822.py", line 51, in __init__
    self.tags = collections.OrderedDict(apt_pkg.TagSection(trimmed_section))
                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: Unable to parse section data
```

So strip the comments from the sources before constructing the `Deb822SourceEntry` objects.