### PR TITLE
test: wait_for_gdb_sleeping_child_process

### DIFF
--- a/tests/integration/test_signal_crashes.py
+++ b/tests/integration/test_signal_crashes.py
@@ -1115,7 +1115,7 @@ class T(unittest.TestCase):
             raise
 
         try:
-            command_process = self.wait_for_gdb_child_process(
+            command_process = self.wait_for_gdb_sleeping_child_process(
                 gdb.pid, expected_command or command
             )
 
@@ -1287,7 +1287,9 @@ class T(unittest.TestCase):
     # False positive return statement for unittest.TestCase.fail
     # See https://github.com/pylint-dev/pylint/issues/4167
     # pylint: disable-next=inconsistent-return-statements
-    def wait_for_gdb_child_process(self, gdb_pid: int, command: str) -> psutil.Process:
+    def wait_for_gdb_sleeping_child_process(
+        self, gdb_pid: int, command: str
+    ) -> psutil.Process:
         """Wait until GDB execv()ed the child process."""
         gdb_process = psutil.Process(gdb_pid)
         timeout = 0.0
@@ -1312,8 +1314,8 @@ class T(unittest.TestCase):
         )
 
     @unittest.mock.patch("time.sleep")
-    def test_wait_for_gdb_child_process(self, sleep_mock: MagicMock) -> None:
-        """Test wait_for_gdb_child_process() helper method."""
+    def test_wait_for_gdb_sleeping_child_process(self, sleep_mock: MagicMock) -> None:
+        """Test wait_for_gdb_sleeping_child_process() helper method."""
         child = MagicMock(spec=psutil.Process)
         child.status.side_effect = ["tracing-stop", "running", "sleeping"]
         child.cmdline.side_effect = [
@@ -1328,7 +1330,7 @@ class T(unittest.TestCase):
                 [child],  # child ready
             ]
 
-            self.wait_for_gdb_child_process(123456789, self.TEST_EXECUTABLE)
+            self.wait_for_gdb_sleeping_child_process(123456789, self.TEST_EXECUTABLE)
 
         sleep_mock.assert_called_with(0.1)
         self.assertEqual(sleep_mock.call_count, 3)
@@ -1337,13 +1339,13 @@ class T(unittest.TestCase):
 
     @unittest.mock.patch("psutil.Process", spec=psutil.Process)
     @unittest.mock.patch("time.sleep")
-    def test_wait_for_gdb_child_process_timeout(
+    def test_wait_for_gdb_sleeping_child_process_timeout(
         self, sleep_mock: MagicMock, process_mock: MagicMock
     ) -> None:
-        """Test wait_for_gdb_child_process() helper runs into timeout."""
+        """Test wait_for_gdb_sleeping_child_process() helper runs into timeout."""
         process_mock.return_value.children.return_value = []
         with unittest.mock.patch.object(self, "fail") as fail_mock:
-            self.wait_for_gdb_child_process(123456789, self.TEST_EXECUTABLE)
+            self.wait_for_gdb_sleeping_child_process(123456789, self.TEST_EXECUTABLE)
         fail_mock.assert_called_once()
         sleep_mock.assert_called_with(0.1)
         self.assertEqual(sleep_mock.call_count, 51)


### PR DESCRIPTION
- `wait_for_gdb_child_process` is used exclusively with the sleep command. Rename to `wait_for_gdb_sleeping_child_process` to make the context of function clearer.

- Modify the wait_for_gdb_sleeping_child_process utility function to make sure to wait until the test process is actually sleeping. The expected behavior is that the process has already entered the "sleeping" state when returning from this function. Some callers use this function to generate a process and then examine the stack
trace at a certain state. However, there are steps between "tracing-stop" and "sleeping", such as "running", that may cause the stack trace from the inspected process to look slightly different when compared a stack trace from when the process once has entered the "sleeping" state. This can be seen on armhf in LP: [#2073933](https://bugs.launchpad.net/ubuntu/+source/apport/+bug/2073933).

  This commit also generally cleans up the test case and adjusts to catch the failing case from before.

