### PR TITLE
pylint 3.2.2 fixes: initialize gdb_sandbox and fix UnboundLocalError in add_kernel_crash_info

### DIFF
--- a/bin/apport-retrace
+++ b/bin/apport-retrace
@@ -477,6 +477,7 @@ def main():
         cache = None
         outdated_msg = None
 
+    gdb_sandbox = None
     if options.gdb_sandbox:
         if report["Architecture"] == system_arch:
             if sandbox:
@@ -546,8 +547,6 @@ def main():
                         " gdb sandbox's. See LP: #1818918 for details."
                     )
                     sys.exit(0)
-    else:
-        gdb_sandbox = None
 
     # interactive gdb session
     if options.gdb:


### PR DESCRIPTION
pylint 3.2.2 complains:

```
************* Module apport-retrace
bin/apport-retrace:515:27: E0601: Using variable 'gdb_sandbox' before assignment (used-before-assignment)
************* Module apport.report
apport/report.py:878:71: E0606: Possibly using variable 'core' before assignment (possibly-used-before-assignment)
```

If `options.gdb_sandbox` evaluates to True, the architecture is the system architecture, and `sandbox` evaluates to False, `gdb_sandbox` will not be set.

The case in `apport/report.py` can be hit by analyzing a local kernel crash report with apport-retrace. `load_report` in `apport-retrace` loads the report with `binary="compressed"`. This leads to `VmCore` being an instance of `CompressedValue` which does not have a `find` method.

Use the high-level interface `tempfile.NamedTemporaryFile` instead of `tempfile.mkstemp` and always write the `VmCore` content. Add support for writing `CompressedValue`. Add unit tests to (hopefully) cover all cases. Note: `add_kernel_crash_info` is only called by `apport-retrace`.