### PR TITLE
tests: fix mypy 1.9.0 complains

### DIFF
--- a/tests/integration/test_crashdb_launchpad.py
+++ b/tests/integration/test_crashdb_launchpad.py
@@ -756,7 +756,9 @@ and more
         part = next(msg_iter)
         assert not part.is_multipart()
         assert part.get_content_type() == "text/plain"
-        description += "\n\n" + part.get_payload(decode=True).decode("UTF-8", "replace")
+        payload = part.get_payload(decode=True)
+        assert isinstance(payload, bytes)
+        description += "\n\n" + payload.decode("UTF-8", "replace")
 
         # create the bug from header and description data
         bug = self.crashdb.launchpad.bugs.createBug(

--- a/tests/integration/test_problem_report.py
+++ b/tests/integration/test_problem_report.py
@@ -535,8 +535,7 @@ class T(unittest.TestCase):
 
     @staticmethod
     def decode_gzipped_message(message: email.message.Message) -> bytes:
-        with tempfile.TemporaryFile() as payload:
-            payload.write(message.get_payload(decode=True))
-            payload.seek(0)
-            with gzip.GzipFile(mode="rb", fileobj=payload) as gz:
-                return gz.read()
+        payload = message.get_payload(decode=True)
+        assert isinstance(payload, bytes)
+        with gzip.GzipFile(mode="rb", fileobj=io.BytesIO(payload)) as gzip_file:
+            return gzip_file.read()


### PR DESCRIPTION
mypy 1.9.0 complains:

```
tests/integration/test_problem_report.py:539: error: Argument 1 to "write" of "BufferedWriter" has incompatible type "Message | bytes | Any"; expected "Buffer"  [arg-type]
tests/integration/test_crashdb_launchpad.py:759: error: Item "Message" of "Message | bytes | Any" has no attribute "decode"  [union-attr]
Found 2 errors in 2 files (checked 85 source files)
```

The changes to `tests/integration/test_problem_report.py` were tested on my machine:

```
TEST_LAUNCHPAD=1 pytest tests/integration/test_crashdb_launchpad.py
```