### PR TITLE
ui: update_report: fix source/binary confusion (LP: #2102147)

### DIFF
--- a/apport/packaging.py
+++ b/apport/packaging.py
@@ -55,6 +55,12 @@ class PackageInfo:
             "this method must be implemented by a concrete subclass"
         )
 
+    def get_installed_binaries(self, source_package: str) -> set[str]:
+        """Return all installed binary packages for a given source."""
+        raise NotImplementedError(
+            "this method must be implemented by a concrete subclass"
+        )
+
     def get_package_origin(self, package: str) -> str | None:
         """Return package origin.
 

--- a/apport/packaging_impl/apt_dpkg.py
+++ b/apport/packaging_impl/apt_dpkg.py
@@ -360,7 +360,7 @@ class __AptDpkgPackageInfo(PackageInfo):
         self._apt_cache = None
         self._sandbox_apt_cache = None
 
-    def _cache(self):
+    def _cache(self) -> apt.Cache:
         """Return apt.Cache() (initialized lazily)."""
         if not self._apt_cache:
             self._clear_apt_cache()
@@ -443,6 +443,14 @@ class __AptDpkgPackageInfo(PackageInfo):
         if self._apt_pkg(package).candidate:
             return self._apt_pkg(package).candidate.source_name
         raise ValueError(f"package {package} does not exist")
+
+    def get_installed_binaries(self, source_package: str) -> set[str]:
+        """Return all installed binary packages for a given source."""
+        return {
+            pkg.name
+            for pkg in self._cache()
+            if pkg.installed and (source_package == pkg.installed.source_name)
+        }
 
     def get_package_origin(self, package: str) -> str | None:
         """Return package origin.

--- a/tests/integration/test_packaging_apt_dpkg.py
+++ b/tests/integration/test_packaging_apt_dpkg.py
@@ -116,6 +116,17 @@ class T(unittest.TestCase):
         self.assertEqual(impl.get_source("bash"), "bash")
         self.assertIn("glibc", impl.get_source("libc6"))
 
+    def test_get_installed_binaries_library(self) -> None:
+        binaries = impl.get_installed_binaries("glibc")
+        self.assertIn("libc6", binaries)
+        self.assertNotIn("glibc", binaries)
+
+    def test_get_installed_binaries_binary(self) -> None:
+        self.assertIn("bash", impl.get_installed_binaries("bash"))
+
+    def test_get_installed_binaries_none(self) -> None:
+        self.assertEqual(set(impl.get_installed_binaries("nonexisting")), set())
+
     def test_get_package_origin(self) -> None:
         """get_package_origin()."""
         # determine distro name


### PR DESCRIPTION
Rather than relying on binary packages being named the same as their
source package, we actually split the two of them. There's an underlying
assumption that we're reporting to a backend that cares about source
packages, so that's what we're basing it all on, by adding a field to
list the binary packages actually installed from that source package.

It might not work perfectly (the Package field will be marked with "not
installed" for glibc, for instance), but it's still much better than the
current state.

Bug-Ubuntu: https://bugs.launchpad.net/ubuntu/+source/apport/+bug/2102147