### PR TITLE
ui: fix passing possible None to ui_error_message

### DIFF
--- a/apport/ui.py
+++ b/apport/ui.py
@@ -528,7 +528,7 @@ class UserInterface:
                 )
                 sys.exit(1)
             elif error.errno == errno.EIO:
-                self.ui_error_message(_("Invalid problem report"), error.strerror)
+                self.ui_error_message(_("Invalid problem report"), str(error.strerror))
                 sys.exit(1)
             raise
 
@@ -1830,7 +1830,7 @@ class UserInterface:
             return False
         except OSError as error:
             self.report = None
-            self.ui_error_message(_("Invalid problem report"), error.strerror)
+            self.ui_error_message(_("Invalid problem report"), str(error.strerror))
             return False
         except (TypeError, ValueError, AssertionError, zlib.error) as error:
             self.report = None


### PR DESCRIPTION
mypy 1.14.1 complains:

```
apport/ui.py:531: error: Argument 2 to "ui_error_message" of "UserInterface" has incompatible type "str | None"; expected "str"  [arg-type]
apport/ui.py:1833: error: Argument 2 to "ui_error_message" of "UserInterface" has incompatible type "str | None"; expected "str"  [arg-type]
```

Convert `error.strerror` to string in case it is `None`.