### PR TITLE
ci: drop Ubuntu 23.10 "Mantic Minotaur"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,6 @@ jobs:
         container:
           - debian:testing-slim
           - ubuntu:jammy
-          - ubuntu:mantic
           - ubuntu:noble
     container:
       image: ${{ matrix.container }}
@@ -52,7 +51,6 @@ jobs:
           - debian:bookworm-slim
           - debian:testing-slim
           - ubuntu:jammy
-          - ubuntu:mantic
           - ubuntu:noble
     container:
       image: ${{ matrix.container }}
@@ -142,7 +140,6 @@ jobs:
       matrix:
         container:
           - ubuntu:jammy
-          - ubuntu:mantic
           - ubuntu:noble
     container:
       image: ${{ matrix.container }}
@@ -175,7 +172,6 @@ jobs:
       matrix:
         container:
           - ubuntu:jammy
-          - ubuntu:mantic
           - ubuntu:noble
     container:
       image: ${{ matrix.container }}


### PR DESCRIPTION
Ubuntu 23.10 "Mantic Minotaur" will be end-of-life on 2024-07-11.