### PR TITLE
apt_dpkg: speed up Contents paths filtering with regular expression and fix parsing paths with spaces

### DIFF
--- a/apport/packaging_impl/apt_dpkg.py
+++ b/apport/packaging_impl/apt_dpkg.py
@@ -1576,13 +1576,13 @@ class __AptDpkgPackageInfo(PackageInfo):
         file2pkg: dict[bytes, bytes], contents_filename: str, dist: str
     ) -> None:
         with gzip.open(contents_filename, "rb") as contents:
-            line_num = 0
-            for line in contents:
-                line_num += 1
+            if dist in {"trusty", "xenial"}:
                 # the first 32 lines are descriptive only for these
                 # releases
-                if dist in {"trusty", "xenial"} and line_num < 33:
-                    continue
+                for _ in range(32):
+                    next(contents)
+
+            for line in contents:
                 path = line.split()[0]
                 if path.split(b"/")[0] == b"usr":
                     if path.split(b"/")[1] not in (

--- a/apport/packaging_impl/apt_dpkg.py
+++ b/apport/packaging_impl/apt_dpkg.py
@@ -1589,9 +1589,8 @@ class __AptDpkgPackageInfo(PackageInfo):
             for line in contents:
                 if path_exclude_pattern.match(line):
                     continue
-                parts = line.split()
-                path = parts[0]
-                package = parts[-1].split(b",")[0].split(b"/")[-1]
+                path, column2 = line.rsplit(maxsplit=1)
+                package = column2.split(b",")[0].split(b"/")[-1]
                 if path in file2pkg:
                     if package == file2pkg[path]:
                         continue

--- a/tests/integration/test_packaging_apt_dpkg.py
+++ b/tests/integration/test_packaging_apt_dpkg.py
@@ -185,7 +185,7 @@ class T(unittest.TestCase):
                     b"""\
 usr/bin/frobnicate                                      foo/frob
 usr/bin/frob                                            foo/frob-utils
-bo/gu/s                                                 na/mypackage
+usr/share/doc/frob-dev/copyright                        foo/frob-dev
 bin/true                                                admin/superutils
 """
                 )
@@ -228,14 +228,22 @@ bin/true                                                admin/superutils
             )
             cache_dir_files = sorted(os.listdir(cache_dir))
             self.assertEqual(len(cache_dir_files), 3)
-            self.assertIsNone(impl.get_file_package("/bo/gu/s", True, cache_dir))
+            self.assertIsNone(
+                impl.get_file_package(
+                    "usr/share/doc/frob-dev/copyright", True, cache_dir
+                )
+            )
 
             # valid cache, should not need to access the mirror
             impl.set_mirror("file:///foo/nonexisting")
             self.assertEqual(
                 impl.get_file_package("/bin/true", True, cache_dir), "superutils"
             )
-            self.assertIsNone(impl.get_file_package("/bo/gu/s", True, cache_dir))
+            self.assertIsNone(
+                impl.get_file_package(
+                    "usr/share/doc/frob-dev/copyright", True, cache_dir
+                )
+            )
             self.assertEqual(
                 impl.get_file_package("/lib/libnew.so.5", True, cache_dir), "libnew5"
             )

--- a/tests/unit/test_packaging_apt_dpkg.py
+++ b/tests/unit/test_packaging_apt_dpkg.py
@@ -276,3 +276,30 @@ var/lib/ieee-data/iab.txt				    net/ieee-data
             },
         )
         open_mock.assert_called_once_with("Contents-amd64", "rb")
+
+    def test_contents_parse_path_with_spaces(self) -> None:
+        """Test _update_given_file2pkg_mapping to parse Contents file correctly."""
+        # Test content taken from
+        # http://archive.ubuntu.com/ubuntu/dists/noble/Contents-amd64.gz
+        contents = (
+            "usr/lib/iannix/Tools/JavaScript Library.js\t\t    "
+            "universe/sound/iannix\n"
+            "usr/lib/python3/dist-packages/ilorest/extensions/BIOS COMMANDS"
+            "/__init__.py universe/python/ilorest\n"
+        )
+
+        file2pkg: dict[bytes, bytes] = {}
+        open_mock = unittest.mock.mock_open(read_data=contents.encode())
+        with unittest.mock.patch("gzip.open", open_mock):
+            # pylint: disable-next=protected-access
+            impl._update_given_file2pkg_mapping(file2pkg, "Contents-amd64", "noble")
+
+        self.assertEqual(
+            {k.decode(): v.decode() for k, v in file2pkg.items()},
+            {
+                "usr/lib/iannix/Tools/JavaScript Library.js": "iannix",
+                "usr/lib/python3/dist-packages/ilorest/extensions/BIOS COMMANDS"
+                "/__init__.py": "ilorest",
+            },
+        )
+        open_mock.assert_called_once_with("Contents-amd64", "rb")


### PR DESCRIPTION
In case no Contents cache exists, `apport-retrace` spends most execution time in `_update_given_file2pkg_mapping` and bytes splitting. Speed up Contents paths filtering with one regular expression. To prevent regressions add a test case that test all previous cases.

Result from parsing the four jammy Contents files on a Ryzen 7 5700G machine: It took around 60 seconds before and 41 seconds afterwards.

The regular expression filters only unwanted directories and is less strict than the previous solution. So they will include multi-arch paths that we missed before. The number of additional paths added to the database are neglectable:

* jammy: 7,861,981 -> 7,903,339 (0.48 %)
* noble: 4,201,611 -> 4,266,551 (1.55 %)