### PR TITLE
report: fix determining bug report URL for Thunderbird

### DIFF
--- a/apport/report.py
+++ b/apport/report.py
@@ -510,7 +510,7 @@ class Report(problem_report.ProblemReport):
         """
         # Launchpad
         p = (
-            r"^https?:\/\/.*launchpad\.net\/"
+            r"^https?:\/\/.*launchpad\.net\/(?:distros/)?"
             r"((?:[^\/]+\/\+source\/)?[^\/]+)(?:.*field\.tags?=([^&]+))?"
         )
         m = re.search(p, urllib.parse.unquote(snap_contact))

--- a/tests/unit/test_report.py
+++ b/tests/unit/test_report.py
@@ -1369,6 +1369,16 @@ No symbol table info available.
         self.assertEqual("ubuntu/+source/chromium-browser", pr["SnapSource"])
         self.assertEqual("snap", pr["SnapTags"])
 
+    def test_add_snap_contact_launchpad_distro(self) -> None:
+        """add_snap_contact_info() with https://launchpad.net/distros/ contact"""
+        report = apport.report.Report()
+        snap_contact = "https://launchpad.net/distros/ubuntu/+source/thunderbird"
+
+        report.add_snap_contact_info(snap_contact)
+
+        self.assertEqual(set(report.keys()), {"ProblemType", "Date", "SnapSource"})
+        self.assertEqual("ubuntu/+source/thunderbird", report["SnapSource"])
+
     def test_add_snap_contact_info_github(self):
         """add_snap_contact_info()
 


### PR DESCRIPTION
When running `ubuntu-bug thunderbird` on a system with the thunderbird snap installed, it collects information correctly and opens a page like https://bugs.launchpad.net/distros/+filebug/a9564134-dfa6-11ee-85a7-c7116d9f638e which is not valid.

The snap contact information contains `distros` in the Launchpad URL:

```
$ snap info thunderbird | grep ^contact
contact:   https://launchpad.net/distros/ubuntu/+source/thunderbird
```

Bug-Ubuntu: https://launchpad.net/bugs/2056758