### PR TITLE
report: drop support for libnih

### DIFF
--- a/apport/report.py
+++ b/apport/report.py
@@ -929,8 +929,8 @@ class Report(problem_report.ProblemReport):
         - ThreadStacktrace: Output of gdb's 'thread apply all bt full' command
         - StacktraceTop: simplified stacktrace (topmost 5 functions) for inline
           inclusion into bug reports and easier processing
-        - AssertionMessage: Value of __abort_msg, __glib_assert_msg, or
-          __nih_abort_msg if present
+        - AssertionMessage: Value of __abort_msg or __glib_assert_msg
+          if present
 
         The optional rootdir can specify a root directory which has the
         executable, libraries, and debug symbols. This does not require
@@ -951,7 +951,6 @@ class Report(problem_report.ProblemReport):
             "ThreadStacktrace": "thread apply all bt full",
             "AssertionMessage": "print __abort_msg->msg",
             "GLibAssertionMessage": "print (char*) __glib_assert_msg",
-            "NihAssertionMessage": "print (char*) __nih_abort_msg",
         }
         gdb_cmd, environ = self.gdb_command(rootdir, gdb_sandbox)
         environ["HOME"] = "/nonexistent"
@@ -1016,12 +1015,6 @@ class Report(problem_report.ProblemReport):
             if '"ERROR:' in self["GLibAssertionMessage"]:
                 self["AssertionMessage"] = self["GLibAssertionMessage"]
             del self["GLibAssertionMessage"]
-
-        # same reason for libnih's assertion messages
-        if "NihAssertionMessage" in self:
-            if self["NihAssertionMessage"].startswith("$"):
-                self["AssertionMessage"] = self["NihAssertionMessage"]
-            del self["NihAssertionMessage"]
 
         # clean up AssertionMessage
         if "AssertionMessage" in self:


### PR DESCRIPTION
libnih upstream is dead since 2012-ish and the Debian package is orphaned since 2016 [1]. The libnih package was removed from Ubuntu in 2022. So drop support for libnih.

[1] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1013225

Note: This change should land in Ubuntu 25.10 since we passed the feature freeze of Ubuntu 25.04.