### PR TITLE
test: support relative path in do_crash

### DIFF
--- a/tests/integration/test_signal_crashes.py
+++ b/tests/integration/test_signal_crashes.py
@@ -19,6 +19,7 @@ import contextlib
 import datetime
 import grp
 import os
+import pathlib
 import resource
 import shutil
 import signal
@@ -381,13 +382,12 @@ class T(unittest.TestCase):
 
     def test_unpackaged_script(self) -> None:
         """Unpackaged scripts do not create a report."""
-        local_exe = os.path.join(self.workdir, "myscript")
-        with open(local_exe, "w", encoding="utf-8") as f:
-            f.write("#!/usr/bin/perl\nsleep(86400);\n")
-        os.chmod(local_exe, 0o755)
+        local_exe = pathlib.Path(self.workdir) / "myscript"
+        local_exe.write_bytes(b"#!/usr/bin/perl\nsleep(86400);\n")
+        local_exe.chmod(0o755)
 
         # absolute path
-        self.do_crash(command=local_exe, args=[], expect_report=False)
+        self.do_crash(command=str(local_exe), args=[], expect_report=False)
 
         self.do_crash(
             command="./myscript", args=[], expect_report=False, cwd=self.workdir


### PR DESCRIPTION
The test `test_unpackaged_script` is skipped, because `do_crash` does not support relative executable path any more:

```
SKIPPED [1] tests/integration/test_signal_crashes.py:382: ./myscript is not executable
```

Determine absolute path for `os.access` and `read_shebang` in `do_crash` when `cwd` is specified.

Also add a commit for using pathlib.

Fixes: 7ae2c0b541a9 ("tests: Convert signal crashes tests into integration tests")