### PR TITLE
test: use unittest.mock.patch for mocking methods

### DIFF
--- a/tests/integration/test_crashdb_launchpad.py
+++ b/tests/integration/test_crashdb_launchpad.py
@@ -692,8 +692,8 @@ and more
         r = self.crashdb.download(crash_id)
         self.assertNotIn("CoreDump", r)
 
-    @unittest.mock.patch.object(CrashDatabase, "_get_source_version", MagicMock())
-    def test_get_fixed_version(self):
+    @unittest.mock.patch.object(CrashDatabase, "_get_source_version")
+    def test_get_fixed_version(self, get_source_version_mock: MagicMock) -> None:
         """get_fixed_version() for fixed bugs
 
         Other cases are already checked in test_marking_segv() (invalid
@@ -701,12 +701,14 @@ and more
         """
         # staging.launchpad.net often does not have Quantal, so mock-patch
         # it to a known value
-        CrashDatabase._get_source_version.return_value = "3.14"
+        get_source_version_mock.return_value = "3.14"
         self._mark_report_fixed(self.get_segv_report())
         fixed_ver = self.crashdb.get_fixed_version(self.get_segv_report())
         self.assertEqual(fixed_ver, "3.14")
+        get_source_version_mock.assert_called_with("coreutils")
         self._mark_report_new(self.get_segv_report())
         self.assertIsNone(self.crashdb.get_fixed_version(self.get_segv_report()))
+        get_source_version_mock.assert_called_with("coreutils")
 
     #
     # Launchpad specific implementation and tests

--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -1614,7 +1614,7 @@ class T(unittest.TestCase):
             pwd.getpwuid = orig_getpwuid
             os.getuid = orig_getuid
 
-    def test_run_crash_known(self):
+    def test_run_crash_known(self) -> None:
         """run_crash() for already known problem"""
         r = self._gen_test_crash()
         report_file = os.path.join(apport.fileutils.report_dir, "test.crash")
@@ -1624,8 +1624,9 @@ class T(unittest.TestCase):
         # known without URL
         with open(report_file, "wb") as f:
             r.write(f)
-        self.ui.crashdb.known = lambda r: True
-        self.ui.run_crash(report_file)
+        with patch.object(self.ui.crashdb, "known", return_value=True) as mock:
+            self.ui.run_crash(report_file)
+        mock.assert_called()
         assert self.ui.report
         self.assertEqual(self.ui.report["_KnownReport"], "1")
         self.assertEqual(self.ui.msg_severity, "info")
@@ -1636,8 +1637,11 @@ class T(unittest.TestCase):
         # known with URL
         with open(report_file, "wb") as f:
             r.write(f)
-        self.ui.crashdb.known = lambda r: "http://myreport/1"
-        self.ui.run_crash(report_file)
+        with patch.object(
+            self.ui.crashdb, "known", return_value="http://myreport/1"
+        ) as mock:
+            self.ui.run_crash(report_file)
+        mock.assert_called()
         assert self.ui.report
         self.assertEqual(self.ui.report["_KnownReport"], "http://myreport/1")
         self.assertEqual(self.ui.msg_severity, "info")

--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -54,6 +54,8 @@ class UserInterfaceMock(apport.ui.UserInterface):
     # pylint: disable=too-many-instance-attributes
     """Concrete apport.ui.UserInterface suitable for automatic testing"""
 
+    crashdb: apport.crashdb_impl.memory.CrashDatabase
+
     def __init__(self, argv: list[str] | None = None) -> None:
         # use our memory crashdb which is designed for testing
         # closed in __del__, pylint: disable=consider-using-with


### PR DESCRIPTION
Use `unittest.mock.patch.object` for mocking methods in the test cases to make mypy happy.