### PR TITLE
apt_dpkg: fix finding source for /lib/x86_64-linux-gnu/libc.so.6

### DIFF
--- a/tests/integration/test_packaging_apt_dpkg.py
+++ b/tests/integration/test_packaging_apt_dpkg.py
@@ -3,6 +3,7 @@
 # TODO: Address following pylint complaints
 # pylint: disable=invalid-name
 
+import glob
 import gzip
 import os
 import pathlib
@@ -161,6 +162,12 @@ class T(unittest.TestCase):
         self.assertEqual(impl.get_file_package("/usr/bin/cat"), "coreutils")
         self.assertEqual(impl.get_file_package("/etc/pam.conf"), "libpam-runtime")
         self.assertIsNone(impl.get_file_package("/nonexisting"))
+
+    def test_get_file_package_libc_so(self) -> None:
+        """get_file_package() on libc.so.6."""
+        libc_so = sorted(glob.glob("/lib/*/libc.so.6"))
+        self.assertIsNotNone(libc_so)
+        self.assertEqual(impl.get_file_package(libc_so[-1]), "libc6")
 
     def test_get_file_package_uninstalled(self):
         """get_file_package() on uninstalled packages."""

--- a/tests/unit/test_packaging_apt_dpkg.py
+++ b/tests/unit/test_packaging_apt_dpkg.py
@@ -133,3 +133,25 @@ Components: main
                 "http://security.ubuntu.com/ubuntu/",
             ],
         )
+
+    @unittest.mock.patch.object(impl, "_get_file2pkg_mapping")
+    @unittest.mock.patch.object(impl, "_save_contents_mapping", MagicMock())
+    def test_get_file_package_uninstalled_usrmerge(
+        self, _get_file2pkg_mapping_mock: MagicMock
+    ) -> None:
+        """get_file_package() on uninstalled usrmerge packages."""
+        # Data from Ubuntu 24.04 (noble)
+        _get_file2pkg_mapping_mock.return_value = {
+            b"usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2": b"libc6",
+            b"usr/lib/x86_64-linux-gnu/libc.so.6": b"libc6",
+            b"usr/libx32/libc.so.6": b"libc6-x32",
+        }
+
+        pkg = impl.get_file_package(
+            "/lib/x86_64-linux-gnu/libc.so.6", True, "/map_cachedir", arch="amd64"
+        )
+
+        self.assertEqual(pkg, "libc6")
+        _get_file2pkg_mapping_mock.assert_called_with(
+            "/map_cachedir", impl.get_distro_codename(), "amd64"
+        )


### PR DESCRIPTION
`apport-retrace` shows following warning on Ubuntu 24.04 (noble):

```
WARNING: /lib/x86_64-linux-gnu/libc.so.6 is needed, but cannot be mapped to a package
```

This is caused by libc6 shipping the file in `/usr/lib/x86_64-linux-gnu/libc.so.6`.