### PR TITLE
problem_report: use iterator in CompressedValue.__len__

### DIFF
--- a/tests/unit/test_problem_report.py
+++ b/tests/unit/test_problem_report.py
@@ -349,6 +349,14 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
         )
         self.assertEqual(len(compressed_value), 65)
 
+    @unittest.skipUnless(zstandard, "zstandard Python module not available")
+    def test_len_zstd_compressed_value_nosize(self) -> None:
+        """Test len() on zstd-compressed CompressedValue without a size header."""
+        compressed_value = problem_report.CompressedValue(
+            compressed_value=base64.b64decode(b"KLUv/QBYEQAAe30=")
+        )
+        self.assertEqual(len(compressed_value), 2)
+
     @unittest.mock.patch("builtins.__import__")
     def test_zstandard_missing(self, import_mock: MagicMock) -> None:
         """Test reading zstd-compressed data when zstandard is missing."""


### PR DESCRIPTION
```
$ apport-cli -c /var/crash/_usr_bin_gnome-shell.1000.crash
Traceback (most recent call last):
  File "/usr/bin/apport-cli", line 420, in <module>
    if not app.run_argv():
           ^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/apport/ui.py", line 925, in run_argv
    self.run_crash(self.args.crash_file)
  File "/usr/lib/python3/dist-packages/apport/ui.py", line 464, in run_crash
    response = self.ui_present_report_details(allowed_to_report)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/bin/apport-cli", line 218, in ui_present_report_details
    _("&Send report (%s)") % self.format_filesize(self.get_complete_size())
                                                  ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/apport/ui.py", line 1236, in get_complete_size
    if self.report[k]:
       ~~~~~~~~~~~^^^
  File "/usr/lib/python3/dist-packages/problem_report.py", line 314, in __len__
    return len(self.get_value())
               ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/problem_report.py", line 281, in get_value
    return _get_zstandard_decompressor().decompress(self.compressed_value)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
zstd.ZstdError: could not determine content size in frame header
```

Instead of decompressing the complete data in memory in `CompressedValue.__len__`, use an iterator to keep the memory footprint small.

Fixes https://bugs.launchpad.net/apport/+bug/2081708