### PR TITLE
Sort of revert the HTTP 1.1 CRLF business

### DIFF
--- a/apport/crashdb_impl/launchpad.py
+++ b/apport/crashdb_impl/launchpad.py
@@ -1236,8 +1236,8 @@ def upload_blob(blob, progress_callback=None, hostname="launchpad.net"):
 
     data_flat = io.BytesIO()
     gen = email.generator.BytesGenerator(data_flat, mangle_from_=False)
-    # HTTP 1.1 mandates CRLF line separators
-    gen.flatten(data, linesep="\r\n")
+    # HTTP 1.1 mandates CRLF line separators but LP prefers LF for now (LP: #2097632)
+    gen.flatten(data, linesep="\n")
 
     # do the request; we need to explicitly set the content type here, as it
     # defaults to x-www-form-urlencoded


### PR DESCRIPTION
It turns out that Launchpad itself isn't ready to cope with CRLF line endings.

Fixes: d27a3c68ac "launchpad: force CRLF as HTTP line separators"
Bug-Ubuntu: https://bugs.launchpad.net/launchpad/+bug/2097168