### PR TITLE
Fix ruff complains and add ruff check to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,12 @@ jobs:
       - name: Run linter tests
         run: tests/run-linters
 
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/ruff-action@v3
+
   unit-and-integration:
     runs-on: ubuntu-latest
     strategy:

--- a/apport/crashdb_impl/launchpad.py
+++ b/apport/crashdb_impl/launchpad.py
@@ -1060,7 +1060,7 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
         # pylint: disable=protected-access
         team = self.options.get("triaging_team", "ubuntu-crashes-universe")
         person = f"{self.launchpad._root_uri}~{team}"
-        if not person.replace(str(self.launchpad._root_uri), "").strip("~") in [
+        if person.replace(str(self.launchpad._root_uri), "").strip("~") not in [
             str(sub).split("/", maxsplit=1)[-1] for sub in bug.subscriptions
         ]:
             bug.subscribe(person=person)

--- a/apport/report.py
+++ b/apport/report.py
@@ -1613,7 +1613,7 @@ class Report(problem_report.ProblemReport):
         it exists.
         """
         if "ExecutablePath" not in self:
-            if not self["ProblemType"] in {"KernelCrash", "KernelOops"}:
+            if self["ProblemType"] not in {"KernelCrash", "KernelOops"}:
                 return None
 
         # kernel crash

--- a/apport_python_hook.py
+++ b/apport_python_hook.py
@@ -104,7 +104,7 @@ def apport_excepthook(
                 report["_PythonExceptionQualifier"] = name
 
         # disambiguate OSErrors with errno:
-        if exc_type == OSError:
+        if exc_type is OSError:
             assert isinstance(exc_obj, OSError)
             if exc_obj.errno is not None:
                 report["_PythonExceptionQualifier"] = str(exc_obj.errno)

--- a/data/general-hooks/parse_segv.py
+++ b/data/general-hooks/parse_segv.py
@@ -374,7 +374,7 @@ def add_info(report):
             return
 
     # Only run on segv for x86 and x86_64...
-    if not report["Architecture"] in {"i386", "amd64"}:
+    if report["Architecture"] not in {"i386", "amd64"}:
         return
 
     try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,3 +102,29 @@ reports = false
 
 # Activate the evaluation score.
 score = false
+
+[tool.ruff]
+include = [
+    "pyproject.toml",
+    "**/*.py",
+    "bin/apport-cli",
+    "bin/apport-retrace",
+    "bin/apport-unpack",
+    "bin/apport-valgrind",
+    "bin/crash-digger",
+    "bin/dupdb-admin",
+    "data/apport",
+    "data/apport-checkreports",
+    "data/apportcheckresume",
+    "data/gcc_ice_hook",
+    "data/iwlwifi_error_dump",
+    "data/java_uncaught_exception",
+    "data/kernel_crashdump",
+    "data/kernel_oops",
+    "data/package_hook",
+    "data/recoverable_problem",
+    "data/unkillable_shutdown",
+    "data/whoopsie-upload-all",
+    "gtk/apport-gtk",
+    "kde/apport-kde",
+]

--- a/tests/unit/test_rethread.py
+++ b/tests/unit/test_rethread.py
@@ -51,7 +51,7 @@ class T(unittest.TestCase):
         t.join()
         # thread did not terminate normally, no return value
         self.assertRaises(AssertionError, t.return_value)
-        self.assertTrue(t.exc_info()[0] == ZeroDivisionError)
+        self.assertIs(t.exc_info()[0], ZeroDivisionError)
         exc = traceback.format_exception(
             t.exc_info()[0], t.exc_info()[1], t.exc_info()[2]
         )


### PR DESCRIPTION
ruff check complains:
```
apport/crashdb_impl/launchpad.py:1063:16: E713 [*] Test for membership should be `not in`
     |
1061 |           team = self.options.get("triaging_team", "ubuntu-crashes-universe")
1062 |           person = f"{self.launchpad._root_uri}~{team}"
1063 |           if not person.replace(str(self.launchpad._root_uri), "").strip("~") in [
     |  ________________^
1064 | |             str(sub).split("/", maxsplit=1)[-1] for sub in bug.subscriptions
1065 | |         ]:
     | |_________^ E713
1066 |               bug.subscribe(person=person)
     |
     = help: Convert to `not in`

apport/report.py:1616:20: E713 [*] Test for membership should be `not in`
     |
1614 |         """
1615 |         if "ExecutablePath" not in self:
1616 |             if not self["ProblemType"] in {"KernelCrash", "KernelOops"}:
     |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ E713
1617 |                 return None
     |
     = help: Convert to `not in`

apport_python_hook.py:107:12: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
    |
106 |         # disambiguate OSErrors with errno:
107 |         if exc_type == OSError:
    |            ^^^^^^^^^^^^^^^^^^^ E721
108 |             assert isinstance(exc_obj, OSError)
109 |             if exc_obj.errno is not None:
    |

data/general-hooks/parse_segv.py:377:12: E713 [*] Test for membership should be `not in`
    |
376 |     # Only run on segv for x86 and x86_64...
377 |     if not report["Architecture"] in {"i386", "amd64"}:
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ E713
378 |         return
    |
    = help: Convert to `not in`

tests/unit/test_rethread.py:54:25: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
   |
52 |         # thread did not terminate normally, no return value
53 |         self.assertRaises(AssertionError, t.return_value)
54 |         self.assertTrue(t.exc_info()[0] == ZeroDivisionError)
   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ E721
55 |         exc = traceback.format_exception(
56 |             t.exc_info()[0], t.exc_info()[1], t.exc_info()[2]
   |

Found 5 errors.
```

Fix those and add `ruff check` to CI.