### PR TITLE
crashdb: make _duplicate_db_sync_status more readable

### DIFF
--- a/apport/crashdb.py
+++ b/apport/crashdb.py
@@ -588,7 +588,7 @@ class CrashDatabase:
                 f"DEBUG: bug {crash_id} got reopened,"
                 f" dropping fixed version {db_fixed_version} from database"
             )
-            self.duplicate_db_fixed(crash_id, real_fixed_version)
+            self.duplicate_db_fixed(crash_id, None)
             return
 
     def _duplicate_db_add_address_signature(self, sig, crash_id):

--- a/tests/unit/test_crashdb.py
+++ b/tests/unit/test_crashdb.py
@@ -593,6 +593,19 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
             5,
         )
 
+    def test_check_duplicate_reopen(self) -> None:
+        """check_duplicate() which calls mark_regression()
+
+        Bug 3 and 4 have the same traceback. Assume bug 3 to be marked
+        as fixed in version 4.1. The check_duplicate() call on bug 4
+        (with version 5) will be a regression.
+        """
+        self.crashes.init_duplicate_db(":memory:")
+        self.assertIsNone(self.crashes.check_duplicate(3))
+        self.crashes.duplicate_db_fixed(3, "4.1")
+
+        self.assertEqual(self.crashes.check_duplicate(4), (3, None))
+
     def test_known_address_sig(self):
         # TODO: Split into separate test cases
         # pylint: disable=too-many-statements


### PR DESCRIPTION
Coverity 2023.9.2 rule COV_PY_COPY_PASTE_ERROR_PYTHON complains about `real_fixed_version` in `CrashDatabase.duplicate_db_fixed` looks like a copy-paste error.

For the "crash got reopened" case, `real_fixed_version` is `None` and therefore the call to `duplicate_db_fixed` sets the fixed version back to 'still unfixed'. Make that code more readable by explicitly passing `None` to `duplicate_db_fixed`.