### PR TITLE
Expect pid parameter of Report.add_proc_info to be of type int

### DIFF
--- a/apport/report.py
+++ b/apport/report.py
@@ -717,7 +717,7 @@ class Report(problem_report.ProblemReport):
 
     def add_proc_info(
         self,
-        pid: int | str | None = None,
+        pid: int | None = None,
         proc_pid_fd: int | None = None,
         extraenv: Iterable[str] | None = None,
     ) -> None:
@@ -744,8 +744,6 @@ class Report(problem_report.ProblemReport):
         - ProcAttrCurrent: /proc/pid/attr/current contents, if not "unconfined"
         - CurrentDesktop: Value of $XDG_CURRENT_DESKTOP, if present
         """
-        if isinstance(pid, str):
-            pid = int(pid)
         if not proc_pid_fd:
             if not pid:
                 pid = self.pid or os.getpid()

--- a/data/apportcheckresume
+++ b/data/apportcheckresume
@@ -27,7 +27,7 @@ from apport.packaging_impl import impl as packaging
 
 
 # pylint: disable-next=missing-function-docstring
-def main(argv=None):
+def main(argv: list[str] | None = None) -> int:
     if argv is None:
         argv = sys.argv
 

--- a/data/java_uncaught_exception
+++ b/data/java_uncaught_exception
@@ -31,7 +31,7 @@ def make_title(report):
 
 
 # pylint: disable-next=missing-function-docstring
-def main():
+def main() -> int:
     if not packaging.enabled():
         return 1
 

--- a/data/recoverable_problem
+++ b/data/recoverable_problem
@@ -23,7 +23,7 @@ import apport.report
 
 
 # pylint: disable-next=missing-function-docstring
-def main():
+def main() -> None:
     # Check parameters
     argparser = argparse.ArgumentParser("%(prog) [options]")
     argparser.add_argument("-p", "--pid", action="store", type=int, dest="optpid")

--- a/data/unkillable_shutdown
+++ b/data/unkillable_shutdown
@@ -16,6 +16,7 @@ SIGTERM to them (which happens during computer shutdown in
 import argparse
 import errno
 import os
+from collections.abc import Container, Iterable
 
 import apport
 import apport.fileutils
@@ -37,7 +38,7 @@ def parse_argv():
     return parser.parse_args()
 
 
-def orphaned_processes(omit_pids):
+def orphaned_processes(omit_pids: Container[str]) -> Iterable[int]:
     """Yield an iterator of running process IDs.
 
     This excludes PIDs which do not have a valid /proc/pid/exe symlink (e. g.
@@ -77,10 +78,10 @@ def orphaned_processes(omit_pids):
             )
             continue
 
-        yield process
+        yield pid
 
 
-def do_report(pid, omit_pids):
+def do_report(pid: int, omit_pids: Iterable[str]) -> None:
     """Create a report for a particular PID."""
 
     report = apport.Report("Bug")

--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -1165,7 +1165,7 @@ class T(unittest.TestCase):
         self.ui.run_crash(self.report_file.name)
         self.assertIsNone(self.ui.msg_severity)
 
-    def test_run_crash_nocore(self):
+    def test_run_crash_nocore(self) -> None:
         """run_crash() for a crash dump without CoreDump"""
         # create a test executable
         with run_test_executable() as pid:
@@ -1185,6 +1185,7 @@ class T(unittest.TestCase):
         self.ui = UserInterfaceMock()
         self.ui.run_crash(report_file)
         self.assertEqual(self.ui.msg_severity, "error")
+        assert self.ui.msg_text is not None
         self.assertIn(
             "memory", self.ui.msg_text, f"{self.ui.msg_title}: {self.ui.msg_text}"
         )


### PR DESCRIPTION
* test: use `tempfile.TemporaryDirectory` in `test_add_proc_info`
* unkillable_shutdown: pass `pid` around as `int`
* Add type hints to all callers of `Report.add_proc_info`
* report: expect `pid` parameter of `add_proc_info` to be of type int