### PR TITLE
setup: determine udev directory dynamically

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -234,10 +234,11 @@ jobs:
           sudo apt-get update
           && sudo apt-get install --no-install-recommends --yes
           ca-certificates dbus dbus-x11 dirmngr dpkg-dev gcc gdb gir1.2-gtk-3.0
-          gir1.2-wnck-3.0 git gnome-icon-theme gpg gvfs-daemons psmisc python3
-          python3-apt python3-dbus python3-distutils-extra python3-gi
-          python3-launchpadlib python3-pyqt5 python3-pytest python3-pytest-cov
-          python3-setuptools ubuntu-dbgsym-keyring ubuntu-keyring valgrind xvfb
+          gir1.2-wnck-3.0 git gnome-icon-theme gpg gvfs-daemons pkg-config
+          psmisc python3 python3-apt python3-dbus python3-distutils-extra
+          python3-gi python3-launchpadlib python3-pyqt5 python3-pytest
+          python3-pytest-cov python3-setuptools ubuntu-dbgsym-keyring
+          ubuntu-keyring valgrind xvfb
       - uses: actions/checkout@v4
       - name: Install
         run: >

--- a/setup.py
+++ b/setup.py
@@ -115,6 +115,13 @@ except (FileNotFoundError, subprocess.CalledProcessError):
     systemd_unit_dir = "/lib/systemd/system"
     systemd_tmpfiles_dir = "/usr/lib/tmpfiles.d"
 
+try:
+    udev_dir = subprocess.check_output(
+        ["pkg-config", "--variable=udevdir", "udev"], text=True
+    ).strip()
+except (FileNotFoundError, subprocess.CalledProcessError):
+    udev_dir = "/lib/udev"
+
 cmdclass = register_java_sub_commands(build_extra, install_fix_hashbangs)
 DistUtilsExtra.auto.setup(
     name="apport",
@@ -131,7 +138,7 @@ DistUtilsExtra.auto.setup(
         ("share/apport", ["gtk/apport-gtk", "kde/apport-kde"]),
         (BASH_COMPLETIONS, glob.glob("data/bash-completion/*")),
         ("lib/pm-utils/sleep.d/", glob.glob("pm-utils/sleep.d/*")),
-        ("/lib/udev/rules.d", glob.glob("udev/*.rules")),
+        (f"{udev_dir}/rules.d", glob.glob("udev/*.rules")),
         (
             systemd_unit_dir,
             glob.glob("data/systemd/*.service") + glob.glob("data/systemd/*.socket"),


### PR DESCRIPTION
On /usr merged systems like Ubuntu 24.04 the udev rules are placed into `/usr/lib/udev/rules.d` instead of `/lib/udev/rules.d`.

Determine the location of the udev directory from the pkg-config file and fallback to the old location on failure. Install `pkg-config` in the `system-installed` test.