### PR TITLE
apport-kde: support launching on Wayland

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,8 +58,8 @@ jobs:
           bash binutils ca-certificates default-jdk-headless dpkg-dev gcc gdb
           gir1.2-gtk-3.0 gir1.2-wnck-3.0 git kmod libc6-dev libxml2-utils
           locales polkitd procps python3 python3-apt python3-distutils-extra
-          python3-gi python3-launchpadlib python3-psutil python3-pytest
-          python3-pytest-cov python3-setuptools python3-systemd
+          python3-gi python3-launchpadlib python3-psutil python3-pyqt5
+          python3-pytest python3-pytest-cov python3-setuptools python3-systemd
           python3-zstandard valgrind
       - uses: actions/checkout@v4
       - name: Enable German locale
@@ -94,8 +94,8 @@ jobs:
           bash binutils ca-certificates default-jdk-headless dpkg-dev gcc gdb
           gir1.2-gtk-3.0 gir1.2-wnck-3.0 git kmod libc6-dev libxml2-utils
           locales pkg-config polkitd python3 python3-apt python3-distutils-extra
-          python3-gi python3-launchpadlib python3-psutil python3-pytest
-          python3-pytest-cov python3-setuptools python3-systemd
+          python3-gi python3-launchpadlib python3-psutil python3-pyqt5
+          python3-pytest python3-pytest-cov python3-setuptools python3-systemd
           python3-zstandard valgrind
       - uses: actions/checkout@v4
       - name: Enable German locale

--- a/kde/apport-kde
+++ b/kde/apport-kde
@@ -583,12 +583,17 @@ class MainUserInterface(apport.ui.UserInterface):
         return filename or None
 
 
-if __name__ == "__main__":
+def main(argv: list[str]) -> None:
+    """Qt Apport User Interface"""
     if not os.environ.get("DISPLAY"):
         apport.logging.fatal(
             "This program needs a running X session. Please see"
             ' "man apport-cli" for a command line version of Apport.'
         )
 
-    UserInterface = MainUserInterface(sys.argv)
+    UserInterface = MainUserInterface(argv)
     sys.exit(UserInterface.run_argv())
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/kde/apport-kde
+++ b/kde/apport-kde
@@ -585,9 +585,9 @@ class MainUserInterface(apport.ui.UserInterface):
 
 def main(argv: list[str]) -> None:
     """Qt Apport User Interface"""
-    if not os.environ.get("DISPLAY"):
+    if not apport.ui.has_display():
         apport.logging.fatal(
-            "This program needs a running X session. Please see"
+            "This program needs a running display server session. Please see"
             ' "man apport-cli" for a command line version of Apport.'
         )
 

--- a/tests/integration/test_ui_kde.py
+++ b/tests/integration/test_ui_kde.py
@@ -1,0 +1,35 @@
+"""Integration tests for the Qt Apport user interface."""
+
+# Copyright (C) 2025 Canonical Ltd.
+# Author: Benjamin Drung <benjamin.drung@canonical.com>
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+import io
+from unittest.mock import patch
+
+import pytest
+
+from tests.helper import import_module_from_file
+from tests.paths import get_data_directory
+
+
+def test_no_environment_variables() -> None:
+    """Test launching apport-kde without any environment variables set."""
+    apport_kde_path = get_data_directory("kde") / "apport-kde"
+    with patch("sys.stderr", new_callable=io.StringIO) as stderr:
+        try:
+            apport_kde = import_module_from_file(apport_kde_path)
+        except SystemExit:
+            pytest.skip(stderr.getvalue().strip())
+    with (
+        patch.dict("os.environ", {}, clear=True),
+        patch("sys.stderr", new_callable=io.StringIO) as stderr,
+        pytest.raises(SystemExit) as error,
+    ):
+        apport_kde.main([str(apport_kde_path)])
+
+    assert (
+        stderr.getvalue() == "ERROR: This program needs a running X"
+        ' session. Please see "man apport-cli" for a command line version of Apport.\n'
+    )
+    assert error.value.code == 1

--- a/tests/integration/test_ui_kde.py
+++ b/tests/integration/test_ui_kde.py
@@ -29,7 +29,7 @@ def test_no_environment_variables() -> None:
         apport_kde.main([str(apport_kde_path)])
 
     assert (
-        stderr.getvalue() == "ERROR: This program needs a running X"
+        stderr.getvalue() == "ERROR: This program needs a running display server"
         ' session. Please see "man apport-cli" for a command line version of Apport.\n'
     )
     assert error.value.code == 1

--- a/tests/system/test_ui_kde.py
+++ b/tests/system/test_ui_kde.py
@@ -13,6 +13,7 @@
 # TODO: Address following pylint complaints
 # pylint: disable=invalid-name
 
+import io
 import os
 import shutil
 import tempfile
@@ -740,6 +741,19 @@ class T(unittest.TestCase):
 
         # No URL in this mode
         self.assertEqual(self.ui.open_url.call_count, 0)
+
+    @unittest.mock.patch("sys.stderr", new_callable=io.StringIO)
+    @unittest.mock.patch("sys.stdout", new_callable=io.StringIO)
+    def test_help(self, stdout: io.StringIO, stderr: io.StringIO) -> None:
+        """Test apport-kde --help."""
+        with self.assertRaisesRegex(SystemExit, "^0$"):
+            apport_kde.main([str(apport_kde_path), "--help"])
+
+        self.assertEqual(stderr.getvalue(), "")
+        self.assertRegex(stdout.getvalue(), "^usage: ")
+        self.assertIn(
+            "Report the crash from given .apport or .crash file", stdout.getvalue()
+        )
 
     def test_administrator_disabled_reporting(self) -> None:
         QTimer.singleShot(0, QCoreApplication.quit)


### PR DESCRIPTION
apport-kde refuses to launch on a Kubuntu 24.04 (noble) Wayland session (where `WAYLAND_DISPLAY` is set):

```
$ env -u DISPLAY ubuntu-bug
ERROR: This program needs a running X session. Please see "man apport-cli" for a command line version of Apport.
```

apport-kde starts succeesful if only `WAYLAND_DISPLAY` is set. So relax the display server check to the same as apport-gtk.