### PR TITLE
launchpad: force CRLF as HTTP line separators

### DIFF
--- a/apport/crashdb_impl/launchpad.py
+++ b/apport/crashdb_impl/launchpad.py
@@ -1236,7 +1236,8 @@ def upload_blob(blob, progress_callback=None, hostname="launchpad.net"):
 
     data_flat = io.BytesIO()
     gen = email.generator.BytesGenerator(data_flat, mangle_from_=False)
-    gen.flatten(data)
+    # HTTP 1.1 mandates CRLF line separators
+    gen.flatten(data, linesep="\r\n")
 
     # do the request; we need to explicitly set the content type here, as it
     # defaults to x-www-form-urlencoded


### PR DESCRIPTION
The Python email library explicitly says both its default and legacy policies do not follow the RFC:

> The default is \n because that’s the internal end-of-line discipline
> used by Python, though \r\n is required by the RFCs.

This is why we cannot have nice things.

It was fine until Launchpad updated its multipart implementation, which became stricter when parsing input. They've temporarily reverted the update, since it broke our error reporting, but we're the ones in the wrong.

Now, there's the bigger question of whether it's appropriate to use the email module to construct a fairly standard HTTP request, and thus bake some obscure knowledge of the HTTP protocol into our code.

The requests library would have given us the needed APIs to generate a multipart/form-data message, but we've deliberately moved away from it to reduce the apport footprint.

We could try adding the headers to the Request object rather than the MIME object, but that wouldn't remove the need for the module entirely, and my experience with email in Python is that it's a fickle beast that one shouldn't touch more than strictly necessary.

Bug-Ubuntu: https://bugs.launchpad.net/ubuntu/+source/apport/+bug/2096327