### PR TITLE
test: put apport-retrace temp files into /var/tmp

### DIFF
--- a/tests/system/test_apport_retrace.py
+++ b/tests/system/test_apport_retrace.py
@@ -21,7 +21,7 @@ CODENAME_DISTRO_RELEASE_MAP = {"jammy": "Ubuntu 22.04"}
 @pytest.fixture(name="module_workdir", scope="module")
 def fixture_module_workdir() -> Iterator[pathlib.Path]:
     """Create a temporary work directory for all test case in this module."""
-    workdir = tempfile.mkdtemp()
+    workdir = tempfile.mkdtemp(prefix="apport_retrace_system_tests_", dir="/var/tmp")
     yield pathlib.Path(workdir)
     shutil.rmtree(workdir)
 


### PR DESCRIPTION
The apport-retrace system tests will write hundreds of megabytes to `module_workdir`. `/tmp` might be on tmpfs and run out of memory when `module_workdir` is placed there.

So put the `module_workdir` into `/var/tmp` to avoid placing those files into memory.

Bug-Ubuntu: https://launchpad.net/bugs/2069815