### PR TITLE
apport-retrace: exit without 0 on error

### DIFF
--- a/bin/apport-retrace
+++ b/bin/apport-retrace
@@ -353,7 +353,7 @@ def load_report(
         except AssertionError as error:
             if "apport format data" in str(error):
                 apport.error("Broken report: %s", str(error))
-                raise _LoadReportException(0) from None
+                raise _LoadReportException(2) from None
             raise
         except (
             MemoryError,
@@ -431,9 +431,9 @@ def main(argv):
     if report["ProblemType"] == "KernelCrash":
         if not set(["Package", "VmCore"]).issubset(set(report.keys())):
             apport.error("report file does not contain the required fields")
-            return 0
+            return 2
         apport.error("KernelCrash processing not implemented yet")
-        return 0
+        return 3
     if not required_fields.issubset(set(report.keys())):
         missing_fields = []
         for required_field in required_fields:
@@ -441,9 +441,9 @@ def main(argv):
                 missing_fields.append(required_field)
         apport.error(
             "report file does not contain one of the required fields: %s",
-            " ".join(missing_fields),
+            " ".join(sorted(missing_fields)),
         )
-        return 0
+        return 2
 
     apport.memdbg("consistency checks passed")
 
@@ -451,7 +451,7 @@ def main(argv):
         system_arch = apport.packaging.get_system_architecture()
         if system_arch != "amd64":
             apport.error("gdb sandboxes are only implemented for amd64 hosts")
-            return 0
+            return 3
         # Create a .dwz directory if it doesn't exist
         if not os.path.exists("/usr/lib/debug/.dwz"):
             os.mkdir("/usr/lib/debug/.dwz")
@@ -537,7 +537,7 @@ def main(argv):
                                 " directory to the gdb sandbox's."
                                 " See LP: #1818918 for details."
                             )
-                            return 0
+                            return 3
                         except FileExistsError:
                             if (
                                 os.readlink(f"/usr/lib/debug/.dwz/{target}")
@@ -551,7 +551,7 @@ def main(argv):
                         " system's /usr/lib/debug/.dwz directory to the"
                         " gdb sandbox's. See LP: #1818918 for details."
                     )
-                    return 0
+                    return 3
 
     # interactive gdb session
     if options.gdb:

--- a/bin/apport-retrace
+++ b/bin/apport-retrace
@@ -325,6 +325,10 @@ def print_traces(report):
         print(report["StacktraceSource"])
 
 
+class _LoadReportException(SystemExit):
+    """Failures that were handled in load_report."""
+
+
 def load_report(
     options: Namespace, crashdb: CrashDatabase
 ) -> tuple[Report, int | None]:
@@ -349,9 +353,8 @@ def load_report(
         except AssertionError as error:
             if "apport format data" in str(error):
                 apport.error("Broken report: %s", str(error))
-                sys.exit(0)
-            else:
-                raise
+                raise _LoadReportException(0) from None
+            raise
         except (
             MemoryError,
             TypeError,
@@ -381,9 +384,8 @@ If you encounter the crash again, please file a new report.
 Thank you for your understanding, and sorry for the inconvenience!
 """,
                 )
-                sys.exit(0)
-            else:
-                raise
+                raise _LoadReportException(0) from None
+            raise
     else:
         apport.fatal(
             '"%s" is neither an existing report file nor a crash ID', options.report
@@ -394,7 +396,7 @@ Thank you for your understanding, and sorry for the inconvenience!
 def main(argv):
     # TODO: Split into smaller functions/methods
     # pylint: disable=too-many-branches,too-many-locals,too-many-nested-blocks
-    # pylint: disable=too-many-statements
+    # pylint: disable=too-many-return-statements,too-many-statements
     apport.memdbg("start")
 
     gettext.textdomain("apport")
@@ -405,7 +407,10 @@ def main(argv):
     apport.memdbg("got crash DB")
 
     # load the report
-    report, crashid = load_report(options, crashdb)
+    try:
+        report, crashid = load_report(options, crashdb)
+    except _LoadReportException as error:
+        return error.code
 
     if options.core_file:
         report["CoreDump"] = (os.path.abspath(options.core_file),)
@@ -426,10 +431,10 @@ def main(argv):
     if report["ProblemType"] == "KernelCrash":
         if not set(["Package", "VmCore"]).issubset(set(report.keys())):
             apport.error("report file does not contain the required fields")
-            sys.exit(0)
+            return 0
         apport.error("KernelCrash processing not implemented yet")
-        sys.exit(0)
-    elif not required_fields.issubset(set(report.keys())):
+        return 0
+    if not required_fields.issubset(set(report.keys())):
         missing_fields = []
         for required_field in required_fields:
             if required_field not in set(report.keys()):
@@ -438,7 +443,7 @@ def main(argv):
             "report file does not contain one of the required fields: %s",
             " ".join(missing_fields),
         )
-        sys.exit(0)
+        return 0
 
     apport.memdbg("consistency checks passed")
 
@@ -446,7 +451,7 @@ def main(argv):
         system_arch = apport.packaging.get_system_architecture()
         if system_arch != "amd64":
             apport.error("gdb sandboxes are only implemented for amd64 hosts")
-            sys.exit(0)
+            return 0
         # Create a .dwz directory if it doesn't exist
         if not os.path.exists("/usr/lib/debug/.dwz"):
             os.mkdir("/usr/lib/debug/.dwz")
@@ -532,7 +537,7 @@ def main(argv):
                                 " directory to the gdb sandbox's."
                                 " See LP: #1818918 for details."
                             )
-                            sys.exit(0)
+                            return 0
                         except FileExistsError:
                             if (
                                 os.readlink(f"/usr/lib/debug/.dwz/{target}")
@@ -546,7 +551,7 @@ def main(argv):
                         " system's /usr/lib/debug/.dwz directory to the"
                         " gdb sandbox's. See LP: #1818918 for details."
                     )
-                    sys.exit(0)
+                    return 0
 
     # interactive gdb session
     if options.gdb:
@@ -689,7 +694,8 @@ Thank you for your understanding, and sorry for the inconvenience!
         else:
             with open(options.output or options.report, "wb") as out:
                 report.write(out)
+    return 0
 
 
 if __name__ == "__main__":
-    main(sys.argv[1:])
+    sys.exit(main(sys.argv[1:]))

--- a/bin/apport-retrace
+++ b/bin/apport-retrace
@@ -36,7 +36,7 @@ from apport import Report
 from apport.crashdb import CrashDatabase, get_crashdb
 
 
-def parse_args():
+def parse_args(argv: list[str]) -> argparse.Namespace:
     """Parse command line options and return args namespace."""
 
     argparser = argparse.ArgumentParser()
@@ -193,7 +193,7 @@ def parse_args():
         help="apport .crash file or the crash ID to process",
     )
 
-    args = argparser.parse_args()
+    args = argparser.parse_args(argv)
 
     # catch invalid usage of -C without -S (cache is only used when making a
     # sandbox)
@@ -391,7 +391,7 @@ Thank you for your understanding, and sorry for the inconvenience!
 
 
 # pylint: disable-next=missing-function-docstring
-def main():
+def main(argv):
     # TODO: Split into smaller functions/methods
     # pylint: disable=too-many-branches,too-many-locals,too-many-nested-blocks
     # pylint: disable=too-many-statements
@@ -399,7 +399,7 @@ def main():
 
     gettext.textdomain("apport")
 
-    options = parse_args()
+    options = parse_args(argv)
 
     crashdb = get_crashdb(options.auth)
     apport.memdbg("got crash DB")
@@ -692,4 +692,4 @@ Thank you for your understanding, and sorry for the inconvenience!
 
 
 if __name__ == "__main__":
-    main()
+    main(sys.argv[1:])

--- a/tests/paths.py
+++ b/tests/paths.py
@@ -11,6 +11,13 @@ _CRASHDB_CONF = _SRCDIR / "etc" / "apport" / "crashdb.conf"
 _DATADIR = _SRCDIR / "data"
 
 
+def get_bin_directory() -> pathlib.Path:
+    """Return absolute path for the scripts directory."""
+    if is_local_source_directory():
+        return _BINDIR
+    return pathlib.Path("/usr/bin")
+
+
 def get_data_directory(local_path: str | None = None) -> pathlib.Path:
     """Return absolute path for apport's data directory.
 

--- a/tests/unit/test_apport_retrace.py
+++ b/tests/unit/test_apport_retrace.py
@@ -1,0 +1,51 @@
+"""Unit tests for apport-retrace."""
+
+import io
+import tempfile
+import unittest
+from unittest.mock import MagicMock
+
+from tests.helper import import_module_from_file
+from tests.paths import get_bin_directory
+
+apport_retrace = import_module_from_file(get_bin_directory() / "apport-retrace")
+
+
+@unittest.mock.patch.object(apport_retrace, "get_crashdb")
+def test_malformed_crash_report(get_crashdb_mock: MagicMock) -> None:
+    """Test apport-retrace to fail on malformed crash report."""
+    with (
+        tempfile.NamedTemporaryFile(mode="w+", suffix=".crash") as crash_file,
+        unittest.mock.patch("sys.stderr", new_callable=io.StringIO) as stderr,
+    ):
+        crash_file.write(
+            "ProblemType: Crash\nArchitecture: amd64\nPackage: gedit 46.2-2\n"
+        )
+        crash_file.flush()
+        return_code = apport_retrace.main(["-x", "/usr/bin/gedit", crash_file.name])
+
+    assert return_code == 2
+    assert (
+        stderr.getvalue()
+        == "ERROR: report file does not contain one of the required fields:"
+        " CoreDump DistroRelease\n"
+    )
+    get_crashdb_mock.assert_called_once_with(None)
+
+
+@unittest.mock.patch.object(apport_retrace, "get_crashdb")
+def test_malformed_kernel_crash_report(get_crashdb_mock: MagicMock) -> None:
+    """Test apport-retrace to fail on malformed kernel crash report."""
+    with (
+        tempfile.NamedTemporaryFile(mode="w+", suffix=".crash") as crash_file,
+        unittest.mock.patch("sys.stderr", new_callable=io.StringIO) as stderr,
+    ):
+        crash_file.write("ProblemType: KernelCrash\n")
+        crash_file.flush()
+        return_code = apport_retrace.main([crash_file.name])
+
+    assert return_code == 2
+    assert (
+        stderr.getvalue() == "ERROR: report file does not contain the required fields\n"
+    )
+    get_crashdb_mock.assert_called_once_with(None)


### PR DESCRIPTION
Exit `apport-retrace` with return code 2 in case the report is malformed and with return code 3 on known errors. Crashes of `apport-retrace` will exit with return code 1.