### PR TITLE
chore: drop obsolete pylint workarounds

### DIFF
--- a/data/apport
+++ b/data/apport
@@ -15,9 +15,6 @@ See https://wiki.ubuntu.com/Apport for details."""
 
 # pylint: disable=too-many-lines
 
-# pylint fails to import the apport module, because it has the same name.
-# See bug https://github.com/PyCQA/pylint/issues/7093
-# pylint: disable=c-extension-no-member,no-name-in-module,not-callable
 # TODO: Address following pylint complaints
 # pylint: disable=invalid-name,missing-function-docstring
 

--- a/data/gcc_ice_hook
+++ b/data/gcc_ice_hook
@@ -25,7 +25,6 @@ if len(sys.argv) != 3:
     )
     sys.exit(1)
 
-# workaround pylint-dev/pylint#7710, pylint: disable-next=unbalanced-tuple-unpacking
 (exename, sourcefile) = sys.argv[1:3]
 
 # create report

--- a/tests/integration/test_signal_crashes.py
+++ b/tests/integration/test_signal_crashes.py
@@ -1035,8 +1035,7 @@ class T(unittest.TestCase):
         # set UTF-8 environment variable, to check proper parsing in apport
         os.putenv("utf8trap", b"\xc3\xa0\xc3\xa4")
         # caller needs to call .wait(), pylint: disable=consider-using-with
-        # False positive, see https://github.com/PyCQA/pylint/issues/7092
-        process = subprocess.Popen(  # pylint: disable=unexpected-keyword-arg
+        process = subprocess.Popen(
             [command] + args, env=env, stdout=subprocess.DEVNULL, user=uid
         )
 

--- a/tests/system/test_signal_crashes.py
+++ b/tests/system/test_signal_crashes.py
@@ -298,8 +298,7 @@ class T(unittest.TestCase):
         # set UTF-8 environment variable, to check proper parsing in apport
         os.putenv("utf8trap", b"\xc3\xa0\xc3\xa4")
         # caller needs to call .wait(), pylint: disable=consider-using-with
-        # False positive, see https://github.com/PyCQA/pylint/issues/7092
-        process = subprocess.Popen(  # pylint: disable=unexpected-keyword-arg
+        process = subprocess.Popen(
             [command] + args, env=env, stdout=subprocess.DEVNULL, user=uid
         )
 


### PR DESCRIPTION
Drop obsolete pylint workarounds that pylint 3.2.7 on Ubuntu 24.10 "oracular" does not complain about any more.