### PR TITLE
apt_dpkg: Map mirror to correct URL for the architecture

### DIFF
--- a/tests/system/test_apport_retrace.py
+++ b/tests/system/test_apport_retrace.py
@@ -84,14 +84,16 @@ def fixture_workdir() -> Iterator[pathlib.Path]:
     shutil.rmtree(workdir)
 
 
-def setup_ubuntu_sandbox_config(configdir: pathlib.Path, release: str) -> None:
+def setup_ubuntu_sandbox_config(
+    configdir: pathlib.Path, release: str, arch: str
+) -> None:
     """Set up sandbox configuration for retracing Ubuntu crashes."""
     config_release_dir = configdir / CODENAME_DISTRO_RELEASE_MAP[release]
     codename_file = config_release_dir / "codename"
     sources_dir = config_release_dir / "sources.list.d"
     sources_file = sources_dir / "ubuntu.sources"
     # pylint: disable-next=protected-access
-    uri = impl._get_mirror()
+    uri = impl._get_mirror(arch)
 
     sources_dir.mkdir(parents=True)
     codename_file.write_text(release)
@@ -101,6 +103,7 @@ def setup_ubuntu_sandbox_config(configdir: pathlib.Path, release: str) -> None:
             Types: deb deb-src
             URIs: {uri}
             Suites: {release}
+            Architertures: {arch}
             Components: main
             Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
             """
@@ -113,7 +116,7 @@ def fixture_sandbox_config(workdir: pathlib.Path) -> str:
     """Setup a sandbox configuration that supports Ubuntu jammy."""
     config = workdir / "config"
     config.mkdir()
-    setup_ubuntu_sandbox_config(config, "jammy")
+    setup_ubuntu_sandbox_config(config, "jammy", "amd64")
     return str(config)
 
 

--- a/tests/unit/test_packaging_apt_dpkg.py
+++ b/tests/unit/test_packaging_apt_dpkg.py
@@ -18,6 +18,7 @@ import apt
 
 from apport.packaging_impl.apt_dpkg import (
     WITH_DEB822_SUPPORT,
+    _map_mirror_to_arch,
     _parse_deb822_sources,
     _read_mirror_file,
     impl,
@@ -90,6 +91,30 @@ class TestPackagingAptDpkg(unittest.TestCase):
         self.assertEqual(impl.is_distro_package("apport"), True)
         getitem_mock.assert_called_once_with("apport")
         exists_mock.assert_called_once_with("/etc/system-image/channel.ini")
+
+    def test_map_mirror_to_arch_ports_to_primary(self) -> None:
+        """Test _map_mirror_to_arch() to map ports to primary."""
+        self.assertEqual(
+            _map_mirror_to_arch("http://de.ports.ubuntu.com/ubuntu-ports", "amd64"),
+            "http://de.archive.ubuntu.com/ubuntu",
+        )
+
+    def test_map_mirror_to_arch_ports_unchanged(self) -> None:
+        """Test _map_mirror_to_arch() to keep ports unchanged."""
+        uri = "http://de.ports.ubuntu.com/ubuntu-ports"
+        self.assertEqual(_map_mirror_to_arch(uri, "ppc64el"), uri)
+
+    def test_map_mirror_to_arch_primary_to_ports(self) -> None:
+        """Test _map_mirror_to_arch() to map primary to ports."""
+        self.assertEqual(
+            _map_mirror_to_arch("http://de.archive.ubuntu.com/ubuntu/", "s390x"),
+            "http://de.ports.ubuntu.com/ubuntu-ports",
+        )
+
+    def test_map_mirror_to_arch_primary_unchanged(self) -> None:
+        """Test _map_mirror_to_arch() to keep ports unchanged."""
+        uri = "http://de.archive.ubuntu.com/ubuntu"
+        self.assertEqual(_map_mirror_to_arch(uri, "amd64"), uri)
 
     @unittest.skipIf(not WITH_DEB822_SUPPORT, "no deb822 support")
     @unittest.mock.patch(


### PR DESCRIPTION
The Ubuntu archive is split. The primary mirrors only has packages for the amd64 and i386 architectures. The ports mirrors host all remaining architectures.

So introduce a mapping function that correctly changes the URL in case known problematic ones were found.