### PR TITLE
packaging: add type hints and drop support for file parameter in bytes type

### DIFF
--- a/apport/fileutils.py
+++ b/apport/fileutils.py
@@ -158,7 +158,7 @@ def likely_packaged(file):
     )
 
 
-def find_file_package(file):
+def find_file_package(file: str) -> str | None:
     """Return the package that ships the given file.
 
     Return None if no package ships it.

--- a/apport/packaging.py
+++ b/apport/packaging.py
@@ -13,6 +13,7 @@ import platform
 import re
 import subprocess
 import sys
+from collections.abc import Iterable
 
 
 class PackageInfo:
@@ -30,7 +31,7 @@ class PackageInfo:
             "this method must be implemented by a concrete subclass"
         )
 
-    def get_available_version(self, package):
+    def get_available_version(self, package: str) -> str:
         """Return the latest available version of a package.
 
         Throw ValueError if package does not exist.
@@ -39,13 +40,13 @@ class PackageInfo:
             "this method must be implemented by a concrete subclass"
         )
 
-    def get_dependencies(self, package):
+    def get_dependencies(self, package: str) -> list[str]:
         """Return a list of packages a package depends on."""
         raise NotImplementedError(
             "this method must be implemented by a concrete subclass"
         )
 
-    def get_source(self, package):
+    def get_source(self, package: str) -> str:
         """Return the source package name for a package.
 
         Throw ValueError if package does not exist.
@@ -54,7 +55,7 @@ class PackageInfo:
             "this method must be implemented by a concrete subclass"
         )
 
-    def get_package_origin(self, package):
+    def get_package_origin(self, package: str) -> str | None:
         """Return package origin.
 
         Return the repository name from which a package was installed, or None
@@ -66,7 +67,7 @@ class PackageInfo:
             "this method must be implemented by a concrete subclass"
         )
 
-    def is_distro_package(self, package):
+    def is_distro_package(self, package: str) -> bool:
         """Check package origin.
 
         Return True if the package is a genuine distro package, or False if it
@@ -78,7 +79,7 @@ class PackageInfo:
             "this method must be implemented by a concrete subclass"
         )
 
-    def get_architecture(self, package):
+    def get_architecture(self, package: str) -> str:
         """Return the architecture of a package.
 
         This might differ on multiarch architectures (e. g. an i386 Firefox
@@ -97,7 +98,7 @@ class PackageInfo:
             "this method must be implemented by a concrete subclass"
         )
 
-    def get_modified_files(self, package):
+    def get_modified_files(self, package: str) -> list[str]:
         """Return list of all modified files of a package."""
         raise NotImplementedError(
             "this method must be implemented by a concrete subclass"
@@ -116,8 +117,13 @@ class PackageInfo:
         return {}
 
     def get_file_package(
-        self, file, uninstalled=False, map_cachedir=None, release=None, arch=None
-    ):
+        self,
+        file: str,
+        uninstalled: bool = False,
+        map_cachedir: str | None = None,
+        release: str | None = None,
+        arch: str | None = None,
+    ) -> str | None:
         """Return the package a file belongs to.
 
         Return None if the file is not shipped by any package.
@@ -135,7 +141,7 @@ class PackageInfo:
         )
 
     @staticmethod
-    def get_system_architecture():
+    def get_system_architecture() -> str:
         """Return the architecture of the system.
 
         This should use the notation of the particular distribution.
@@ -144,7 +150,7 @@ class PackageInfo:
             "this method must be implemented by a concrete subclass"
         )
 
-    def get_library_paths(self):
+    def get_library_paths(self) -> str:
         """Return a list of default library search paths.
 
         The entries should be separated with a colon ':', like for
@@ -154,7 +160,7 @@ class PackageInfo:
         # simple default implementation, pylint: disable=no-self-use
         return "/lib:/usr/lib"
 
-    def set_mirror(self, url):
+    def set_mirror(self, url: str) -> None:
         """Explicitly set a distribution mirror URL.
 
         This might be called for operations that need to fetch distribution
@@ -188,7 +194,7 @@ class PackageInfo:
             "this method must be implemented by a concrete subclass"
         )
 
-    def compare_versions(self, ver1, ver2):
+    def compare_versions(self, ver1: str, ver2: str) -> int:
         """Compare two package versions.
 
         Return -1 for ver < ver2, 0 for ver1 == ver2, and 1 for ver1 > ver2.
@@ -197,7 +203,7 @@ class PackageInfo:
             "this method must be implemented by a concrete subclass"
         )
 
-    def enabled(self):
+    def enabled(self) -> bool:
         """Return whether Apport should generate crash reports.
 
         Signal crashes are controlled by /proc/sys/kernel/core_pattern, but
@@ -217,7 +223,7 @@ class PackageInfo:
 
         return re.search(r"^\s*enabled\s*=\s*0\s*$", conf, re.M) is None
 
-    def get_kernel_package(self):
+    def get_kernel_package(self) -> str:
         """Return the actual Linux kernel package name.
 
         This is used when the user reports a bug against the "linux" package.
@@ -226,20 +232,21 @@ class PackageInfo:
             "this method must be implemented by a concrete subclass"
         )
 
+    # pylint: disable-next=too-many-arguments
     def install_packages(
         self,
-        rootdir,
-        configdir,
-        release,
-        packages,
-        verbose=False,
-        cache_dir=None,
-        permanent_rootdir=False,
-        architecture=None,
-        origins=None,
-        install_dbg=True,
-        install_deps=False,
-    ):  # pylint: disable=too-many-arguments
+        rootdir: str,
+        configdir: str | None,
+        release: str,
+        packages: list[tuple[str, str | None]],
+        verbose: bool = False,
+        cache_dir: str | None = None,
+        permanent_rootdir: bool = False,
+        architecture: str | None = None,
+        origins: Iterable[str] | None = None,
+        install_dbg: bool = True,
+        install_deps: bool = False,
+    ) -> str:
         """Install packages into a sandbox (for apport-retrace).
 
         In order to work without any special permissions and without touching
@@ -291,7 +298,7 @@ class PackageInfo:
             "this method must be implemented by a concrete subclass"
         )
 
-    def is_native_origin_package(self, package):
+    def is_native_origin_package(self, package: str) -> bool:
         """Check if a package is one which has been allow listed.
 
         Return True for a package which came from an origin which is listed in
@@ -324,13 +331,13 @@ class PackageInfo:
     _os_version = None
 
     @staticmethod
-    def _sanitize_operating_system_name(name):
+    def _sanitize_operating_system_name(name: str) -> str:
         # Strip GNU/Linux from e.g. "Debian GNU/Linux"
         if name.endswith(" GNU/Linux"):
             name = name.rsplit(maxsplit=1)[0]
         return name
 
-    def get_os_version(self):
+    def get_os_version(self) -> tuple[str, str]:
         """Return (osname, osversion) tuple.
 
         This is read from /etc/os-release, or if that doesn't exist,

--- a/apport/packaging.py
+++ b/apport/packaging.py
@@ -302,8 +302,10 @@ class PackageInfo:
         # pylint: disable=no-self-use,unused-argument
         return False
 
-    def get_uninstalled_package(self):
+    def get_uninstalled_package(self) -> str:
         """Return a valid package name which is not installed.
+
+        Raises a ValueError in case no uninstalled package was found.
 
         This is only used in the test suite. The default implementation should
         work, but might be slow for your backend, so you might want to
@@ -317,7 +319,7 @@ class PackageInfo:
                 continue
             except ValueError:
                 return package
-        return None
+        raise ValueError
 
     _os_version = None
 

--- a/apport/packaging_impl/apt_dpkg.py
+++ b/apport/packaging_impl/apt_dpkg.py
@@ -1853,19 +1853,18 @@ class __AptDpkgPackageInfo(PackageInfo):
                     continue
                 origin_path = self._find_source_file_from_origin(origin, src_list_d)
                 extension = ".sources"
-                if origin_path:
-                    if origin_path.endswith(".list"):
-                        extension = ".list"
-                        with open(origin_path, encoding="utf-8") as src:
-                            source_list_content = [SourceEntry(line) for line in src]
-                    else:
-                        source_list_content = _parse_deb822_sources(origin_path)
-                else:
+                if not origin_path:
                     source_list_content = self.create_ppa_source_from_origin(
                         origin, distro_name, release_codename
                     )
                     if not WITH_DEB822_SUPPORT:
                         extension = ".list"
+                elif origin_path.endswith(".list"):
+                    extension = ".list"
+                    with open(origin_path, encoding="utf-8") as src:
+                        source_list_content = [SourceEntry(line) for line in src]
+                else:
+                    source_list_content = _parse_deb822_sources(origin_path)
                 if source_list_content:
                     with open(
                         os.path.join(

--- a/apport/packaging_impl/apt_dpkg.py
+++ b/apport/packaging_impl/apt_dpkg.py
@@ -1427,27 +1427,21 @@ class __AptDpkgPackageInfo(PackageInfo):
         raise ValueError("package does not exist")
 
     @staticmethod
-    def _check_files_md5(sumfile):
+    def _check_files_md5(sumfile: bytes) -> list[str]:
         """Call md5sum.
 
         This is separate from get_modified_files so that it is automatically
         testable.
         """
-        if os.path.exists(sumfile):
-            args = [sumfile]
-            stdin = None
-        else:
-            assert isinstance(sumfile, bytes), "md5sum list value must be a byte array"
-            args = []
-            stdin = sumfile
+        env: dict[str, str] = {}
         md5sum = subprocess.run(
-            ["/usr/bin/md5sum", "-c"] + args,
+            ["/usr/bin/md5sum", "-c"],
             check=False,
-            input=stdin,
+            input=sumfile,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             cwd="/",
-            env={},
+            env=env,
         )
 
         # if md5sum succeeded, don't bother parsing the output

--- a/apport/packaging_impl/apt_dpkg.py
+++ b/apport/packaging_impl/apt_dpkg.py
@@ -957,10 +957,10 @@ class __AptDpkgPackageInfo(PackageInfo):
         apt.apt_pkg.config.set("Acquire::http::Proxy::api.launchpad.net", "DIRECT")
         apt.apt_pkg.config.set("Acquire::http::Proxy::launchpad.net", "DIRECT")
 
-        if verbose:
-            fetchProgress = apt.progress.text.AcquireProgress()
-        else:
+        if not verbose:
             fetchProgress = apt.progress.base.AcquireProgress()
+        else:
+            fetchProgress = apt.progress.text.AcquireProgress()
         if not tmp_aptroot:
             apt_cache = self._sandbox_cache(
                 aptroot,

--- a/apport/packaging_impl/apt_dpkg.py
+++ b/apport/packaging_impl/apt_dpkg.py
@@ -857,7 +857,7 @@ class __AptDpkgPackageInfo(PackageInfo):
         self, package, aptroot, apt_cache, candidate, archivedir, pkg_versions
     ):
         # TODO: Split into smaller functions/methods
-        # pylint: disable=too-many-branches
+        # pylint: disable=too-many-branches,too-many-locals
         virtual_mapping = self._virtual_mapping(aptroot)
         # Remember all the virtual packages that this package provides,
         # so that if we encounter that virtual package as a
@@ -879,10 +879,10 @@ class __AptDpkgPackageInfo(PackageInfo):
             # but as policy states it is invalid to use that in
             # Replaces/Depends, we can safely choose the first value
             # here.
-            conflict = conflict[0]
-            if apt_cache.is_virtual_package(conflict[0]):
+            conflict_pkg, conflict_ver, conflict_comptype = conflict[0]
+            if apt_cache.is_virtual_package(conflict_pkg):
                 try:
-                    providers = virtual_mapping[conflict[0]]
+                    providers = virtual_mapping[conflict_pkg]
                 except KeyError:
                     # We may not have seen the virtual package that
                     # this conflicts with, so we can assume it's not
@@ -898,7 +898,7 @@ class __AptDpkgPackageInfo(PackageInfo):
                     debs = os.path.join(archivedir, f"{p}_*.deb")
                     for path in glob.glob(debs):
                         ver = self._deb_version(path)
-                        if apt.apt_pkg.check_dep(ver, conflict[2], conflict[1]):
+                        if apt.apt_pkg.check_dep(ver, conflict_comptype, conflict_ver):
                             os.unlink(path)
                     try:
                         del pkg_versions[p]
@@ -906,13 +906,13 @@ class __AptDpkgPackageInfo(PackageInfo):
                         pass
                 del providers
             else:
-                debs = os.path.join(archivedir, f"{conflict[0]}_*.deb")
+                debs = os.path.join(archivedir, f"{conflict_pkg}_*.deb")
                 for path in glob.glob(debs):
                     ver = self._deb_version(path)
-                    if apt.apt_pkg.check_dep(ver, conflict[2], conflict[1]):
+                    if apt.apt_pkg.check_dep(ver, conflict_comptype, conflict_ver):
                         os.unlink(path)
                         try:
-                            del pkg_versions[conflict[0]]
+                            del pkg_versions[conflict_pkg]
                         except KeyError:
                             pass
 

--- a/apport/packaging_impl/apt_dpkg.py
+++ b/apport/packaging_impl/apt_dpkg.py
@@ -1667,8 +1667,6 @@ class __AptDpkgPackageInfo(PackageInfo):
             # the update of the mapping only needs to be done once
             self._contents_update = False
 
-        if isinstance(file, bytes):
-            file = file.decode()
         if file[0] != "/":
             file = f"/{file}"
         files = [file[1:].encode()]

--- a/apport/packaging_impl/rpm.py
+++ b/apport/packaging_impl/rpm.py
@@ -43,9 +43,9 @@ class RPMPackageInfo:
     # e.g. official_keylist = ('30c9ecf8','4f2a6fd2','897da07a','1ac70ce6')
     official_keylist = ()
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.ts = rpm.TransactionSet()  # connect to the rpmdb
-        self._mirror = None
+        self._mirror: str | None = None
 
     def get_version(self, package):
         """Return the installed version of a package."""
@@ -59,14 +59,14 @@ class RPMPackageInfo:
             return None
         return f"{hdr['e']}:{hdr['v']}-{hdr['r']}"
 
-    def get_available_version(self, package):
+    def get_available_version(self, package: str) -> str:
         """Return the latest available version of a package."""
         # used in report.py, which is used by the frontends
         raise NotImplementedError(
             "method must be implemented by distro-specific RPMPackageInfo subclass"
         )
 
-    def get_dependencies(self, package):
+    def get_dependencies(self, package: str) -> list[str]:
         """Return a list of packages a package depends on."""
         hdr = self._get_header(package)
         # parse this package's Requires
@@ -84,12 +84,12 @@ class RPMPackageInfo:
                     reqs.append(rh_envra)
         return reqs
 
-    def get_source(self, package):
+    def get_source(self, package: str) -> str:
         """Return the source package name for a package."""
         hdr = self._get_header(package)
         return hdr["sourcerpm"]
 
-    def get_architecture(self, package):
+    def get_architecture(self, package: str) -> str:
         """Return the architecture of a package.
 
         This might differ on multiarch architectures (e. g.  an i386 Firefox
@@ -109,7 +109,7 @@ class RPMPackageInfo:
                 files.append(f)
         return files
 
-    def get_modified_files(self, package):
+    def get_modified_files(self, package: str) -> list[str]:
         """Return list of all modified files of a package."""
         hdr = self._get_header(package)
 
@@ -139,8 +139,13 @@ class RPMPackageInfo:
         return modified
 
     def get_file_package(
-        self, file, uninstalled=False, map_cachedir=None, release=None, arch=None
-    ):
+        self,
+        file: str,
+        uninstalled: bool = False,
+        map_cachedir: str | None = None,
+        release: str | None = None,
+        arch: str | None = None,
+    ) -> str | None:
         """Return the package a file belongs to.
 
         Return None if the file is not shipped by any package.
@@ -160,7 +165,7 @@ class RPMPackageInfo:
         )
 
     @staticmethod
-    def get_system_architecture():
+    def get_system_architecture() -> str:
         """Return the architecture of the system, in the notation used by the
         particular distribution."""
         rpmarch = subprocess.run(
@@ -172,7 +177,7 @@ class RPMPackageInfo:
         arch = rpmarch.stdout.strip()
         return arch
 
-    def is_distro_package(self, package):
+    def is_distro_package(self, package: str) -> bool:
         """Check if a package is a genuine distro package (True) or comes from
         a third-party source."""
         # This is a list of official keys, set by the concrete subclass
@@ -192,7 +197,7 @@ class RPMPackageInfo:
                 return True
         return False
 
-    def set_mirror(self, url):
+    def set_mirror(self, url: str) -> None:
         """Explicitly set a distribution mirror URL for operations that need to
         fetch distribution files/packages from the network.
 
@@ -224,7 +229,7 @@ class RPMPackageInfo:
             "method must be implemented by distro-specific RPMPackageInfo subclass"
         )
 
-    def compare_versions(self, ver1, ver2):
+    def compare_versions(self, ver1: str, ver2: str) -> int:
         """Compare two package versions.
 
         Return -1 for ver < ver2, 0 for ver1 == ver2, and 1 for ver1 > ver2.

--- a/tests/integration/test_packaging.py
+++ b/tests/integration/test_packaging.py
@@ -14,7 +14,6 @@ class T(unittest.TestCase):
     def test_get_uninstalled_package(self) -> None:
         """get_uninstalled_package()"""
         p = apport.packaging.get_uninstalled_package()
-        self.assertIsNotNone(p)
         self.assertNotEqual(apport.packaging.get_available_version(p), "")
         self.assertRaises(ValueError, apport.packaging.get_version, p)
         self.assertTrue(apport.packaging.is_distro_package(p))

--- a/tests/integration/test_packaging_apt_dpkg.py
+++ b/tests/integration/test_packaging_apt_dpkg.py
@@ -45,18 +45,16 @@ class T(unittest.TestCase):
         try:
             f1 = os.path.join(td, "test 1.txt")
             f2 = os.path.join(td, "test:2.txt")
-            sumfile = os.path.join(td, "sums.txt")
             with open(f1, "w", encoding="utf-8") as fd:
                 fd.write("Some stuff")
             with open(f2, "w", encoding="utf-8") as fd:
                 fd.write("More stuff")
             # use one relative and one absolute path in checksums file
-            with open(sumfile, "wb") as fd:
-                fd.write(
-                    b"2e41290da2fa3f68bd3313174467e3b5  " + f1[1:].encode() + b"\n"
-                )
-                fd.write(b"f6423dfbc4faf022e58b4d3f5ff71a70  " + f2.encode() + b"\n")
-                fd.write(b"deadbeef000001111110000011110000  /bin/\xc3\xa4")
+            sumfile = (
+                b"2e41290da2fa3f68bd3313174467e3b5  " + f1[1:].encode() + b"\n"
+                b"f6423dfbc4faf022e58b4d3f5ff71a70  " + f2.encode() + b"\n"
+                b"deadbeef000001111110000011110000  /bin/\xc3\xa4"
+            )
             self.assertEqual(impl._check_files_md5(sumfile), [], "correct md5sums")
 
             with open(f1, "w", encoding="utf-8") as fd:
@@ -70,10 +68,6 @@ class T(unittest.TestCase):
             with open(f1, "w", encoding="utf-8") as fd:
                 fd.write("Some stuff")
             self.assertEqual(impl._check_files_md5(sumfile), [f2], "file 2 wrong")
-
-            # check using a direct md5 list as argument
-            with open(sumfile, "rb") as fd:
-                self.assertEqual(impl._check_files_md5(fd.read()), [f2], "file 2 wrong")
 
         finally:
             shutil.rmtree(td)

--- a/tests/system/test_packaging_apt_dpkg.py
+++ b/tests/system/test_packaging_apt_dpkg.py
@@ -356,7 +356,9 @@ def test_install_packages_system(
     orig_cwd = os.getcwd()
     try:
         os.chdir(workdir)
-        impl.install_packages("root", None, None, [("coreutils", None)], False, "cache")
+        impl.install_packages(
+            "root", None, release, [("coreutils", None)], False, "cache"
+        )
     finally:
         os.chdir(orig_cwd)
         assert os.path.exists(os.path.join(rootdir, "usr/bin/stat"))


### PR DESCRIPTION
Add type hints to most methods of `PackageInfo` and its subclasses.

The method `_search_contents` is only called by `get_file_package` and `get_file_package` requires the `file` parameter to be of type `str`. Otherwise the `uninstalled=False` case would fail.

So drop supporting `bytes` in `_search_contents`.