### PR TITLE
hookutils.attach_mac_events pkexec refactoring

### DIFF
--- a/tests/integration/test_hookutils.py
+++ b/tests/integration/test_hookutils.py
@@ -268,10 +268,6 @@ class T(unittest.TestCase):
             ' pid=1361 comm="cupsd" capability=36  capname="block_suspend"\n'
         )
 
-        report = problem_report.ProblemReport()
-        apport.hookutils.attach_mac_events(report)
-        self.assertIn("KernLog", report)
-
         # No AppArmor messages
         report = problem_report.ProblemReport()
         report["KernLog"] = (

--- a/tests/unit/test_hookutils.py
+++ b/tests/unit/test_hookutils.py
@@ -374,3 +374,10 @@ class TestHookutils(unittest.TestCase):
             )
 
             self.assertEqual(match_content, "test\ncontent\n")
+
+    @staticmethod
+    @unittest.mock.patch("subprocess.run")
+    def test_execute_multiple_root_commands_no_commands(run_mock: MagicMock) -> None:
+        outputs = apport.hookutils.execute_multiple_root_commands({})
+        assert not outputs
+        assert not run_mock.called


### PR DESCRIPTION
This should reduce the number of `pkexec` calls to 1 for this function, no matter the branching.