### PR TITLE
tests: fix flaky tests waiting for sleep command

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -187,8 +187,9 @@ jobs:
           ca-certificates chaos-marmosets dbus dbus-x11 dirmngr dpkg-dev gcc gdb
           gir1.2-gtk-3.0 gir1.2-wnck-3.0 git gnome-icon-theme gpg gvfs-daemons
           psmisc python3 python3-apt python3-dbus python3-gi
-          python3-launchpadlib python3-pyqt5 python3-pytest python3-pytest-cov
-          ubuntu-dbgsym-keyring ubuntu-keyring valgrind xterm xvfb
+          python3-launchpadlib python3-psutil python3-pyqt5 python3-pytest
+          python3-pytest-cov ubuntu-dbgsym-keyring ubuntu-keyring valgrind
+          xterm xvfb
       - uses: actions/checkout@v4
       - name: Start D-Bus daemon
         run: mkdir -p /run/dbus && dbus-daemon --system --fork
@@ -224,8 +225,8 @@ jobs:
           ca-certificates chaos-marmosets dbus dbus-x11 dirmngr dpkg-dev gcc gdb
           gir1.2-gtk-3.0 gir1.2-wnck-3.0 git gnome-icon-theme gpg gvfs-daemons
           pkg-config psmisc python3 python3-apt python3-dbus
-          python3-distutils-extra python3-gi python3-launchpadlib python3-pyqt5
-          python3-pytest python3-pytest-cov python3-setuptools
+          python3-distutils-extra python3-gi python3-launchpadlib python3-psutil
+          python3-pyqt5 python3-pytest python3-pytest-cov python3-setuptools
           ubuntu-dbgsym-keyring ubuntu-keyring valgrind xvfb
       - uses: actions/checkout@v4
       - name: Install

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -12,7 +12,7 @@ import time
 import unittest.mock
 import urllib.error
 import urllib.request
-from collections.abc import Callable, Generator, Iterator, Sequence
+from collections.abc import Callable, Generator, Iterator, Sequence, Set
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -157,3 +157,19 @@ def wait_for_sleeping_state(pid: int, timeout: float = 5.0) -> None:
         f"{pid=} did not enter 'sleeping' state after {timeout=} seconds."
         f" Got {last_state!r} instead."
     )
+
+
+def wait_for_process_to_appear(
+    process: str, already_running: Set[int], timeout: float = 5.0
+) -> int:
+    """Wait for process to appear and return its PID."""
+    waited = 0.0
+    while waited < timeout:
+        pids = pids_of(process) - already_running
+        if pids:
+            assert len(pids) == 1, f"Found more than one PID for {process!r}"
+            return pids.pop()
+        time.sleep(0.1)
+        timeout -= 0.1
+
+    raise TimeoutError(f"PID for {process!r} not found within {timeout=} seconds.")

--- a/tests/system/test_signal_crashes.py
+++ b/tests/system/test_signal_crashes.py
@@ -16,7 +16,13 @@ import time
 import unittest
 
 import apport.fileutils
-from tests.helper import get_init_system, pids_of, skip_if_command_is_missing
+from tests.helper import (
+    get_init_system,
+    pids_of,
+    skip_if_command_is_missing,
+    wait_for_process_to_appear,
+    wait_for_sleeping_state,
+)
 from tests.paths import (
     get_data_directory,
     is_local_source_directory,
@@ -247,9 +253,11 @@ class T(unittest.TestCase):
             + self.TEST_ARGS,
         )
         try:
-            pids = pids_of(self.TEST_EXECUTABLE) - self.running_test_executables
-            self.assertEqual(len(pids), 1)
-            os.kill(pids.pop(), signal.SIGSEGV)
+            sleep_pid = wait_for_process_to_appear(
+                self.TEST_EXECUTABLE, self.running_test_executables
+            )
+            wait_for_sleeping_state(sleep_pid)
+            os.kill(sleep_pid, signal.SIGSEGV)
 
             self.wait_for_no_instance_running(self.TEST_EXECUTABLE)
             self.wait_for_apport_to_finish()


### PR DESCRIPTION
- Introduce `wait_for_sleep_cmd` test utility function to wait for a sleep command process to enter the "sleeping" state.
- Make the `create_test_process` helper functions use  `wait_for_sleep_cmd` when invoked with no arguments (the default is test executable is the sleep command) to ensure the process has entered the "sleeping" state before returning.
- Manually call this utility in `test_crash_system_slice` since it calls sleep in a more roundabout fashion via `systemd-run`. This fixes LP: [#2076186](https://bugs.launchpad.net/ubuntu/+source/apport/+bug/2076186), where armhf autopkgtests were failing due to looking for the `sleep` process before it had fully entered the "sleeping" state.
- Add a dependency on `python3-psutil` in the github CI workflow. This will also require the addition of `python3-psutil` to the Test Depends for the `system-tests` test in the packaging.