### PR TITLE
"Fix" the apport-retrace tests on s390x

### DIFF
--- a/apport/packaging.py
+++ b/apport/packaging.py
@@ -150,6 +150,15 @@ class PackageInfo:
             "this method must be implemented by a concrete subclass"
         )
 
+    @staticmethod
+    def get_native_multiarch_triplet() -> str:
+        """Return the GNU multiarch triplet for of the system architecture, if
+        applicable, raises NotImplementedError otherwise.
+        """
+        raise NotImplementedError(
+            "this method must be implemented by a concrete subclass if applicable"
+        )
+
     def get_library_paths(self) -> str:
         """Return a list of default library search paths.
 

--- a/apport/packaging_impl/apt_dpkg.py
+++ b/apport/packaging_impl/apt_dpkg.py
@@ -705,6 +705,18 @@ class __AptDpkgPackageInfo(PackageInfo):
         assert arch
         return arch
 
+    @staticmethod
+    @functools.cache
+    def get_native_multiarch_triplet() -> str:
+        """Return the multiarch triplet for the system architecture"""
+        dpkg = subprocess.run(
+            ["dpkg-architecture", "-qDEB_HOST_MULTIARCH"],
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+        )
+        return dpkg.stdout.strip()
+
     def get_library_paths(self) -> str:
         """Return a list of default library search paths.
 
@@ -712,14 +724,7 @@ class __AptDpkgPackageInfo(PackageInfo):
         $LD_LIBRARY_PATH. This needs to take any multiarch directories into
         account.
         """
-        dpkg = subprocess.run(
-            ["dpkg-architecture", "-qDEB_HOST_MULTIARCH"],
-            check=True,
-            stdout=subprocess.PIPE,
-        )
-        multiarch_triple = dpkg.stdout.decode().strip()
-
-        return f"/lib/{multiarch_triple}:/lib"
+        return f"/lib/{self.get_native_multiarch_triplet()}:/lib"
 
     def set_mirror(self, url: str) -> None:
         """Explicitly set a distribution mirror URL for operations that need to

--- a/apport/report.py
+++ b/apport/report.py
@@ -1887,7 +1887,7 @@ class Report(problem_report.ProblemReport):
         environ: dict[str, str] = {}
 
         if sandbox:
-            native_multiarch = "x86_64-linux-gnu"
+            native_multiarch = packaging.get_native_multiarch_triplet()
             # N.B. set solib-absolute-prefix is an alias for set sysroot
             command += [
                 "--ex",

--- a/tests/system/test_apport_retrace.py
+++ b/tests/system/test_apport_retrace.py
@@ -197,6 +197,10 @@ def _assert_cache_has_content(
 
 
 @pytest.mark.skipif(not has_internet(), reason="online test")
+@pytest.mark.skipif(
+    impl.get_system_architecture() == "s390x",
+    reason="GDB has issues with divide-by-zero on s390x (LP: #2075204)",
+)
 def test_retrace_system_sandbox(
     workdir: pathlib.Path, module_cachedir: pathlib.Path, divide_by_zero_crash: str
 ) -> None:


### PR DESCRIPTION
This contains a small fix as well as a workaround for the underlying issue (which is that GDB can't cope with divide-by-zero on s390x)