### PR TITLE
ui: drop unneeded int conversion in run_hang

### DIFF
--- a/apport/ui.py
+++ b/apport/ui.py
@@ -915,8 +915,7 @@ class UserInterface:
             self.run_symptom()
             return True
         if self.args.hanging:
-            self.run_hang(self.args.pid)
-            return True
+            return self.run_hang(self.args.pid)
         if self.args.filebug:
             return self.run_report_bug()
         if self.args.update_report is not None:

--- a/apport/ui.py
+++ b/apport/ui.py
@@ -578,12 +578,12 @@ class UserInterface:
         self.cur_package = apport.fileutils.find_file_package(path)
         self.report.add_os_info()
         allowed_to_report = apport.fileutils.allowed_to_report()
-        response = self.ui_present_report_details(allowed_to_report, modal_for=int(pid))
+        response = self.ui_present_report_details(allowed_to_report, modal_for=pid)
         if response.report:
             apport.fileutils.mark_hanging_process(self.report, pid)
-            os.kill(int(pid), signal.SIGABRT)
+            os.kill(pid, signal.SIGABRT)
         else:
-            os.kill(int(pid), signal.SIGKILL)
+            os.kill(pid, signal.SIGKILL)
 
         if response.restart:
             self.wait_for_pid(pid)

--- a/apport/ui.py
+++ b/apport/ui.py
@@ -559,13 +559,6 @@ class UserInterface:
         """
         self.report = apport.Report("Hang")
 
-        if not self.args.pid:
-            self.ui_error_message(
-                _("No PID specified"),
-                _("You need to specify a PID. See --help for more information."),
-            )
-            return False
-
         try:
             self.report.add_proc_info(pid)
         except ValueError as error:
@@ -915,7 +908,13 @@ class UserInterface:
             self.run_symptom()
             return True
         if self.args.hanging:
-            return self.run_hang(self.args.pid)
+            if not self.args.pid:
+                self.ui_error_message(
+                    _("No PID specified"),
+                    _("You need to specify a PID. See --help for more information."),
+                )
+                return False
+            return self.run_hang(int(self.args.pid))
         if self.args.filebug:
             return self.run_report_bug()
         if self.args.update_report is not None:

--- a/tests/unit/test_ui.py
+++ b/tests/unit/test_ui.py
@@ -101,3 +101,13 @@ class TestUI(unittest.TestCase):
             _("Unable to start web browser"),
             _("Unable to start web browser to open %s.") % ("https://example.org"),
         )
+
+    @unittest.mock.patch("apport.ui.UserInterface.ui_error_message")
+    def test_hanging_without_pid(self, error_message_mock: MagicMock) -> None:
+        """Test calling apport --hanging without providing a process ID."""
+        ui = apport.ui.UserInterface(["ui-test", "--hanging"])
+        self.assertFalse(ui.run_argv())
+        error_message_mock.assert_called_once_with(
+            _("No PID specified"),
+            _("You need to specify a PID. See --help for more information."),
+        )


### PR DESCRIPTION
The method `UserInterface.run_hang` requires `pid` to be of type `int`.