### PR TITLE
Format code with black 25

### DIFF
--- a/apport/hookutils.py
+++ b/apport/hookutils.py
@@ -508,7 +508,7 @@ def root_command_output(  # pylint: disable=redefined-builtin
 
 
 def execute_multiple_root_commands(
-    command_map: Mapping[str, str]
+    command_map: Mapping[str, str],
 ) -> dict[str, str | bytes]:
     """Execute multiple commands as root and return their respective outputs.
 

--- a/problem_report.py
+++ b/problem_report.py
@@ -34,7 +34,7 @@ from typing import TypeAlias
 CHUNK_SIZE = 131_072  # 128 kB chunks
 # magic number (0x1F 0x8B) and compression method (0x08 for DEFLATE)
 GZIP_HEADER_START = b"\037\213\010"
-ZSTANDARD_MAGIC_NUMBER = b"\x28\xB5\x2F\xFD"
+ZSTANDARD_MAGIC_NUMBER = b"\x28\xb5\x2f\xfd"
 
 
 class MalformedProblemReport(ValueError):

--- a/tests/integration/test_apport_unpack.py
+++ b/tests/integration/test_apport_unpack.py
@@ -22,7 +22,7 @@ from tests.paths import local_test_environment
 class TestApportUnpack(unittest.TestCase):
     # pylint: disable=missing-class-docstring,missing-function-docstring
     UTF8_STR = b"a\xe2\x99\xa5b"
-    BINDATA = b"\x00\x01\xFF\x40"
+    BINDATA = b"\x00\x01\xff\x40"
     env: dict[str, str]
     report_file: str
     unpack_dir: str

--- a/tests/integration/test_hooks.py
+++ b/tests/integration/test_hooks.py
@@ -424,7 +424,7 @@ class T(unittest.TestCase):
         gcc_path = self._gcc_version_path()[1]
 
         with tempfile.NamedTemporaryFile() as test_source:
-            test_source.write(b"int f(int x); \xFF\xFF")
+            test_source.write(b"int f(int x); \xff\xff")
             test_source.flush()
             test_source.seek(0)
 

--- a/tests/integration/test_report.py
+++ b/tests/integration/test_report.py
@@ -1195,7 +1195,7 @@ int main() { return f(42); }
                 None,
                 "does not match on wrong Foo UTF-8 value",
             )
-            r_bash["Foo"] = b"\x01\xFF"
+            r_bash["Foo"] = b"\x01\xff"
             self.assertEqual(
                 r_bash.search_bug_patterns(pattern_url),
                 None,

--- a/tests/run-linters
+++ b/tests/run-linters
@@ -33,8 +33,8 @@ run_black() {
         return
     fi
     black_version=$(black --version | head -n1 | cut -d' ' -f 2)
-    if test "${black_version%%.*}" -lt 24; then
-        echo "Skipping black tests, black $black_version is installed but version >= 24 is needed"
+    if test "${black_version%%.*}" -lt 25; then
+        echo "Skipping black tests, black $black_version is installed but version >= 25 is needed"
         return
     fi
     echo "Running black..."

--- a/tests/unit/test_problem_report.py
+++ b/tests/unit/test_problem_report.py
@@ -780,7 +780,7 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
 
         d = {
             "newtext": "Goodbye world",
-            "newbin": "11\000\001\002\xFFZZ",
+            "newbin": "11\000\001\002\xffZZ",
             "overwrite": "I am good",
         }
 
@@ -788,7 +788,7 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
         self.assertEqual(pr["oldtext"], "Hello world")
         self.assertEqual(pr["oldbin"], bin_data)
         self.assertEqual(pr["newtext"], "Goodbye world")
-        self.assertEqual(pr["newbin"], "11\000\001\002\xFFZZ")
+        self.assertEqual(pr["newbin"], "11\000\001\002\xffZZ")
         self.assertEqual(pr["overwrite"], "I am good")
 
     def test_load_key_filter(self) -> None:


### PR DESCRIPTION
Ubuntu 25.04 (plucky) ships black 25.1.0-1. So use black >= 25 for formatting.

Note: black 24.2 would change `apport/hookutils.py` back.