### PR TITLE
launchpad: fix dynamic adaption of chunck size

### DIFF
--- a/apport/crashdb_impl/launchpad.py
+++ b/apport/crashdb_impl/launchpad.py
@@ -1176,14 +1176,14 @@ class HTTPSProgressConnection(http.client.HTTPSConnection):
             t1 = time.time()
             http.client.HTTPSConnection.send(self, data[sent : (sent + chunksize)])
             sent += chunksize
-            t2 = time.time()
+            duration = time.time() - t1
 
             # adjust chunksize so that it takes between .5 and 2
             # seconds to send a chunk
             if chunksize > 1024:
-                if t2 - t1 < 0.5:
+                if duration < 0.5:
                     chunksize <<= 1
-                elif t2 - t1 > 2:
+                elif duration > 2:
                     chunksize >>= 1
 
 

--- a/apport/crashdb_impl/launchpad.py
+++ b/apport/crashdb_impl/launchpad.py
@@ -1180,11 +1180,10 @@ class HTTPSProgressConnection(http.client.HTTPSConnection):
 
             # adjust chunksize so that it takes between .5 and 2
             # seconds to send a chunk
-            if chunksize > 1024:
-                if duration < 0.5:
-                    chunksize <<= 1
-                elif duration > 2:
-                    chunksize >>= 1
+            if duration < 0.5:
+                chunksize <<= 1
+            elif duration > 2 and chunksize > 1024:
+                chunksize >>= 1
 
 
 class HTTPSProgressHandler(urllib.request.HTTPSHandler):


### PR DESCRIPTION
The chunk size in `HTTPSProgressConnection.send` starts with 1024. The chunk size is checked for being bigger than 1024 before increasing or decreasing it. Therefore this condition will never met and the chunk size will stay at 1024.

Only check for the chunk size to be bigger than 1024 before decreasing it (not before increasing it).

I ran the integration tests locally, but `HTTPSProgressConnection` is not covered by it:

```
TEST_LAUNCHPAD=1 pytest -ra --cov=. --cov-report=html --cov-branch tests/integration/test_crashdb_launchpad.py
```