### PR TITLE
fileutils: avoid geteuid call in make_report_file for uid=0

### DIFF
--- a/apport/fileutils.py
+++ b/apport/fileutils.py
@@ -27,6 +27,7 @@ import socket
 import stat
 import subprocess
 import time
+from typing import IO
 
 from apport.packaging_impl import impl as packaging
 from problem_report import ProblemReport
@@ -414,7 +415,7 @@ def increment_crash_counter(report: ProblemReport, filename: str) -> None:
         report["CrashCounter"] = str(crash_counter)
 
 
-def make_report_file(report, uid=None):
+def make_report_file(report: ProblemReport, uid: int | str | None = None) -> IO[bytes]:
     """Construct a canonical pathname for a report and open it for writing.
 
     If uid is not given, it defaults to the effective uid of the current
@@ -430,7 +431,7 @@ def make_report_file(report, uid=None):
     else:
         raise ValueError("report has neither ExecutablePath nor Package attribute")
 
-    if not uid:
+    if uid is None:
         uid = os.geteuid()
 
     path = os.path.join(report_dir, f"{subject}.{str(uid)}.crash")

--- a/tests/integration/test_fileutils.py
+++ b/tests/integration/test_fileutils.py
@@ -302,6 +302,15 @@ class T(unittest.TestCase):
         os.symlink(os.path.join(apport.fileutils.report_dir, "pwned"), path)
         self.assertRaises(OSError, apport.fileutils.make_report_file, pr)
 
+    def test_make_report_file_uid_0(self) -> None:
+        """make_report_file(report, uid=0)"""
+        report = problem_report.ProblemReport()
+        report["ExecutablePath"] = "/bin/sh"
+        with apport.fileutils.make_report_file(report, uid=0) as report_file:
+            self.assertEqual(
+                report_file.name, f"{apport.fileutils.report_dir}/_bin_sh.0.crash"
+            )
+
     def test_check_files_md5(self) -> None:
         """check_files_md5()"""
         f1 = os.path.join(apport.fileutils.report_dir, "test 1.txt")


### PR DESCRIPTION
The function `make_report_file` should only call `os.geteuid()` in case `uid` is not given. It also does this call for `uid = 0`.