### PR TITLE
Address complaints from pylint extensions

### DIFF
--- a/apport/crashdb.py
+++ b/apport/crashdb.py
@@ -308,7 +308,7 @@ class CrashDatabase:
                     contents = dupdb_url.read().decode("UTF-8")
                 if "<title>404 Not Found" in contents:
                     continue
-            except (OSError, urllib.error.URLError):
+            except OSError:
                 # does not exist, failed to load, etc.
                 continue
 

--- a/apport/packaging_impl/apt_dpkg.py
+++ b/apport/packaging_impl/apt_dpkg.py
@@ -465,7 +465,7 @@ class __AptDpkgPackageInfo(PackageInfo):
         try:
             with urllib.request.urlopen(url) as response:
                 content = response.read()
-        except (urllib.error.URLError, urllib.error.HTTPError):
+        except urllib.error.URLError:
             apport.logging.warning("cannot connect to: %s", urllib.parse.unquote(url))
             return None
         except OSError:
@@ -1736,7 +1736,7 @@ class __AptDpkgPackageInfo(PackageInfo):
                 ) as response:
                     response.read()
                     return user, ppa_name
-            except (urllib.error.URLError, urllib.error.HTTPError):
+            except urllib.error.URLError:
                 index += 1
                 if index == len(components):
                     if try_ppa:
@@ -1786,7 +1786,7 @@ class __AptDpkgPackageInfo(PackageInfo):
                 debug_entry.comps = ["main/debug"]
                 debug_entry.suites = [release_codename]
                 return [main_entry, debug_entry]
-            except (urllib.error.URLError, urllib.error.HTTPError):
+            except urllib.error.URLError:
                 return [main_entry]
         else:
             ppa_line = (
@@ -1797,7 +1797,7 @@ class __AptDpkgPackageInfo(PackageInfo):
                 with contextlib.closing(urllib.request.urlopen(debug_url)) as response:
                     response.read()
                 add_debug = " main/debug"
-            except (urllib.error.URLError, urllib.error.HTTPError):
+            except urllib.error.URLError:
                 add_debug = ""
             return [
                 SourceEntry(ppa_line + add_debug),

--- a/apport/report.py
+++ b/apport/report.py
@@ -1242,7 +1242,7 @@ class Report(problem_report.ProblemReport):
         try:
             with urllib.request.urlopen(url) as request:
                 patterns = request.read().decode("UTF-8", errors="replace")
-        except (OSError, urllib.error.URLError):
+        except OSError:
             # doesn't exist or failed to load
             return None
 

--- a/data/apport
+++ b/data/apport
@@ -809,13 +809,13 @@ def receive_arguments_via_socket() -> argparse.Namespace:
         sys.exit(0)
 
     # Extract and validate the fd
-    fds = listen_fds()
-    if len(fds) < 1:
+    socket_fds = listen_fds()
+    if len(socket_fds) < 1:
         logging.getLogger().error("Invalid socket activation, no fd provided")
         sys.exit(1)
 
     # Open the socket
-    sock = socket.fromfd(int(fds[0]), socket.AF_UNIX, socket.SOCK_STREAM)
+    sock = socket.fromfd(int(socket_fds[0]), socket.AF_UNIX, socket.SOCK_STREAM)
     atexit.register(sock.shutdown, socket.SHUT_RDWR)
 
     # Replace stdin by the socket activation fd

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ load-plugins = [
     "pylint.extensions.eq_without_hash",
     "pylint.extensions.no_self_use",
     "pylint.extensions.private_import",
+    "pylint.extensions.redefined_variable_type",
     "pylint.extensions.set_membership",
     "pylint.extensions.typing",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ load-plugins = [
     "pylint.extensions.dunder",
     "pylint.extensions.eq_without_hash",
     "pylint.extensions.no_self_use",
+    "pylint.extensions.overlapping_exceptions",
     "pylint.extensions.private_import",
     "pylint.extensions.redefined_variable_type",
     "pylint.extensions.set_membership",

--- a/tests/integration/test_problem_report.py
+++ b/tests/integration/test_problem_report.py
@@ -142,13 +142,13 @@ class T(unittest.TestCase):
             os.path.join(self.workdir, "nonexistent"),
         )
         # Test exception handling: Non-binary and nonexistent key
-        tests = [
+        exception_tests = [
             (ValueError, "Txt"),
             (ValueError, ["Foo", "Txt"]),
             (KeyError, "Bar"),
             (KeyError, ["Foo", "Bar"]),
         ]
-        for exc, keys_arg in tests:
+        for exc, keys_arg in exception_tests:
             report.seek(0)
             self.assertRaises(exc, pr.extract_keys, report, keys_arg, self.workdir)
 


### PR DESCRIPTION
The pylint `redefined_variable_type` extension complains:

```
************* Module tests.integration.test_problem_report
tests/integration/test_problem_report.py:156:8: R0204: Redefinition of tests type from list to dict (redefined-variable-type)
************* Module apport
data/apport:824:4: R0204: Redefinition of fds type from list to array.array (redefined-variable-type)
```

Use different variable names.

```
************* Module apport.report
apport/report.py:1245:15: W0714: Overlapping exceptions (OSError is an ancestor class of urllib.error.URLError) (overlapping-except)
************* Module apport.crashdb
apport/crashdb.py:311:19: W0714: Overlapping exceptions (OSError is an ancestor class of urllib.error.URLError) (overlapping-except)
************* Module apport.packaging_impl.apt_dpkg
apport/packaging_impl/apt_dpkg.py:449:15: W0714: Overlapping exceptions (urllib.error.URLError is an ancestor class of urllib.error.HTTPError) (overlapping-except)
apport/packaging_impl/apt_dpkg.py:1720:19: W0714: Overlapping exceptions (urllib.error.URLError is an ancestor class of urllib.error.HTTPError) (overlapping-except)
apport/packaging_impl/apt_dpkg.py:1770:19: W0714: Overlapping exceptions (urllib.error.URLError is an ancestor class of urllib.error.HTTPError) (overlapping-except)
apport/packaging_impl/apt_dpkg.py:1781:19: W0714: Overlapping exceptions (urllib.error.URLError is an ancestor class of urllib.error.HTTPError) (overlapping-except)
```