### PR TITLE
test: do not check for exact encoded gzip data in test_write_file

### DIFF
--- a/tests/integration/test_problem_report.py
+++ b/tests/integration/test_problem_report.py
@@ -228,18 +228,12 @@ class T(unittest.TestCase):
             out = io.BytesIO()
             pr.write(out)
 
-            self.assertEqual(
-                out.getvalue().decode(),
-                textwrap.dedent(
-                    """\
-                    ProblemType: Crash
-                    Date: now!
-                    File: base64
-                     H4sICAAAAAAC/0ZpbGUA
-                     S8vPZ0hKLAIACq50HgcAAAA=
-                    """
-                ),
-            )
+            # check that written report is read correctly again
+            report = problem_report.ProblemReport()
+            out.seek(0)
+            report.load(out, binary="compressed")
+            self.assertIsInstance(report["File"], problem_report.CompressedValue)
+            self.assertEqual(report["File"].get_value(), b"foo\0bar")
 
     def test_write_delayed_fileobj(self) -> None:
         """Write a report with file pointers and delayed data."""


### PR DESCRIPTION
The test case `test_write_file` fails on s390x from time to time due to the encoded chunks have a different on-disk representation. Instead of the expected one compressed chunk

```
File: base64
 H4sICAAAAAAC/0ZpbGUA
 c3RyxIAMcBAFAK/2p9MfAAAA
```

there could be two compressed chunks:

```
File: base64
 H4sICAAAAAAC/0ZpbGUA
 cnTChAxwEA==
 BRgAr/an0x8AAAA=
```

The raw data is identical, but the zlib compressed data on disk differs! So make the test case less picky by just checking that the data is compressed and that the decompressed data is correct.

Bug: https://launchpad.net/bugs/2076269