### PR TITLE
test: do not check for exact encoded gzip data

### DIFF
--- a/tests/integration/test_problem_report.py
+++ b/tests/integration/test_problem_report.py
@@ -188,21 +188,13 @@ class T(unittest.TestCase):
             out = io.BytesIO()
             pr.write(out)
 
-        self.assertEqual(
-            out.getvalue().decode(),
-            textwrap.dedent(
-                """\
-                ProblemType: Crash
-                Date: now!
-                Afile: base64
-                 H4sICAAAAAAC/0FmaWxlAA==
-                 c3RyhEIGBoYoRiYAM5XUCxAAAAA=
-                File: base64
-                 H4sICAAAAAAC/0ZpbGUA
-                 c3RyhEIGBoYoRiYAM5XUCxAAAAA=
-                """
-            ),
-        )
+        self.assertIn("Afile: base64\n", out.getvalue().decode())
+        self.assertIn("File: base64\n", out.getvalue().decode())
+        report = problem_report.ProblemReport()
+        out.seek(0)
+        report.load(out)
+        self.assertEqual(report["File"], bin_data)
+        self.assertEqual(report["Afile"], bin_data)
 
         # force compression/encoding bool
         with tempfile.NamedTemporaryFile() as temp:

--- a/tests/unit/test_report.py
+++ b/tests/unit/test_report.py
@@ -1489,12 +1489,14 @@ No symbol table info available.
         report_output = io.BytesIO()
         report.write(report_output)
 
-        expected_report = (
-            DIVIDE_BY_ZERO_REPORT + "CoreDump: base64\n"
-            " H4sICAAAAAAC/0NvcmVEdW1wAA==\n"
-            " q3f1cWNiZGSAAgC2f6EYDwAAAA==\n"
+        report_without_coredump = re.sub(
+            "\nCoreDump:.*", "\n", report_output.getvalue().decode(), flags=re.DOTALL
         )
-        self.assertEqual(report_output.getvalue().decode(), expected_report)
+        self.assertEqual(report_without_coredump, DIVIDE_BY_ZERO_REPORT)
+        written_report = apport.report.Report()
+        report_output.seek(0)
+        written_report.load(report_output)
+        self.assertEqual(written_report["CoreDump"], coredump["COREDUMP"])
         stat_mock.assert_called_once_with("/usr/bin/divide-by-zero")
 
     @unittest.mock.patch("os.stat")


### PR DESCRIPTION
The test cases `test_modify`, `test_write_file`, and `test_report_from_systemd_coredump_storage_journal` fail on s390x from time to time due to the encoded chunks have a different on-disk representation. Instead of the expected one compressed chunk

```
File: base64
 H4sICAAAAAAC/0ZpbGUA
 c3RyxIAMcBAFAK/2p9MfAAAA
```

there could be two compressed chunks:

```
File: base64
 H4sICAAAAAAC/0ZpbGUA
 cnTChAxwEA==
 BRgAr/an0x8AAAA=
```

The raw data is identical, but the zlib compressed data on disk differs! So make the test case less picky by just checking that the data is compressed and that the decompressed data is correct.

Bug: https://launchpad.net/bugs/2076269