### PR TITLE
test: rename pidof to pids_of

### DIFF
--- a/tests/helper.py
+++ b/tests/helper.py
@@ -52,8 +52,8 @@ def import_module_from_file(path: pathlib.Path) -> Any:
     return module
 
 
-def pidof(program: str) -> set[int]:
-    """Find the process ID of a running program.
+def pids_of(program: str) -> set[int]:
+    """Find the process IDs of a running program.
 
     This function wraps the pidof command and returns a set of
     process IDs.

--- a/tests/integration/test_helper.py
+++ b/tests/integration/test_helper.py
@@ -4,17 +4,17 @@ import os
 import sys
 import unittest
 
-from tests.helper import pidof, read_shebang
+from tests.helper import pids_of, read_shebang
 
 
 class TestHelper(unittest.TestCase):
     # pylint: disable=missing-class-docstring,missing-function-docstring
 
-    def test_pidof_non_existing_program(self) -> None:
-        self.assertEqual(pidof("non-existing"), set())
+    def test_pids_of_non_existing_program(self) -> None:
+        self.assertEqual(pids_of("non-existing"), set())
 
-    def test_pidof_running_python(self) -> None:
-        pids = pidof(sys.executable)
+    def test_pids_of_running_python(self) -> None:
+        pids = pids_of(sys.executable)
         self.assertGreater(len(pids), 0)
         self.assertIn(os.getpid(), pids)
 

--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -30,7 +30,7 @@ import apport.report
 import apport.ui
 import problem_report
 from apport.ui import _, run_as_real_user
-from tests.helper import pidof, run_test_executable, skip_if_command_is_missing
+from tests.helper import pids_of, run_test_executable, skip_if_command_is_missing
 from tests.paths import local_test_environment, patch_data_dir, restore_data_dir
 
 ORIGINAL_SUBPROCESS_RUN = subprocess.run
@@ -245,7 +245,7 @@ class T(unittest.TestCase):
         os.environ["APPORT_IGNORE_OBSOLETE_PACKAGES"] = "1"
         os.environ["APPORT_DISABLE_DISTRO_CHECK"] = "1"
 
-        self.running_test_executables = pidof(self.TEST_EXECUTABLE)
+        self.running_test_executables = pids_of(self.TEST_EXECUTABLE)
 
     def update_report_file(self):
         self.report_file.seek(0)
@@ -267,7 +267,7 @@ class T(unittest.TestCase):
         self.report_file.close()
 
         self.assertEqual(
-            pidof(self.TEST_EXECUTABLE) - self.running_test_executables,
+            pids_of(self.TEST_EXECUTABLE) - self.running_test_executables,
             set(),
             "no stray test processes",
         )
@@ -903,7 +903,7 @@ class T(unittest.TestCase):
             ) as gdb:
                 timeout = 10.0
                 while timeout > 0:
-                    pids = pidof(self.TEST_EXECUTABLE) - self.running_test_executables
+                    pids = pids_of(self.TEST_EXECUTABLE) - self.running_test_executables
                     if pids:
                         pid = pids.pop()
                         break

--- a/tests/system/test_signal_crashes.py
+++ b/tests/system/test_signal_crashes.py
@@ -16,7 +16,7 @@ import time
 import unittest
 
 import apport.fileutils
-from tests.helper import get_init_system, pidof, skip_if_command_is_missing
+from tests.helper import get_init_system, pids_of, skip_if_command_is_missing
 from tests.paths import (
     get_data_directory,
     is_local_source_directory,
@@ -117,7 +117,7 @@ class T(unittest.TestCase):
             f"{self.TEST_EXECUTABLE.replace('/', '_')}.{os.getuid()}.crash",
         )
 
-        self.running_test_executables = pidof(self.TEST_EXECUTABLE)
+        self.running_test_executables = pids_of(self.TEST_EXECUTABLE)
 
     def tearDown(self):
         shutil.rmtree(self.report_dir)
@@ -237,7 +237,7 @@ class T(unittest.TestCase):
             + self.TEST_ARGS,
         )
         try:
-            pids = pidof(self.TEST_EXECUTABLE) - self.running_test_executables
+            pids = pids_of(self.TEST_EXECUTABLE) - self.running_test_executables
             self.assertEqual(len(pids), 1)
             os.kill(pids.pop(), signal.SIGSEGV)
 
@@ -296,7 +296,7 @@ class T(unittest.TestCase):
         self, program: pathlib.Path | str, timeout_sec: float = 10.0
     ) -> None:
         while timeout_sec > 0:
-            if not pidof(str(program)) - self.running_test_executables:
+            if not pids_of(str(program)) - self.running_test_executables:
                 break
             time.sleep(0.2)
             timeout_sec -= 0.2


### PR DESCRIPTION
Rename the function `pidof` to `pids_of` to reflect that it will return a set of process IDs. This was requested in https://github.com/canonical/apport/pull/358#discussion_r1679388131.