### PR TITLE
Apply uncontroversial ruff format changes

### DIFF
--- a/apport/crashdb_impl/debian.py
+++ b/apport/crashdb_impl/debian.py
@@ -8,7 +8,6 @@
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
 
-
 import email.mime.text
 import smtplib
 import tempfile

--- a/apport/crashdb_impl/github.py
+++ b/apport/crashdb_impl/github.py
@@ -87,7 +87,7 @@ class Github:
 
         self.__authentication_data = {
             "client_id": self.__client_id,
-            "device_code": f'{response["device_code"]}',
+            "device_code": f"{response['device_code']}",
             "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
         }
         self.__cooldown = response["interval"]

--- a/apport/hookutils.py
+++ b/apport/hookutils.py
@@ -327,10 +327,7 @@ def attach_alsa_old(report):
                 codec = os.path.basename(codecpath)
                 for name in os.listdir(codecpath):
                     path = os.path.join(codecpath, name)
-                    key = (
-                        f"Card{card}.Codecs"
-                        f".{path_to_key(codec)}.{path_to_key(name)}"
-                    )
+                    key = f"Card{card}.Codecs.{path_to_key(codec)}.{path_to_key(name)}"
                     attach_file(report, path, key)
 
 

--- a/apport/report.py
+++ b/apport/report.py
@@ -1446,10 +1446,7 @@ class Report(problem_report.ProblemReport):
         if len(trace) < 1:
             return None
         if len(trace) < 3:
-            return (
-                f"{os.path.basename(self['ExecutablePath'])}"
-                f" crashed with {trace[0]}"
-            )
+            return f"{os.path.basename(self['ExecutablePath'])} crashed with {trace[0]}"
 
         trace_re = re.compile(r'^\s*File\s*"(\S+)".* in (.+)$')
         i = len(trace) - 1

--- a/apport/ui.py
+++ b/apport/ui.py
@@ -363,8 +363,7 @@ class UserInterface:
         except ImportError as error:
             # this can happen while upgrading python packages
             apport.logging.fatal(
-                "Could not import module, is a package upgrade in progress?"
-                " Error: %s",
+                "Could not import module, is a package upgrade in progress? Error: %s",
                 str(error),
             )
         except KeyError:

--- a/bin/apport-retrace
+++ b/bin/apport-retrace
@@ -128,8 +128,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "--dynamic-origins",
         action="store_true",
         help=_(
-            "Create and use third-party repositories from origins specified"
-            " in reports"
+            "Create and use third-party repositories from origins specified in reports"
         ),
     )
     argparser.add_argument(
@@ -683,8 +682,7 @@ Thank you for your understanding, and sorry for the inconvenience!
                             crashdb.mark_retrace_failed(crashid, invalid_msg)
                         else:
                             apport.log(
-                                "Report has no crash signature,"
-                                " so retrace is flawed",
+                                "Report has no crash signature, so retrace is flawed",
                                 options.timestamps,
                             )
                             crashdb.mark_retrace_failed(crashid)

--- a/data/apport
+++ b/data/apport
@@ -554,8 +554,7 @@ def forward_crash_to_container(
         with open("uid_map", "r", encoding="utf-8", opener=proc_host_pid_opener) as fd:
             if not apport.fileutils.search_map(fd, task_uid):
                 logger.error(
-                    "host pid %s crashed in a container"
-                    " with no access to the binary",
+                    "host pid %s crashed in a container with no access to the binary",
                     options.global_pid,
                 )
                 return
@@ -567,8 +566,7 @@ def forward_crash_to_container(
         with open("gid_map", "r", encoding="utf-8", opener=proc_host_pid_opener) as fd:
             if not apport.fileutils.search_map(fd, task_gid):
                 logger.error(
-                    "host pid %s crashed in a container"
-                    " with no access to the binary",
+                    "host pid %s crashed in a container with no access to the binary",
                     options.global_pid,
                 )
                 return
@@ -925,8 +923,7 @@ def process_crash_from_kernel(options: argparse.Namespace) -> int:
             return process_crash_from_kernel_with_proc_pid(options, proc_pid)
     except FileNotFoundError as error:
         logging.getLogger().error(
-            "%s not found. "
-            "Cannot collect crash information for process %i any more.",
+            "%s not found. Cannot collect crash information for process %i any more.",
             error.filename,
             options.pid,
         )

--- a/data/general-hooks/parse_segv.py
+++ b/data/general-hooks/parse_segv.py
@@ -331,8 +331,7 @@ class ParseSegv:
         # Handle I/O port operations
         if self.insn in {"out", "in"} and not understood:
             msg = (
-                f"disallowed I/O port operation"
-                f" on port {self.register_value(self.src)}"
+                f"disallowed I/O port operation on port {self.register_value(self.src)}"
             )
             reason.append(msg)
             details.append(msg)

--- a/problem_report.py
+++ b/problem_report.py
@@ -45,8 +45,7 @@ class MalformedProblemReport(ValueError):
 
     def __init__(self, message: str, *args: object):
         super().__init__(
-            f"Malformed problem report: {message}."
-            f" Is this a proper .crash text file?",
+            f"Malformed problem report: {message}. Is this a proper .crash text file?",
             *args,
         )
 

--- a/tests/integration/test_apport_unpack.py
+++ b/tests/integration/test_apport_unpack.py
@@ -131,8 +131,7 @@ class TestApportUnpack(unittest.TestCase):
         """Test unpacking a report file that has a malformed CoreDump entry."""
         with tempfile.NamedTemporaryFile("wb") as report_file:
             report_file.write(
-                b"CoreDump: base64\n H4sICAAAAAAC/0NvcmVEdW1wAA==\n"
-                b" 7Z0LYFPV/cdP0rQ\n"
+                b"CoreDump: base64\n H4sICAAAAAAC/0NvcmVEdW1wAA==\n 7Z0LYFPV/cdP0rQ\n"
             )
             report_file.flush()
             process = self._call_apport_unpack([report_file.name, self.unpack_dir])

--- a/tests/integration/test_crashdb_launchpad.py
+++ b/tests/integration/test_crashdb_launchpad.py
@@ -153,8 +153,7 @@ NameError: global name 'weird' is not defined"""
         r.add_user_info()
         self.assertEqual(
             r.standard_title(),
-            "foo crashed with NameError in fuzz():"
-            " global name 'weird' is not defined",
+            "foo crashed with NameError in fuzz(): global name 'weird' is not defined",
         )
 
         return self._create_bug_from_report("Python", r)
@@ -189,8 +188,7 @@ and more
             target=self.crashdb.lp_distro,
         )
         sys.stderr.write(
-            f"(Created uncommon description:"
-            f" https://{self.hostname}/bugs/{bug.id}) "
+            f"(Created uncommon description: https://{self.hostname}/bugs/{bug.id}) "
         )
 
         return bug.id
@@ -855,8 +853,7 @@ NameError: global name 'weird' is not defined"""
         r.add_user_info()
         self.assertEqual(
             r.standard_title(),
-            "foo crashed with NameError in fuzz():"
-            " global name 'weird' is not defined",
+            "foo crashed with NameError in fuzz(): global name 'weird' is not defined",
         )
 
         # file it

--- a/tests/integration/test_dupdb_admin.py
+++ b/tests/integration/test_dupdb_admin.py
@@ -84,8 +84,7 @@ class TestDupdbAdmin(unittest.TestCase):
         lines = stdout.rstrip().split("\n")
         self.assertEqual(len(lines), 2, lines)
         self.assertIn(
-            "0: /bin/crash:11:foo_bar:d01:raise:<signal handler called>:__frob"
-            " [open]",
+            "0: /bin/crash:11:foo_bar:d01:raise:<signal handler called>:__frob [open]",
             lines[0],
         )
         self.assertIn("2: /usr/bin/broken:11:h:g:f:e:d [fixed in: 42]", lines[1])

--- a/tests/integration/test_fileutils.py
+++ b/tests/integration/test_fileutils.py
@@ -370,7 +370,7 @@ f6423dfbc4faf022e58b4d3f5ff71a70  {f2}
 
             # nonempty
             f.write(
-                b"[main]\none=1\ntwo = TWO\nb1 = 1\nb2=False\n" b"[spethial]\none= 99\n"
+                b"[main]\none=1\ntwo = TWO\nb1 = 1\nb2=False\n[spethial]\none= 99\n"
             )
             f.flush()
             self.assertIsNone(apport.fileutils.get_config("main", "foo"))

--- a/tests/integration/test_problem_report.py
+++ b/tests/integration/test_problem_report.py
@@ -88,7 +88,7 @@ class T(unittest.TestCase):
                 WhiteSpace:
                   foo   bar
                  baz
-                   blip{'  '}
+                   blip{"  "}
                 Extra: appended
                 """
             ),

--- a/tests/integration/test_python_crashes.py
+++ b/tests/integration/test_python_crashes.py
@@ -68,7 +68,7 @@ class T(unittest.TestCase):
         os.write(
             fd,
             f"""\
-#!/usr/bin/env {os.getenv('PYTHON', 'python3')}
+#!/usr/bin/env {os.getenv("PYTHON", "python3")}
 import apport_python_hook
 apport_python_hook.install()
 
@@ -386,7 +386,7 @@ func(42)
                     fd,
                     textwrap.dedent(
                         f"""\
-                        #!/usr/bin/env {os.getenv('PYTHON', 'python3')}
+                        #!/usr/bin/env {os.getenv("PYTHON", "python3")}
                         import apport_python_hook
                         apport_python_hook.install()
 

--- a/tests/integration/test_recoverable_problem.py
+++ b/tests/integration/test_recoverable_problem.py
@@ -46,8 +46,7 @@ class TestRecoverableProblem(unittest.TestCase):
             time.sleep(0.1)
             seconds += 0.1
         self.fail(
-            f"timeout while waiting for .crash file to be created"
-            f" in {self.report_dir}."
+            f"timeout while waiting for .crash file to be created in {self.report_dir}."
         )
 
     @unittest.mock.patch("os.listdir")

--- a/tests/integration/test_report.py
+++ b/tests/integration/test_report.py
@@ -242,7 +242,7 @@ class T(unittest.TestCase):
             testscript.write_text(
                 textwrap.dedent(
                     f"""\
-                    #!/usr/bin/{os.getenv('PYTHON', 'python3')}
+                    #!/usr/bin/{os.getenv("PYTHON", "python3")}
                     import sys
                     sys.stdin.readline()
                     """

--- a/tests/integration/test_signal_crashes.py
+++ b/tests/integration/test_signal_crashes.py
@@ -1229,8 +1229,7 @@ class T(unittest.TestCase):
                 os.unlink(core_path)
             except OSError as error:
                 sys.stderr.write(
-                    f"WARNING: cannot clean up core file {core_path}:"
-                    f" {str(error)}\n"
+                    f"WARNING: cannot clean up core file {core_path}: {str(error)}\n"
                 )
 
             self.fail("leaves unexpected core file behind")

--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -908,7 +908,6 @@ class T(unittest.TestCase):
                 env={"HOME": self.workdir},
                 stdout=subprocess.PIPE,
             ) as gdb:
-
                 try:
                     pid = wait_for_process_to_appear(
                         self.TEST_EXECUTABLE,
@@ -1996,9 +1995,7 @@ class T(unittest.TestCase):
         # working noninteractive script
         self._write_symptom_script(
             "itching.py",
-            "def run(report, ui):\n"
-            '  report["itch"] = "scratch"\n'
-            '  return "bash"\n',
+            'def run(report, ui):\n  report["itch"] = "scratch"\n  return "bash"\n',
         )
         self.ui = UserInterfaceMock(["ui-test", "-s", "itching"])
         self.ui.present_details_response = apport.ui.Action(report=True)

--- a/tests/system/test_packaging_apt_dpkg.py
+++ b/tests/system/test_packaging_apt_dpkg.py
@@ -742,7 +742,7 @@ def test_create_sources_for_a_named_ppa(
         if {"deb", "deb-src"} == set(e.types)
         and "jammy" in e.suites
         and "main" in e.comps
-        and "http://ppa.launchpad.net/" "daisy-pluckers/daisy-seeds/ubuntu" in e.uris
+        and "http://ppa.launchpad.net/daisy-pluckers/daisy-seeds/ubuntu" in e.uris
     ]
     assert [
         e
@@ -750,7 +750,7 @@ def test_create_sources_for_a_named_ppa(
         if "deb" in e.types
         and "jammy" in e.suites
         and "main/debug" in e.comps
-        and "http://ppa.launchpad.net/" "daisy-pluckers/daisy-seeds/ubuntu" in e.uris
+        and "http://ppa.launchpad.net/daisy-pluckers/daisy-seeds/ubuntu" in e.uris
     ]
 
     trusted_gpg_d = pathlib.Path(rootdir) / "etc" / "apt" / "trusted.gpg.d"
@@ -781,8 +781,8 @@ def test_create_sources_for_an_unnamed_ppa(
         if {"deb", "deb-src"} == set(e.types)
         and "jammy" in e.suites
         and "main" in e.comps
-        and "http://ppa.launchpad.net/"
-        "apport-hackers/apport-autopkgtests/ubuntu" in e.uris
+        and "http://ppa.launchpad.net/apport-hackers/apport-autopkgtests/ubuntu"
+        in e.uris
     ]
     assert [
         e
@@ -790,8 +790,8 @@ def test_create_sources_for_an_unnamed_ppa(
         if "deb" in e.types
         and "jammy" in e.suites
         and "main/debug" in e.comps
-        and "http://ppa.launchpad.net/"
-        "apport-hackers/apport-autopkgtests/ubuntu" in e.uris
+        and "http://ppa.launchpad.net/apport-hackers/apport-autopkgtests/ubuntu"
+        in e.uris
     ]
 
     trusted_gpg_d = pathlib.Path(rootdir) / "etc" / "apt" / "trusted.gpg.d"

--- a/tests/system/test_python_crashes.py
+++ b/tests/system/test_python_crashes.py
@@ -66,7 +66,7 @@ class T(unittest.TestCase):
         os.write(
             fd,
             f"""\
-#!/usr/bin/env {os.getenv('PYTHON', 'python3')}
+#!/usr/bin/env {os.getenv("PYTHON", "python3")}
 import apport_python_hook
 apport_python_hook.install()
 
@@ -224,8 +224,7 @@ func(42)
         signature = pr.crash_signature()
         assert signature
         self.assertIn(
-            "dbus.exceptions.DBusException"
-            "(org.freedesktop.DBus.Error.UnknownMethod):",
+            "dbus.exceptions.DBusException(org.freedesktop.DBus.Error.UnknownMethod):",
             signature,
         )
 

--- a/tests/unit/test_fileutils.py
+++ b/tests/unit/test_fileutils.py
@@ -140,9 +140,7 @@ class T(unittest.TestCase):
 
         # ancient report
         r = io.BytesIO(
-            b"ProblemType: Crash\n"
-            b"Date: Wed Aug 01 00:00:01 1990\n"
-            b"CrashCounter: 3\n"
+            b"ProblemType: Crash\nDate: Wed Aug 01 00:00:01 1990\nCrashCounter: 3\n"
         )
         self.assertEqual(apport.fileutils.get_recent_crashes(r), 0)
 

--- a/tests/unit/test_problem_report.py
+++ b/tests/unit/test_problem_report.py
@@ -167,7 +167,7 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
             WhiteSpace:
               foo   bar
              baz
-               blip{'  '}
+               blip{"  "}
             """
         )
         pr = problem_report.ProblemReport()
@@ -275,11 +275,7 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
     def test_load_incorrect_padding(self) -> None:
         """Throw exception when base64 encoded data has incorrect padding."""
         report = problem_report.ProblemReport()
-        content = (
-            b"CoreDump: base64\n"
-            b" H4sICAAAAAAC/0NvcmVEdW1wAA==\n"
-            b" 7Z0LYFPV/cdP0rQ\n"
-        )
+        content = b"CoreDump: base64\n H4sICAAAAAAC/0NvcmVEdW1wAA==\n 7Z0LYFPV/cdP0rQ\n"
         with io.BytesIO(content) as report_file:
             with self.assertRaisesRegex(
                 problem_report.MalformedProblemReport,
@@ -620,9 +616,9 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
              fourth
              fifth
             LargeMultiline:
-             {'A' * 120}
-             {'B' * 90}
-            Largeline: {'A' * 999}
+             {"A" * 120}
+             {"B" * 90}
+            Largeline: {"A" * 999}
             Simple: bar
             SimpleLineEnd: bar
             SimpleUTF8: 1äö2Φ3
@@ -665,7 +661,7 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
             f"""\
              foo   bar
             baz
-              blip{'  '}
+              blip{"  "}
             line4
             line♥5!!
             łıµ€ ⅝

--- a/tests/unit/test_report.py
+++ b/tests/unit/test_report.py
@@ -1252,8 +1252,7 @@ No symbol table info available.
 
         # all resolvable, but too short
         pr["Stacktrace"] = (
-            "#0  0x00007f491fac5687 in kill ()"
-            " at ../sysdeps/unix/syscall-template.S:82"
+            "#0  0x00007f491fac5687 in kill () at ../sysdeps/unix/syscall-template.S:82"
         )
         self.assertIsNone(pr.crash_signature_addresses())
 


### PR DESCRIPTION
Black and `ruff format` disagree how to format some multi-line Python code, but ruff is more aggressive in unwrapping lines. So apply the uncontroversial ruff format changes:

```
ruff format
black -C .
```