### PR TITLE
test: check loaded report in test_modify

### DIFF
--- a/tests/unit/test_problem_report.py
+++ b/tests/unit/test_problem_report.py
@@ -506,6 +506,8 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
         pr.load(io.BytesIO(report))
 
         self.assertEqual(pr["Long"], "xxx\n.\nyyy")
+        self.assertEqual(pr["Short"], "Bar")
+        self.assertEqual(pr["File"], b"ABABABABABABABABABAB\0\0\0\0\0\0\0\0\0\0Z")
 
         # write back unmodified
         out = io.BytesIO()


### PR DESCRIPTION
Verify that `test_modify` loaded the Report correctly before modifying and storing it. Add those assersions to reduce the scope for the recent test failure on s390x (LP: #2076269).