### PR TITLE
Split __AptDpkgPackageInfo.install_packages() into smaller methods

### DIFF
--- a/apport/packaging_impl/apt_dpkg.py
+++ b/apport/packaging_impl/apt_dpkg.py
@@ -189,6 +189,19 @@ def _read_mirror_file(uri: str) -> list[str]:
     return mirrors
 
 
+def _read_package_version_dict(pkg_list_filename: str) -> dict[str, str]:
+    pkg_versions = {}
+    if os.path.exists(pkg_list_filename):
+        with open(pkg_list_filename, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                (p, v) = line.split()
+                pkg_versions[p] = v
+    return pkg_versions
+
+
 def _unpack_packages(
     packages: list[tuple[str, str | None]],
     pkg_versions: dict[str, str],
@@ -1175,15 +1188,7 @@ class __AptDpkgPackageInfo(PackageInfo):
 
         # read original package list
         pkg_list = os.path.join(rootdir, "packages.txt")
-        pkg_versions = {}
-        if os.path.exists(pkg_list):
-            with open(pkg_list, encoding="utf-8") as f:
-                for line in f:
-                    line = line.strip()
-                    if not line:
-                        continue
-                    (p, v) = line.split()
-                    pkg_versions[p] = v
+        pkg_versions = _read_package_version_dict(pkg_list)
 
         # mark packages for installation
         real_pkgs = set()

--- a/apport/packaging_impl/apt_dpkg.py
+++ b/apport/packaging_impl/apt_dpkg.py
@@ -1169,7 +1169,7 @@ class __AptDpkgPackageInfo(PackageInfo):
 
         archivedir = apt.apt_pkg.config.find_dir("Dir::Cache::archives")
 
-        obsolete = ""
+        obsolete: list[str] = []
 
         src_records = apt.apt_pkg.SourceRecords()
 
@@ -1199,7 +1199,7 @@ class __AptDpkgPackageInfo(PackageInfo):
                     cache_pkg = apt_cache[pkg]
                 except KeyError:
                     m = f"package {pkg.replace('%', '%%')} does not exist, ignoring"
-                    obsolete += f"{m}\n"
+                    obsolete.append(f"{m}\n")
                     apport.logging.warning("%s", m)
                     continue
                 for dep in cache_pkg.candidate.dependencies:
@@ -1256,7 +1256,7 @@ class __AptDpkgPackageInfo(PackageInfo):
                 cache_pkg = apt_cache[pkg]
             except KeyError:
                 m = f"package {pkg.replace('%', '%%')} does not exist, ignoring"
-                obsolete += f"{m}\n"
+                obsolete.append(f"{m}\n")
                 apport.logging.warning("%s", m)
                 continue
 
@@ -1266,7 +1266,7 @@ class __AptDpkgPackageInfo(PackageInfo):
                     cache_pkg.candidate = cache_pkg.versions[ver]
             except KeyError:
                 if not get_package_from_launchpad(pkg, ver):
-                    obsolete += (
+                    obsolete.append(
                         f"{pkg} version {ver} required,"
                         f" but {cache_pkg.candidate.version} is available\n"
                     )
@@ -1301,7 +1301,7 @@ class __AptDpkgPackageInfo(PackageInfo):
                         try:
                             dbg.candidate = dbg.versions[candidate.version]
                         except KeyError:
-                            obsolete += (
+                            obsolete.append(
                                 f"outdated -dbg package for {pkg}:"
                                 f" package version {ver}"
                                 f" -dbg version {dbg.candidate.version}\n"
@@ -1378,7 +1378,7 @@ class __AptDpkgPackageInfo(PackageInfo):
                                         candidate.version
                                     ]
                                 except KeyError:
-                                    obsolete += (
+                                    obsolete.append(
                                         f"outdated debug symbol package"
                                         f" for {pkg}: package version"
                                         f" {candidate.version}"
@@ -1391,7 +1391,9 @@ class __AptDpkgPackageInfo(PackageInfo):
                                 if get_package_from_launchpad(dbgsym_pkg, ver):
                                     pkg_found = True
                             if not pkg_found:
-                                obsolete += f"no debug symbol package found for {pkg}\n"
+                                obsolete.append(
+                                    f"no debug symbol package found for {pkg}\n"
+                                )
 
         real_pkgs.difference_update(
             _unpack_packages(packages, pkg_versions, apt_cache, real_pkgs)
@@ -1442,7 +1444,7 @@ class __AptDpkgPackageInfo(PackageInfo):
         if permanent_rootdir:
             self._save_virtual_mapping(aptroot)
 
-        return obsolete
+        return "".join(obsolete)
 
     def package_name_glob(self, nameglob):
         """Return known package names which match given glob."""

--- a/apport/packaging_impl/apt_dpkg.py
+++ b/apport/packaging_impl/apt_dpkg.py
@@ -1202,14 +1202,18 @@ class __AptDpkgPackageInfo(PackageInfo):
                     obsolete.append(f"{m}\n")
                     apport.logging.warning("%s", m)
                     continue
-                for dep in cache_pkg.candidate.dependencies:
+                candidate = cache_pkg.candidate
+                assert candidate is not None
+                for dep in candidate.dependencies:
                     # the dependency may be satisfied by a different package
                     name = dep[0].name
                     if name not in apt_cache:
                         name = apt_cache.get_providing_packages(name)[0].name
                     # the version in dep is the one from pkg's dependencies,
                     # so use the version from the cache
-                    dep_pkg_vers = apt_cache[name].candidate.version
+                    dep_candidate = apt_cache[name].candidate
+                    assert dep_candidate is not None
+                    dep_pkg_vers = dep_candidate.version
                     # if the dependency is in the list of packages we don't
                     # need to look up its dependencies again
                     if name in [pkg[0] for pkg in packages]:

--- a/apport/packaging_impl/apt_dpkg.py
+++ b/apport/packaging_impl/apt_dpkg.py
@@ -1204,29 +1204,30 @@ class __AptDpkgPackageInfo(PackageInfo):
                     continue
                 for dep in cache_pkg.candidate.dependencies:
                     # the dependency may be satisfied by a different package
-                    if dep[0].name not in apt_cache:
-                        dep[0] = apt_cache.get_providing_packages(dep[0].name)[0]
+                    name = dep[0].name
+                    if name not in apt_cache:
+                        name = apt_cache.get_providing_packages(name)[0].name
                     # the version in dep is the one from pkg's dependencies,
                     # so use the version from the cache
-                    dep_pkg_vers = apt_cache[dep[0].name].candidate.version
+                    dep_pkg_vers = apt_cache[name].candidate.version
                     # if the dependency is in the list of packages we don't
                     # need to look up its dependencies again
-                    if dep[0].name in [pkg[0] for pkg in packages]:
+                    if name in [pkg[0] for pkg in packages]:
                         continue
                     # if the package is already extracted in the sandbox
                     # because the report needs that package we don't want to
                     # install a newer version which may cause a CRC mismatch
                     # with the installed dbg symbols
-                    if dep[0].name in pkg_versions:
-                        inst_version = pkg_versions[dep[0].name]
+                    if name in pkg_versions:
+                        inst_version = pkg_versions[name]
                         if self.compare_versions(inst_version, dep_pkg_vers) > -1:
-                            deps.append((dep[0].name, inst_version))
+                            deps.append((name, inst_version))
                         else:
-                            deps.append((dep[0].name, dep_pkg_vers))
+                            deps.append((name, dep_pkg_vers))
                     else:
-                        deps.append((dep[0].name, dep_pkg_vers))
-                    if dep[0].name not in [pkg[0] for pkg in packages]:
-                        packages.append((dep[0].name, None))
+                        deps.append((name, dep_pkg_vers))
+                    if name not in [pkg[0] for pkg in packages]:
+                        packages.append((name, None))
             packages.extend(deps)
 
         for pkg, ver in packages:

--- a/apport/packaging_impl/apt_dpkg.py
+++ b/apport/packaging_impl/apt_dpkg.py
@@ -202,6 +202,19 @@ def _read_package_version_dict(pkg_list_filename: str) -> dict[str, str]:
     return pkg_versions
 
 
+def _write_package_version_dict(
+    pkg_list_filename: str, pkg_versions: dict[str, str]
+) -> None:
+    pkgs = list(pkg_versions.keys())
+    pkgs.sort()
+    with open(pkg_list_filename, "w", encoding="utf-8") as f:
+        for p in pkgs:
+            f.write(p)
+            f.write(" ")
+            f.write(pkg_versions[p])
+            f.write("\n")
+
+
 def _unpack_packages(
     packages: list[tuple[str, str | None]],
     pkg_versions: dict[str, str],
@@ -1368,14 +1381,7 @@ class __AptDpkgPackageInfo(PackageInfo):
         )
 
         # update package list
-        pkgs = list(pkg_versions.keys())
-        pkgs.sort()
-        with open(pkg_list, "w", encoding="utf-8") as f:
-            for p in pkgs:
-                f.write(p)
-                f.write(" ")
-                f.write(pkg_versions[p])
-                f.write("\n")
+        _write_package_version_dict(pkg_list, pkg_versions)
 
         if tmp_aptroot:
             shutil.rmtree(aptroot)


### PR DESCRIPTION
The method `__AptDpkgPackageInfo.install_packages()` has a too high complexity. Carve out various helper methods to reduce the McCabe rating from 89 to 54.