### PR TITLE
ci: run installed tests on Ubuntu 24.04

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,7 +83,7 @@ jobs:
           path: ./coverage*.xml
 
   unit-and-integration-installed:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
     steps:
@@ -99,7 +99,7 @@ jobs:
           git iputils-ping kmod libc6-dev locales pkg-config python3 python3-apt
           python3-distutils-extra python3-launchpadlib python3-psutil
           python3-pytest python3-pytest-cov python3-setuptools python3-systemd
-          valgrind
+          python3-zstandard valgrind
       - uses: actions/checkout@v4
       - name: Enable German locale
         run: sudo sed -i 's/^# de_DE/de_DE/g' /etc/locale.gen && sudo locale-gen
@@ -208,7 +208,7 @@ jobs:
           path: ./coverage.xml
 
   system-installed:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
     steps:
@@ -216,8 +216,10 @@ jobs:
         run: >
           sudo apt-get remove --purge --yes
           apport python3-apport python3-problem-report
-      - name: Enable 'deb-src' URIs in /etc/apt/sources.list
-        run: sudo sed -i '/^#\sdeb-src /s/^#\s//' /etc/apt/sources.list
+      - name: Enable 'deb-src' URIs in /etc/apt/sources.list.d/ubuntu.sources
+        run: >
+          sudo sed -i 's/^Types: deb$/Types: deb deb-src/'
+          /etc/apt/sources.list.d/ubuntu.sources
       - name: Install dependencies
         run: >
           sudo apt-get update


### PR DESCRIPTION
Ubuntu 24.04 "noble" is the latest Ubuntu LTS version and the GitHub-hosted runners support it.