### PR TITLE
Fix hang when cancelling/closing Apport

### DIFF
--- a/apport/REThread.py
+++ b/apport/REThread.py
@@ -17,14 +17,18 @@ import threading
 
 
 class REThread(threading.Thread):
-    """Thread with return values and exception propagation."""
+    """Thread with return values and exception propagation.
+
+    The thread is marked as daemon thread. The entire Python program exits
+    when no alive non-daemon threads are left.
+    """
 
     def __init__(self, group=None, target=None, name=None, args=(), kwargs=None):
         """Initialize Thread, identical to threading.Thread.__init__()."""
         if kwargs is None:
             kwargs = {}
 
-        threading.Thread.__init__(self, group, target, name, args, kwargs)
+        threading.Thread.__init__(self, group, target, name, args, kwargs, daemon=True)
         self.__target = target
         self.__args = args
         self.__kwargs = kwargs


### PR DESCRIPTION
Canceling the upload of problem information after sending information acquired with `ubuntu-bug [package name]` causes the upload dialog to become unresponsive.

The main thread is terminated when cancelling the crash collection/uploading, but the spawned background thread will continue running.

Mark the spawned background threads as daemon threads. This will stop those threads when the main tread terminates.

Bug-Ubuntu: https://launchpad.net/bugs/1537310