### PR TITLE
apport: Add Teamviewer to report-ignore

### DIFF
--- a/etc/apport/report-ignore/ignore-teamviewer
+++ b/etc/apport/report-ignore/ignore-teamviewer
@@ -1,0 +1,4 @@
+# Ignore TeamViewer crashes as it causes a crash in GDB
+# due to a custom shared library they ship which misses
+# the .text section (LP: #2041830)
+/opt/teamviewer/tv_bin/TeamViewer


### PR DESCRIPTION
Teamviewer ships its own libicudata.so which does not have a `.text` section ([gdb crashes with "internal-error: sect_index_text not initialized" when .text missing](https://sourceware.org/bugzilla/show_bug.cgi?id=25678)). Whenever apport tries to create a coredump for a Teamviewer crash, it triggers a [crash in GDB](https://bugs.launchpad.net/ubuntu/+source/gdb/+bug/2041830). This change prevents apport from creating a report for a Teamviewer crash.