### PR TITLE
test: assert that title is not None

### DIFF
--- a/tests/unit/test_report.py
+++ b/tests/unit/test_report.py
@@ -322,7 +322,7 @@ class T(unittest.TestCase):
         )
         self.assertFalse(r.has_useful_stacktrace())
 
-    def test_standard_title(self):
+    def test_standard_title(self) -> None:
         # TODO: Split into separate test cases
         # pylint: disable=too-many-statements
         """standard_title()."""
@@ -442,6 +442,7 @@ Key: /apps/avant-window-navigator/app/active_png isn't set.
 Restarting AWN usually solves this issue"""
 
         t = report.standard_title()
+        assert t
         self.assertTrue(t.startswith("apport-gtk crashed with"))
         self.assertTrue(t.endswith("setup_chooser()"))
 


### PR DESCRIPTION
mypy complains:

```
tests/unit/test_report.py:445: error: Item "None" of "str | None" has no attribute "startswith"  [union-attr]
tests/unit/test_report.py:446: error: Item "None" of "str | None" has no attribute "endswith"  [union-attr]
```