### PR TITLE
report: Support comments in denylist files

### DIFF
--- a/apport/report.py
+++ b/apport/report.py
@@ -102,7 +102,9 @@ def _read_list_files_in_directory(directory: str) -> Iterator[str]:
             try:
                 with list_file.open(encoding="utf-8") as fd:
                     for line in fd:
-                        yield line.strip()
+                        stripped = line.strip()
+                        if stripped and not stripped.startswith("#"):
+                            yield stripped
             except OSError:
                 continue
     except OSError:


### PR DESCRIPTION
`/etc/apport/report-ignore/README` contains comments. Users or maintainers might want to add comments to their denylist files.

Support comments by ignoring lines starting with `#`.

See https://github.com/canonical/apport/pull/394 for a use case.