### PR TITLE
report: Fix possible None.startswith() call

### DIFF
--- a/apport/report.py
+++ b/apport/report.py
@@ -1072,11 +1072,11 @@ class Report(problem_report.ProblemReport):
 
                 # handle XErrors
                 if unwinding_xerror:
-                    if fn.startswith("_X") or fn in {
-                        "handle_response",
-                        "handle_error",
-                        "XWindowEvent",
-                    }:
+                    if (
+                        fn
+                        and fn.startswith("_X")
+                        or fn in {"handle_response", "handle_error", "XWindowEvent"}
+                    ):
                         continue
                     unwinding_xerror = False
 


### PR DESCRIPTION
In `Report._gen_stacktrace_top` `fn` might be set to `None` and calling `fn.startswith` will fail in that case.