### PR TITLE
ui: skip value not empty check in get_complete_size

### DIFF
--- a/apport/ui.py
+++ b/apport/ui.py
@@ -1232,11 +1232,10 @@ class UserInterface:
         # report wasn't loaded, so count manually
         size = 0
         for k in self.report:
-            if self.report[k]:
-                try:
-                    size += self.report[k].get_on_disk_size()
-                except AttributeError:
-                    size += len(self.report[k])
+            try:
+                size += self.report[k].get_on_disk_size()
+            except AttributeError:
+                size += len(self.report[k])
         return size
 
     def get_reduced_size(self) -> int:
@@ -1245,11 +1244,10 @@ class UserInterface:
         size = 0
         for k in self.report:
             if k != "CoreDump":
-                if self.report[k]:
-                    try:
-                        size += self.report[k].get_on_disk_size()
-                    except AttributeError:
-                        size += len(self.report[k])
+                try:
+                    size += self.report[k].get_on_disk_size()
+                except AttributeError:
+                    size += len(self.report[k])
 
         return size
 


### PR DESCRIPTION
```
$ apport-cli -c /var/crash/_usr_bin_gnome-shell.1000.crash
Traceback (most recent call last):
  File "/usr/bin/apport-cli", line 420, in <module>
    if not app.run_argv():
           ^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/apport/ui.py", line 925, in run_argv
    self.run_crash(self.args.crash_file)
  File "/usr/lib/python3/dist-packages/apport/ui.py", line 464, in run_crash
    response = self.ui_present_report_details(allowed_to_report)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/bin/apport-cli", line 218, in ui_present_report_details
    _("&Send report (%s)") % self.format_filesize(self.get_complete_size())
                                                  ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/apport/ui.py", line 1236, in get_complete_size
    if self.report[k]:
       ~~~~~~~~~~~^^^
  File "/usr/lib/python3/dist-packages/problem_report.py", line 314, in __len__
    return len(self.get_value())
               ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/problem_report.py", line 281, in get_value
    return _get_zstandard_decompressor().decompress(self.compressed_value)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
zstd.ZstdError: could not determine content size in frame header
```

Evaluating `self.report[k]` will decompress `CompressedValue` which can be expensive. `self.report[k]` will not be `None`, because `ProblemReport.__setitem__` does not allow setting it to `None`. So try to call `get_on_disk_size()` or `len()` directly on the value.

Fixes https://bugs.launchpad.net/apport/+bug/2081708