### PR TITLE
test: set branch code coverage in pyproject.toml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,7 +76,7 @@ jobs:
           && python3 -m coverage xml -o coverage-setup.xml
       - name: Run unit and integration tests
         run: >
-          python3 -m pytest -ra --cov=$(pwd) --cov-branch --cov-report=xml
+          python3 -m pytest -ra --cov=$(pwd) --cov-report=xml
           --durations=0 tests/unit/ tests/integration/
       - name: Upload coverage
         uses: actions/upload-artifact@v4
@@ -117,7 +117,7 @@ jobs:
           WORKDIR=$(mktemp -d -t apport.XXXXXXXXXX)
           && cp -r tests "$WORKDIR"
           && cd "$WORKDIR"
-          && python3 -m pytest -ra --cov=$(pwd) --cov-branch --cov-report=xml
+          && python3 -m pytest -ra --cov=$(pwd) --cov-report=xml
           --durations=0 tests/unit/ tests/integration/
           && cd -
           && cp "$WORKDIR/coverage.xml" .
@@ -152,7 +152,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run all tests (to check if they are skipped or succeed)
         run: >
-          SKIP_ONLINE_TESTS=1 python3 -m pytest -ra --cov=$(pwd) --cov-branch
+          SKIP_ONLINE_TESTS=1 python3 -m pytest -ra --cov=$(pwd)
           --cov-report=xml --durations=0 tests/
       - name: Upload coverage
         uses: actions/upload-artifact@v4
@@ -200,7 +200,7 @@ jobs:
         env:
           GDK_BACKEND: x11
         run: >
-          xvfb-run python3 -m pytest -ra --cov=$(pwd) --cov-branch
+          xvfb-run python3 -m pytest -ra --cov=$(pwd)
           --cov-report=xml --durations=0 tests/system/
       - name: Stop D-Bus daemon
         run: kill $(cat /run/dbus/pid)
@@ -251,7 +251,7 @@ jobs:
           WORKDIR=$(mktemp -d -t apport.XXXXXXXXXX)
           && cp -r tests "$WORKDIR"
           && cd "$WORKDIR"
-          && sudo xvfb-run python3 -m pytest -ra --cov=$(pwd) --cov-branch
+          && sudo xvfb-run python3 -m pytest -ra --cov=$(pwd)
           --cov-report=xml --durations=0 tests/system/
           && cd -
           && cp "$WORKDIR/coverage.xml" .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,9 @@ reports = false
 # Activate the evaluation score.
 score = false
 
+[tool.pytest.ini_options]
+addopts = "--cov-branch"
+
 [tool.ruff]
 include = [
     "pyproject.toml",


### PR DESCRIPTION
To avoid needing to specify `--cov-branch` on the pytest calls, set the branch code coverage in `pyproject.toml`.