### PR TITLE
test: assert that error_title is not None

### DIFF
--- a/tests/system/test_ui_gtk.py
+++ b/tests/system/test_ui_gtk.py
@@ -775,7 +775,7 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
     @unittest.mock.patch(
         "apport.fileutils.allowed_to_report", MagicMock(return_value=True)
     )
-    def test_broken_crash_details(self):
+    def test_broken_crash_details(self) -> None:
         """Broken crash report with showing details."""
         # pylint: disable=attribute-defined-outside-init
         self.error_title = None
@@ -834,7 +834,7 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
         self.assertEqual(self.app.crashdb.latest_id(), -1)
 
         # proper error message
-        self.assertIsNotNone(self.error_title)
+        assert self.error_text is not None
         self.assertIn("cannot be reported", self.error_text)
         self.assertIn("decompressing", self.error_text)
 


### PR DESCRIPTION
mypy complains:

```
tests/system/test_ui_gtk.py:838: error: Argument 2 to "assertIn" of "TestCase" has incompatible type "None"; expected "Iterable[Any] | Container[Any]"  [arg-type]
tests/system/test_ui_gtk.py:839: error: Argument 2 to "assertIn" of "TestCase" has incompatible type "None"; expected "Iterable[Any] | Container[Any]"  [arg-type]
```