### PR TITLE
package_hook: Handle failures of removed packages

### DIFF
--- a/data/package_hook
+++ b/data/package_hook
@@ -12,6 +12,7 @@
 """Collect information about a package installation/upgrade failure."""
 
 import argparse
+import contextlib
 import os
 import sys
 
@@ -68,7 +69,10 @@ def main():
     # create report
     report = apport.Report("Package")
     report.add_package(options.package)
-    report["SourcePackage"] = apport.packaging.get_source(options.package)
+    # get_source can fail on distribution upgrades where the package in question has
+    # been removed from the newer release. See https://launchpad.net/bugs/2078695
+    with contextlib.suppress(ValueError):
+        report["SourcePackage"] = apport.packaging.get_source(options.package)
     report["ErrorMessage"] = (sys.stdin, False)
 
     if options.tags:


### PR DESCRIPTION
package_hook can fail on distribution upgrades where the package in question has been removed from the newer release:

```
$ /usr/share/apport/package_hook -p mime-support --tags dist-upgrade [...]
Traceback (most recent call last):
  File "/usr/share/apport/package_hook", line 95, in <module>
    main()
  File "/usr/share/apport/package_hook", line 71, in main
    report["SourcePackage"] = apport.packaging.get_source(options.package)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/apport/packaging_impl/apt_dpkg.py", line 308, in get_source
    raise ValueError(f"package {package} does not exist")
ValueError: package mime-support does not exist
```

`__AptDpkgPackageInfo.get_source` will raise `ValueError` in case the package is not installed and not found in the APT cache any more. This can be the case on upgrades for package that were removed from the newer release.

Bug-Ubuntu: https://launchpad.net/bugs/2078695