### PR TITLE
tests: skip anonymization test on environments that are too generic

### DIFF
--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -1487,7 +1487,16 @@ class T(unittest.TestCase):
         self.ui.report.write(dump)
         report = dump.getvalue().decode("UTF-8")
 
-        for s in self._get_sensitive_strings():
+        sensitive_strings = self._get_sensitive_strings()
+
+        # In some environment the UID is just a generic name, e.g. buildd, that
+        # tends to also be used in image names and the likes.
+        build_name = self.ui.report.get("CloudBuildName", "")
+        for s in sensitive_strings:
+            if s in build_name:  # pragma: no cover
+                self.skipTest("Environment too generic for the test to be meaningful.")
+
+        for s in sensitive_strings:
             self.assertIsNone(
                 re.search(rf"\b{re.escape(s)}\b", report),
                 f"dump contains sensitive word '{s}':\n{report}",


### PR DESCRIPTION
Relevant log, from a [PPA build on Noble](https://launchpadlibrarian.net/773820283/buildlog_ubuntu-noble-amd64.apport_2.28.1-0ubuntu3.4~ppa1_BUILDING.txt.gz):

```
self = <tests.integration.test_ui.T testMethod=test_run_crash_anonymity>

    def test_run_crash_anonymity(self):
        """run_crash() anonymization"""
        r = self._gen_test_crash()
        utf8_val = b"\xc3\xa4 " + os.uname()[1].encode("UTF-8") + b" \xe2\x99\xa5 "
        r["ProcUnicodeValue"] = utf8_val.decode("UTF-8")
        r["ProcByteArrayValue"] = utf8_val
        report_file = os.path.join(apport.fileutils.report_dir, "test.crash")
        with open(report_file, "wb") as f:
            r.write(f)
        self.ui = UserInterfaceMock()
        self.ui.present_details_response = apport.ui.Action(report=True)
        self.ui.run_crash(report_file)
        self.assertIsNone(self.ui.msg_severity, self.ui.msg_text)

        assert self.ui.report
        self.assertNotIn("ProcCwd", self.ui.report)

        dump = io.BytesIO()
        # this contains more or less random characters which might contain the
        # user name
        del self.ui.report["CoreDump"]
        self.ui.report.write(dump)
        report = dump.getvalue().decode("UTF-8")

        for s in self._get_sensitive_strings():
>           self.assertIsNone(
                re.search(rf"\b{re.escape(s)}\b", report),
                f"dump contains sensitive word '{s}':\n{report}",
            )
E           AssertionError: <re.Match object; span=(97, 103), match='buildd'> is not None : dump contains sensitive word 'buildd':
E           ProblemType: Crash
E           Architecture: amd64
E           CasperMD5CheckResult: unknown
E           CloudBuildName: ubuntu-base:buildd
```

V2:
- Fix the code on environments without cloud build info
- Linter fixes
- Skip coverage on the skipTest branch since it's an edge case.

V3: Actually quote an excerpt of the build logs