### PR TITLE
github: relax report parameter type for upload() to a Mapping

### DIFF
--- a/apport/crashdb_impl/github.py
+++ b/apport/crashdb_impl/github.py
@@ -13,11 +13,10 @@ import json
 import time
 import urllib.parse
 import urllib.request
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from typing import Any
 
-import apport
 import apport.crashdb
 
 
@@ -156,7 +155,7 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
         self.issue_url = None
         self.github = None
 
-    def _format_report(self, report: apport.Report) -> dict:
+    def _format_report(self, report: Mapping[str, Any]) -> dict[str, str | list[str]]:
         """Formats report info as markdown and creates Github issue JSON."""
         body_markdown = ""
         for key, value in report.items():
@@ -176,7 +175,7 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
 
     def upload(
         self,
-        report: apport.Report,
+        report: Mapping[str, Any],
         progress_callback: Callable | None = None,
         user_message_callback: Callable | None = None,
     ) -> IssueHandle:

--- a/tests/integration/test_github.py
+++ b/tests/integration/test_github.py
@@ -9,6 +9,7 @@
 
 """Integration tests for the apport.crashdb_impl.github module."""
 
+import typing
 import unittest
 from unittest.mock import ANY, MagicMock, Mock, patch
 
@@ -36,7 +37,7 @@ class TestGitHub(unittest.TestCase):
             "expires_in": 20,
         }
 
-    def test__format_report(self):
+    def test__format_report(self) -> None:
         data = {"bold1": "normal1", "bold2": "normal2"}
         expected_body = "**bold1**\nnormal1\n\n**bold2**\nnormal2\n\n"
 
@@ -48,11 +49,13 @@ class TestGitHub(unittest.TestCase):
     @patch("apport.crashdb_impl.github.Github.api_authentication")
     @patch("apport.crashdb_impl.github.Github.api_open_issue")
     @patch("apport.crashdb_impl.github.Github.authentication_complete")
-    def test_upload(self, mock_auth, mock_api, mock_api_auth):
+    def test_upload(
+        self, mock_auth: MagicMock, mock_api: MagicMock, mock_api_auth: MagicMock
+    ) -> None:
         mock_api.return_value = {"html_url": "doesntmatterhere"}
         mock_auth.return_value = True
         mock_api_auth.return_value = self.api_auth_return_value
-        nodata = {}
+        nodata: dict[str, typing.Any] = {}
         snapdata = {"SnapGitOwner": "gimli", "SnapGitName": "axe"}
 
         with self.github as github:


### PR DESCRIPTION
The integration tests for `CrashDatabase.upload` pass a dictionary as report instead of a `ProblemReport` or `Report` object. Relax the input type to a `Mapping`