### PR TITLE
zstd: Pass a maximum decompressed size for coredumps

### DIFF
--- a/problem_report.py
+++ b/problem_report.py
@@ -34,6 +34,9 @@ from collections.abc import Generator, Iterable, Iterator
 GZIP_HEADER_START = b"\037\213\010"
 ZSTANDARD_MAGIC_NUMBER = b"\x28\xB5\x2F\xFD"
 
+# 2**29 is 512 MiB
+COREDUMP_MAX_SIZE = 2**29
+
 
 class MalformedProblemReport(ValueError):
     """Raised when a problem report violates the crash report format.
@@ -278,7 +281,9 @@ class CompressedValue:
         assert self.compressed_value is not None
 
         if self.compressed_value.startswith(ZSTANDARD_MAGIC_NUMBER):
-            return _get_zstandard_decompressor().decompress(self.compressed_value)
+            return _get_zstandard_decompressor().decompress(
+                self.compressed_value, max_output_size=COREDUMP_MAX_SIZE
+            )
         if self.compressed_value.startswith(GZIP_HEADER_START):
             return gzip.decompress(self.compressed_value)
         # legacy zlib format

--- a/tests/unit/test_problem_report.py
+++ b/tests/unit/test_problem_report.py
@@ -323,6 +323,15 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
         )
 
     @unittest.skipUnless(zstandard, "zstandard Python module not available")
+    def test_reading_zstd_compressed_value_nosize(self) -> None:
+        """Test reading zstd-compressed CompressedValue without a size header."""
+        report = problem_report.ProblemReport()
+        content = b"CoreDump: base64\n KLUv/QBYEQAAe30=\n"
+        with io.BytesIO(content) as report_file:
+            report.load(report_file, binary="compressed")
+        self.assertEqual(report["CoreDump"].get_value(), b"{}")
+
+    @unittest.skipUnless(zstandard, "zstandard Python module not available")
     def test_writing_zstd_compressed_value(self) -> None:
         """Test writing zstd-compressed CompressedValue."""
         compressed_value = problem_report.CompressedValue(


### PR DESCRIPTION
This fixes handling of systemd coredumps, which don't necessarily include a decompressed size header.

Maximum size was picked at 512M from looking at existing core dumps.

Fixes https://bugs.launchpad.net/apport/+bug/2081708