### PR TITLE
report: fix extracting glib assertion from crashdump

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,11 +56,11 @@ jobs:
           apt-get update
           && apt-get install --no-install-recommends --yes
           bash binutils ca-certificates default-jdk-headless dpkg-dev gcc gdb
-          gir1.2-gtk-3.0 gir1.2-wnck-3.0 git kmod libc6-dev libxml2-utils
-          locales polkitd procps python3 python3-apt python3-distutils-extra
-          python3-gi python3-launchpadlib python3-psutil python3-pyqt5
-          python3-pytest python3-pytest-cov python3-setuptools python3-systemd
-          python3-zstandard valgrind xterm
+          gir1.2-gtk-3.0 gir1.2-wnck-3.0 git kmod libc6-dev libglib2.0-dev
+          libxml2-utils locales pkg-config polkitd procps python3 python3-apt
+          python3-distutils-extra python3-gi python3-launchpadlib python3-psutil
+          python3-pyqt5 python3-pytest python3-pytest-cov python3-setuptools
+          python3-systemd python3-zstandard valgrind xterm
       - uses: actions/checkout@v4
       - name: Enable German locale
         run: sed -i 's/^# de_DE/de_DE/g' /etc/locale.gen && locale-gen
@@ -92,11 +92,11 @@ jobs:
           sudo apt-get update
           && sudo apt-get install --no-install-recommends --yes
           bash binutils ca-certificates default-jdk-headless dpkg-dev gcc gdb
-          gir1.2-gtk-3.0 gir1.2-wnck-3.0 git kmod libc6-dev libxml2-utils
-          locales pkg-config polkitd python3 python3-apt python3-distutils-extra
-          python3-gi python3-launchpadlib python3-psutil python3-pyqt5
-          python3-pytest python3-pytest-cov python3-setuptools python3-systemd
-          python3-zstandard valgrind xterm
+          gir1.2-gtk-3.0 gir1.2-wnck-3.0 git kmod libc6-dev libglib2.0-dev
+          libxml2-utils locales pkg-config polkitd python3 python3-apt
+          python3-distutils-extra python3-gi python3-launchpadlib python3-psutil
+          python3-pyqt5 python3-pytest python3-pytest-cov python3-setuptools
+          python3-systemd python3-zstandard valgrind xterm
       - uses: actions/checkout@v4
       - name: Enable German locale
         run: sudo sed -i 's/^# de_DE/de_DE/g' /etc/locale.gen && sudo locale-gen

--- a/apport/report.py
+++ b/apport/report.py
@@ -950,7 +950,7 @@ class Report(problem_report.ProblemReport):
             "Stacktrace": "bt full",
             "ThreadStacktrace": "thread apply all bt full",
             "AssertionMessage": "print __abort_msg->msg",
-            "GLibAssertionMessage": "print __glib_assert_msg",
+            "GLibAssertionMessage": "print (char*) __glib_assert_msg",
             "NihAssertionMessage": "print (char*) __nih_abort_msg",
         }
         gdb_cmd, environ = self.gdb_command(rootdir, gdb_sandbox)


### PR DESCRIPTION
Printing `__glib_assert_msg` with GDB on Ubuntu 24.04 (noble) fails:

```
(gdb) print __glib_assert_msg
'__glib_assert_msg' has unknown type; cast it to its declared type
```

So cast `__glib_assert_msg` to `char*` and revive the `test_add_gdb_info_abort_glib` test case.

`extra_gcc_args` in `_generate_sigsegv_report` must be placed last because the glib linker flags must be last.