### PR TITLE
test: Use MagicMock for subprocess.CompletedProcess.args

### DIFF
--- a/tests/unit/test_hookutils.py
+++ b/tests/unit/test_hookutils.py
@@ -105,9 +105,9 @@ class TestHookutils(unittest.TestCase):
 
     @unittest.mock.patch("subprocess.run")
     @unittest.mock.patch("os.path.exists", MagicMock(return_value=True))
-    def test_attach_journal_errors_with_date(self, run_mock):
+    def test_attach_journal_errors_with_date(self, run_mock: MagicMock) -> None:
         run_mock.return_value = subprocess.CompletedProcess(
-            args=None, returncode=0, stdout=b"journalctl output", stderr=b""
+            args=MagicMock(), returncode=0, stdout=b"journalctl output", stderr=b""
         )
         now = datetime.datetime.now()
 
@@ -128,9 +128,9 @@ class TestHookutils(unittest.TestCase):
 
     @unittest.mock.patch("subprocess.run")
     @unittest.mock.patch("os.path.exists", MagicMock(return_value=True))
-    def test_attach_journal_errors_without_date(self, run_mock):
+    def test_attach_journal_errors_without_date(self, run_mock: MagicMock) -> None:
         run_mock.return_value = subprocess.CompletedProcess(
-            args=None, returncode=0, stdout=b"journalctl output", stderr=b""
+            args=MagicMock(), returncode=0, stdout=b"journalctl output", stderr=b""
         )
 
         report = apport.Report()


### PR DESCRIPTION
mypy complains:

```
error: Argument "args" to "CompletedProcess" has incompatible type "None"; expected "str | bytes | PathLike[str] | PathLike[bytes] | Sequence[str | bytes | PathLike[str] | PathLike[bytes]]"  [arg-type]
```

Since `subprocess.CompletedProcess.args` is not used by the tests use `MagicMock` to make mypy happy.