### PR TITLE
apport-cli: translate the answers Yes and No

### DIFF
--- a/bin/apport-cli
+++ b/bin/apport-cli
@@ -309,8 +309,8 @@ class CLIUserInterface(apport.ui.UserInterface):
         "None" on cancel/dialog closing.
         """
         dialog = CLIDialog(text, None)
-        r_yes = dialog.addbutton("&Yes")
-        r_no = dialog.addbutton("&No")
+        r_yes = dialog.addbutton(_("&Yes"))
+        r_no = dialog.addbutton(_("&No"))
         r_cancel = dialog.addbutton(_("&Cancel"))
         result = dialog.run()
         if result == r_yes:


### PR DESCRIPTION
apport-cli uses the same character for the No and the Cancel option in the Italien translation:

```
Cosa fare? Le opzioni sono:
Y: Yes
N: No
N: Annulla
Scegliere (Y/N/N):
```

Translate all the answers to allow picking different characters.

Bug-Ubuntu: https://launchpad.net/bugs/2084650