### PR TITLE
test: add type hints to unproblematic system tests

### DIFF
--- a/tests/integration/test_signal_crashes.py
+++ b/tests/integration/test_signal_crashes.py
@@ -140,7 +140,7 @@ class T(unittest.TestCase):
             shutil.rmtree(self.report_dir)
             shutil.rmtree(self.workdir)
 
-    def test_empty_core_dump(self):
+    def test_empty_core_dump(self) -> None:
         """Empty core dumps do not generate a report."""
         test_proc = self.create_test_process()
         try:
@@ -159,6 +159,7 @@ class T(unittest.TestCase):
                 stdin=subprocess.PIPE,
                 stderr=subprocess.PIPE,
             ) as app:
+                assert app.stdin is not None and app.stderr is not None
                 app.stdin.close()
                 assert app.wait() == 0, app.stderr.read()
                 app.stderr.close()
@@ -234,7 +235,7 @@ class T(unittest.TestCase):
         self.assertNotIn("root", pr["UserGroups"])
 
     @unittest.skip("fix test as multiple instances can be started within 30s")
-    def test_parallel_crash(self):
+    def test_parallel_crash(self) -> None:
         """Only one apport instance is ran at a time."""
         test_proc = self.create_test_process()
         test_proc2 = self.create_test_process("/bin/dd", args=[])
@@ -254,6 +255,7 @@ class T(unittest.TestCase):
                 stdin=subprocess.PIPE,
                 stderr=subprocess.PIPE,
             ) as app:
+                assert app.stdin is not None and app.stderr is not None
                 time.sleep(0.5)  # give it some time to grab the lock
 
                 with subprocess.Popen(
@@ -271,6 +273,7 @@ class T(unittest.TestCase):
                     stdin=subprocess.PIPE,
                     stderr=subprocess.PIPE,
                 ) as app2:
+                    assert app2.stdin is not None and app2.stderr is not None
                     # app should wait indefinitely for stdin, while app2 should
                     # terminate immediately (give it 5 seconds)
                     timeout = 50

--- a/tests/system/test_apport_valgrind.py
+++ b/tests/system/test_apport_valgrind.py
@@ -29,20 +29,22 @@ with open("/proc/meminfo", encoding="utf-8") as f:
 class TestApportValgrind(unittest.TestCase):
     """System tests for bin/apport-valgrind."""
 
+    env: dict[str, str]
+
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls) -> None:
         cls.env = os.environ | local_test_environment()
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.workdir = tempfile.mkdtemp()
         self.pwd = os.getcwd()
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         shutil.rmtree(self.workdir)
         os.chdir(self.pwd)
 
     @unittest.skipIf(MEM_TOTAL_MiB < 2000, f"{MEM_TOTAL_MiB} MiB is not enough memory")
-    def test_sandbox_cache_options(self):
+    def test_sandbox_cache_options(self) -> None:
         """apport-valgrind creates a user specified sandbox and cache"""
         sandbox = os.path.join(self.workdir, "test-sandbox")
         cache = os.path.join(self.workdir, "test-cache")

--- a/tests/system/test_github_query.py
+++ b/tests/system/test_github_query.py
@@ -11,14 +11,14 @@ SOME_ID = "a654870577ad2a2ab5b1"
 class TestGitHubQuery(unittest.TestCase):
     """System tests for the apport.crashdb_impl.github module."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.crashdb = self._get_gh_database("Lorem", "Ipsum")
         self.message_cb = Mock()
         self.github = apport.crashdb_impl.github.Github(
             self.crashdb.app_id, self.message_cb
         )
 
-    def test_api_authentication(self):
+    def test_api_authentication(self) -> None:
         """Test if we can contact Github authentication service."""
         with self.github as github:
             data = {"client_id": SOME_ID, "scope": "public_repo"}
@@ -39,7 +39,9 @@ class TestGitHubQuery(unittest.TestCase):
             self.assertIsInstance(response["interval"], int)
 
     @staticmethod
-    def _get_gh_database(repository_owner, repository_name):
+    def _get_gh_database(
+        repository_owner: str, repository_name: str
+    ) -> apport.crashdb_impl.github.CrashDatabase:
         return apport.crashdb_impl.github.CrashDatabase(
             None,
             {

--- a/tests/system/test_python_crashes.py
+++ b/tests/system/test_python_crashes.py
@@ -38,9 +38,10 @@ class T(unittest.TestCase):
     """Test apport_python_hook.py"""
 
     env: dict[str, str]
+    orig_report_dir: str
 
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls) -> None:
         cls.env = os.environ | local_test_environment()
         cls.orig_report_dir = apport.fileutils.report_dir
         apport.fileutils.report_dir = tempfile.mkdtemp()
@@ -48,10 +49,10 @@ class T(unittest.TestCase):
         atexit.register(shutil.rmtree, apport.fileutils.report_dir)
 
     @classmethod
-    def tearDownClass(cls):
+    def tearDownClass(cls) -> None:
         apport.fileutils.report_dir = cls.orig_report_dir
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         for f in apport.fileutils.get_all_reports():
             os.unlink(f)
 
@@ -97,7 +98,7 @@ func(42)
 
         return script
 
-    def test_dbus_service_unknown_invalid(self):
+    def test_dbus_service_unknown_invalid(self) -> None:
         """DBus.Error.ServiceUnknown with an invalid name"""
         self._test_crash(
             extracode=textwrap.dedent(
@@ -116,7 +117,7 @@ func(42)
             pr["DbusErrorAnalysis"], "no service file providing com.example.NotExisting"
         )
 
-    def test_dbus_service_unknown_wrongbus_notrunning(self):
+    def test_dbus_service_unknown_wrongbus_notrunning(self) -> None:
         """DBus.Error.ServiceUnknown with a valid name on a different bus
         (not running)"""
         subprocess.call(["killall", "gvfsd-metadata"])
@@ -139,7 +140,7 @@ func(42)
         )
         self.assertIn("gvfsd-metadata is not running", pr["DbusErrorAnalysis"])
 
-    def test_dbus_service_unknown_wrongbus_running(self):
+    def test_dbus_service_unknown_wrongbus_running(self) -> None:
         """DBus.Error.ServiceUnknown with a valid name on a different bus
         (running)"""
         self._test_crash(
@@ -166,7 +167,7 @@ func(42)
         )
         self.assertIn("gvfsd-metadata is running", pr["DbusErrorAnalysis"])
 
-    def test_dbus_service_timeout_running(self):
+    def test_dbus_service_timeout_running(self) -> None:
         """DBus.Error.NoReply with a running service"""
         # ensure the service is running
         metadata_obj = dbus.SessionBus().get_object(

--- a/tests/system/test_signal_crashes.py
+++ b/tests/system/test_signal_crashes.py
@@ -147,7 +147,7 @@ class T(unittest.TestCase):
             r.load(f)
         totalmb = int(r["MemFree"].split()[0]) + int(r["Cached"].split()[0])
         totalmb = int(totalmb / 1024)
-        r = None
+        del r
 
         test_proc = self.create_test_process()
         try:
@@ -186,7 +186,7 @@ class T(unittest.TestCase):
                     totalmb -= 1
                 err = app.communicate()[1]
             self.assertEqual(app.returncode, 0, err)
-            onemb = None
+            del onemb
         finally:
             test_proc.kill()
             test_proc.wait()

--- a/tests/system/test_signal_crashes.py
+++ b/tests/system/test_signal_crashes.py
@@ -29,6 +29,14 @@ class T(unittest.TestCase):
     # pylint: disable=protected-access
     TEST_EXECUTABLE = os.path.realpath("/bin/sleep")
     TEST_ARGS = ["86400"]
+    apport_path: pathlib.Path | str | None
+    all_reports: list[str]
+    ifpath: str
+    orig_environ: dict[str, str]
+    orig_core_dir: str
+    orig_cwd: str
+    orig_ignore_file: str
+    orig_report_dir: str
 
     @classmethod
     def setUpClass(cls):
@@ -62,7 +70,7 @@ class T(unittest.TestCase):
         cls.orig_report_dir = apport.fileutils.report_dir
 
     @classmethod
-    def tearDownClass(cls):
+    def tearDownClass(cls) -> None:
         os.environ.clear()
         os.environ.update(cls.orig_environ)
         apport.fileutils.core_dir = cls.orig_core_dir
@@ -70,7 +78,7 @@ class T(unittest.TestCase):
         apport.fileutils.report_dir = cls.orig_report_dir
         os.chdir(cls.orig_cwd)
 
-    def setUp(self):
+    def setUp(self) -> None:
         if self.apport_path is None:
             self.skipTest(
                 "kernel crash dump helper is not active; please enable"
@@ -119,7 +127,7 @@ class T(unittest.TestCase):
 
         self.running_test_executables = pids_of(self.TEST_EXECUTABLE)
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         shutil.rmtree(self.report_dir)
         shutil.rmtree(self.workdir)
 
@@ -138,8 +146,9 @@ class T(unittest.TestCase):
             apport.fileutils.delete_report(r)
         self.assertEqual(unexpected_reports, [])
 
-    def test_limit_size(self):
+    def test_limit_size(self) -> None:
         """Core dumps are capped on available memory size."""
+        assert self.apport_path is not None
         # determine how much data we have to pump into apport in order to make
         # sure that it will refuse the core dump
         r = apport.Report()
@@ -216,7 +225,7 @@ class T(unittest.TestCase):
     )
     @skip_if_command_is_missing("systemd-run")
     @unittest.skipIf(os.geteuid() != 0, "this test needs to be run as root")
-    def test_crash_system_slice(self):
+    def test_crash_system_slice(self) -> None:
         """Report generation for a protected process running in the system
         slice"""
         apport.fileutils.report_dir = self.orig_report_dir
@@ -290,7 +299,8 @@ class T(unittest.TestCase):
         time.sleep(0.3)  # needs some more setup time
         return process
 
-    def wait_for_apport_to_finish(self, timeout_sec=10.0):
+    def wait_for_apport_to_finish(self, timeout_sec: float = 10.0) -> None:
+        assert self.apport_path is not None
         self.wait_for_no_instance_running(self.apport_path, timeout_sec)
 
     def wait_for_no_instance_running(

--- a/tests/system/test_signal_crashes.py
+++ b/tests/system/test_signal_crashes.py
@@ -166,6 +166,7 @@ class T(unittest.TestCase):
                 stdin=subprocess.PIPE,
                 stderr=subprocess.PIPE,
             ) as app:
+                assert app.stdin is not None
                 # pipe an entire total memory size worth of spaces into it,
                 # which must be bigger than the 'usable' memory size. apport
                 # should digest that and the report should not have a core

--- a/tests/system/test_ui_gtk.py
+++ b/tests/system/test_ui_gtk.py
@@ -55,6 +55,8 @@ else:
 class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
     # pylint: disable=missing-class-docstring,missing-function-docstring
     POLLING_INTERVAL_MS = 10
+    distro: str
+    orig_environ: dict[str, str]
 
     @classmethod
     def setUpClass(cls):
@@ -66,11 +68,11 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
         cls.distro = r["DistroRelease"].split()[0]
 
     @classmethod
-    def tearDownClass(cls):
+    def tearDownClass(cls) -> None:
         os.environ.clear()
         os.environ.update(cls.orig_environ)
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.report_dir = tempfile.mkdtemp()
         apport.fileutils.report_dir = self.report_dir
         os.environ["APPORT_REPORT_DIR"] = self.report_dir
@@ -100,22 +102,22 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
         apport.report.GENERAL_HOOK_DIR = self.hook_dir
         apport.report.PACKAGE_HOOK_DIR = self.hook_dir
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         shutil.rmtree(self.report_dir)
         shutil.rmtree(self.hook_dir)
 
-    def test_close_button(self):
+    def test_close_button(self) -> None:
         """Clicking the close button on the window does not report the
         crash."""
 
-        def c():
+        def c() -> None:
             self.app.w("dialog_crash_new").destroy()
 
         GLib.idle_add(c)
         result = self.app.ui_present_report_details(True)
         self.assertFalse(result.report)
 
-    def test_kernel_crash_layout(self):
+    def test_kernel_crash_layout(self) -> None:
         """Display crash dialog for kernel crash.
 
         +-----------------------------------------------------------------+
@@ -146,7 +148,7 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
         self.assertFalse(self.app.w("subtitle_label").get_property("visible"))
         self.assertFalse(self.app.w("ignore_future_problems").get_property("visible"))
 
-    def test_package_crash_layout(self):
+    def test_package_crash_layout(self) -> None:
         """Display crash dialog for a failed package installation.
 
         +-----------------------------------------------------------------+
@@ -181,7 +183,7 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
             self.app.w("subtitle_label").get_text(), _("Package: apport 1.2.3~0ubuntu1")
         )
 
-    def test_regular_crash_thread_layout(self):
+    def test_regular_crash_thread_layout(self) -> None:
         """A thread of execution has failed, but the application persists.
 
         +-----------------------------------------------------------------+
@@ -202,7 +204,7 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
         self.assertTrue(self.app.w("dont_send_button").get_property("visible"))
         self.assertEqual(self.app.w("continue_button").get_label(), _("Send"))
 
-    def test_regular_crash_layout(self):
+    def test_regular_crash_layout(self) -> None:
         """Display crash dialog for an application crash.
 
         +-----------------------------------------------------------------+
@@ -255,7 +257,7 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
             .endswith("of this program version")
         )
 
-    def test_regular_crash_layout_restart(self):
+    def test_regular_crash_layout_restart(self) -> None:
         """Display crash dialog for an application crash offering a restart.
 
         +-----------------------------------------------------------------+
@@ -313,7 +315,7 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
         self.assertTrue(self.app.w("relaunch_app").get_property("visible"))
         self.assertTrue(self.app.w("relaunch_app").get_active())
 
-    def test_regular_crash_layout_norestart(self):
+    def test_regular_crash_layout_norestart(self) -> None:
         """Display crash dialog for an application crash offering no restart.
 
         +-----------------------------------------------------------------+
@@ -361,7 +363,7 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
         self.assertTrue(self.app.w("continue_button").get_property("visible"))
         self.assertEqual(self.app.w("continue_button").get_label(), _("Send"))
 
-    def test_hang_layout(self):
+    def test_hang_layout(self) -> None:
         """Display crash dialog for a hanging process.
 
         +-----------------------------------------------------------------+
@@ -416,7 +418,7 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
         self.assertTrue(self.app.w("subtitle_label").get_property("visible"))
         self.assertFalse(self.app.w("ignore_future_problems").get_property("visible"))
 
-    def test_system_crash_layout(self):
+    def test_system_crash_layout(self) -> None:
         """Display crash dialog for a system application crash.
 
         +---------------------------------------------------------------+
@@ -459,7 +461,7 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
             self.app.w("ignore_future_problems").get_label().endswith("of this type")
         )
 
-    def test_system_crash_from_console_layout(self):
+    def test_system_crash_from_console_layout(self) -> None:
         """Display crash dialog from console.
 
         +-------------------------------------------------------------------+
@@ -512,7 +514,7 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
         self.assertFalse(self.app.w("ignore_future_problems").get_property("visible"))
 
     @unittest.mock.patch.object(GTKUserInterface, "can_examine_locally", MagicMock())
-    def test_examine_button(self):
+    def test_examine_button(self) -> None:
         """Crash dialog showing or not showing "Examine locally".
 
         +---------------------------------------------------------------------+
@@ -538,7 +540,7 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
         self.assertTrue(self.app.w("examine").get_property("visible"))
         self.assertTrue(result.examine)
 
-    def test_apport_bug_package_layout(self):
+    def test_apport_bug_package_layout(self) -> None:
         """Display report detail dialog.
 
         +-------------------------------------------------------------------+
@@ -573,7 +575,7 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
         self.assertTrue(self.app.w("details_scrolledwindow").get_property("visible"))
         self.assertTrue(self.app.w("dialog_crash_new").get_resizable())
 
-    def test_apport_bug_package_layout_load_file(self):
+    def test_apport_bug_package_layout_load_file(self) -> None:
         """Bug layout from a loaded report."""
         self.app.report_file = "/tmp/foo.apport"
         self.app.report = apport.report.Report("Bug")
@@ -600,7 +602,7 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
         self.assertTrue(self.app.w("details_scrolledwindow").get_property("visible"))
         self.assertTrue(self.app.w("dialog_crash_new").get_resizable())
 
-    def test_recoverable_crash_layout(self):
+    def test_recoverable_crash_layout(self) -> None:
         """Display crash dialog for a recoverable crash.
 
         +-----------------------------------------------------------------+
@@ -645,7 +647,7 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
         self.assertTrue(self.app.w("continue_button").get_property("visible"))
         self.assertEqual(self.app.w("continue_button").get_label(), _("Send"))
 
-    def test_administrator_disabled_reporting(self):
+    def test_administrator_disabled_reporting(self) -> None:
         GLib.idle_add(Gtk.main_quit)
         self.app.ui_present_report_details(False)
         self.assertFalse(
@@ -666,10 +668,10 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
     @unittest.mock.patch(
         "apport.fileutils.allowed_to_report", MagicMock(return_value=True)
     )
-    def test_crash_nodetails(self):
+    def test_crash_nodetails(self) -> None:
         """Crash report without showing details"""
 
-        def cont():
+        def cont() -> bool:
             if Gtk.events_pending():
                 return True  # pragma: no cover
             if not self.app.w("continue_button").get_visible():
@@ -715,10 +717,10 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
     @unittest.mock.patch(
         "apport.fileutils.allowed_to_report", MagicMock(return_value=True)
     )
-    def test_crash_details(self):
+    def test_crash_details(self) -> None:
         """Crash report with showing details"""
 
-        def show_details():
+        def show_details() -> bool:
             if Gtk.events_pending():
                 return True  # pragma: no cover
             if not self.app.w("show_details").get_visible():
@@ -727,7 +729,7 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
             GLib.timeout_add(self.POLLING_INTERVAL_MS, cont)
             return False
 
-        def cont():
+        def cont() -> bool:
             if Gtk.events_pending():
                 return True  # pragma: no cover
             # wait until data collection is done and tree filled
@@ -781,7 +783,7 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
         self.error_title = None
         self.error_text = None
 
-        def show_details():
+        def show_details() -> bool:
             if Gtk.events_pending():
                 return True  # pragma: no cover
             if not self.app.w("show_details").get_visible():
@@ -790,7 +792,7 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
             GLib.timeout_add(self.POLLING_INTERVAL_MS, cont)
             return False
 
-        def cont():
+        def cont() -> bool:
             # wait until data collection is done and tree filled
             if Gtk.events_pending():
                 return True  # pragma: no cover
@@ -802,7 +804,7 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
             GLib.timeout_add(self.POLLING_INTERVAL_MS, ack_error)
             return False
 
-        def ack_error():
+        def ack_error() -> bool:
             # wait until error dialog gets visible
             if Gtk.events_pending():
                 return True  # pragma: no cover
@@ -842,10 +844,10 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
     @unittest.mock.patch(
         "apport.fileutils.allowed_to_report", MagicMock(return_value=True)
     )
-    def test_crash_noaccept(self):
+    def test_crash_noaccept(self) -> None:
         """Crash report with non-accepting crash DB"""
 
-        def cont():
+        def cont() -> bool:
             if Gtk.events_pending():
                 return True  # pragma: no cover
             if not self.app.w("continue_button").get_visible():
@@ -879,10 +881,10 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
     @unittest.mock.patch(
         "apport.fileutils.allowed_to_report", MagicMock(return_value=True)
     )
-    def test_kerneloops_nodetails(self):
+    def test_kerneloops_nodetails(self) -> None:
         """Kernel oops report without showing details"""
 
-        def cont():
+        def cont() -> bool:
             if Gtk.events_pending():
                 return True  # pragma: no cover
             if not self.app.w("continue_button").get_visible():
@@ -916,10 +918,10 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
         # URL was opened
         self.assertEqual(self.app.open_url.call_count, 1)
 
-    def test_bug_report_installed_package(self):
+    def test_bug_report_installed_package(self) -> None:
         """Bug report for installed package"""
 
-        def c():
+        def c() -> bool:
             if Gtk.events_pending():
                 return True  # pragma: no cover
             dont_send_button = self.app.w("dont_send_button")
@@ -938,10 +940,10 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
         self.assertTrue(self.app.report["Package"].startswith("bash "))
         self.assertNotEqual(self.app.report["Dependencies"], "")
 
-    def test_bug_report_uninstalled_package(self):
+    def test_bug_report_uninstalled_package(self) -> None:
         """Bug report for uninstalled package"""
 
-        def c():
+        def c() -> bool:
             if Gtk.events_pending():
                 return True  # pragma: no cover
             dont_send_button = self.app.w("dont_send_button")
@@ -963,11 +965,11 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
         self.assertEqual(self.app.report["Package"], f"{pkg} (not installed)")
 
     @unittest.mock.patch.object(GTKUserInterface, "open_url", MagicMock())
-    def test_update_report(self):
+    def test_update_report(self) -> None:
         """Updating an existing report."""
         self.app.report_file = None
 
-        def cont():
+        def cont() -> bool:
             if Gtk.events_pending():
                 return True  # pragma: no cover
             if self.app.tree_model.get_iter_first() is None:
@@ -997,12 +999,12 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
         self.assertEqual(self.app.open_url.call_count, 0)
 
     @unittest.mock.patch.object(GTKUserInterface, "open_url", MagicMock())
-    def test_update_report_different_binary_source(self):
+    def test_update_report_different_binary_source(self) -> None:
         """Updating an existing report on a source package which does not have
         a binary of the same name"""
         self.app.report_file = None
 
-        def cont():
+        def cont() -> bool:
             if Gtk.events_pending():
                 return True  # pragma: no cover
             if self.app.tree_model.get_iter_first() is None:
@@ -1048,7 +1050,7 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
         self.assertEqual(self.app.open_url.call_count, 0)
 
     @unittest.mock.patch.object(GTKUserInterface, "get_desktop_entry", MagicMock())
-    def test_missing_icon(self):
+    def test_missing_icon(self) -> None:
         # LP: 937354
         self.app.report["ProblemType"] = "Crash"
         self.app.report["Package"] = "apport 1.2.3~0ubuntu1"
@@ -1059,10 +1061,10 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
         GLib.idle_add(Gtk.main_quit)
         self.app.ui_present_report_details(True)
 
-    def test_resizing(self):
+    def test_resizing(self) -> None:
         """Problem report window resizability and sizing."""
 
-        def show_details(data):
+        def show_details(data: dict[str, dict[int, int]]) -> bool:
             if not self.app.w("show_details").get_visible():
                 return True  # pragma: no cover
 
@@ -1072,7 +1074,7 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
             GLib.timeout_add(200, hide_details, data)
             return False
 
-        def hide_details(data):
+        def hide_details(data: dict[str, dict[int, int]]) -> bool:
             # wait until data collection is done and tree filled
             if self.app.tree_model.get_iter_first() is None:
                 return True  # pragma: no cover
@@ -1083,7 +1085,7 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
             GLib.timeout_add(200, details_hidden, data)
             return False
 
-        def details_hidden(data):
+        def details_hidden(data: dict[str, dict[int, int]]) -> bool:
             # wait until data collection is done and tree filled
             if self.app.w("details_scrolledwindow").get_visible():
                 return True  # pragma: no cover
@@ -1093,7 +1095,7 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
             Gtk.main_quit()
             return False
 
-        data = {}
+        data: dict[str, dict[int, int]] = {}
         GLib.timeout_add(200, show_details, data)
         self.app.run_crash(self.app.report_file)
 
@@ -1108,10 +1110,10 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
         self.assertTrue(data["detail_resizable"])
         self.assertFalse(data["hidden_resizable"])
 
-    def test_dialog_nonascii(self):
+    def test_dialog_nonascii(self) -> None:
         """Non-ASCII title/text in dialogs"""
 
-        def close(response):
+        def close(response: int) -> bool:
             if Gtk.events_pending():
                 return True  # pragma: no cover
             if not self.app.md:
@@ -1131,7 +1133,7 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
             "title", b"http://example.com \xe2\x99\xaa".decode("UTF-8")
         )
 
-    def test_immediate_close(self):
+    def test_immediate_close(self) -> None:
         """Close details window immediately."""
         # this reproduces https://launchpad.net/bugs/938090
         self.app.w("dialog_crash_new").destroy()
@@ -1141,10 +1143,10 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
     @unittest.mock.patch.object(
         GTKUserInterface, "ui_start_upload_progress", MagicMock()
     )
-    def test_close_during_collect(self):
+    def test_close_during_collect(self) -> None:
         """Close details window during information collection"""
 
-        def show_details():
+        def show_details() -> bool:
             if Gtk.events_pending():
                 return True  # pragma: no cover
             if not self.app.w("show_details").get_visible():
@@ -1153,7 +1155,7 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
             GLib.timeout_add(self.POLLING_INTERVAL_MS, close)
             return False
 
-        def close():
+        def close() -> bool:
             if Gtk.events_pending():
                 return True  # pragma: no cover
             self.app.w("dialog_crash_new").destroy()
@@ -1164,7 +1166,7 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
 
         self.assertEqual(self.app.ui_start_upload_progress.call_count, 0)
 
-    def test_text_to_markup(self):
+    def test_text_to_markup(self) -> None:
         """Test text_to_markup() with different URLs."""
         urls = ["https://example.com", "https://example.com/file-bug-report"]
         for url in urls:
@@ -1174,7 +1176,7 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
                     f'Contact them via <a href="{url}">{url}</a> for help.',
                 )
 
-    def test_text_to_markup_url_followed_by_dot(self):
+    def test_text_to_markup_url_followed_by_dot(self) -> None:
         """Test text_to_markup() with https URL followed by a dot."""
         url = "https://example.com/file-bug-report"
         self.assertEqual(
@@ -1188,7 +1190,7 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
             self.skipTest("installed terminal application needed")
         self.app.ui_run_terminal("true")
 
-    def test_ui_update_view_destroyed(self):
+    def test_ui_update_view_destroyed(self) -> None:
         """Test ui_update_view if the dialog is already destroyed."""
         self.app.w("details_treeview").destroy()
         self.app.ui_update_view()

--- a/tests/system/test_ui_kde.py
+++ b/tests/system/test_ui_kde.py
@@ -61,6 +61,9 @@ class T(unittest.TestCase):
         "The collected information is being sent to the bug tracking system. "
         "This might take a few minutes.",
     )
+    argv: list[str]
+    distro: str
+    orig_environ: dict[str, str]
 
     @classmethod
     def setUpClass(cls):
@@ -74,11 +77,11 @@ class T(unittest.TestCase):
         cls.distro = r["DistroRelease"]
 
     @classmethod
-    def tearDownClass(cls):
+    def tearDownClass(cls) -> None:
         os.environ.clear()
         os.environ.update(cls.orig_environ)
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.report_dir = tempfile.mkdtemp()
         apport.fileutils.report_dir = self.report_dir
         os.environ["APPORT_REPORT_DIR"] = self.report_dir
@@ -106,7 +109,7 @@ class T(unittest.TestCase):
         with open(self.ui.report_file, "wb") as f:
             self.ui.report.write(f)
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         if self.ui.dialog:
             QCoreApplication.processEvents()
             self.ui.dialog.done(0)
@@ -117,18 +120,18 @@ class T(unittest.TestCase):
         shutil.rmtree(self.report_dir)
         shutil.rmtree(self.hook_dir)
 
-    def test_close_button(self):
+    def test_close_button(self) -> None:
         """Clicking the close button on the window does not report the
         crash."""
 
-        def c():
+        def c() -> None:
             self.ui.dialog.reject()
 
         QTimer.singleShot(0, c)
         result = self.ui.ui_present_report_details(True)
         self.assertFalse(result.report)
 
-    def test_kernel_crash_layout(self):
+    def test_kernel_crash_layout(self) -> None:
         """Display crash dialog for kernel crash.
 
         +-----------------------------------------------------------------+
@@ -155,7 +158,7 @@ class T(unittest.TestCase):
         self.assertFalse(self.ui.dialog.closed_button.isVisible())
         self.assertFalse(self.ui.dialog.text.isVisible())
 
-    def test_package_crash_layout(self):
+    def test_package_crash_layout(self) -> None:
         """Display crash dialog for a failed package installation.
 
         +-----------------------------------------------------------------+
@@ -186,7 +189,7 @@ class T(unittest.TestCase):
             self.ui.dialog.text.text(), _("Package: apport 1.2.3~0ubuntu1")
         )
 
-    def test_regular_crash_thread_layout(self):
+    def test_regular_crash_thread_layout(self) -> None:
         """A thread of execution has failed, but the application persists."""
         self.ui.report["ProblemType"] = "Crash"
         self.ui.report["ProcStatus"] = "Name:\tsystemd\nPid:\t1"
@@ -195,7 +198,7 @@ class T(unittest.TestCase):
         self.assertFalse(self.ui.dialog.closed_button.isVisible())
         self.assertEqual(self.ui.dialog.continue_button.text(), _("Continue"))
 
-    def test_regular_crash_layout(self):
+    def test_regular_crash_layout(self) -> None:
         """Display crash dialog for an application crash.
 
         +-----------------------------------------------------------------+
@@ -246,7 +249,7 @@ class T(unittest.TestCase):
             )
         )
 
-    def test_regular_crash_layout_restart(self):
+    def test_regular_crash_layout_restart(self) -> None:
         """Display crash dialog for an application crash offering a restart.
 
         +-----------------------------------------------------------------+
@@ -299,7 +302,7 @@ class T(unittest.TestCase):
             )
         )
 
-    def test_regular_crash_layout_norestart(self):
+    def test_regular_crash_layout_norestart(self) -> None:
         """Display crash dialog for an application crash offering no restart.
 
         +-----------------------------------------------------------------+
@@ -343,7 +346,7 @@ class T(unittest.TestCase):
         self.assertEqual(self.ui.dialog.continue_button.text(), _("Continue"))
         self.assertFalse(self.ui.dialog.closed_button.isVisible())
 
-    def test_system_crash_layout(self):
+    def test_system_crash_layout(self) -> None:
         """Display crash dialog for a system application crash.
 
         +-----------------------------------------------------------------+
@@ -383,7 +386,7 @@ class T(unittest.TestCase):
             str(self.ui.dialog.ignore_future_problems.text()).endswith("of this type")
         )
 
-    def test_apport_bug_package_layout(self):
+    def test_apport_bug_package_layout(self) -> None:
         """Display report detail dialog.
 
         +-------------------------------------------------------------------+
@@ -414,7 +417,7 @@ class T(unittest.TestCase):
         self.assertTrue(self.ui.dialog.cancel_button.isVisible())
         self.assertTrue(self.ui.dialog.treeview.isVisible())
 
-    def test_recoverable_crash_layout(self):
+    def test_recoverable_crash_layout(self) -> None:
         """Display crash dialog for a recoverable crash.
 
         +-----------------------------------------------------------------+
@@ -458,7 +461,7 @@ class T(unittest.TestCase):
         self.assertEqual(self.ui.dialog.continue_button.text(), _("Continue"))
         self.assertFalse(self.ui.dialog.closed_button.isVisible())
 
-    def test_ui_question_choice_hide_dialog(self):
+    def test_ui_question_choice_hide_dialog(self) -> None:
         """Test hiding/closing a UI question choice dialog.
 
         +---------------------+
@@ -475,7 +478,7 @@ class T(unittest.TestCase):
             apport_kde.Dialog, "__init__", include_instance=True
         ) as dialog_mock:
 
-            def hide_dialog():
+            def hide_dialog() -> None:
                 if dialog_mock.call_count >= 1:
                     dialog = dialog_mock.call_args[0][0]
                     if dialog.isVisible():
@@ -495,10 +498,10 @@ class T(unittest.TestCase):
     @unittest.mock.patch(
         "apport.fileutils.allowed_to_report", MagicMock(return_value=True)
     )
-    def test_1_crash_nodetails(self):
+    def test_1_crash_nodetails(self) -> None:
         """Crash report without showing details"""
 
-        def cont():
+        def cont() -> None:
             if self.ui.dialog and self.ui.dialog.continue_button.isVisible():
                 self.ui.dialog.continue_button.click()
                 return
@@ -532,10 +535,10 @@ class T(unittest.TestCase):
     @unittest.mock.patch(
         "apport.fileutils.allowed_to_report", MagicMock(return_value=True)
     )
-    def test_1_crash_details(self):
+    def test_1_crash_details(self) -> None:
         """Crash report with showing details"""
 
-        def show_details():
+        def show_details() -> None:
             if self.ui.dialog and self.ui.dialog.show_details.isVisible():
                 self.ui.dialog.show_details.click()
                 QTimer.singleShot(1000, cont)
@@ -583,10 +586,10 @@ class T(unittest.TestCase):
     @unittest.mock.patch(
         "apport.fileutils.allowed_to_report", MagicMock(return_value=True)
     )
-    def test_1_crash_noaccept(self):
+    def test_1_crash_noaccept(self) -> None:
         """Crash report with non-accepting crash DB"""
 
-        def cont():
+        def cont() -> None:
             if self.ui.dialog and self.ui.dialog.continue_button.isVisible():
                 self.ui.dialog.continue_button.click()
                 return
@@ -612,12 +615,12 @@ class T(unittest.TestCase):
         self.assertTrue(r["Package"].startswith("bash "))
         self.assertIn("libc", r["Dependencies"])
 
-    def test_bug_report_installed_package(self):
+    def test_bug_report_installed_package(self) -> None:
         """Bug report for installed package."""
         self.ui.report_file = None
         self.ui.args.package = "bash"
 
-        def c():
+        def c() -> None:
             if self.ui.dialog and self.ui.dialog.cancel_button.isVisible():
                 self.ui.dialog.cancel_button.click()
                 return
@@ -632,14 +635,14 @@ class T(unittest.TestCase):
         self.assertTrue(self.ui.report["Package"].startswith("bash "))
         self.assertNotEqual(self.ui.report["Dependencies"], "")
 
-    def test_bug_report_uninstalled_package(self):
+    def test_bug_report_uninstalled_package(self) -> None:
         """Bug report for uninstalled package"""
         pkg = apport.packaging.get_uninstalled_package()
 
         self.ui.report_file = None
         self.ui.args.package = pkg
 
-        def c():
+        def c() -> None:
             if self.ui.dialog and self.ui.dialog.cancel_button.isVisible():
                 self.ui.dialog.cancel_button.click()
                 return
@@ -656,11 +659,11 @@ class T(unittest.TestCase):
         self.assertEqual(self.ui.report["Package"], f"{pkg} (not installed)")
 
     @unittest.mock.patch.object(MainUserInterface, "open_url", MagicMock())
-    def test_1_update_report(self):
+    def test_1_update_report(self) -> None:
         """Updating an existing report"""
         self.ui.report_file = None
 
-        def cont():
+        def cont() -> None:
             if self.ui.dialog and self.ui.dialog.continue_button.isVisible():
                 self.ui.dialog.continue_button.click()
                 return
@@ -689,12 +692,12 @@ class T(unittest.TestCase):
         self.assertEqual(self.ui.open_url.call_count, 0)
 
     @unittest.mock.patch.object(MainUserInterface, "open_url", MagicMock())
-    def test_1_update_report_different_binary_source(self):
+    def test_1_update_report_different_binary_source(self) -> None:
         """Updating an existing report on a source package which does not have
         a binary of the same name"""
         self.ui.report_file = None
 
-        def cont():
+        def cont() -> None:
             if self.ui.dialog and self.ui.dialog.continue_button.isVisible():
                 self.ui.dialog.continue_button.click()
                 return
@@ -738,7 +741,7 @@ class T(unittest.TestCase):
         # No URL in this mode
         self.assertEqual(self.ui.open_url.call_count, 0)
 
-    def test_administrator_disabled_reporting(self):
+    def test_administrator_disabled_reporting(self) -> None:
         QTimer.singleShot(0, QCoreApplication.quit)
         self.ui.ui_present_report_details(False)
         self.assertFalse(self.ui.dialog.send_error_report.isVisible())


### PR DESCRIPTION
Fix mypy:

* test: delete variables instead of assigning None
* test: assert that stdin and stderr are not None

Then add type hints to all unproblematic system tests.