### PR TITLE
test: move mypy config to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,10 @@ ignore-words-list = "buildd"
 line_length = 88
 profile = "black"
 
+[tool.mypy]
+disallow_incomplete_defs = true
+ignore_missing_imports = true
+
 [tool.pydocstyle]
 # TODO: Address the ignored codes (except D203,D213)
 ignore = "D1,D203,D205,D209,D213,D400,D401,D402,D415"

--- a/tests/run-linters
+++ b/tests/run-linters
@@ -56,8 +56,8 @@ run_mypy() {
         return
     fi
     echo "Running mypy..."
-    mypy --disallow-incomplete-defs --ignore-missing-imports ${PYTHON_FILES} data/apport
-    mypy --disallow-incomplete-defs --ignore-missing-imports --scripts-are-modules ${PYTHON_SCRIPTS_WITHOUT_APPORT}
+    mypy ${PYTHON_FILES} data/apport
+    mypy --scripts-are-modules ${PYTHON_SCRIPTS_WITHOUT_APPORT}
 }
 
 run_pycodestyle() {


### PR DESCRIPTION
Move mypy configuration to `pyproject.toml` to support using those setting when called manually.