### PR TITLE
report: Ignore missing COREDUMP_FILENAME

### DIFF
--- a/apport/report.py
+++ b/apport/report.py
@@ -21,6 +21,7 @@ import glob
 import grp
 import importlib.util
 import io
+import logging
 import os
 import pathlib
 import pwd
@@ -2024,7 +2025,13 @@ class Report(problem_report.ProblemReport):
         filename = coredump.get("COREDUMP_FILENAME")
         if filename:
             assert isinstance(filename, str)
-            self["CoreDump"] = problem_report.CompressedFile(filename)
+            try:
+                self["CoreDump"] = problem_report.CompressedFile(filename)
+            except FileNotFoundError:
+                logging.getLogger(__name__).warning(
+                    "Ignoring COREDUMP_FILENAME '%s' because it does not exist.",
+                    filename,
+                )
 
     @classmethod
     def from_systemd_coredump(cls, coredump):

--- a/problem_report.py
+++ b/problem_report.py
@@ -189,14 +189,22 @@ class CompressedFile:
 
     filename: str
 
+    def __init__(self, filename: str) -> None:
+        self.filename = filename
+        # pylint: disable-next=consider-using-with
+        self._compressed_file = open(self.filename, "rb")
+
+    def __del__(self):
+        if hasattr(self, "_compressed_file"):
+            self._compressed_file.close()
+
     def iter_compressed(self) -> Iterator[bytes]:
         """Iterate over the compressed content of the file in 1 MB chunks."""
-        with open(self.filename, "rb") as compressed_file:
-            while True:
-                block = compressed_file.read(1048576)
-                if not block:
-                    break
-                yield block
+        while True:
+            block = self._compressed_file.read(1048576)
+            if not block:
+                break
+            yield block
 
     def is_readable(self) -> bool:
         """Check if the compressed file is readable by the effective user."""


### PR DESCRIPTION
If a systemd-coredump report points to a coredump file that does not exist (any more), Apport will fail:

```
Traceback (most recent call last):
  File "/usr/share/apport/apport", line 1244, in <module>
    sys.exit(main(sys.argv[1:]))
             ^^^^^^^^^^^^^^^^^^
  File "/usr/share/apport/apport", line 761, in main
    return process_crash_from_systemd_coredump(options.systemd_coredump_instance)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/apport/apport", line 1240, in process_crash_from_systemd_coredump
    return process_crash(report, real_user, report_owner)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/apport/apport", line 1146, in process_crash
    info.write(reportfile)
  File "/usr/lib/python3/dist-packages/problem_report.py", line 548, in write
    self._write_binary_item_compressed_and_encoded(file, k)
  File "/usr/lib/python3/dist-packages/problem_report.py", line 722, in _write_binary_item_compressed_and_encoded
    self._write_binary_item_base64_encoded(
  File "/usr/lib/python3/dist-packages/problem_report.py", line 629, in _write_binary_item_base64_encoded
    for chunk in chunks:
  File "/usr/lib/python3/dist-packages/problem_report.py", line 649, in _generate_compressed_chunks
    yield from value.iter_compressed()
  File "/usr/lib/python3/dist-packages/problem_report.py", line 194, in iter_compressed
    with open(self.filename, "rb") as compressed_file:
         ^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/var/lib/systemd/coredump/core.tracker-extract.1000.92c6d53b71364e3286fd6011f3dad5e7.4441.1710845299000000.zst'
```

Ignore the missing coredump file and print a warning for it.

Bug: https://launchpad.net/bugs/2058380