### PR TITLE
CI: only run the linters on a single configuration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,14 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        container:
-          - debian:testing-slim
-          - ubuntu:jammy
-          - ubuntu:noble
-          - ubuntu:oracular
     container:
-      image: ${{ matrix.container }}
+      image: ubuntu:oracular
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
@@ -33,19 +27,8 @@ jobs:
           black gir1.2-gtk-3.0 gir1.2-wnck-3.0 isort mypy pycodestyle
           pydocstyle pyflakes3 pylint python3 python3-apt python3-dbus
           python3-distutils-extra python3-gi python3-launchpadlib
-          python3-psutil python3-pytest python3-rpm python3-typeshed
-          python3-yaml python3-systemd
-      - name: Install python3-pyqt5 on non-jammy (to avoid false positives)
-        run: >
-          . /etc/os-release &&
-          if test "${VERSION_CODENAME-}" != jammy; then
-            apt-get install --no-install-recommends --yes python3-pyqt5;
-          fi
-      # python3-zstandard is not available on ubuntu:jammy
-      - name: Install optional dependencies
-        run: >
-          apt-get install --no-install-recommends --yes python3-zstandard
-          || true
+          python3-psutil python3-pyqt5 python3-pytest python3-rpm
+          python3-typeshed python3-yaml python3-systemd python3-zstandard
       - name: Run linter tests
         run: tests/run-linters
 


### PR DESCRIPTION
Having the same linters run on multiple configurations is IMHO a waste of resources, for gains that have been thus far theoretical, and with actual costs due to discrepancies in the analysis for the various versions.