### PR TITLE
apport-gtk: check for available display on startup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,10 +56,11 @@ jobs:
           apt-get update
           && apt-get install --no-install-recommends --yes
           bash binutils ca-certificates default-jdk-headless dpkg-dev gcc gdb
-          git kmod libc6-dev libxml2-utils locales polkitd procps
-          python3 python3-apt python3-distutils-extra python3-launchpadlib
-          python3-psutil python3-pytest python3-pytest-cov python3-setuptools
-          python3-systemd python3-zstandard valgrind
+          gir1.2-gtk-3.0 gir1.2-wnck-3.0 git kmod libc6-dev libxml2-utils
+          locales polkitd procps python3 python3-apt python3-distutils-extra
+          python3-gi python3-launchpadlib python3-psutil python3-pytest
+          python3-pytest-cov python3-setuptools python3-systemd
+          python3-zstandard valgrind
       - uses: actions/checkout@v4
       - name: Enable German locale
         run: sed -i 's/^# de_DE/de_DE/g' /etc/locale.gen && locale-gen
@@ -91,10 +92,11 @@ jobs:
           sudo apt-get update
           && sudo apt-get install --no-install-recommends --yes
           bash binutils ca-certificates default-jdk-headless dpkg-dev gcc gdb
-          git kmod libc6-dev libxml2-utils locales pkg-config
-          polkitd python3 python3-apt python3-distutils-extra
-          python3-launchpadlib python3-psutil python3-pytest python3-pytest-cov
-          python3-setuptools python3-systemd python3-zstandard valgrind
+          gir1.2-gtk-3.0 gir1.2-wnck-3.0 git kmod libc6-dev libxml2-utils
+          locales pkg-config polkitd python3 python3-apt python3-distutils-extra
+          python3-gi python3-launchpadlib python3-psutil python3-pytest
+          python3-pytest-cov python3-setuptools python3-systemd
+          python3-zstandard valgrind
       - uses: actions/checkout@v4
       - name: Enable German locale
         run: sudo sed -i 's/^# de_DE/de_DE/g' /etc/locale.gen && sudo locale-gen

--- a/apport/ui.py
+++ b/apport/ui.py
@@ -121,6 +121,11 @@ def _get_users_environ(uid: int) -> dict[str, str]:
     }
 
 
+def has_display() -> bool:
+    """Check if a display server is specified in the environment."""
+    return bool(os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"))
+
+
 def run_as_real_user(
     args: list[str], *, get_user_env: bool = False, **kwargs: Any
 ) -> None:

--- a/gtk/apport-gtk
+++ b/gtk/apport-gtk
@@ -650,7 +650,7 @@ def text_to_markup(text: str) -> str:
 
 def main(argv: list[str]) -> None:
     """GTK Apport user interface."""
-    if not apport.ui.has_display():
+    if not apport.ui.has_display() or Gdk.Display.get_default() is None:
         apport.fatal(
             "This program needs a running display server session. Please see"
             ' "man apport-cli" for a command line version of Apport.'

--- a/gtk/apport-gtk
+++ b/gtk/apport-gtk
@@ -652,7 +652,7 @@ def main(argv: list[str]) -> None:
     """GTK Apport user interface."""
     if not apport.ui.has_display():
         apport.fatal(
-            "This program needs a running X session. Please see"
+            "This program needs a running display server session. Please see"
             ' "man apport-cli" for a command line version of Apport.'
         )
     app = GTKUserInterface(argv)

--- a/gtk/apport-gtk
+++ b/gtk/apport-gtk
@@ -650,11 +650,16 @@ def text_to_markup(text: str) -> str:
     )
 
 
-if __name__ == "__main__":
+def main(argv: list[str]) -> None:
+    """GTK Apport user interface."""
     if not have_display:
         apport.fatal(
             "This program needs a running X session. Please see"
             ' "man apport-cli" for a command line version of Apport.'
         )
-    app = GTKUserInterface(sys.argv)
+    app = GTKUserInterface(argv)
     app.run_argv()
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/gtk/apport-gtk
+++ b/gtk/apport-gtk
@@ -36,8 +36,6 @@ except (AssertionError, ImportError, RuntimeError) as error:
     sys.stderr.write(f"Cannot start: {str(error)}\n")
     sys.exit(1)
 
-have_display = bool(os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"))
-
 
 def find_xid_for_pid(pid: int) -> int | None:
     """Return the X11 Window (xid) for the supplied process ID."""
@@ -602,7 +600,7 @@ class GTKUserInterface(apport.ui.UserInterface):
         return None
 
     def ui_has_terminal(self) -> bool:
-        return have_display and self._get_terminal() is not None
+        return apport.ui.has_display() and self._get_terminal() is not None
 
     def ui_run_terminal(self, command: str) -> None:
         program = self._get_terminal()
@@ -652,7 +650,7 @@ def text_to_markup(text: str) -> str:
 
 def main(argv: list[str]) -> None:
     """GTK Apport user interface."""
-    if not have_display:
+    if not apport.ui.has_display():
         apport.fatal(
             "This program needs a running X session. Please see"
             ' "man apport-cli" for a command line version of Apport.'

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -84,6 +84,15 @@ def read_shebang(command: str) -> str | None:
 
 
 @contextlib.contextmanager
+def restore_os_environ() -> Generator[None]:
+    """Restore os.environ after leaving this context manager."""
+    orig_env = os.environ.copy()
+    yield
+    os.environ.clear()
+    os.environ.update(orig_env)
+
+
+@contextlib.contextmanager
 def run_test_executable(
     args: Sequence[str] = (os.path.realpath("/bin/sleep"), "86400"),
     env: dict[str, str] | None = None,

--- a/tests/integration/test_ui_gtk.py
+++ b/tests/integration/test_ui_gtk.py
@@ -1,0 +1,35 @@
+"""Integration tests for the GTK Apport user interface."""
+
+# Copyright (C) 2025 Canonical Ltd.
+# Author: Benjamin Drung <benjamin.drung@canonical.com>
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+import io
+import os
+import unittest.mock
+
+import pytest
+
+from tests.helper import import_module_from_file, restore_os_environ
+from tests.paths import get_data_directory
+
+
+@restore_os_environ()
+def test_unusable_display() -> None:
+    """Test apport-gtk to not crash if no usable display is found (LP: #2006981)."""
+    os.environ |= {"DISPLAY": ":42", "WAYLAND_DISPLAY": "bogus"}
+    apport_gtk_path = get_data_directory("gtk") / "apport-gtk"
+    with unittest.mock.patch("sys.stderr", new_callable=io.StringIO) as stderr:
+        try:
+            apport_gtk = import_module_from_file(apport_gtk_path)
+        except SystemExit:
+            pytest.skip(stderr.getvalue().strip())
+    with unittest.mock.patch("sys.stderr", new_callable=io.StringIO) as stderr:
+        with pytest.raises(SystemExit) as error:
+            apport_gtk.main([str(apport_gtk_path)])
+
+    assert (
+        stderr.getvalue() == "ERROR: This program needs a running display server"
+        ' session. Please see "man apport-cli" for a command line version of Apport.\n'
+    )
+    assert error.value.code == 1


### PR DESCRIPTION
apport-gtk might crash when the desktop environment crashes itself. This kind of crash used to be reproducible by killing gnome-shell (`killall -11 gnome-shell`), but I fail to reproduce it now. The crash can be artificially created:

```
WAYLAND_DISPLAY=bogus DISPLAY=:42 /usr/share/apport/apport-gtk
```

Tested on Ubuntu 25.04 (plucky) on 2025-02-18.

Check for available display on startup. Install gir1.2-gtk-3.0, gir1.2-wnck-3.0, and python3-gi for the new integration test.

Bug-Ubuntu: https://launchpad.net/bugs/2006981
