### PR TITLE
recent-syslog: read stdout after process completion

### DIFF
--- a/apport/hookutils.py
+++ b/apport/hookutils.py
@@ -565,11 +565,17 @@ def attach_root_command_outputs(report, command_map):
 
 def __filter_re_process(pattern, process):
     lines = ""
+    # Get stdout while waiting for process to complete
     while process.poll() is None:
         for line in process.stdout:
             line = line.decode("UTF-8", errors="replace")
             if pattern.search(line):
                 lines += line
+    # Ensure all stdout is read after process completion
+    for line in process.stdout:
+        line = line.decode("UTF-8", errors="replace")
+        if pattern.search(line):
+            lines += line
     process.stdout.close()
     process.wait()
     if process.returncode == 0:


### PR DESCRIPTION
The recent_syslog integration tests were failing autopkgtest due to getting an empty string for the syslog. This was caused by the syslog command finishing before the python code entered the poll loop in `__filter_re_process` and also not checking that the buffer was empty on completion (LP:[#2073935](https://pad.lv/2073935)).


Originally this bug was reported against s390x since it reproduced often there, but there's nothing architecture specific about the issue (other than the process scheduling it seems). For completeness, you can reproduce the output with the following code:

```python
from subprocess import Popen, PIPE
import time

with Popen(["echo", "content"], stdout=PIPE) as p:
    time.sleep(1)
    pre_complete_content = ""
    post_complete_content = ""
    while p.poll() is None:
        for line in p.stdout:
            pre_complete_content += line.decode("UTF-8")
    p.wait()
    for line in p.stdout:
        post_complete_content += line.decode("UTF-8")

print(f"{pre_complete_content=}")
print(f"{post_complete_content=}")
```
```
cpete@atlas:$ python3 test-fail.py
pre_complete_content=''
post_complete_content='content\n'
```