### PR TITLE
apport: create /var/crash with setgid permission

### DIFF
--- a/data/apport
+++ b/data/apport
@@ -631,9 +631,13 @@ def check_kernel_crash() -> None:
 
 
 def create_directory(path: str, mode: int) -> None:
-    """Ensure the directory is created with the correct mode."""
-    os.makedirs(path, exist_ok=True)
-    os.chmod(path, mode)
+    """Ensure the directory is created.
+
+    Only set the directory mode if the directory is newly created.
+    """
+    with contextlib.suppress(FileExistsError):
+        os.makedirs(path)
+        os.chmod(path, mode)
 
 
 def write_to_proc_sys(path: str, value: str) -> None:

--- a/data/apport
+++ b/data/apport
@@ -648,7 +648,7 @@ def write_to_proc_sys(path: str, value: str) -> None:
 
 def start_apport() -> None:
     """Start Apport crash handler."""
-    create_directory(apport.fileutils.report_dir, 0o1777)
+    create_directory(apport.fileutils.report_dir, 0o3777)
     write_to_proc_sys(
         "kernel/core_pattern", f"|{__file__} -p%p -s%s -c%c -d%d -P%P -u%u -g%g -- %E"
     )


### PR DESCRIPTION
In case `/var/crash` exists, let `apport --start` not modify the permission of the directory. Otherwise the permission might be changed to an unwanted mode (see discussion in the linked bug).

Create `/var/crash` with mode 3777 instead of 1777 to have the `setgid` permission set. The `setgid` permission causes crash files created in `/var/crash` to inherit its group ownership.

Bug: https://launchpad.net/bugs/2066995