### PR TITLE
test: replace assertTrue by more specific assert checks

### DIFF
--- a/tests/integration/test_github.py
+++ b/tests/integration/test_github.py
@@ -42,9 +42,10 @@ class TestGitHub(unittest.TestCase):
         expected_body = "**bold1**\nnormal1\n\n**bold2**\nnormal2\n\n"
 
         result = self.crashdb._format_report(data)
-        self.assertTrue("body" in result and result["body"] == expected_body)
-        self.assertTrue("title" in result)
-        self.assertTrue(self.crashdb.labels == set(result["labels"]))
+        self.assertIn("body", result)
+        self.assertEqual(result["body"], expected_body)
+        self.assertIn("title", result)
+        self.assertEqual(self.crashdb.labels, set(result["labels"]))
 
     @patch("apport.crashdb_impl.github.Github.api_authentication")
     @patch("apport.crashdb_impl.github.Github.api_open_issue")

--- a/tests/integration/test_problem_report.py
+++ b/tests/integration/test_problem_report.py
@@ -278,14 +278,14 @@ class T(unittest.TestCase):
         pr = problem_report.ProblemReport()
         pr.load(out)
 
-        self.assertTrue(pr["File"] == data)
+        self.assertEqual(pr["File"], data)
         self.assertEqual(pr["Before"], "xtestx")
         self.assertEqual(pr["ZAfter"], "ytesty")
 
         # write it again
         io2 = io.BytesIO()
         pr.write(io2)
-        self.assertTrue(out.getvalue() == io2.getvalue())
+        self.assertEqual(out.getvalue(), io2.getvalue())
 
         # check gzip compatibility
         out.seek(0)
@@ -321,9 +321,9 @@ class T(unittest.TestCase):
 
         self.assertNotIn("FileSmallLimit", pr)
         self.assertNotIn("FileLimitMinus1", pr)
-        self.assertTrue(pr["FileExactLimit"] == data)
-        self.assertTrue(pr["FileLimitPlus1"] == data)
-        self.assertTrue(pr["FileLimitNone"] == data)
+        self.assertEqual(pr["FileExactLimit"], data)
+        self.assertEqual(pr["FileLimitPlus1"], data)
+        self.assertEqual(pr["FileLimitNone"], data)
         self.assertEqual(pr["Before"], "xtestx")
         self.assertEqual(pr["ZAfter"], "ytesty")
 


### PR DESCRIPTION
In case of failures `TestCase.assertTrue` will only tell that the value is not True. Replace `assertTrue` by `assertEqual` or `assertIn` to get better failure messages. Following snippet was used to find the instances:

```
git grep assertTrue | grep ==
```