### PR TITLE
run-linters: check Python code in debian/ if present

### DIFF
--- a/tests/run-linters
+++ b/tests/run-linters
@@ -15,6 +15,7 @@
 set -eu
 
 PYTHON_FILES="apport apport_python_hook.py data problem_report.py setup.py setuptools_apport tests"
+test ! -d debian || PYTHON_FILES="$PYTHON_FILES debian"
 PYTHON_SCRIPTS_WITHOUT_APPORT=$(find bin data gtk kde -type f -executable ! -name apport-bug ! -name apport-collect ! -name is-enabled ! -name root_info_wrapper ! -name apport)
 PYTHON_SCRIPTS="$PYTHON_SCRIPTS_WITHOUT_APPORT data/apport"
 


### PR DESCRIPTION
The Ubuntu package ships package hooks in `debian/package-hooks`. Check Python code in the `debian` directory if this directory exists.