### PR TITLE
test: concatenate string literals

### DIFF
--- a/tests/integration/test_fileutils.py
+++ b/tests/integration/test_fileutils.py
@@ -370,7 +370,7 @@ f6423dfbc4faf022e58b4d3f5ff71a70  {f2}
 
             # nonempty
             f.write(
-                b"[main]\none=1\ntwo = TWO\nb1 = 1\nb2=False\n" b"[spethial]\none= 99\n"
+                b"[main]\none=1\ntwo = TWO\nb1 = 1\nb2=False\n[spethial]\none= 99\n"
             )
             f.flush()
             self.assertIsNone(apport.fileutils.get_config("main", "foo"))

--- a/tests/system/test_packaging_apt_dpkg.py
+++ b/tests/system/test_packaging_apt_dpkg.py
@@ -742,7 +742,7 @@ def test_create_sources_for_a_named_ppa(
         if {"deb", "deb-src"} == set(e.types)
         and "jammy" in e.suites
         and "main" in e.comps
-        and "http://ppa.launchpad.net/" "daisy-pluckers/daisy-seeds/ubuntu" in e.uris
+        and "http://ppa.launchpad.net/daisy-pluckers/daisy-seeds/ubuntu" in e.uris
     ]
     assert [
         e
@@ -750,7 +750,7 @@ def test_create_sources_for_a_named_ppa(
         if "deb" in e.types
         and "jammy" in e.suites
         and "main/debug" in e.comps
-        and "http://ppa.launchpad.net/" "daisy-pluckers/daisy-seeds/ubuntu" in e.uris
+        and "http://ppa.launchpad.net/daisy-pluckers/daisy-seeds/ubuntu" in e.uris
     ]
 
     trusted_gpg_d = pathlib.Path(rootdir) / "etc" / "apt" / "trusted.gpg.d"


### PR DESCRIPTION
`ruff format` found consecutive string literals that could be combined.