### PR TITLE
ci: add Ubuntu 25.04 "Plucky Puffin"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,6 +42,7 @@ jobs:
           - debian:testing-slim
           - ubuntu:noble
           - ubuntu:oracular
+          - ubuntu:plucky
     container:
       image: ${{ matrix.container }}
       options: --cap-add=SYS_PTRACE --security-opt seccomp=unconfined
@@ -126,6 +127,7 @@ jobs:
         container:
           - ubuntu:noble
           - ubuntu:oracular
+          - ubuntu:plucky
     container:
       image: ${{ matrix.container }}
     steps:
@@ -158,6 +160,7 @@ jobs:
         container:
           - ubuntu:noble
           - ubuntu:oracular
+          - ubuntu:plucky
     container:
       image: ${{ matrix.container }}
       options: --cap-add=SYS_PTRACE --security-opt seccomp=unconfined


### PR DESCRIPTION
Ubuntu 25.04 "Plucky Puffin" is the current development series.