### PR TITLE
com.ubuntu.apport.policy: fix order of entries

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,16 +55,16 @@ jobs:
           apt-get update
           && apt-get install --no-install-recommends --yes
           bash binutils ca-certificates default-jdk-headless dpkg-dev gcc gdb
-          git iputils-ping kmod libc6-dev locales procps python3 python3-apt
-          python3-distutils-extra python3-launchpadlib python3-psutil
-          python3-pytest python3-pytest-cov python3-setuptools python3-systemd
-          python3-zstandard valgrind
+          git iputils-ping kmod libc6-dev libxml2-utils locales polkitd procps
+          python3 python3-apt python3-distutils-extra python3-launchpadlib
+          python3-psutil python3-pytest python3-pytest-cov python3-setuptools
+          python3-systemd python3-zstandard valgrind
       - uses: actions/checkout@v4
       - name: Enable German locale
         run: sed -i 's/^# de_DE/de_DE/g' /etc/locale.gen && locale-gen
-      - name: Build Java subdir
+      - name: Build (Java and PolicyKit XML)
         run: >
-          python3 -m coverage run ./setup.py build_java_subdir
+          python3 -m coverage run ./setup.py build
           && python3 -m coverage xml -o coverage-setup.xml
       - name: Run unit and integration tests
         run: >
@@ -90,10 +90,10 @@ jobs:
           sudo apt-get update
           && sudo apt-get install --no-install-recommends --yes
           bash binutils ca-certificates default-jdk-headless dpkg-dev gcc gdb
-          git iputils-ping kmod libc6-dev locales pkg-config python3 python3-apt
-          python3-distutils-extra python3-launchpadlib python3-psutil
-          python3-pytest python3-pytest-cov python3-setuptools python3-systemd
-          python3-zstandard valgrind
+          git iputils-ping kmod libc6-dev libxml2-utils locales pkg-config
+          polkitd python3 python3-apt python3-distutils-extra
+          python3-launchpadlib python3-psutil python3-pytest python3-pytest-cov
+          python3-setuptools python3-systemd python3-zstandard valgrind
       - uses: actions/checkout@v4
       - name: Enable German locale
         run: sudo sed -i 's/^# de_DE/de_DE/g' /etc/locale.gen && sudo locale-gen

--- a/apport/com.ubuntu.apport.policy.in
+++ b/apport/com.ubuntu.apport.policy.in
@@ -10,25 +10,25 @@
   <action id="com.ubuntu.apport.root-info">
     <_description>Collect system information</_description>
     <_message>Authentication is required to collect system information for this problem report</_message>
-    <annotate key="org.freedesktop.policykit.exec.path">/usr/share/apport/root_info_wrapper</annotate>
-    <!-- <annotate key="org.freedesktop.policykit.exec.allow_gui">true</annotate> -->
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
       <allow_active>auth_admin</allow_active>
     </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">/usr/share/apport/root_info_wrapper</annotate>
+    <!-- <annotate key="org.freedesktop.policykit.exec.allow_gui">true</annotate> -->
   </action>
 
   <action id="com.ubuntu.apport.apport-gtk-root">
     <_description>System problem reports</_description>
     <_message>Please enter your password to access problem reports of system programs</_message>
-    <annotate key="org.freedesktop.policykit.exec.path">/usr/share/apport/apport-gtk</annotate>
-    <annotate key="org.freedesktop.policykit.exec.allow_gui">true</annotate>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
       <allow_active>auth_admin</allow_active>
     </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">/usr/share/apport/apport-gtk</annotate>
+    <annotate key="org.freedesktop.policykit.exec.allow_gui">true</annotate>
   </action>
 
 </policyconfig>

--- a/tests/integration/test_xml.py
+++ b/tests/integration/test_xml.py
@@ -1,0 +1,40 @@
+# Copyright (C) 2024 Canonical Ltd.
+# Author: Benjamin Drung <bdrung@ubuntu.com>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 2 of the License, or (at your
+# option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
+# the full text of the license.
+
+"""Validate XML files."""
+
+import subprocess
+
+import pytest
+
+from tests.paths import is_local_source_directory
+
+
+def get_policy_xml() -> str:
+    """Determine path to Apport PolicyKit XML."""
+    if not is_local_source_directory():
+        return "/usr/share/polkit-1/actions/com.ubuntu.apport.policy"
+    policy_xml = "build/share/polkit-1/actions/com.ubuntu.apport.policy"
+    return policy_xml
+
+
+def test_validate_xml() -> None:
+    """Validate Apport PolicyKit XML."""
+    cmd = [
+        "xmllint",
+        "--noout",
+        "--nonet",
+        "--dtdvalid",
+        "/usr/share/polkit-1/policyconfig-1.dtd",
+        get_policy_xml(),
+    ]
+    try:
+        subprocess.check_call(cmd)
+    except FileNotFoundError as error:
+        pytest.skip(f"{error.filename} not available")


### PR DESCRIPTION
The `/usr/share/polkit-1/actions/com.ubuntu.apport.policy` PolicyKit actions file does not validate against the provided `/usr/share/polkit-1/policyconfig-1.dtd`:

```
$ xmllint --noout --nonet --dtdvalid /usr/share/polkit-1/policyconfig-1.dtd /usr/share/polkit-1/actions/com.ubuntu.apport.policy
/usr/share/polkit-1/actions/com.ubuntu.apport.policy:10: element action: validity error : Element action content does not follow the DTD, expecting (vendor? , vendor_url? , description+ , message+ , icon_name? , defaults , annotate*), got (description message annotate defaults )
/usr/share/polkit-1/actions/com.ubuntu.apport.policy:22: element action: validity error : Element action content does not follow the DTD, expecting (vendor? , vendor_url? , description+ , message+ , icon_name? , defaults , annotate*), got (description message annotate annotate defaults )
Document /usr/share/polkit-1/actions/com.ubuntu.apport.policy does not validate against /usr/share/polkit-1/policyconfig-1.dtd
```

Move some annotations around to make it validate.

Bug: https://launchpad.net/bugs/2084152