### PR TITLE
launchpad: don't systematically order retrace on private reports (FR-7945)

### DIFF
--- a/apport/crashdb_impl/launchpad.py
+++ b/apport/crashdb_impl/launchpad.py
@@ -1079,11 +1079,10 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
         # privacy/retracing for distro reports
         # FIXME: ugly hack until LP has a real crash db
         if "DistroRelease" in report:
-            if arch and (
-                "VmCore" in report
-                or "CoreDump" in report
-                or "LaunchpadPrivate" in report
-            ):
+            if "LaunchpadPrivate" in report:
+                hdr["Private"] = "yes"
+
+            if arch and ("VmCore" in report or "CoreDump" in report):
                 hdr["Private"] = "yes"
                 hdr["Subscribers"] = report.get(
                     "LaunchpadSubscribe",

--- a/tests/unit/test_crashdb_launchpad.py
+++ b/tests/unit/test_crashdb_launchpad.py
@@ -1,0 +1,90 @@
+# Copyright (C) 2024 Canonical Ltd.
+# Author: Simon Chopin <simon.chopin@canonical.com>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 2 of the License, or (at your
+# option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
+# the full text of the license.
+
+"""Unit tests for apport.crash_impl.launchpad"""
+
+from apport.crashdb_impl.launchpad import CrashDatabase
+from apport.report import Report
+
+
+def python_crash() -> Report:
+    """Generate a report that looks like a Python crash"""
+    report = Report("Crash")
+    report["Package"] = "python-goo 3epsilon1"
+    report["SourcePackage"] = "pygoo"
+    report["PackageArchitecture"] = "all"
+    report["DistroRelease"] = "Ubuntu 24.04"
+    report["ExecutablePath"] = "/usr/bin/pygoo"
+    report[
+        "Traceback"
+    ] = """Traceback (most recent call last):
+  File "test.py", line 7, in <module>
+    print(_f(5))
+  File "test.py", line 5, in _f
+    return g_foo00(x+1)
+  File "test.py", line 2, in g_foo00
+    return x/0
+ZeroDivisionError: integer division or modulo by zero"""
+    return report
+
+
+def native_crash() -> Report:
+    """Generate a report that looks like a native binary crash"""
+    report = Report("Crash")
+    report["Signal"] = "6"
+    report["SignalName"] = "SIGABRT"
+    report["Package"] = "bash"
+    report["SourcePackage"] = "bash"
+    report["DistroRelease"] = "Ubuntu 24.04"
+    report["PackageArchitecture"] = "i386"
+    report["Architecture"] = "amd64"
+    report["ExecutablePath"] = "/bin/bash"
+    report["CoreDump"] = "/var/lib/apport/coredump/core.bash"
+    report["AssertionMessage"] = "foo.c:42 main: i > 0"
+    return report
+
+
+def test_python_crash_headers():
+    # pylint: disable=protected-access
+    """Test _generate_upload_headers in case of a Python crash"""
+    crashdb = CrashDatabase(None, {"distro": "ubuntu"})
+    report = python_crash()
+    headers = crashdb._generate_upload_headers(report)
+
+    assert "need-duplicate-check" in headers["Tags"].split(" ")
+    assert headers.get("Private") == "yes"
+
+
+def test_native_crash_headers():
+    # pylint: disable=protected-access
+    """Test _generate_upload_headers in case of a native crash"""
+    crashdb = CrashDatabase(None, {"distro": "ubuntu"})
+    report = native_crash()
+    headers = crashdb._generate_upload_headers(report)
+
+    assert "i386" in headers["Tags"].split(" ")
+    assert "need-i386-retrace" in headers["Tags"].split(" ")
+    assert headers.get("Private") == "yes"
+
+
+def test_private_bug_headers():
+    # pylint: disable=protected-access
+    """Test _generate_upload_headers for a bug in a package for which
+    the hook explicitly says it should be private"""
+    crashdb = CrashDatabase(None, {"distro": "ubuntu"})
+    report = Report("Bug")
+    report["Package"] = "apport"
+    report["SourcePackage"] = "apport"
+    report["PackageArchitecture"] = "all"
+    report["Architecture"] = "amd64"
+    report["DistroRelease"] = "Ubuntu 24.04"
+    report["LaunchpadPrivate"] = "yes"
+    headers = crashdb._generate_upload_headers(report)
+
+    assert headers.get("Private") == "yes"

--- a/tests/unit/test_crashdb_launchpad.py
+++ b/tests/unit/test_crashdb_launchpad.py
@@ -9,6 +9,8 @@
 
 """Unit tests for apport.crash_impl.launchpad"""
 
+import re
+
 from apport.crashdb_impl.launchpad import CrashDatabase
 from apport.report import Report
 
@@ -88,3 +90,4 @@ def test_private_bug_headers():
     headers = crashdb._generate_upload_headers(report)
 
     assert headers.get("Private") == "yes"
+    assert not re.search(r"need-[a-z0-9]+-retrace", headers.get("Tags", ""))


### PR DESCRIPTION
Just because a report is marked as LaunchpadPrivate and has an actual
architecture attached to it doesn't mean it should be retraced. A
contrario, any report that is designated as LaunchpadPrivate should be
marked as private, even if get_os_info() was never called on it.

Fixes https://bugs.launchpad.net/ubuntu/+source/apport/+bug/2068933

The review will be much easier if done commit-wise.
