### PR TITLE
test: fix expected traceback for Python 3.13

### DIFF
--- a/tests/integration/test_python_crashes.py
+++ b/tests/integration/test_python_crashes.py
@@ -507,7 +507,8 @@ func(42)
                 )
                 pr = self._load_report()
                 self.assertIn(":FileNotFoundError:", pr.crash_signature())
-                self.assertIn("os.getcwd()\nFileNotFoundError", pr["Traceback"])
+                self.assertIn("os.getcwd()\n", pr["Traceback"])
+                self.assertIn("\nFileNotFoundError", pr["Traceback"])
 
     def test_subclassed_os_error(self) -> None:
         """Raise OSError with known subclass."""


### PR DESCRIPTION
Python 3.13 changes the format of the tracebacks. `test_getcwd_error` will cause this traceback:

```
Traceback (most recent call last):
  File "/var/tmp/./tmpom46qzi6", line 14, in <module>
    os.getcwd()
    ~~~~~~~~~^^
FileNotFoundError: [Errno 2] No such file or directory
```

So check for `os.getcwd()` and `FileNotFoundError` in the traceback separately.