### PR TITLE
apport-gtk: Fix TypeError on dialog close

### DIFF
--- a/gtk/apport-gtk
+++ b/gtk/apport-gtk
@@ -632,7 +632,7 @@ class GTKUserInterface(apport.ui.UserInterface):
         return True
 
     def on_progress_window_close_event(
-        self, widget: Gtk.Widget, event: Gdk.Event
+        self, widget: Gtk.Widget, event: Gdk.Event | None = None
     ) -> None:
         # pylint: disable=unused-argument
         self.w("window_information_collection").hide()


### PR DESCRIPTION
`on_progress_window_close_event` is connected to those four objects:

* GtkWindow delete-event (window_information_collection)
* GtkButton clicked (button_cancel_collecting)
* GtkWindow delete-event (window_report_upload)
* GtkButton clicked (button_cancel_upload)

`GtkWindow::delete-event` takes an event parameter, but `GtkButton::clicked` does not.

Commit c997c1b12ec6 ("Add type hints to UserInterface class") released in apport 2.30.0 dropped support for not providing `event` when calling `on_progress_window_close_event`.

Fixes: c997c1b12ec6 ("Add type hints to UserInterface class")
LP: #2080524