### PR TITLE
whoopsie-upload-all: exit with 0 if whoopsie is disabled

### DIFF
--- a/data/whoopsie-upload-all
+++ b/data/whoopsie-upload-all
@@ -222,8 +222,8 @@ def main() -> None:
         )
         != 0
     ):
-        sys.stderr.write("ERROR: whoopsie.path is not enabled\n")
-        sys.exit(1)
+        logging.info("whoopsie.path is not enabled, doing nothing")
+        return
 
     stamps = collect_info()
     # print('stamps:', stamps)


### PR DESCRIPTION
`apport-autoreport.service` fails if auto-reporting is disabled:

```
$ systemctl status apport-autoreport.service
× apport-autoreport.service - Process error reports when automatic reporting is enabled
     Loaded: loaded (/usr/lib/systemd/system/apport-autoreport.service; static)
     Active: failed (Result: exit-code) since Thu 2024-06-13 21:55:08 CEST; 1h 9min ago
TriggeredBy: ● apport-autoreport.timer
             ● apport-autoreport.path
    Process: 1059564 ExecStart=/usr/share/apport/whoopsie-upload-all --timeout 20 (code=exited, status=1/FAILURE)
   Main PID: 1059564 (code=exited, status=1/FAILURE)
        CPU: 86ms

Jun 13 21:55:08 host systemd[1]: Starting apport-autoreport.service - Process error reports when automatic reporting is enabled...
Jun 13 21:55:08 host whoopsie-upload-all[1059564]: ERROR: whoopsie.path is not enabled
Jun 13 21:55:08 host systemd[1]: apport-autoreport.service: Main process exited, code=exited, status=1/FAILURE
Jun 13 21:55:08 host systemd[1]: apport-autoreport.service: Failed with result 'exit-code'.
Jun 13 21:55:08 host systemd[1]: Failed to start apport-autoreport.service - Process error reports when automatic reporting is enabled.
```

Change the log message to info level and exit with 0 in that case.

Bug: https://launchpad.net/bugs/2069360