### PR TITLE
problem_report: introduce ProblemReportValue type alias

### DIFF
--- a/bin/apport-cli
+++ b/bin/apport-cli
@@ -159,12 +159,12 @@ class CLIUserInterface(apport.ui.UserInterface):
         max_show = 1000000
         for key, value in self.report.sorted_items():
             details += f"== {key} =================================\n"
-            # string value
-            keylen = len(value)
-            if isinstance(value, str) and keylen < max_show:
-                s = value
-            elif keylen >= max_show:
-                s = _("(%i bytes)") % keylen
+            if isinstance(value, str):
+                keylen = len(value)
+                if keylen < max_show:
+                    s = value
+                else:
+                    s = _("(%i bytes)") % keylen
             else:
                 s = _("(binary data)")
 

--- a/problem_report.py
+++ b/problem_report.py
@@ -503,7 +503,7 @@ class ProblemReport(collections.UserDict):
 
     def sorted_items(
         self, keys: Iterable[str] | None = None
-    ) -> Iterator[tuple[str, (bytes | CompressedValue | str | tuple)]]:
+    ) -> Iterator[tuple[str, (bytes | CompressedFile | CompressedValue | str | tuple)]]:
         """Iterate over all non-internal items sorted.
 
         The most interesting fields will be returned first. The remaining

--- a/problem_report.py
+++ b/problem_report.py
@@ -29,6 +29,7 @@ import time
 import typing
 import zlib
 from collections.abc import Generator, Iterable, Iterator
+from typing import TypeAlias
 
 CHUNK_SIZE = 131_072  # 128 kB chunks
 # magic number (0x1F 0x8B) and compression method (0x08 for DEFLATE)
@@ -330,6 +331,9 @@ class CompressedValue:
         return self.get_value().splitlines()
 
 
+ProblemReportValue: TypeAlias = bytes | CompressedFile | CompressedValue | str | tuple
+
+
 class ProblemReport(collections.UserDict):
     """Class to store, load, and handle problem reports."""
 
@@ -503,7 +507,7 @@ class ProblemReport(collections.UserDict):
 
     def sorted_items(
         self, keys: Iterable[str] | None = None
-    ) -> Iterator[tuple[str, (bytes | CompressedFile | CompressedValue | str | tuple)]]:
+    ) -> Iterator[tuple[str, ProblemReportValue]]:
         """Iterate over all non-internal items sorted.
 
         The most interesting fields will be returned first. The remaining
@@ -912,9 +916,7 @@ class ProblemReport(collections.UserDict):
         file.write(msg.as_string().encode("UTF-8"))
         file.write(b"\n")
 
-    def __setitem__(
-        self, k: str, v: bytes | CompressedFile | CompressedValue | str | tuple
-    ) -> None:
+    def __setitem__(self, k: str, v: ProblemReportValue) -> None:
         assert hasattr(k, "isalnum")
         if not k.replace(".", "").replace("-", "").replace("_", "").isalnum():
             raise ValueError(

--- a/problem_report.py
+++ b/problem_report.py
@@ -536,7 +536,7 @@ class ProblemReport(collections.UserDict):
             value = self[key]
             if value is None:
                 continue
-            yield key, self[key]
+            yield key, value
 
     def write(self, file: typing.IO[bytes], only_new: bool = False) -> None:
         """Write information into the given file-like object.


### PR DESCRIPTION
* problem_report: reuse `self[key]` in `sorted_items` (for the following commits)
* apport-cli: only calculate length for strings to show
* problem_report: sorted_items can also return `CompressedFile`
* Add a type alias for the value type of the `ProblemReport` class.