### PR TITLE
apport: Ignore container crash reports from systemd-coredump

### DIFF
--- a/data/apport
+++ b/data/apport
@@ -1234,6 +1234,14 @@ def process_crash_from_systemd_coredump(instance: str) -> int:
     except _JournalMessageNotFound as error:
         logging.getLogger(__name__).error("%s", error)
         return 1
+    if "COREDUMP_CONTAINER_CMDLINE" in coredump:
+        logging.getLogger(__name__).info(
+            "Ignoring %s crash because it happened inside a container."
+            " Please install systemd-coredump inside the container for"
+            " forwarding future crashes.",
+            coredump["COREDUMP_EXE"],
+        )
+        return 0
     report = apport.report.Report.from_systemd_coredump(coredump)
     real_user = UserGroupID.from_systemd_coredump(coredump)
     report_owner = _determine_report_owner(report, real_user)


### PR DESCRIPTION
systemd-coredump stores crashes that happen inside a container on the host in case it cannot forward the crash to the container. Apport cannot do anything useful with these crash reports, because the information about the crashed process does not contain the process number seen from inside the container and because the crashed process is already gone when Apport gets the crash from systemd-coredump.

So let Apport just ignore crash reports from systemd-coredump if the crashes happened inside containers.

Bug-Ubuntu: https://launchpad.net/bugs/2063349