### PR TITLE
test: put apport-retrace temp files into /var/tmp

### DIFF
--- a/tests/system/test_apport_retrace.py
+++ b/tests/system/test_apport_retrace.py
@@ -79,7 +79,7 @@ def fixture_divide_by_zero_crash(module_workdir: pathlib.Path) -> str:
 @pytest.fixture(name="workdir")
 def fixture_workdir() -> Iterator[pathlib.Path]:
     """Create a temporary work directory for the test case."""
-    workdir = tempfile.mkdtemp()
+    workdir = tempfile.mkdtemp(prefix="apport_retrace_system_test_", dir="/var/tmp")
     yield pathlib.Path(workdir)
     shutil.rmtree(workdir)
 


### PR DESCRIPTION
The apport-retrace system tests will write hundreds of megabytes to `workdir`. `/tmp` might be on tmpfs and run out of memory when `workdir` is placed there. Moving `module_workdir` to `/var/tmp` was not enough.

So put the `workdir` into `/var/tmp` to avoid placing those files into memory.

Bug-Ubuntu: https://launchpad.net/bugs/2069815