### PR TITLE
ci: Drop testing Ubuntu 22.04 "jammy" and increase required Python version to at least 3.11

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,6 @@ jobs:
         container:
           - debian:bookworm-slim
           - debian:testing-slim
-          - ubuntu:jammy
           - ubuntu:noble
           - ubuntu:oracular
     container:
@@ -59,12 +58,7 @@ jobs:
           git iputils-ping kmod libc6-dev locales procps python3 python3-apt
           python3-distutils-extra python3-launchpadlib python3-psutil
           python3-pytest python3-pytest-cov python3-setuptools python3-systemd
-          valgrind
-      # python3-zstandard is not available on ubuntu:jammy
-      - name: Install optional dependencies
-        run: >
-          apt-get install --no-install-recommends --yes python3-zstandard
-          || true
+          python3-zstandard valgrind
       - uses: actions/checkout@v4
       - name: Enable German locale
         run: sed -i 's/^# de_DE/de_DE/g' /etc/locale.gen && locale-gen
@@ -130,7 +124,6 @@ jobs:
       fail-fast: false
       matrix:
         container:
-          - ubuntu:jammy
           - ubuntu:noble
           - ubuntu:oracular
     container:
@@ -163,7 +156,6 @@ jobs:
       fail-fast: false
       matrix:
         container:
-          - ubuntu:jammy
           - ubuntu:noble
           - ubuntu:oracular
     container:

--- a/apport/ui.py
+++ b/apport/ui.py
@@ -150,12 +150,11 @@ def run_as_real_user(
     if get_user_env:
         env |= _get_users_environ(uid)
     env["HOME"] = pwuid.pw_dir
-    # mypy on Ubuntu 22.04 and 22.10 does not know user and groups
     subprocess.run(
         args,
         check=False,
         env=env,
-        user=uid,  # type: ignore
+        user=uid,
         group=gid,
         extra_groups=os.getgrouplist(pwuid.pw_name, gid),
         **kwargs,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ description = "intercept, process, and report crashes and bug reports"
 dynamic = ["version"]
 license = {text = "GPLv2+"}
 name = "apport"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 
 [tool.black]
 line-length = 88

--- a/tests/integration/test_packaging_apt_dpkg.py
+++ b/tests/integration/test_packaging_apt_dpkg.py
@@ -14,7 +14,7 @@ import tempfile
 import time
 import unittest
 
-from apport.packaging_impl.apt_dpkg import WITH_DEB822_SUPPORT, impl
+from apport.packaging_impl.apt_dpkg import impl
 from tests.helper import skip_if_command_is_missing
 
 
@@ -444,7 +444,6 @@ usr/bin/frob                                            foo/frob
 
         self.assertEqual(impl.get_file_package(file), pkg)
 
-    @unittest.skipUnless(WITH_DEB822_SUPPORT, "deb822 not supported on this system")
     def test_mirror_from_deb822_apt_sources(self) -> None:
         sources_list_d = pathlib.Path(self.workdir) / "sources.list.d"
         sources_list_d.mkdir()

--- a/tests/system/test_packaging_apt_dpkg.py
+++ b/tests/system/test_packaging_apt_dpkg.py
@@ -17,11 +17,7 @@ from collections.abc import Iterator
 import pytest
 from apt import apt_pkg
 
-from apport.packaging_impl.apt_dpkg import (
-    WITH_DEB822_SUPPORT,
-    _parse_deb822_sources,
-    impl,
-)
+from apport.packaging_impl.apt_dpkg import _parse_deb822_sources, impl
 from tests.helper import has_internet, skip_if_command_is_missing
 
 if shutil.which("dpkg") is None:
@@ -29,18 +25,7 @@ if shutil.which("dpkg") is None:
 
 AptStyle: typing.TypeAlias = typing.Literal["deb822", "one-line"]
 
-pytestmark = pytest.mark.parametrize(
-    "apt_style",
-    [
-        "one-line",
-        pytest.param(
-            "deb822",
-            marks=pytest.mark.skipif(
-                not WITH_DEB822_SUPPORT, reason="deb822 not supported on this system"
-            ),
-        ),
-    ],
-)
+pytestmark = pytest.mark.parametrize("apt_style", ["one-line", "deb822"])
 
 
 @pytest.fixture(name="workdir")
@@ -748,43 +733,24 @@ def test_create_sources_for_a_named_ppa(
     impl._build_apt_sandbox(
         rootdir, os.path.join(configdir, release), "ubuntu", "jammy", origins=[ppa]
     )
-    if WITH_DEB822_SUPPORT:
-        ppasource = os.path.join(
-            rootdir, "etc", "apt", "sources.list.d", f"{ppa}.sources"
-        )
-        entries = _parse_deb822_sources(ppasource)
-        assert [
-            e
-            for e in entries
-            if {"deb", "deb-src"} == set(e.types)
-            and "jammy" in e.suites
-            and "main" in e.comps
-            and "http://ppa.launchpad.net/"
-            "daisy-pluckers/daisy-seeds/ubuntu" in e.uris
-        ]
-        assert [
-            e
-            for e in entries
-            if "deb" in e.types
-            and "jammy" in e.suites
-            and "main/debug" in e.comps
-            and "http://ppa.launchpad.net/"
-            "daisy-pluckers/daisy-seeds/ubuntu" in e.uris
-        ]
-    else:
-        with open(
-            os.path.join(rootdir, "etc", "apt", "sources.list.d", f"{ppa}.list"),
-            encoding="utf-8",
-        ) as f:
-            sources = f.read().splitlines()
-        assert (
-            "deb http://ppa.launchpad.net/daisy-pluckers/daisy-seeds/ubuntu"
-            " jammy main main/debug" in sources
-        )
-        assert (
-            "deb-src http://ppa.launchpad.net/daisy-pluckers/daisy-seeds/ubuntu"
-            " jammy main" in sources
-        )
+    ppasource = os.path.join(rootdir, "etc", "apt", "sources.list.d", f"{ppa}.sources")
+    entries = _parse_deb822_sources(ppasource)
+    assert [
+        e
+        for e in entries
+        if {"deb", "deb-src"} == set(e.types)
+        and "jammy" in e.suites
+        and "main" in e.comps
+        and "http://ppa.launchpad.net/" "daisy-pluckers/daisy-seeds/ubuntu" in e.uris
+    ]
+    assert [
+        e
+        for e in entries
+        if "deb" in e.types
+        and "jammy" in e.suites
+        and "main/debug" in e.comps
+        and "http://ppa.launchpad.net/" "daisy-pluckers/daisy-seeds/ubuntu" in e.uris
+    ]
 
     gpg = subprocess.run(
         [
@@ -824,43 +790,26 @@ def test_create_sources_for_an_unnamed_ppa(
     impl._build_apt_sandbox(
         rootdir, os.path.join(configdir, release), "ubuntu", "jammy", origins=[ppa]
     )
-    if WITH_DEB822_SUPPORT:
-        ppasource = os.path.join(
-            rootdir, "etc", "apt", "sources.list.d", f"{ppa}.sources"
-        )
-        entries = _parse_deb822_sources(ppasource)
-        assert [
-            e
-            for e in entries
-            if {"deb", "deb-src"} == set(e.types)
-            and "jammy" in e.suites
-            and "main" in e.comps
-            and "http://ppa.launchpad.net/"
-            "apport-hackers/apport-autopkgtests/ubuntu" in e.uris
-        ]
-        assert [
-            e
-            for e in entries
-            if "deb" in e.types
-            and "jammy" in e.suites
-            and "main/debug" in e.comps
-            and "http://ppa.launchpad.net/"
-            "apport-hackers/apport-autopkgtests/ubuntu" in e.uris
-        ]
-    else:
-        with open(
-            os.path.join(rootdir, "etc", "apt", "sources.list.d", f"{ppa}.list"),
-            encoding="utf-8",
-        ) as f:
-            sources = f.read().splitlines()
-        assert (
-            "deb http://ppa.launchpad.net/apport-hackers/apport-autopkgtests/ubuntu"
-            " jammy main main/debug" in sources
-        )
-        assert (
-            "deb-src http://ppa.launchpad.net/apport-hackers/apport-autopkgtests/ubuntu"
-            " jammy main" in sources
-        )
+    ppasource = os.path.join(rootdir, "etc", "apt", "sources.list.d", f"{ppa}.sources")
+    entries = _parse_deb822_sources(ppasource)
+    assert [
+        e
+        for e in entries
+        if {"deb", "deb-src"} == set(e.types)
+        and "jammy" in e.suites
+        and "main" in e.comps
+        and "http://ppa.launchpad.net/"
+        "apport-hackers/apport-autopkgtests/ubuntu" in e.uris
+    ]
+    assert [
+        e
+        for e in entries
+        if "deb" in e.types
+        and "jammy" in e.suites
+        and "main/debug" in e.comps
+        and "http://ppa.launchpad.net/"
+        "apport-hackers/apport-autopkgtests/ubuntu" in e.uris
+    ]
 
     gpg = subprocess.run(
         [

--- a/tests/unit/test_packaging_apt_dpkg.py
+++ b/tests/unit/test_packaging_apt_dpkg.py
@@ -17,7 +17,6 @@ from unittest.mock import MagicMock
 import apt
 
 from apport.packaging_impl.apt_dpkg import (
-    WITH_DEB822_SUPPORT,
     _map_mirror_to_arch,
     _parse_deb822_sources,
     _read_mirror_file,
@@ -116,7 +115,6 @@ class TestPackagingAptDpkg(unittest.TestCase):
         uri = "http://de.archive.ubuntu.com/ubuntu"
         self.assertEqual(_map_mirror_to_arch(uri, "amd64"), uri)
 
-    @unittest.skipIf(not WITH_DEB822_SUPPORT, "no deb822 support")
     @unittest.mock.patch(
         "builtins.open",
         new_callable=unittest.mock.mock_open,

--- a/tests/unit/test_ui.py
+++ b/tests/unit/test_ui.py
@@ -99,7 +99,5 @@ class TestUI(unittest.TestCase):
         open_mock.assert_called_once_with("https://example.org", new=1, autoraise=True)
         error_message_mock.assert_called_once_with(
             _("Unable to start web browser"),
-            # False positive on Ubuntu 22.04 "jammy"
-            # pylint: disable-next=consider-using-f-string
             _("Unable to start web browser to open %s.") % ("https://example.org"),
         )


### PR DESCRIPTION
Ubuntu 24.04 "noble" is the latest Ubuntu LTS version.

Debian 12 "Bookworm" ships Python 3.11 and Ubuntu 24.04 "noble" ships Python 3.12. So bump the baseline after dropping Ubuntu 22.04 "jammy".
