### PR TITLE
Clear APT::Architectures when setting architecture

### DIFF
--- a/apport/packaging_impl/apt_dpkg.py
+++ b/apport/packaging_impl/apt_dpkg.py
@@ -1043,6 +1043,11 @@ class __AptDpkgPackageInfo(PackageInfo):
             aptroot = tempfile.mkdtemp()
 
         apt.apt_pkg.config.set("APT::Architecture", architecture)
+        # Disable foreign architectures or we might fail to download packages
+        # due to split archives. Clearing is not enough, we need to push our
+        # architecture into the list too, or apt runs dpkg --print-foreign-architectures
+        apt.apt_pkg.config.clear("APT::Architectures")
+        apt.apt_pkg.config.set("APT::Architectures::", architecture)
         apt.apt_pkg.config.set("Acquire::Languages", "none")
         # directly connect to Launchpad when downloading deb files
         apt.apt_pkg.config.set("Acquire::http::Proxy::api.launchpad.net", "DIRECT")


### PR DESCRIPTION
When we set the architecture for our faked chroot, we need to unset foreign architectures as well, otherwise wew end up fetching e.g. i386 packages from ports.