### PR TITLE
test: ensure orig_apt_proxy is always a string

### DIFF
--- a/tests/system/test_packaging_apt_dpkg.py
+++ b/tests/system/test_packaging_apt_dpkg.py
@@ -423,7 +423,7 @@ def test_install_packages_permanent_sandbox(configdir, cachedir, rootdir, apt_st
     assert os.path.exists(os.path.join(rootdir, "usr/bin/stat"))
 
     # Prevent packages from downloading.
-    orig_apt_proxy = apt_pkg.config.get("Acquire::http::Proxy")
+    orig_apt_proxy = apt_pkg.config.get("Acquire::http::Proxy", "")
     apt_pkg.config.set("Acquire::http::Proxy", "http://nonexistent")
     orig_http_proxy = os.environ.get("http_proxy")
     os.environ["http_proxy"] = "http://nonexistent"


### PR DESCRIPTION
mypy complains:

```
tests/system/test_packaging_apt_dpkg.py:490: error: Argument 2 to "set" of "Configuration" has incompatible type "str | None"; expected "str"  [arg-type]
```

`apt_pkg.config.get` will return an empty string in case the config is not set. So it is safe to let the `get` method return an empty string as fallback value.