### PR TITLE
test: some refactoring and fix test_find_package_desktopfile_multiple

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,7 +60,7 @@ jobs:
           locales polkitd procps python3 python3-apt python3-distutils-extra
           python3-gi python3-launchpadlib python3-psutil python3-pyqt5
           python3-pytest python3-pytest-cov python3-setuptools python3-systemd
-          python3-zstandard valgrind
+          python3-zstandard valgrind xterm
       - uses: actions/checkout@v4
       - name: Enable German locale
         run: sed -i 's/^# de_DE/de_DE/g' /etc/locale.gen && locale-gen
@@ -96,7 +96,7 @@ jobs:
           locales pkg-config polkitd python3 python3-apt python3-distutils-extra
           python3-gi python3-launchpadlib python3-psutil python3-pyqt5
           python3-pytest python3-pytest-cov python3-setuptools python3-systemd
-          python3-zstandard valgrind
+          python3-zstandard valgrind xterm
       - uses: actions/checkout@v4
       - name: Enable German locale
         run: sudo sed -i 's/^# de_DE/de_DE/g' /etc/locale.gen && sudo locale-gen

--- a/tests/integration/test_fileutils.py
+++ b/tests/integration/test_fileutils.py
@@ -6,6 +6,7 @@
 import glob
 import os
 import pwd
+import re
 import shutil
 import sys
 import tempfile
@@ -65,6 +66,7 @@ class T(unittest.TestCase):
 
     @staticmethod
     def _packages_with_desktop_files() -> Iterator[tuple[str, int, int]]:
+        desktop_path_re = re.compile("^/usr/share/applications/[^/]+.desktop$")
         for path in sorted(glob.glob("/usr/share/applications/*.desktop")):
             pkg = apport.packaging.get_file_package(path)
             if pkg is None:
@@ -73,9 +75,7 @@ class T(unittest.TestCase):
             display_num = 0
             no_display_num = 0
             for desktop_file in apport.packaging.get_files(pkg):
-                if not desktop_file.endswith(".desktop"):
-                    continue
-                if desktop_file.startswith("/usr/share/mimelnk"):
+                if not desktop_path_re.match(desktop_file):
                     continue
                 with open(desktop_file, "rb") as desktop_file:
                     if b"NoDisplay=true" in desktop_file.read():

--- a/tests/integration/test_fileutils.py
+++ b/tests/integration/test_fileutils.py
@@ -3,6 +3,7 @@
 # TODO: Address following pylint complaints
 # pylint: disable=invalid-name
 
+import glob
 import os
 import pwd
 import shutil
@@ -64,10 +65,7 @@ class T(unittest.TestCase):
 
     @staticmethod
     def _packages_with_desktop_files() -> Iterator[tuple[str, int, int]]:
-        for d in sorted(os.listdir("/usr/share/applications/")):
-            if not d.endswith(".desktop"):
-                continue
-            path = os.path.join("/usr/share/applications/", d)
+        for path in sorted(glob.glob("/usr/share/applications/*.desktop")):
             pkg = apport.packaging.get_file_package(path)
             if pkg is None:
                 continue


### PR DESCRIPTION
Split `test_find_package_desktopfile` into multiple separate test cases (plus some refactorings, see individual commits).

The test case `test_find_package_desktopfile_multiple` can fail when gnome-terminal is installed. The logic in
`_packages_with_desktop_files` treats following files from gnome-terminal as .desktop files:

* /usr/share/applications/org.gnome.Terminal.Preferences.desktop
* /usr/share/applications/org.gnome.Terminal.desktop
* /usr/share/xdg-terminals/org.gnome.Terminal.desktop

`_packages_with_desktop_files` should ignore files in `/usr/share/xdg-terminals`. Use a regular expression to ignore all
`.desktop` files outside `/usr/share/applications`.