### PR TITLE
test: add type hints to unproblematic integration tests

### DIFF
--- a/tests/integration/test_apport_checkreports.py
+++ b/tests/integration/test_apport_checkreports.py
@@ -23,14 +23,14 @@ class TestApportCheckreports(unittest.TestCase):
     # pylint: disable=missing-function-docstring
     """Test apport-checkreports"""
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.data_dir = get_data_directory()
         self.env = os.environ | local_test_environment()
 
         self.report_dir = tempfile.mkdtemp()
         self.env["APPORT_REPORT_DIR"] = self.report_dir
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         shutil.rmtree(self.report_dir)
 
     def _call(
@@ -63,18 +63,18 @@ class TestApportCheckreports(unittest.TestCase):
         if user and os.geteuid() == 0:
             os.chown(path, 1000, -1)
 
-    def test_has_no_system_report(self):
+    def test_has_no_system_report(self) -> None:
         self._write_report("_bin_sleep.1000.crash")
         self._call(args=["--system"], expected_returncode=1)
 
     @unittest.skipIf(os.geteuid() != 0, "this test needs to be run as root")
-    def test_has_system_report(self):
+    def test_has_system_report(self) -> None:
         self._write_report("_usr_bin_yes.0.crash", user=False)
         self._call(args=["-s"], expected_returncode=0, expected_stdout="yes\n")
 
-    def test_has_user_report(self):
+    def test_has_user_report(self) -> None:
         self._write_report("_bin_sleep.1000.crash")
         self._call(expected_returncode=0, expected_stdout="sleep\n")
 
-    def test_no_report(self):
+    def test_no_report(self) -> None:
         self._call(expected_returncode=1)

--- a/tests/integration/test_apport_unpack.py
+++ b/tests/integration/test_apport_unpack.py
@@ -24,9 +24,12 @@ class TestApportUnpack(unittest.TestCase):
     UTF8_STR = b"a\xe2\x99\xa5b"
     BINDATA = b"\x00\x01\xFF\x40"
     env: dict[str, str]
+    report_file: str
+    unpack_dir: str
+    workdir: str
 
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls) -> None:
         cls.env = os.environ | local_test_environment() | {"LANGUAGE": "C.UTF-8"}
         cls.workdir = tempfile.mkdtemp()
 
@@ -45,14 +48,14 @@ class TestApportUnpack(unittest.TestCase):
         cls.unpack_dir = os.path.join(cls.workdir, "un pack")
 
     @classmethod
-    def tearDownClass(cls):
+    def tearDownClass(cls) -> None:
         shutil.rmtree(cls.workdir)
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         if os.path.isdir(self.unpack_dir):
             shutil.rmtree(self.unpack_dir)
 
-    def test_unpack(self):
+    def test_unpack(self) -> None:
         """apport-unpack for all possible data types"""
         process = self._call_apport_unpack([self.report_file, self.unpack_dir])
         self.assertEqual(process.returncode, 0)
@@ -64,7 +67,7 @@ class TestApportUnpack(unittest.TestCase):
         self.assertEqual(self._get_unpack("binary"), self.BINDATA)
         self.assertEqual(self._get_unpack("compressed"), b"FooFoo!")
 
-    def test_unpack_stdin(self):
+    def test_unpack_stdin(self) -> None:
         """apport-unpack unpacks report from stdin"""
         with open(self.report_file, "rb") as report_file:
             process = subprocess.run(
@@ -85,14 +88,14 @@ class TestApportUnpack(unittest.TestCase):
         self.assertEqual(self._get_unpack("binary"), self.BINDATA)
         self.assertEqual(self._get_unpack("compressed"), b"FooFoo!")
 
-    def test_help(self):
+    def test_help(self) -> None:
         """Call apport-unpack with --help."""
         process = self._call_apport_unpack(["--help"])
         self.assertEqual(process.returncode, 0)
         self.assertEqual(process.stderr, "")
         self.assertTrue(process.stdout.startswith("usage:"), process.stdout)
 
-    def test_error(self):
+    def test_error(self) -> None:
         """Call apport-unpack with wrong arguments."""
         process = self._call_apport_unpack([])
         self.assertEqual(process.returncode, 2)
@@ -109,7 +112,7 @@ class TestApportUnpack(unittest.TestCase):
         self.assertIn("/nonexisting.crash", process.stderr)
         self.assertEqual(process.stdout, "")
 
-    def test_broken_report(self):
+    def test_broken_report(self) -> None:
         with tempfile.NamedTemporaryFile("wb") as report_file:
             report_file.write(b"AB\xfc:CD\n")
             report_file.flush()
@@ -124,7 +127,7 @@ class TestApportUnpack(unittest.TestCase):
         )
         self.assertEqual(process.stdout, "")
 
-    def test_broken_core_dump(self):
+    def test_broken_core_dump(self) -> None:
         """Test unpacking a report file that has a malformed CoreDump entry."""
         with tempfile.NamedTemporaryFile("wb") as report_file:
             report_file.write(
@@ -152,6 +155,6 @@ class TestApportUnpack(unittest.TestCase):
             stderr=subprocess.PIPE,
         )
 
-    def _get_unpack(self, fname):
+    def _get_unpack(self, fname: str) -> bytes:
         with open(os.path.join(self.unpack_dir, fname), "rb") as file_:
             return file_.read()

--- a/tests/integration/test_crash_digger.py
+++ b/tests/integration/test_crash_digger.py
@@ -27,7 +27,7 @@ from tests.paths import local_test_environment
 class T(unittest.TestCase):
     """Test crash-digger"""
 
-    def setUp(self):
+    def setUp(self) -> None:
         """Set up config dir, crashdb.conf, and apport-retrace for testing"""
         self.env = os.environ | local_test_environment()
 
@@ -75,11 +75,11 @@ class T(unittest.TestCase):
         os.mkdir(apport.fileutils.report_dir)
         self.env["APPORT_REPORT_DIR"] = apport.fileutils.report_dir
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         shutil.rmtree(self.workdir)
         apport.fileutils.report_dir = self.orig_report_dir
 
-    def call(self, args):
+    def call(self, args: list[str]) -> tuple[str, str]:
         """Call crash-digger with given arguments.
 
         Return a pair (stdout, stderr).
@@ -94,7 +94,7 @@ class T(unittest.TestCase):
         )
         return (crash_digger.stdout, crash_digger.stderr)
 
-    def test_crashes(self):
+    def test_crashes(self) -> None:
         """Crash retracing."""
         (out, err) = self.call(
             [
@@ -130,7 +130,7 @@ class T(unittest.TestCase):
 
         self.assertFalse(os.path.isdir(os.path.join(self.workdir, "dupdb", "sig")))
 
-    def test_crashes_error(self):
+    def test_crashes_error(self) -> None:
         """Crash retracing if apport-retrace fails on bug #1."""
         # make apport-retrace fail on bug 1
         os.rename(self.apport_retrace, f"{self.apport_retrace}.bak")
@@ -211,7 +211,7 @@ class T(unittest.TestCase):
 
         self.assertFalse(os.path.isdir(os.path.join(self.workdir, "dupdb", "sig")))
 
-    def test_crashes_transient_error(self):
+    def test_crashes_transient_error(self) -> None:
         """Crash retracing if apport-retrace reports a transient error."""
         # make apport-retrace fail on bug 1
         os.rename(self.apport_retrace, f"{self.apport_retrace}.bak")
@@ -257,7 +257,7 @@ class T(unittest.TestCase):
 
         self.assertFalse(os.path.exists(self.lock_file))
 
-    def test_dupcheck(self):
+    def test_dupcheck(self) -> None:
         """Duplicate checking."""
         (out, err) = self.call(
             [
@@ -278,7 +278,7 @@ class T(unittest.TestCase):
         self.assertFalse(os.path.exists(self.apport_retrace_log))
         self.assertFalse(os.path.exists(self.lock_file))
 
-    def test_stderr_redirection(self):
+    def test_stderr_redirection(self) -> None:
         """apport-retrace's stderr is redirected to stdout."""
         with open(self.apport_retrace, "w", encoding="utf-8") as f:
             f.write("#!/bin/sh\necho ApportRetraceError >&2\n")
@@ -297,7 +297,7 @@ class T(unittest.TestCase):
         self.assertEqual(err, "", f"no error messages:\n{err}")
         self.assertIn("ApportRetraceError", out)
 
-    def test_publish_db(self):
+    def test_publish_db(self) -> None:
         """Duplicate database publishing."""
         (out, err) = self.call(
             [
@@ -318,7 +318,7 @@ class T(unittest.TestCase):
 
         self.assertTrue(os.path.isdir(os.path.join(self.workdir, "dupdb", "sig")))
 
-    def test_alternate_crashdb(self):
+    def test_alternate_crashdb(self) -> None:
         """Alternate crash database name."""
         # existing DB "empty" has no crashes
         (out, err) = self.call(

--- a/tests/integration/test_dupdb_admin.py
+++ b/tests/integration/test_dupdb_admin.py
@@ -23,7 +23,11 @@ class TestDupdbAdmin(unittest.TestCase):
     # pylint: disable=missing-function-docstring
     """Test dupdb-admin"""
 
-    def setUp(self):
+    env: dict[str, str]
+    db_file: str
+    workdir: str
+
+    def setUp(self) -> None:
         self.workdir = tempfile.mkdtemp()
         self.db_file = os.path.join(self.workdir, "apport_duplicates.db")
         self.env = os.environ | local_test_environment()
@@ -33,7 +37,7 @@ class TestDupdbAdmin(unittest.TestCase):
         )
         self.crashes.init_duplicate_db(self.db_file)
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         shutil.rmtree(self.workdir)
 
     def _call(
@@ -68,10 +72,10 @@ class TestDupdbAdmin(unittest.TestCase):
             ]
         return sorted(found_directories), sorted(found_files)
 
-    def test_dump_empty_database(self):
+    def test_dump_empty_database(self) -> None:
         self._call(["dump"])
 
-    def test_dump_database(self):
+    def test_dump_database(self) -> None:
         self.assertIsNone(self.crashes.check_duplicate(0))
         self.assertIsNone(self.crashes.check_duplicate(2))
         self.crashes.duplicate_db_fixed(2, "42")
@@ -86,27 +90,27 @@ class TestDupdbAdmin(unittest.TestCase):
         )
         self.assertIn("2: /usr/bin/broken:11:h:g:f:e:d [fixed in: 42]", lines[1])
 
-    def test_changeid(self):
+    def test_changeid(self) -> None:
         self.assertIsNone(self.crashes.check_duplicate(2))
         self._call(["changeid", "2", "1"])
         stdout = self._call(["dump"], expected_stdout=None)[0]
         self.assertIn("1: /usr/bin/broken:11:h:g:f:e:d [open]", stdout)
 
-    def test_changeid_missing_argument(self):
+    def test_changeid_missing_argument(self) -> None:
         self.assertIsNone(self.crashes.check_duplicate(2))
         stderr = self._call(["changeid", "2"], expected_returncode=2)[1]
         self.assertIn("the following arguments are required: new_id", stderr)
 
-    def test_missing_db_file(self):
+    def test_missing_db_file(self) -> None:
         os.remove(self.db_file)
         stderr = self._call(["dump"], expected_returncode=1)[1]
         self.assertIn("file does not exist", stderr)
 
-    def test_no_command(self):
+    def test_no_command(self) -> None:
         stderr = self._call([], expected_returncode=2)[1]
         self.assertIn("the following arguments are required: command", stderr)
 
-    def test_publish(self):
+    def test_publish(self) -> None:
         self.assertIsNone(self.crashes.check_duplicate(1))
         pub_path = f"{self.workdir}/www"
         self._call(["publish", pub_path])
@@ -114,20 +118,20 @@ class TestDupdbAdmin(unittest.TestCase):
         self.assertEqual(directories, ["address", "sig"])
         self.assertEqual(files, ["sig/_bin_crash_11"])
 
-    def test_publish_missing_argument(self):
+    def test_publish_missing_argument(self) -> None:
         stderr = self._call(["publish"], expected_returncode=2)[1]
         self.assertIn("the following arguments are required: path", stderr)
 
-    def test_removeid(self):
+    def test_removeid(self) -> None:
         self.assertIsNone(self.crashes.check_duplicate(1))
         self._call(["removeid", "1"])
         self._call(["dump"])
 
-    def test_removeid_missing_argument(self):
+    def test_removeid_missing_argument(self) -> None:
         self.assertIsNone(self.crashes.check_duplicate(1))
         stderr = self._call(["removeid"], expected_returncode=2)[1]
         self.assertIn("the following arguments are required: id", stderr)
 
-    def test_unknown_command(self):
+    def test_unknown_command(self) -> None:
         stderr = self._call(["nonexisting"], expected_returncode=2)[1]
         self.assertIn("invalid choice: 'nonexisting'", stderr)

--- a/tests/integration/test_github.py
+++ b/tests/integration/test_github.py
@@ -10,7 +10,7 @@
 """Integration tests for the apport.crashdb_impl.github module."""
 
 import unittest
-from unittest.mock import ANY, Mock, patch
+from unittest.mock import ANY, MagicMock, Mock, patch
 
 import apport.crashdb_impl.github
 
@@ -19,7 +19,7 @@ class TestGitHub(unittest.TestCase):
     # pylint: disable=missing-class-docstring,missing-function-docstring
     # pylint: disable=protected-access
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.crashdb = self._get_gh_database("Lorem", "Ipsum")
         self.crashdb_barren = self._get_gh_database(None, None)
 
@@ -87,7 +87,7 @@ class TestGitHub(unittest.TestCase):
             )
 
     @patch("apport.crashdb_impl.github.Github.api_authentication")
-    def test_authentication_complete(self, mock_api):
+    def test_authentication_complete(self, mock_api: MagicMock) -> None:
         base_response = self.api_auth_return_value
         mocked = [base_response.copy() for i in range(7)]
         mocked[2]["error"] = "foo"
@@ -119,7 +119,7 @@ class TestGitHub(unittest.TestCase):
                 "Failed login", "Github authentication expired. Please try again."
             )
 
-    def test_not_implemented_methods(self):
+    def test_not_implemented_methods(self) -> None:
         ni = NotImplementedError
         self.assertRaises(ni, self.crashdb._mark_dup_checked, None, None)
         self.assertRaises(ni, self.crashdb.can_update, None)
@@ -140,7 +140,9 @@ class TestGitHub(unittest.TestCase):
         self.assertRaises(ni, self.crashdb.update, None, None, None, None)
 
     @staticmethod
-    def _get_gh_database(repository_owner, repository_name):
+    def _get_gh_database(
+        repository_owner: str | None, repository_name: str | None
+    ) -> apport.crashdb_impl.github.CrashDatabase:
         return apport.crashdb_impl.github.CrashDatabase(
             None,
             {

--- a/tests/integration/test_helper.py
+++ b/tests/integration/test_helper.py
@@ -10,16 +10,16 @@ from tests.helper import pidof, read_shebang
 class TestHelper(unittest.TestCase):
     # pylint: disable=missing-class-docstring,missing-function-docstring
 
-    def test_pidof_non_existing_program(self):
+    def test_pidof_non_existing_program(self) -> None:
         self.assertEqual(pidof("non-existing"), set())
 
-    def test_pidof_running_python(self):
+    def test_pidof_running_python(self) -> None:
         pids = pidof(sys.executable)
         self.assertGreater(len(pids), 0)
         self.assertIn(os.getpid(), pids)
 
-    def test_read_shebang_binary(self):
+    def test_read_shebang_binary(self) -> None:
         self.assertIsNone(read_shebang(sys.executable))
 
-    def test_read_shebang_shell_script(self):
+    def test_read_shebang_shell_script(self) -> None:
         self.assertEqual(read_shebang("/usr/bin/ldd"), "/bin/bash")

--- a/tests/integration/test_hooks.py
+++ b/tests/integration/test_hooks.py
@@ -32,18 +32,18 @@ class T(unittest.TestCase):
     env: dict[str, str]
 
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls) -> None:
         cls.data_dir = get_data_directory()
         cls.env = os.environ | local_test_environment()
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.orig_report_dir = apport.fileutils.report_dir
         apport.fileutils.report_dir = tempfile.mkdtemp()
         self.env["APPORT_REPORT_DIR"] = apport.fileutils.report_dir
 
         self.workdir = tempfile.mkdtemp()
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         shutil.rmtree(apport.fileutils.report_dir)
         apport.fileutils.report_dir = self.orig_report_dir
 
@@ -60,7 +60,7 @@ class T(unittest.TestCase):
         )
         self.assertIn("ProblemType: Crash", process.stdout)
 
-    def test_package_hook_nologs(self):
+    def test_package_hook_nologs(self) -> None:
         """package_hook without any log files."""
         ph = subprocess.run(
             [str(self.data_dir / "package_hook"), "-p", "bash"],
@@ -81,7 +81,7 @@ class T(unittest.TestCase):
         self.assertEqual(r["Package"], f"bash {apport.packaging.get_version('bash')}")
         self.assertEqual(r["ErrorMessage"], "something is wrong")
 
-    def test_package_hook_uninstalled(self):
+    def test_package_hook_uninstalled(self) -> None:
         """package_hook on an uninstalled package (might fail to install)."""
         pkg = apport.packaging.get_uninstalled_package()
         ph = subprocess.run(
@@ -103,7 +103,7 @@ class T(unittest.TestCase):
         self.assertEqual(r["Package"], f"{pkg} (not installed)")
         self.assertEqual(r["ErrorMessage"], "something is wrong")
 
-    def test_package_hook_logs(self):
+    def test_package_hook_logs(self) -> None:
         """package_hook with a log dir and a log file."""
         with open(os.path.join(self.workdir, "log_1.log"), "w", encoding="utf-8") as f:
             f.write("Log 1\nbla")
@@ -159,7 +159,7 @@ class T(unittest.TestCase):
         self.assertEqual(r[log1key], "Log 1\nbla")
         self.assertEqual(r[log2key], "Yet\nanother\nlog")
 
-    def test_package_hook_tags(self):
+    def test_package_hook_tags(self) -> None:
         """package_hook with extra tags argument."""
         cmd = [
             str(self.data_dir / "package_hook"),
@@ -180,7 +180,7 @@ class T(unittest.TestCase):
 
         self.assertEqual(r["Tags"], "dist-upgrade verybad")
 
-    def test_kernel_crashdump_kexec(self):
+    def test_kernel_crashdump_kexec(self) -> None:
         """kernel_crashdump using kexec-tools."""
         with open(os.path.join(apport.fileutils.report_dir, "vmcore"), "wb") as vmcore:
             vmcore.write(b"\x01" * 100)
@@ -225,7 +225,7 @@ class T(unittest.TestCase):
         self.assertIn("linux", r["Package"])
         self.assertIn(os.uname()[2].split("-")[0], r["Package"])
 
-    def test_kernel_crashdump_kdump(self):
+    def test_kernel_crashdump_kdump(self) -> None:
         """kernel_crashdump using kdump-tools."""
         timedir = datetime.datetime.strftime(datetime.datetime.now(), "%Y%m%d%H%M")
         vmcore_dir = os.path.join(apport.fileutils.report_dir, timedir)
@@ -275,7 +275,7 @@ class T(unittest.TestCase):
         r.add_package_info(r["Package"])
         self.assertIn(os.uname()[2].split("-")[0], r["Package"])
 
-    def test_kernel_crashdump_log_symlink(self):
+    def test_kernel_crashdump_log_symlink(self) -> None:
         """Attempt DoS with vmcore.log symlink.
 
         We must only accept plain files, otherwise vmcore.log might be a
@@ -295,7 +295,7 @@ class T(unittest.TestCase):
 
         self.assertEqual(apport.fileutils.get_new_reports(), [])
 
-    def test_kernel_crashdump_kdump_log_symlink(self):
+    def test_kernel_crashdump_kdump_log_symlink(self) -> None:
         """Attempt DoS with dmesg symlink with kdump-tools."""
         timedir = datetime.datetime.strftime(datetime.datetime.now(), "%Y%m%d%H%M")
         vmcore_dir = os.path.join(apport.fileutils.report_dir, timedir)
@@ -316,7 +316,7 @@ class T(unittest.TestCase):
         self.assertEqual(apport.fileutils.get_new_reports(), [])
 
     @unittest.skipIf(os.geteuid() != 0, "this test needs to be run as root")
-    def test_kernel_crashdump_kdump_log_dir_symlink(self):
+    def test_kernel_crashdump_kdump_log_dir_symlink(self) -> None:
         """Attempted DoS with dmesg dir symlink with kdump-tools."""
         timedir = datetime.datetime.strftime(datetime.datetime.now(), "%Y%m%d%H%M")
         vmcore_dir = os.path.join(apport.fileutils.report_dir, timedir)
@@ -341,7 +341,7 @@ class T(unittest.TestCase):
         )
         self.assertEqual(apport.fileutils.get_new_reports(), [])
 
-    def _gcc_version_path(self):
+    def _gcc_version_path(self) -> tuple[str, str]:
         """Determine a valid version and executable path of gcc and return it
         as a tuple."""
         try:
@@ -364,7 +364,7 @@ class T(unittest.TestCase):
 
         return (gcc_ver, gcc_path)
 
-    def test_gcc_ide_hook_file(self):
+    def test_gcc_ide_hook_file(self) -> None:
         """gcc_ice_hook with a temporary file."""
         (gcc_version, gcc_path) = self._gcc_version_path()
 
@@ -398,7 +398,7 @@ class T(unittest.TestCase):
         self.assertNotEqual(r["Package"].split()[1], "")  # has package version
         self.assertIn("libc", r["Dependencies"])
 
-    def test_gcc_ide_hook_file_binary(self):
+    def test_gcc_ide_hook_file_binary(self) -> None:
         """gcc_ice_hook with a temporary file with binary data."""
         gcc_path = self._gcc_version_path()[1]
 
@@ -424,7 +424,7 @@ class T(unittest.TestCase):
                 r.load(f)
             self.assertEqual(r["PreprocessedSource"], test_source.read())
 
-    def test_gcc_ide_hook_pipe(self):
+    def test_gcc_ide_hook_pipe(self) -> None:
         """gcc_ice_hook with piping."""
         (gcc_version, gcc_path) = self._gcc_version_path()
 
@@ -453,7 +453,7 @@ class T(unittest.TestCase):
 
         self.assertEqual(r["Package"].split()[0], f"gcc-{gcc_version}")
 
-    def test_kernel_oops_hook(self):
+    def test_kernel_oops_hook(self) -> None:
         test_source = """------------[ cut here ]------------
 kernel BUG at /tmp/oops.c:5!
 invalid opcode: 0000 [#1] SMP

--- a/tests/integration/test_hookutils.py
+++ b/tests/integration/test_hookutils.py
@@ -23,18 +23,18 @@ from tests.helper import skip_if_command_is_missing
 class T(unittest.TestCase):
     """Integration tests for the apport.hookutils module."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.workdir = tempfile.mkdtemp()
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         shutil.rmtree(self.workdir)
 
     @skip_if_command_is_missing("/usr/bin/as")
-    def test_module_license_evaluation(self):
+    def test_module_license_evaluation(self) -> None:
         """Module licenses can be validated correctly."""
         # pylint: disable=protected-access
 
-        def _build_ko(license_name):
+        def _build_ko(license_name: str) -> str:
             ko_filename = os.path.join(self.workdir, f"{license_name}.ko")
             with tempfile.NamedTemporaryFile(
                 mode="w+", prefix=f"{license_name}-", suffix=".S"
@@ -69,7 +69,7 @@ class T(unittest.TestCase):
         self.assertIn(bad_ko, nonfree)
 
     @skip_if_command_is_missing("/sbin/modinfo")
-    def test_real_module_license_evaluation(self):
+    def test_real_module_license_evaluation(self) -> None:
         """Module licenses can be validated correctly for real module."""
         # pylint: disable=protected-access
         isofs_license = apport.hookutils._get_module_license("isofs")
@@ -193,7 +193,7 @@ class T(unittest.TestCase):
         apport.hookutils.attach_file_if_exists(report, "/etc/../etc/passwd")
         self.assertEqual(list(report), [])
 
-    def test_recent_syslog(self):
+    def test_recent_syslog(self) -> None:
         """recent_syslog"""
         self.assertEqual(
             apport.hookutils.recent_syslog(re.compile("."), path="/nonexisting"), ""
@@ -210,7 +210,7 @@ class T(unittest.TestCase):
     @unittest.mock.patch(
         "apport.hookutils._root_command_prefix", MagicMock(return_value=[])
     )
-    def test_attach_mac_events(self):
+    def test_attach_mac_events(self) -> None:
         # TODO: Split into separate test cases
         # pylint: disable=too-many-statements
         """attach_mac_events()"""
@@ -353,7 +353,7 @@ class T(unittest.TestCase):
         apport.hookutils.attach_mac_events(report, "/usr/sbin/cupsd")
         self.assertEqual(report["Tags"], "apparmor")
 
-    def test_recent_syslog_overflow(self):
+    def test_recent_syslog_overflow(self) -> None:
         """recent_syslog on a huge file"""
         log = os.path.join(self.workdir, "syslog")
         with open(log, "w", encoding="utf-8") as f:
@@ -378,7 +378,7 @@ class T(unittest.TestCase):
         is None,
         "no logind session",
     )
-    def test_in_session_of_problem(self):
+    def test_in_session_of_problem(self) -> None:
         """in_session_of_problem()"""
         report = apport.report.Report(date="Sat Jan  1 12:00:00 2011")
         self.assertFalse(apport.hookutils.in_session_of_problem(report))
@@ -406,7 +406,7 @@ class T(unittest.TestCase):
         finally:
             locale.setlocale(locale.LC_TIME, orig_ctime)
 
-    def test_xsession_errors(self):
+    def test_xsession_errors(self) -> None:
         """xsession_errors()"""
         with open(
             os.path.join(self.workdir, ".xsession-errors"), "w", encoding="UTF-8"
@@ -486,7 +486,7 @@ GdkPixbuf-CRITICAL **: gdk_pixbuf_scale_simple: another standard glib assertion
         apport.hookutils.attach_conffiles(report, "nonexisting")
         apport.hookutils.attach_default_grub(report)
 
-    def test_command_output(self):
+    def test_command_output(self) -> None:
         """Test apport.hookutils.command_output."""
         orig_lcm = os.environ.get("LC_MESSAGES")
         os.environ["LC_MESSAGES"] = "en_US.UTF-8"
@@ -513,7 +513,7 @@ GdkPixbuf-CRITICAL **: gdk_pixbuf_scale_simple: another standard glib assertion
         self.assertEqual(out, "hello")
 
     @staticmethod
-    def _get_mem_usage():
+    def _get_mem_usage() -> int:
         """Get current memory usage in kB."""
         with open("/proc/self/status", encoding="utf-8") as f:
             for line in f:

--- a/tests/integration/test_java_crashes.py
+++ b/tests/integration/test_java_crashes.py
@@ -25,7 +25,7 @@ from tests.paths import get_data_directory, local_test_environment
 class TestJavaCrashes(unittest.TestCase):
     """Integration tests for the Java crash collection support."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.env = os.environ | local_test_environment()
         datadir = get_data_directory()
         self.orig_report_dir = apport.fileutils.report_dir
@@ -40,11 +40,11 @@ class TestJavaCrashes(unittest.TestCase):
         if not self.apport_jar_path.exists():
             self.skipTest(f"{self.apport_jar_path} missing")
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         shutil.rmtree(apport.fileutils.report_dir)
         apport.fileutils.report_dir = self.orig_report_dir
 
-    def test_crash_class(self):
+    def test_crash_class(self) -> None:
         """Crash in a .class file."""
         crash_class = self.crash_jar_path.with_suffix(".class")
         self.assertTrue(crash_class.exists(), f"{crash_class} missing")
@@ -65,7 +65,7 @@ class TestJavaCrashes(unittest.TestCase):
 
         self._check_crash_report(str(crash_class))
 
-    def test_crash_jar(self):
+    def test_crash_jar(self) -> None:
         """Crash in a .jar file."""
         self.assertTrue(self.crash_jar_path.exists(), f"{self.crash_jar_path} missing")
         java = subprocess.run(
@@ -85,7 +85,7 @@ class TestJavaCrashes(unittest.TestCase):
 
         self._check_crash_report(f"{self.crash_jar_path}!/crash.class")
 
-    def _check_crash_report(self, main_file):
+    def _check_crash_report(self, main_file: str) -> None:
         """Check that we have one crash report, and verify its contents."""
         reports = apport.fileutils.get_new_reports()
         self.assertEqual(len(reports), 1, "did not create a crash report")

--- a/tests/integration/test_packaging.py
+++ b/tests/integration/test_packaging.py
@@ -11,7 +11,7 @@ import apport.packaging
 class T(unittest.TestCase):
     """Integration tests for the apport.packaging module."""
 
-    def test_get_uninstalled_package(self):
+    def test_get_uninstalled_package(self) -> None:
         """get_uninstalled_package()"""
         p = apport.packaging.get_uninstalled_package()
         self.assertIsNotNone(p)
@@ -19,7 +19,7 @@ class T(unittest.TestCase):
         self.assertRaises(ValueError, apport.packaging.get_version, p)
         self.assertTrue(apport.packaging.is_distro_package(p))
 
-    def test_get_os_version(self):
+    def test_get_os_version(self) -> None:
         """get_os_version()"""
         (n, v) = apport.packaging.get_os_version()
         self.assertEqual(type(n), str)

--- a/tests/integration/test_packaging_apt_dpkg.py
+++ b/tests/integration/test_packaging_apt_dpkg.py
@@ -23,7 +23,7 @@ class T(unittest.TestCase):
     # pylint: disable=missing-class-docstring,missing-function-docstring
     # pylint: disable=protected-access,too-many-public-methods
 
-    def setUp(self):
+    def setUp(self) -> None:
         # save and restore configuration file
         self.orig_conf = impl.configuration
         self.orig_environ = os.environ.copy()
@@ -33,13 +33,13 @@ class T(unittest.TestCase):
         impl._apt_cache = None
         impl._sandbox_apt_cache = None
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         impl.configuration = self.orig_conf
         os.environ.clear()
         os.environ.update(self.orig_environ)
         shutil.rmtree(self.workdir)
 
-    def test_check_files_md5(self):
+    def test_check_files_md5(self) -> None:
         """_check_files_md5()."""
         td = tempfile.mkdtemp()
         try:
@@ -78,18 +78,18 @@ class T(unittest.TestCase):
         finally:
             shutil.rmtree(td)
 
-    def test_get_version(self):
+    def test_get_version(self) -> None:
         """get_version()."""
         self.assertTrue(impl.get_version("libc6").startswith("2"))
         self.assertRaises(ValueError, impl.get_version, "nonexisting")
         self.assertRaises(ValueError, impl.get_version, "wukrainian")
 
-    def test_get_available_version(self):
+    def test_get_available_version(self) -> None:
         """get_available_version()."""
         self.assertTrue(impl.get_available_version("libc6").startswith("2"))
         self.assertRaises(ValueError, impl.get_available_version, "nonexisting")
 
-    def test_get_dependencies_depends_and_pre_depends(self):
+    def test_get_dependencies_depends_and_pre_depends(self) -> None:
         """get_dependencies() on package with both Depends and Pre-Depends."""
         d = impl.get_dependencies("bash")
         self.assertGreater(len(d), 2)
@@ -100,7 +100,7 @@ class T(unittest.TestCase):
                 continue
             self.assertTrue(impl.get_version(dep))
 
-    def test_get_dependencies_pre_depends_only(self):
+    def test_get_dependencies_pre_depends_only(self) -> None:
         """get_dependencies() on package with Pre-Depends only."""
         d = impl.get_dependencies("coreutils")
         self.assertGreaterEqual(len(d), 1)
@@ -108,20 +108,20 @@ class T(unittest.TestCase):
         for dep in d:
             self.assertTrue(impl.get_version(dep))
 
-    def test_get_dependencies_depends_only(self):
+    def test_get_dependencies_depends_only(self) -> None:
         """get_dependencies() on package with Depends only."""
         d = impl.get_dependencies("sysvinit-utils")
         self.assertIn("libc6", d)
         for dep in d:
             self.assertTrue(impl.get_version(dep))
 
-    def test_get_source(self):
+    def test_get_source(self) -> None:
         """get_source()."""
         self.assertRaises(ValueError, impl.get_source, "nonexisting")
         self.assertEqual(impl.get_source("bash"), "bash")
         self.assertIn("glibc", impl.get_source("libc6"))
 
-    def test_get_package_origin(self):
+    def test_get_package_origin(self) -> None:
         """get_package_origin()."""
         # determine distro name
         distro = impl.get_os_version()[0]
@@ -133,12 +133,12 @@ class T(unittest.TestCase):
         self.assertEqual(impl.get_package_origin("bash"), distro)
         # no non-native test here, hard to come up with a generic one
 
-    def test_is_distro_package(self):
+    def test_is_distro_package(self) -> None:
         """is_distro_package()."""
         self.assertRaises(ValueError, impl.is_distro_package, "nonexisting")
         self.assertTrue(impl.is_distro_package("bash"))
 
-    def test_get_architecture(self):
+    def test_get_architecture(self) -> None:
         """get_architecture()."""
         self.assertRaises(ValueError, impl.get_architecture, "nonexisting")
         # just assume that bash uses the native architecture
@@ -151,12 +151,12 @@ class T(unittest.TestCase):
         system_arch = dpkg.stdout.strip()
         self.assertEqual(impl.get_architecture("bash"), system_arch)
 
-    def test_get_files(self):
+    def test_get_files(self) -> None:
         """get_files()."""
         self.assertRaises(ValueError, impl.get_files, "nonexisting")
         self.assertIn("/usr/share/man/man1/bash.1.gz", impl.get_files("bash"))
 
-    def test_get_file_package(self):
+    def test_get_file_package(self) -> None:
         """get_file_package() on installed files."""
         self.assertEqual(impl.get_file_package("/usr/bin/bash"), "bash")
         self.assertEqual(impl.get_file_package("/usr/bin/cat"), "coreutils")
@@ -169,7 +169,7 @@ class T(unittest.TestCase):
         self.assertIsNotNone(libc_so)
         self.assertEqual(impl.get_file_package(libc_so[-1]), "libc6")
 
-    def test_get_file_package_uninstalled(self):
+    def test_get_file_package_uninstalled(self) -> None:
         """get_file_package() on uninstalled packages."""
         # generate a test Contents.gz
         basedir = tempfile.mkdtemp()
@@ -471,7 +471,7 @@ Components: main
             "http://primary-mirror.example.com/distro/",
         )
 
-    def test_mirror_from_apt_sources(self):
+    def test_mirror_from_apt_sources(self) -> None:
         s = os.path.join(self.workdir, "sources.list")
 
         # valid file, should grab the first mirror
@@ -519,14 +519,14 @@ deb http://secondary.mirror tuxy extra
         actual = impl._get_primary_mirror_from_apt_sources(self.workdir)
         self.assertEqual(actual, expected)
 
-    def test_get_modified_conffiles(self):
+    def test_get_modified_conffiles(self) -> None:
         """get_modified_conffiles()"""
         # very shallow
         self.assertEqual(type(impl.get_modified_conffiles("bash")), type({}))
         self.assertEqual(type(impl.get_modified_conffiles("apport")), type({}))
         self.assertEqual(type(impl.get_modified_conffiles("nonexisting")), type({}))
 
-    def test_get_system_architecture(self):
+    def test_get_system_architecture(self) -> None:
         """get_system_architecture()."""
         arch = impl.get_system_architecture()
         # must be nonempty without line breaks
@@ -534,7 +534,7 @@ deb http://secondary.mirror tuxy extra
         self.assertNotIn("\n", arch)
 
     @skip_if_command_is_missing("dpkg-architecture")
-    def test_get_library_paths(self):
+    def test_get_library_paths(self) -> None:
         """get_library_paths()."""
         paths = impl.get_library_paths()
         # must be nonempty without line breaks
@@ -543,7 +543,7 @@ deb http://secondary.mirror tuxy extra
         self.assertIn("/lib", paths)
         self.assertNotIn("\n", paths)
 
-    def test_compare_versions(self):
+    def test_compare_versions(self) -> None:
         """compare_versions."""
         self.assertEqual(impl.compare_versions("1", "2"), -1)
         self.assertEqual(impl.compare_versions("1.0-1ubuntu1", "1.0-1ubuntu2"), -1)
@@ -552,7 +552,7 @@ deb http://secondary.mirror tuxy extra
         self.assertEqual(impl.compare_versions("1:1.0-1", "2007-2"), 1)
         self.assertEqual(impl.compare_versions("1:1.0-1~1", "1:1.0-1"), -1)
 
-    def test_enabled(self):
+    def test_enabled(self) -> None:
         """enabled."""
         impl.configuration = "/nonexisting"
         self.assertEqual(impl.enabled(), True)
@@ -575,11 +575,11 @@ deb http://secondary.mirror tuxy extra
             f.flush()
             self.assertEqual(impl.enabled(), True)
 
-    def test_get_kernel_package(self):
+    def test_get_kernel_package(self) -> None:
         """get_kernel_package()."""
         self.assertIn("linux", impl.get_kernel_package())
 
-    def test_package_name_glob(self):
+    def test_package_name_glob(self) -> None:
         """package_name_glob()."""
         self.assertGreater(len(impl.package_name_glob("a*")), 5)
         self.assertIn("bash", impl.package_name_glob("ba*h"))

--- a/tests/integration/test_packaging_rpm.py
+++ b/tests/integration/test_packaging_rpm.py
@@ -17,32 +17,32 @@ except ImportError:
 class TestPackagingRpm(unittest.TestCase):
     """Integration tests for the apport.packaging_impl.rpm module."""
 
-    def test_get_dependencies(self):
+    def test_get_dependencies(self) -> None:
         """get_dependencies()."""
         deps = impl.get_dependencies("bash")
         self.assertNotEqual(deps, [])
 
-    def test_get_header(self):
+    def test_get_header(self) -> None:
         """_get_header()."""
         # pylint: disable=protected-access
         hdr = impl._get_header("alsa-utils")
         self.assertEqual(hdr["n"], "alsa-utils")
 
-    def test_get_headers_by_tag(self):
+    def test_get_headers_by_tag(self) -> None:
         """_get_headers_by_tag()."""
         # pylint: disable=protected-access
         headers_by_tag = impl._get_headers_by_tag("basenames", "/bin/bash")
         self.assertEqual(len(headers_by_tag), 1)
         self.assertTrue(headers_by_tag[0]["n"].startswith("bash"))
 
-    def test_get_system_architecture(self):
+    def test_get_system_architecture(self) -> None:
         """get_system_architecture()."""
         arch = impl.get_system_architecture()
         # must be nonempty without line breaks
         self.assertNotEqual(arch, "")
         self.assertNotIn("\n", arch)
 
-    def test_get_version(self):
+    def test_get_version(self) -> None:
         """get_version()."""
         ver = impl.get_version("bash")
         self.assertIsNotNone(ver)

--- a/tests/integration/test_problem_report.py
+++ b/tests/integration/test_problem_report.py
@@ -21,13 +21,13 @@ bin_data = b"ABABABABAB\0\0\0Z\x01\x02"
 class T(unittest.TestCase):
     # pylint: disable=missing-class-docstring,missing-function-docstring
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.workdir = tempfile.mkdtemp()
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         shutil.rmtree(self.workdir)
 
-    def test_compressed_values(self):
+    def test_compressed_values(self) -> None:
         """Handle of CompressedValue values."""
         large_val = b"A" * 5000000
 
@@ -66,7 +66,7 @@ class T(unittest.TestCase):
         self.assertEqual(pr["Bin"], bin_data)
         self.assertEqual(pr["Large"], large_val.decode("ASCII"))
 
-    def test_write_append(self):
+    def test_write_append(self) -> None:
         """write() with appending to an existing file."""
         pr = problem_report.ProblemReport(date="now!")
         pr["Simple"] = "bar"
@@ -176,7 +176,7 @@ class T(unittest.TestCase):
             with open(os.path.join(self.workdir, key), "rb") as f:
                 self.assertEqual(f.read(), expected)
 
-    def test_write_file(self):
+    def test_write_file(self) -> None:
         """Write a report with binary file data."""
         with tempfile.NamedTemporaryFile() as temp:
             temp.write(bin_data)
@@ -241,7 +241,7 @@ class T(unittest.TestCase):
                 ),
             )
 
-    def test_write_delayed_fileobj(self):
+    def test_write_delayed_fileobj(self) -> None:
         """Write a report with file pointers and delayed data."""
         (fout, fin) = os.pipe()
 
@@ -271,7 +271,7 @@ class T(unittest.TestCase):
         pr2.load(out)
         self.assertEqual(pr2["BinFile"], "ab" * 512 * 1024 + "hello world")
 
-    def test_big_file(self):
+    def test_big_file(self) -> None:
         """Write and re-decoding a big random file."""
         # create 1 MB random file
         with tempfile.NamedTemporaryFile() as temp:
@@ -308,7 +308,7 @@ class T(unittest.TestCase):
         self.assertEqual(pr["File"].get_value(), data)
         self.assertEqual(pr["File"].name, "File")
 
-    def test_size_limit(self):
+    def test_size_limit(self) -> None:
         """Write and a big random file with a size limit key."""
         # create 1 MB random file
         with tempfile.NamedTemporaryFile() as temp:
@@ -341,7 +341,7 @@ class T(unittest.TestCase):
         self.assertEqual(pr["Before"], "xtestx")
         self.assertEqual(pr["ZAfter"], "ytesty")
 
-    def test_add_to_existing(self):  # pylint: disable=too-many-statements
+    def test_add_to_existing(self) -> None:  # pylint: disable=too-many-statements
         """Add information to an existing report."""
         # original report
         pr = problem_report.ProblemReport()
@@ -420,7 +420,7 @@ class T(unittest.TestCase):
 
         os.unlink(rep)
 
-    def test_write_mime_binary(self):
+    def test_write_mime_binary(self) -> None:
         """write_mime() for binary values and file references."""
         with tempfile.NamedTemporaryFile() as temp:
             with tempfile.NamedTemporaryFile() as tempgz:
@@ -494,7 +494,7 @@ class T(unittest.TestCase):
         self.assertEqual(parts[6].get_filename(), "ZValue.gz")
         self.assertEqual(self.decode_gzipped_message(parts[6]), bin_data)
 
-    def test_write_mime_filter(self):
+    def test_write_mime_filter(self) -> None:
         """write_mime() with key filters."""
         pr = problem_report.ProblemReport(date="now!")
         pr["GoodText"] = "Hi"

--- a/tests/integration/test_recoverable_problem.py
+++ b/tests/integration/test_recoverable_problem.py
@@ -16,6 +16,7 @@ import tempfile
 import time
 import unittest
 import unittest.mock
+from unittest.mock import MagicMock
 
 import apport.report
 from tests.paths import get_data_directory, local_test_environment
@@ -24,7 +25,7 @@ from tests.paths import get_data_directory, local_test_environment
 class TestRecoverableProblem(unittest.TestCase):
     """Test recoverable_problem"""
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.env = os.environ | local_test_environment()
         self.report_dir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, self.report_dir)
@@ -51,7 +52,9 @@ class TestRecoverableProblem(unittest.TestCase):
 
     @unittest.mock.patch("os.listdir")
     @unittest.mock.patch("time.sleep")
-    def test_wait_for_report_timeout(self, sleep_mock, listdir_mock):
+    def test_wait_for_report_timeout(
+        self, sleep_mock: MagicMock, listdir_mock: MagicMock
+    ) -> None:
         """Test wait_for_report() helper runs into timeout."""
         listdir_mock.return_value = []
         with unittest.mock.patch.object(self, "fail") as fail_mock:
@@ -60,7 +63,7 @@ class TestRecoverableProblem(unittest.TestCase):
         sleep_mock.assert_called_with(0.1)
         self.assertEqual(sleep_mock.call_count, 101)
 
-    def _call_recoverable_problem(self, data):
+    def _call_recoverable_problem(self, data: str) -> None:
         cmd = [self.datadir / "recoverable_problem"]
         proc = subprocess.run(
             cmd,
@@ -76,7 +79,7 @@ class TestRecoverableProblem(unittest.TestCase):
             raise subprocess.CalledProcessError(proc.returncode, cmd[0])
         self.assertEqual(proc.stderr, "")
 
-    def test_recoverable_problem(self):
+    def test_recoverable_problem(self) -> None:
         """recoverable_problem with valid data"""
         self._call_recoverable_problem("hello\0there")
         path = self._wait_for_report()
@@ -86,7 +89,7 @@ class TestRecoverableProblem(unittest.TestCase):
             self.assertEqual(report["hello"], "there")
             self.assertIn(f"Pid:\t{os.getpid()}", report["ProcStatus"])
 
-    def test_recoverable_problem_dupe_sig(self):
+    def test_recoverable_problem_dupe_sig(self) -> None:
         """recoverable_problem duplicate signature includes ExecutablePath"""
         self._call_recoverable_problem("Package\0test\0DuplicateSignature\0ds")
         path = self._wait_for_report()
@@ -97,7 +100,7 @@ class TestRecoverableProblem(unittest.TestCase):
             self.assertEqual(report["DuplicateSignature"], f"{exec_path}:ds")
             self.assertIn(f"Pid:\t{os.getpid()}", report["ProcStatus"])
 
-    def test_invalid_data(self):
+    def test_invalid_data(self) -> None:
         """recoverable_problem with invalid data"""
         self.assertRaises(
             subprocess.CalledProcessError, self._call_recoverable_problem, "hello"

--- a/tests/integration/test_report.py
+++ b/tests/integration/test_report.py
@@ -31,12 +31,14 @@ class T(unittest.TestCase):
     # pylint: disable=protected-access,too-many-public-methods
     """Test apport.report module."""
 
+    orig_data_dir: dict[str, str] | None
+
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls) -> None:
         cls.orig_data_dir = patch_data_dir(apport.report)
 
     @classmethod
-    def tearDownClass(cls):
+    def tearDownClass(cls) -> None:
         restore_data_dir(apport.report, cls.orig_data_dir)
 
     def wait_for_proc_cmdline(self, pid: int, timeout_sec: float = 10.0) -> None:
@@ -55,7 +57,7 @@ class T(unittest.TestCase):
         )
 
     @unittest.mock.patch("time.sleep")
-    def test_wait_for_proc_cmdline_failure(self, sleep_mock):
+    def test_wait_for_proc_cmdline_failure(self, sleep_mock: MagicMock) -> None:
         """Test wait_for_proc_cmdline() helper runs into timeout."""
         open_mock = unittest.mock.mock_open(read_data="")
         with unittest.mock.patch("builtins.open", open_mock):
@@ -65,7 +67,7 @@ class T(unittest.TestCase):
         sleep_mock.assert_called_with(0.1)
         self.assertEqual(sleep_mock.call_count, 3)
 
-    def test_add_package_info(self):
+    def test_add_package_info(self) -> None:
         """add_package_info()."""
         # determine bash version
         bashversion = apport.packaging.get_version("bash")
@@ -93,7 +95,7 @@ class T(unittest.TestCase):
         pr.add_package_info()
         self.assertNotIn("Package", pr)
 
-    def test_add_os_info(self):
+    def test_add_os_info(self) -> None:
         """add_os_info()."""
         pr = apport.report.Report()
         pr.add_os_info()
@@ -110,7 +112,7 @@ class T(unittest.TestCase):
         self.assertEqual(pr["Uname"], "foonux 1.2")
         self.assertEqual(pr["DistroRelease"], dr)
 
-    def test_add_user_info(self):
+    def test_add_user_info(self) -> None:
         """add_user_info()."""
         pr = apport.report.Report()
         pr.add_user_info()
@@ -286,7 +288,7 @@ class T(unittest.TestCase):
         self.assertIn(lang, r["ProcEnviron"].encode("UTF-8"))
         self.assertIn("XDG_RUNTIME_DIR=<set>", r["ProcEnviron"])
 
-    def test_add_proc_info_current_desktop(self):
+    def test_add_proc_info_current_desktop(self) -> None:
         """add_proc_info() CurrentDesktop"""
         with subprocess.Popen(
             ["cat"], stdin=subprocess.PIPE, env={"LANG": "xx_YY.UTF-8"}
@@ -351,7 +353,7 @@ class T(unittest.TestCase):
             cat.communicate(b"")
         self.assertIn("PATH=(custom, user)", r["ProcEnviron"])
 
-    def test_check_interpreted(self):
+    def test_check_interpreted(self) -> None:
         # TODO: Split into separate test cases
         # pylint: disable=too-many-statements
         """_check_interpreted()."""
@@ -541,7 +543,7 @@ class T(unittest.TestCase):
             if restore_root:
                 os.setresuid(0, 0, -1)
 
-    def test_check_interpreted_no_exec(self):
+    def test_check_interpreted_no_exec(self) -> None:
         """_check_interpreted() does not run module code"""
         # python script through -m, with dot separator; top-level module
         pr = apport.report.Report()
@@ -561,7 +563,7 @@ class T(unittest.TestCase):
         self.assertNotIn("UnreportableReason", pr)
 
     @skip_if_command_is_missing("twistd")
-    def test_check_interpreted_twistd(self):
+    def test_check_interpreted_twistd(self) -> None:
         """_check_interpreted() for programs ran through twistd"""
         # LP#761374
         pr = apport.report.Report()
@@ -697,7 +699,7 @@ int main() { return f(42); }
         return pr
 
     @staticmethod
-    def _validate_core(core_path):
+    def _validate_core(core_path: str) -> None:
         subprocess.check_call(["sync"])
         count = 0
         while count < 21:
@@ -708,7 +710,7 @@ int main() { return f(42); }
         assert os.path.exists(core_path)
         subprocess.run(["readelf", "-n", core_path], check=True, stdout=subprocess.PIPE)
 
-    def _validate_gdb_fields(self, pr):
+    def _validate_gdb_fields(self, pr: apport.report.Report) -> None:
         self.assertIn("Stacktrace", pr)
         self.assertIn("ThreadStacktrace", pr)
         self.assertIn("StacktraceTop", pr)
@@ -724,7 +726,7 @@ int main() { return f(42); }
         self.assertIn("Thread 1 (", pr["ThreadStacktrace"])
         self.assertLessEqual(len(pr["StacktraceTop"].splitlines()), 5)
 
-    def test_add_gdb_info(self):
+    def test_add_gdb_info(self) -> None:
         """add_gdb_info() with core dump file reference."""
         pr = apport.report.Report()
         # should not throw an exception for missing fields
@@ -756,7 +758,7 @@ int main() { return f(42); }
         self.assertNotEqual(pr["Disassembly"], "")
         self.assertNotIn("AssertionMessage", pr)
 
-    def test_add_gdb_info_load(self):
+    def test_add_gdb_info_load(self) -> None:
         """add_gdb_info() with inline core dump."""
         with tempfile.NamedTemporaryFile() as rep:
             self._generate_sigsegv_report(rep)
@@ -769,7 +771,7 @@ int main() { return f(42); }
 
         self._validate_gdb_fields(pr)
 
-    def test_add_gdb_info_damaged(self):
+    def test_add_gdb_info_damaged(self) -> None:
         """add_gdb_info() with damaged core dump"""
         pr = self._generate_sigsegv_report()
         del pr["Stacktrace"]
@@ -788,7 +790,7 @@ int main() { return f(42); }
             "not a core dump: file format not recognized", pr["UnreportableReason"]
         )
 
-    def test_add_gdb_info_short_core_file(self):
+    def test_add_gdb_info_short_core_file(self) -> None:
         """add_gdb_info() with damaged core dump in gzip file"""
         pr = self._generate_sigsegv_report()
         del pr["Stacktrace"]
@@ -808,7 +810,7 @@ int main() { return f(42); }
         self.assertTrue(pr["UnreportableReason"].startswith("Invalid core dump"))
 
     @unittest.mock.patch("gzip.GzipFile.read")
-    def test_add_gdb_info_damaged_gz_core(self, mock_gzread):
+    def test_add_gdb_info_damaged_gz_core(self, mock_gzread: MagicMock) -> None:
         """add_gdb_info() with damaged gzip file of core dump"""
         pr = self._generate_sigsegv_report()
         del pr["Stacktrace"]
@@ -828,7 +830,7 @@ int main() { return f(42); }
         self.assertNotIn("Stacktrace", pr)
         self.assertNotIn("StacktraceTop", pr)
 
-    def test_add_gdb_info_exe_missing(self):
+    def test_add_gdb_info_exe_missing(self) -> None:
         """add_gdb_info() with missing executable"""
         pr = self._generate_sigsegv_report()
         # change it to something that doesn't exist
@@ -839,7 +841,7 @@ int main() { return f(42); }
     @unittest.mock.patch(
         "apport.hookutils._root_command_prefix", MagicMock(return_value=[])
     )
-    def test_add_zz_parse_segv_details(self):
+    def test_add_zz_parse_segv_details(self) -> None:
         """parse-segv produces sensible results"""
         with tempfile.NamedTemporaryFile() as rep:
             self._generate_sigsegv_report(rep)
@@ -870,7 +872,7 @@ int main() { return f(42); }
             # data/general-hooks/parse_segv.py only runs for x86 and x86_64
             self.assertIn("not located in a known VMA region", pr["SegvAnalysis"])
 
-    def test_add_gdb_info_script(self):
+    def test_add_gdb_info_script(self) -> None:
         """add_gdb_info() with a script."""
         # This needs to handle different bash locations across releases
         # to get the core filename right
@@ -924,7 +926,7 @@ int main() { return f(42); }
             self._validate_gdb_fields(pr)
             self.assertIn("in kill_builtin", pr["Stacktrace"])
 
-    def test_add_gdb_info_abort(self):
+    def test_add_gdb_info_abort(self) -> None:
         """add_gdb_info() with SIGABRT/assert()
 
         If these come from an assert(), the report should have the assertion
@@ -1067,7 +1069,7 @@ int main() { return f(42); }
         self._validate_gdb_fields(pr)
         self.assertIn("Assertion failed in main: 1 < 0", pr["AssertionMessage"])
 
-    def test_search_bug_patterns(self):
+    def test_search_bug_patterns(self) -> None:
         # TODO: Split into separate test cases
         # pylint: disable=too-many-statements
         """search_bug_patterns()."""
@@ -1253,7 +1255,7 @@ int main() { return f(42); }
             "gracefully handles nonexisting URL domain",
         )
 
-    def test_add_hooks_info(self):
+    def test_add_hooks_info(self) -> None:
         # TODO: Split into separate test cases
         # pylint: disable=too-many-statements
         """add_hooks_info()."""
@@ -1498,7 +1500,7 @@ int main() { return f(42); }
             apport.report.GENERAL_HOOK_DIR = orig_general_hook_dir
             apport.report.PACKAGE_HOOK_DIR = orig_package_hook_dir
 
-    def test_add_hooks_info_opt(self):
+    def test_add_hooks_info_opt(self) -> None:
         """add_hooks_info() for a package in /opt"""
         orig_general_hook_dir = apport.report.GENERAL_HOOK_DIR
         apport.report.GENERAL_HOOK_DIR = tempfile.mkdtemp()
@@ -1557,7 +1559,7 @@ int main() { return f(42); }
             apport.report._opt_dir = orig_opt_dir
 
     @unittest.mock.patch("sys.stderr", new_callable=io.StringIO)
-    def test_add_hooks_info_errors(self, stderr_mock):
+    def test_add_hooks_info_errors(self, stderr_mock: MagicMock) -> None:
         """add_hooks_info() with errors in hooks"""
         orig_general_hook_dir = apport.report.GENERAL_HOOK_DIR
         apport.report.GENERAL_HOOK_DIR = tempfile.mkdtemp()
@@ -1625,7 +1627,7 @@ int main() { return f(42); }
             apport.report.GENERAL_HOOK_DIR = orig_general_hook_dir
             apport.report.PACKAGE_HOOK_DIR = orig_package_hook_dir
 
-    def test_ignoring(self):
+    def test_ignoring(self) -> None:
         """mark_ignore() and check_ignored()."""
         orig_ignore_file = apport.report.apport.report._ignore_file
         workdir = tempfile.mkdtemp()
@@ -1688,7 +1690,7 @@ int main() { return f(42); }
             shutil.rmtree(workdir)
             apport.report.apport.report._ignore_file = orig_ignore_file
 
-    def test_denylisting(self):
+    def test_denylisting(self) -> None:
         """check_ignored() for system-wise denylist."""
         orig_denylist_dir = apport.report._DENYLIST_DIR
         apport.report._DENYLIST_DIR = tempfile.mkdtemp()
@@ -1740,7 +1742,7 @@ int main() { return f(42); }
             apport.report._DENYLIST_DIR = orig_denylist_dir
             apport.report._ignore_file = orig_ignore_file
 
-    def test_allowlisting(self):
+    def test_allowlisting(self) -> None:
         """check_ignored() for system-wise allowlist."""
         orig_allowlist_dir = apport.report._ALLOWLIST_DIR
         apport.report._ALLOWLIST_DIR = tempfile.mkdtemp()
@@ -1794,7 +1796,7 @@ int main() { return f(42); }
             apport.report._ALLOWLIST_DIR = orig_allowlist_dir
             apport.report.apport.report._ignore_file = orig_ignore_file
 
-    def test_obsolete_packages(self):
+    def test_obsolete_packages(self) -> None:
         """obsolete_packages()."""
         report = apport.report.Report()
         self.assertEqual(report.obsolete_packages(), [])
@@ -1823,7 +1825,7 @@ int main() { return f(42); }
         )
         self.assertEqual(report.obsolete_packages(), [])
 
-    def test_address_to_offset_live(self):
+    def test_address_to_offset_live(self) -> None:
         """_address_to_offset() for current /proc/pid/maps"""
         # this primarily checks that the parser actually gets along with the
         # real /proc/pid/maps and not just with our static test case above
@@ -1834,32 +1836,32 @@ int main() { return f(42); }
         self.assertEqual(res.split("+", 1)[1], "5")
         self.assertIn("python", res.split("+", 1)[0])
 
-    def test_command_output(self):
+    def test_command_output(self) -> None:
         out = apport.report._command_output(["echo", "hello"])
         self.assertEqual(out, "hello")
 
-    def test_command_output_passes_env(self):
+    def test_command_output_passes_env(self) -> None:
         fake_env = {"GCONV_PATH": "/tmp"}
         out = apport.report._command_output(["env"], env=fake_env)
         self.assertIn("GCONV_PATH", out)
 
-    def test_command_output_timeout(self):
+    def test_command_output_timeout(self) -> None:
         with self.assertRaisesRegex(OSError, "timed out after 0.1 seconds: fail$"):
             apport.report._command_output(
                 ["sh", "-c", "echo fail; sleep 3600"], timeout=0.1
             )
 
-    def test_command_output_timeout_no_output(self):
+    def test_command_output_timeout_no_output(self) -> None:
         with self.assertRaisesRegex(
             OSError, "timed out after 0.1 seconds with no stdout"
         ):
             apport.report._command_output(["sleep", "3600"], timeout=0.1)
 
-    def test_command_output_raises_error(self):
+    def test_command_output_raises_error(self) -> None:
         with self.assertRaisesRegex(OSError, "failed with exit code 1"):
             apport.report._command_output(["false"])
 
-    def test_extrapath_preferred(self):
+    def test_extrapath_preferred(self) -> None:
         """If extrapath is passed it is preferred."""
         bin_true = apport.report._which_extrapath("true", None)
         # need something to be preferred

--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -301,7 +301,7 @@ class T(unittest.TestCase):
         finally:
             locale.setlocale(locale.LC_NUMERIC, locale_numeric)
 
-    def test_get_size_loaded(self):
+    def test_get_size_loaded(self) -> None:
         """get_complete_size() and get_reduced_size() for loaded Reports"""
         self.ui.load_report(self.report_file.name)
 
@@ -324,7 +324,7 @@ class T(unittest.TestCase):
         self.assertTrue(rs > 51000)
         self.assertTrue(rs < 60000)
 
-    def test_get_size_constructed(self):
+    def test_get_size_constructed(self) -> None:
         """get_complete_size() and get_reduced_size() for on-the-fly Reports"""
         self.ui.report = apport.Report("Bug")
         self.ui.report["Hello"] = "World"
@@ -335,7 +335,7 @@ class T(unittest.TestCase):
 
         self.assertEqual(s, self.ui.get_reduced_size())
 
-    def test_load_report(self):
+    def test_load_report(self) -> None:
         """load_report()"""
         # valid report
         self.ui.load_report(self.report_file.name)
@@ -369,7 +369,7 @@ class T(unittest.TestCase):
         self.assertEqual(self.ui.msg_title, _("Invalid problem report"))
         self.assertEqual(self.ui.msg_severity, "error")
 
-    def test_restart(self):
+    def test_restart(self) -> None:
         """restart()"""
         # test with only ProcCmdline
         p = os.path.join(apport.fileutils.report_dir, "ProcCmdline")
@@ -401,7 +401,7 @@ class T(unittest.TestCase):
         self.update_report_file()
         self.ui.load_report(self.report_file.name)
 
-    def test_collect_info_distro(self):
+    def test_collect_info_distro(self) -> None:
         """collect_info() on report without information (distro bug)"""
         # report without any information (distro bug)
         self.ui.report = apport.Report("Bug")
@@ -417,7 +417,7 @@ class T(unittest.TestCase):
             "no progress dialog for distro bug info collection",
         )
 
-    def test_collect_info_exepath(self):
+    def test_collect_info_exepath(self) -> None:
         """collect_info() on report with only ExecutablePath"""
         # report with only package information
         self.report = apport.Report("Bug")
@@ -454,7 +454,7 @@ class T(unittest.TestCase):
             "progress dialog for package bug info collection finished",
         )
 
-    def test_collect_info_package(self):
+    def test_collect_info_package(self) -> None:
         """collect_info() on report with a package"""
         # report with only package information
         self.ui.report = apport.Report("Bug")
@@ -497,7 +497,7 @@ class T(unittest.TestCase):
             "progress dialog for package bug info collection finished",
         )
 
-    def test_collect_info_permissions(self):
+    def test_collect_info_permissions(self) -> None:
         """collect_info() leaves the report accessible to the group"""
         self.ui.report = apport.Report("Bug")
         self.ui.cur_package = "bash"
@@ -523,7 +523,7 @@ class T(unittest.TestCase):
             if bash_hook:
                 f.write(f"    report['BashHook'] = '{bash_hook}'\n")
 
-    def test_collect_info_crashdb_spec(self):
+    def test_collect_info_crashdb_spec(self) -> None:
         """collect_info() with package hook that defines a CrashDB"""
         self._write_crashdb_config_hook("{ 'impl': 'memory', 'local_opt': '1' }", "Moo")
         self.ui.report = apport.Report("Bug")
@@ -534,7 +534,7 @@ class T(unittest.TestCase):
         self.assertEqual(self.ui.report["BashHook"], "Moo")
         self.assertEqual(self.ui.crashdb.options["local_opt"], "1")
 
-    def test_collect_info_crashdb_name(self):
+    def test_collect_info_crashdb_name(self) -> None:
         """collect_info() with package hook that chooses a different CrashDB"""
         self._write_crashdb_config_hook("debug", "Moo")
         self.ui.report = apport.Report("Bug")
@@ -544,7 +544,7 @@ class T(unittest.TestCase):
         self.assertEqual(self.ui.report["BashHook"], "Moo")
         self.assertEqual(self.ui.crashdb.options["distro"], "debug")
 
-    def test_collect_info_crashdb_errors(self):
+    def test_collect_info_crashdb_errors(self) -> None:
         """collect_info() with package hook setting a broken CrashDB field"""
         # nonexisting implementation
         self._write_crashdb_config_hook("{ 'impl': 'nonexisting', 'local_opt': '1' }")
@@ -578,7 +578,7 @@ class T(unittest.TestCase):
         self.assertIn("package hook", self.ui.report["UnreportableReason"])
         self.assertFalse(os.path.exists("/tmp/pwned"))
 
-    def test_handle_duplicate(self):
+    def test_handle_duplicate(self) -> None:
         """handle_duplicate()"""
         self.ui.load_report(self.report_file.name)
         self.assertEqual(self.ui.handle_duplicate(), False)
@@ -602,12 +602,12 @@ class T(unittest.TestCase):
         self.assertEqual(self.ui.msg_severity, "info")
         self.assertIsNone(self.ui.opened_url)
 
-    def test_run_nopending(self):
+    def test_run_nopending(self) -> None:
         """Run the frontend without any pending reports."""
         self.ui = UserInterfaceMock()
         self.assertEqual(self.ui.run_argv(), False)
 
-    def test_run_restart(self):
+    def test_run_restart(self) -> None:
         """Running the frontend with pending reports offers restart."""
         r = self._gen_test_crash()
         report_file = os.path.join(apport.fileutils.report_dir, "test.crash")
@@ -618,14 +618,14 @@ class T(unittest.TestCase):
         self.ui.run_argv()
         self.assertEqual(self.ui.offer_restart, True)
 
-    def test_run_report_bug_noargs(self):
+    def test_run_report_bug_noargs(self) -> None:
         """run_report_bug() without specifying arguments"""
         self.ui = UserInterfaceMock(["ui-test", "-f"])
         self.assertEqual(self.ui.run_argv(), False)
         self.assertEqual(self.ui.msg_severity, "error")
 
     @unittest.mock.patch("sys.stdout", new_callable=io.StringIO)
-    def test_run_version(self, stdout_mock):
+    def test_run_version(self, stdout_mock: MagicMock) -> None:
         """run_report_bug() as "ubuntu-bug" with version argument"""
         self.ui = UserInterfaceMock(["ubuntu-bug", "-v"])
         self.assertEqual(self.ui.run_argv(), True)
@@ -745,7 +745,7 @@ class T(unittest.TestCase):
         self.assertTrue(self.ui.ic_progress_pulses > 0)
 
     @staticmethod
-    def _find_unused_pid():
+    def _find_unused_pid() -> int:
         """Find and return an unused PID."""
         pid = 1
         while True:
@@ -757,7 +757,7 @@ class T(unittest.TestCase):
                     break
         return pid
 
-    def test_run_report_bug_wrong_pid(self):
+    def test_run_report_bug_wrong_pid(self) -> None:
         """run_report_bug() for a nonexisting pid"""
         # silently ignore missing PID; this happens when the user closes
         # the application prematurely
@@ -783,7 +783,7 @@ class T(unittest.TestCase):
             if restore_root:
                 os.setresuid(0, 0, -1)
 
-    def test_run_report_bug_unpackaged_pid(self):
+    def test_run_report_bug_unpackaged_pid(self) -> None:
         """run_report_bug() for a pid of an unpackaged program"""
         # create unpackaged test program
         (fd, exename) = tempfile.mkstemp()
@@ -819,7 +819,7 @@ class T(unittest.TestCase):
         self.assertEqual(self.ui.report["SourcePackage"], "coreutils")
 
     @unittest.mock.patch("apport.packaging_impl.impl.get_version")
-    def test_run_report_bug_kernel_thread(self, get_version_mock):
+    def test_run_report_bug_kernel_thread(self, get_version_mock: MagicMock) -> None:
         """run_report_bug() for a pid of a kernel thread"""
         # The kernel package might not be installed in chroot environments.
         # Therefore mock get_version for the kernel package.
@@ -847,7 +847,7 @@ class T(unittest.TestCase):
         )
         get_version_mock.assert_any_call(kernel_package)
 
-    def test_run_report_bug_file(self):
+    def test_run_report_bug_file(self) -> None:
         """run_report_bug() with saving report into a file"""
         d = os.path.join(apport.fileutils.report_dir, "home")
         os.mkdir(d)
@@ -882,7 +882,7 @@ class T(unittest.TestCase):
         self.assertIsNone(self.ui.msg_severity)
         self.assertTrue(self.ui.present_details_shown)
 
-    def _gen_test_crash(self):
+    def _gen_test_crash(self) -> apport.Report:
         """Generate a Report with real crash data."""
         core_path = os.path.join(self.workdir, "core")
         try:
@@ -1000,7 +1000,7 @@ class T(unittest.TestCase):
         self.assertTrue(self.ui.report.check_ignored())
         self.assertEqual(self.ui.offer_restart, False)
 
-    def test_run_crash_abort(self):
+    def test_run_crash_abort(self) -> None:
         """run_crash() for an abort() without assertion message"""
         r = self._gen_test_crash()
         r["Signal"] = "6"
@@ -1135,7 +1135,7 @@ class T(unittest.TestCase):
             self.assertFalse(os.path.exists("/tmp/pwned"))
             self.assertIn("invalid Package:", self.ui.msg_text)
 
-    def test_run_crash_malicious_exec_path(self):
+    def test_run_crash_malicious_exec_path(self) -> None:
         """ExecutablePath: path traversal"""
         hook_dir = "/tmp/share/apport/package-hooks"
         os.makedirs(hook_dir, exist_ok=True)
@@ -1154,7 +1154,7 @@ class T(unittest.TestCase):
 
             self.assertFalse(os.path.exists("/tmp/pwned"))
 
-    def test_run_crash_ignore(self):
+    def test_run_crash_ignore(self) -> None:
         """run_crash() on a crash with the Ignore field"""
         self.report["Ignore"] = "True"
         self.report["ExecutablePath"] = "/bin/bash"
@@ -1188,7 +1188,7 @@ class T(unittest.TestCase):
             "memory", self.ui.msg_text, f"{self.ui.msg_title}: {self.ui.msg_text}"
         )
 
-    def test_run_crash_preretraced(self):
+    def test_run_crash_preretraced(self) -> None:
         """run_crash() pre-retraced reports.
 
         This happens with crashes which are pre-processed by
@@ -1254,7 +1254,7 @@ class T(unittest.TestCase):
         )
         self.assertTrue(self.ui.present_details_shown)
 
-    def test_run_crash_errors(self):
+    def test_run_crash_errors(self) -> None:
         """run_crash() on various error conditions"""
         # crash report with invalid Package name
         r = apport.Report()
@@ -1462,7 +1462,7 @@ class T(unittest.TestCase):
         ]
         return [s for s in sensitive_strings if s]
 
-    def test_run_crash_anonymity(self):
+    def test_run_crash_anonymity(self) -> None:
         """run_crash() anonymization"""
         r = self._gen_test_crash()
         utf8_val = b"\xc3\xa4 " + os.uname()[1].encode("UTF-8") + b" \xe2\x99\xa5 "
@@ -1508,7 +1508,7 @@ class T(unittest.TestCase):
             (uname[0], "0xDEADBEEF", uname[2], uname[3], uname[4])
         )
 
-        def fake_add_gdb_info(self):
+        def fake_add_gdb_info(self: apport.report.Report) -> None:
             self["Stacktrace"] = textwrap.dedent(
                 """\
                 #0  0xDEADBEEF in h (p=0x0) at crash.c:25
@@ -1543,7 +1543,7 @@ class T(unittest.TestCase):
             self.assertIsNone(self.ui.report.crash_signature_addresses())
         add_gdb_info_mock.assert_called_once()
 
-    def test_run_crash_anonymity_substring(self):
+    def test_run_crash_anonymity_substring(self) -> None:
         """run_crash() anonymization only catches whole words"""
         # pretend the hostname is "ed", a substring of e. g. "crashed"
         uname = os.uname()
@@ -1573,7 +1573,7 @@ class T(unittest.TestCase):
             self.assertEqual(self.ui.report["ProcInfo2"], '"hostname.localnet"')
             self.assertEqual(self.ui.report["ProcInfo3"], "education")
 
-    def test_run_crash_anonymity_escaping(self):
+    def test_run_crash_anonymity_escaping(self) -> None:
         """run_crash() anonymization escapes special chars"""
         # inject GECOS field with regexp control chars
         orig_getpwuid = pwd.getpwuid
@@ -1679,7 +1679,7 @@ class T(unittest.TestCase):
         self.assertIn("No additional information collected.", self.ui.msg_text)
         self.assertFalse(self.ui.present_details_shown)
 
-    def test_run_update_report_existing_package_from_bug(self):
+    def test_run_update_report_existing_package_from_bug(self) -> None:
         """run_update_report() on an existing package (from bug)"""
         self.ui = UserInterfaceMock(["ui-test", "-u", "1"])
         self.ui.present_details_response = apport.ui.Action(report=True)
@@ -1698,7 +1698,7 @@ class T(unittest.TestCase):
         self.assertIn("Dependencies", self.ui.report)
         self.assertIn("ProcEnviron", self.ui.report)
 
-    def test_run_update_report_existing_package_cli_tags(self):
+    def test_run_update_report_existing_package_cli_tags(self) -> None:
         """run_update_report() on an existing package (CLI argument)
         with extra tag"""
         argv = ["ui-test", "-u", "1", "-p", "bash", "--tag", "foo"]
@@ -1718,7 +1718,7 @@ class T(unittest.TestCase):
         self.assertIn("ProcEnviron", self.ui.report)
         self.assertIn("foo", self.ui.report.get_tags())
 
-    def test_run_update_report_existing_package_cli_cmdname(self):
+    def test_run_update_report_existing_package_cli_cmdname(self) -> None:
         """run_update_report() on an existing package (-collect program)"""
         self.ui = UserInterfaceMock(["apport-collect", "-p", "bash", "1"])
         self.ui.present_details_response = apport.ui.Action(report=True)
@@ -1735,7 +1735,7 @@ class T(unittest.TestCase):
         self.assertIn("Dependencies", self.ui.report)
         self.assertIn("ProcEnviron", self.ui.report)
 
-    def test_run_update_report_noninstalled_but_hook(self):
+    def test_run_update_report_noninstalled_but_hook(self) -> None:
         """run_update_report() on an uninstalled package with a source hook"""
         self.ui = UserInterfaceMock(["ui-test", "-u", "1"])
         self.ui.present_details_response = apport.ui.Action(report=True)
@@ -1757,7 +1757,7 @@ class T(unittest.TestCase):
         self.assertEqual(self.ui.report["MachineType"], "Laptop")
         self.assertIn("ProcEnviron", self.ui.report)
 
-    def test_run_update_report_different_binary_source(self):
+    def test_run_update_report_different_binary_source(self) -> None:
         """run_update_report() on a source package which does not have
         a binary of the same name"""
         # this test assumes that the source package name is not an
@@ -1786,7 +1786,7 @@ class T(unittest.TestCase):
         self.assertEqual(self.ui.report["MachineType"], "Laptop")
         self.assertIn("ProcEnviron", self.ui.report)
 
-    def _run_hook(self, code):
+    def _run_hook(self, code: str) -> None:
         with open(
             os.path.join(self.hookdir, "coreutils.py"), "w", encoding="utf-8"
         ) as hook:
@@ -1797,7 +1797,7 @@ class T(unittest.TestCase):
         self.ui.args.package = "coreutils"
         self.ui.run_report_bug()
 
-    def test_interactive_hooks_information(self):
+    def test_interactive_hooks_information(self) -> None:
         """Interactive hooks: HookUI.information()"""
         self.ui.present_details_response = apport.ui.Action()
         self._run_hook(
@@ -1814,7 +1814,7 @@ class T(unittest.TestCase):
         self.assertEqual(self.ui.report["end"], "1")
         self.assertEqual(self.ui.msg_text, "InfoText")
 
-    def test_interactive_hooks_yesno(self):
+    def test_interactive_hooks_yesno(self) -> None:
         """Interactive hooks: HookUI.yesno()"""
         self.ui.present_details_response = apport.ui.Action(report=True)
         self.ui.question_yesno_response = True
@@ -1843,7 +1843,7 @@ class T(unittest.TestCase):
         self.assertEqual(self.ui.report["answer"], "None")
         self.assertEqual(self.ui.report["end"], "1")
 
-    def test_interactive_hooks_file(self):
+    def test_interactive_hooks_file(self) -> None:
         """Interactive hooks: HookUI.file()"""
         self.ui.present_details_response = apport.ui.Action(report=True)
         self.ui.question_file_response = "/etc/fstab"
@@ -1867,7 +1867,7 @@ class T(unittest.TestCase):
         self.assertEqual(self.ui.report["answer"], "None")
         self.assertEqual(self.ui.report["end"], "1")
 
-    def test_interactive_hooks_choices(self):
+    def test_interactive_hooks_choices(self) -> None:
         """Interactive hooks: HookUI.choice()"""
         self.ui.present_details_response = apport.ui.Action(report=True)
         self.ui.question_choice_response = [1]
@@ -1910,7 +1910,7 @@ class T(unittest.TestCase):
         assert self.ui.report
         self.assertEqual(self.ui.report["answer"], "None")
 
-    def test_interactive_hooks_cancel(self):
+    def test_interactive_hooks_cancel(self) -> None:
         """Interactive hooks: user cancels"""
         self.assertRaises(
             SystemExit,
@@ -2068,10 +2068,14 @@ class T(unittest.TestCase):
         self.assertTrue(self.ui.report["Package"].startswith("bash"))
 
     @unittest.mock.patch("sys.stderr", new_callable=io.StringIO)
-    def test_parse_argv_single_arg(self, stderr_mock):
+    def test_parse_argv_single_arg(self, stderr_mock: MagicMock) -> None:
         """parse_args() option inference for a single argument"""
 
-        def _chk(program_name, arg, expected_opts):
+        def _chk(
+            program_name: str,
+            arg: str | None,
+            expected_opts: dict[str, bool | int | str | list[str] | None],
+        ) -> None:
             argv = [program_name]
             if arg:
                 argv.append(arg)
@@ -2235,10 +2239,13 @@ class T(unittest.TestCase):
         )
 
     @unittest.mock.patch("sys.stderr", new_callable=io.StringIO)
-    def test_parse_argv_apport_bug(self, stderr_mock):
+    def test_parse_argv_apport_bug(self, stderr_mock: MagicMock) -> None:
         """parse_args() option inference when invoked as *-bug"""
 
-        def _chk(args, expected_opts):
+        def _chk(
+            args: list[str],
+            expected_opts: dict[str, bool | int | str | list[str] | None],
+        ) -> None:
             ui = apport.ui.UserInterface(["apport-bug"] + args)
             expected_opts["version"] = False
             self.assertEqual(ui.args.__dict__, expected_opts)
@@ -2498,7 +2505,7 @@ class T(unittest.TestCase):
         self.assertEqual(self.ui.upload_progress_pulses, 0)
         self.assertEqual(self.ui.crashdb.latest_id(), latest_id_before)
 
-    def test_get_desktop_entry(self):
+    def test_get_desktop_entry(self) -> None:
         """Parsee .desktop files."""
         with tempfile.NamedTemporaryFile(mode="w+") as desktop_file:
             desktop_file.write(
@@ -2530,7 +2537,7 @@ class T(unittest.TestCase):
                 },
             )
 
-    def test_get_desktop_entry_broken(self):
+    def test_get_desktop_entry_broken(self) -> None:
         """Parse broken .desktop files."""
         # duplicate key
         with tempfile.NamedTemporaryFile(mode="w+") as desktop_file:
@@ -2596,7 +2603,7 @@ class T(unittest.TestCase):
 
             self.assertIsNone(self.ui.get_desktop_entry())
 
-    def test_wait_for_pid(self):
+    def test_wait_for_pid(self) -> None:
         # fork a test process
         with run_test_executable() as pid:
             pass

--- a/tests/integration/test_ui_cli.py
+++ b/tests/integration/test_ui_cli.py
@@ -30,17 +30,19 @@ class TestApportCli(unittest.TestCase):
     # pylint: disable=missing-function-docstring
     """Test apport-cli."""
 
+    orig_environ: dict[str, str]
+
     @classmethod
     def setUpClass(cls):
         cls.orig_environ = os.environ.copy()
         os.environ |= local_test_environment()
 
     @classmethod
-    def tearDownClass(cls):
+    def tearDownClass(cls) -> None:
         os.environ.clear()
         os.environ.update(cls.orig_environ)
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.app = apport_cli.CLIUserInterface([APPORT_CLI_PATH])
         self.app.report = apport.report.Report()
         self.app.report.add_os_info()

--- a/tests/integration/test_unkillable_shutdown.py
+++ b/tests/integration/test_unkillable_shutdown.py
@@ -29,14 +29,14 @@ class TestUnkillableShutdown(unittest.TestCase):
     TEST_EXECUTABLE = os.path.realpath("/bin/sleep")
     TEST_ARGS = ["86400"]
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.data_dir = get_data_directory()
         self.env = os.environ | local_test_environment()
 
         self.report_dir = tempfile.mkdtemp()
         self.env["APPORT_REPORT_DIR"] = self.report_dir
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         shutil.rmtree(self.report_dir)
 
     def _call(self, omit: list | None = None) -> None:
@@ -55,7 +55,7 @@ class TestUnkillableShutdown(unittest.TestCase):
         self.assertEqual(process.stdout, "")
 
     @staticmethod
-    def _get_all_pids():
+    def _get_all_pids() -> list[int]:
         return [int(pid) for pid in os.listdir("/proc") if pid.isdigit()]
 
     @contextlib.contextmanager
@@ -86,7 +86,7 @@ class TestUnkillableShutdown(unittest.TestCase):
         finally:
             runner.kill()
 
-    def test_omit_all_processes(self):
+    def test_omit_all_processes(self) -> None:
         """unkillable_shutdown will write no reports."""
         self._call(omit=self._get_all_pids())
         self.assertEqual(os.listdir(self.report_dir), [])
@@ -101,7 +101,7 @@ class TestUnkillableShutdown(unittest.TestCase):
             [f"{self.TEST_EXECUTABLE.replace('/', '_')}.{os.geteuid()}.crash"],
         )
 
-    def test_write_reports(self):
+    def test_write_reports(self) -> None:
         """unkillable_shutdown will write reports."""
         # Ensure that at least one process is honoured by unkillable_shutdown.
         with self._launch_process_with_different_session_id():

--- a/tests/integration/test_whoopsie_upload_all.py
+++ b/tests/integration/test_whoopsie_upload_all.py
@@ -15,6 +15,7 @@ import shutil
 import tempfile
 import unittest
 import unittest.mock
+from unittest.mock import MagicMock
 
 from tests.helper import import_module_from_file
 from tests.paths import get_data_directory
@@ -27,7 +28,7 @@ whoopsie_upload_all = import_module_from_file(
 class TestWhoopsieUploadAll(unittest.TestCase):
     """Integration tests for whoopsie-upload-all."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.report_dir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, self.report_dir)
 
@@ -38,7 +39,7 @@ class TestWhoopsieUploadAll(unittest.TestCase):
         return report
 
     @unittest.mock.patch("sys.stderr", new_callable=io.StringIO)
-    def test_process_report_malformed_report(self, stderr_mock):
+    def test_process_report_malformed_report(self, stderr_mock: MagicMock) -> None:
         """Test process_report() raises MalformedProblemReport."""
         report = self._write_report(b"AB\xfc:CD\n")
         self.assertIsNone(whoopsie_upload_all.process_report(report))


### PR DESCRIPTION
Add type hints to the integration tests where mypy will be happy about. Leave the problematic integration tests untoched for a later point in time.