### PR TITLE
crashdb: deduplicate code in duplicate_db_publish and add type hints

### DIFF
--- a/apport/crashdb.py
+++ b/apport/crashdb.py
@@ -19,6 +19,7 @@ import sys
 import urllib.error
 import urllib.parse
 import urllib.request
+from collections.abc import Iterable
 from typing import Any
 
 from apport.packaging_impl import impl as packaging
@@ -375,6 +376,31 @@ class CrashDatabase:
         )
         self.duplicate_db.commit()
 
+    def _write_hash_files(
+        self, basedir: str, sig_crash_tuples: Iterable[tuple[str, int]]
+    ) -> None:
+        os.mkdir(basedir)
+        cur_hash = None
+        cur_file = None
+
+        for sig, crash_id in sig_crash_tuples:
+            h = self.duplicate_sig_hash(sig)
+            if h is None:
+                # some entries can't be represented in a single line
+                continue
+            if h != cur_hash:
+                cur_hash = h
+                if cur_file:
+                    cur_file.close()
+                # hard to change, pylint: disable-next=consider-using-with
+                cur_file = open(os.path.join(basedir, cur_hash), "w", encoding="utf-8")
+
+            assert cur_file is not None
+            cur_file.write(f"{crash_id} {sig}\n")
+
+        if cur_file:
+            cur_file.close()
+
     def duplicate_db_publish(self, publish_dir):
         """Create text files suitable for www publishing.
 
@@ -391,7 +417,6 @@ class CrashDatabase:
         built in a new directory which is the given one with ".new" appended,
         then moved to the given name in an almost atomic way.
         """
-        # hard to change, pylint: disable=consider-using-with
         assert self.duplicate_db, "init_duplicate_db() needs to be called before"
 
         # first create the temporary new dir; if that fails, nothing has been
@@ -400,54 +425,13 @@ class CrashDatabase:
         os.mkdir(out)
 
         # crash addresses
-        addr_base = os.path.join(out, "address")
-        os.mkdir(addr_base)
-        cur_hash = None
-        cur_file = None
-
         cur = self.duplicate_db.cursor()
-
         cur.execute("SELECT * from address_signatures ORDER BY signature")
-        for sig, crash_id in cur.fetchall():
-            h = self.duplicate_sig_hash(sig)
-            if h is None:
-                # some entries can't be represented in a single line
-                continue
-            if h != cur_hash:
-                cur_hash = h
-                if cur_file:
-                    cur_file.close()
-                cur_file = open(
-                    os.path.join(addr_base, cur_hash), "w", encoding="utf-8"
-                )
-
-            cur_file.write(f"{crash_id} {sig}\n")
-
-        if cur_file:
-            cur_file.close()
+        self._write_hash_files(os.path.join(out, "address"), cur.fetchall())
 
         # duplicate signatures
-        sig_base = os.path.join(out, "sig")
-        os.mkdir(sig_base)
-        cur_hash = None
-        cur_file = None
-
         cur.execute("SELECT signature, crash_id from crashes ORDER BY signature")
-        for sig, crash_id in cur.fetchall():
-            h = self.duplicate_sig_hash(sig)
-            if h is None:
-                # some entries can't be represented in a single line
-                continue
-            if h != cur_hash:
-                cur_hash = h
-                if cur_file:
-                    cur_file.close()
-                cur_file = open(os.path.join(sig_base, cur_hash), "wb")
-
-            cur_file.write(f"{crash_id} {sig}\n".encode("UTF-8"))
-
-        if cur_file:
-            cur_file.close()
+        self._write_hash_files(os.path.join(out, "sig"), cur.fetchall())
 
         # switch over tree; this is as atomic as we can be with directories
         if os.path.exists(publish_dir):

--- a/apport/crashdb.py
+++ b/apport/crashdb.py
@@ -16,16 +16,17 @@ import functools
 import os
 import shutil
 import sys
+import typing
 import urllib.error
 import urllib.parse
 import urllib.request
 from collections.abc import Iterable
-from typing import Any
+from typing import Any, Literal
 
 from apport.packaging_impl import impl as packaging
 
 
-def _u(string):
+def _u(string: str | bytes) -> str:
     """Convert str to an unicode if it isn't already."""
     if isinstance(string, bytes):
         return string.decode("UTF-8", "ignore")
@@ -52,7 +53,7 @@ class CrashDatabase:
         self.duplicate_db = None
         self.format_version = None
 
-    def get_bugpattern_baseurl(self):
+    def get_bugpattern_baseurl(self) -> str | None:
         """Return the base URL for bug patterns.
 
         See apport.report.Report.search_bug_patterns() for details. If this
@@ -76,7 +77,7 @@ class CrashDatabase:
     #
     # Tests are in apport/crashdb_impl/memory.py.
 
-    def init_duplicate_db(self, path):
+    def init_duplicate_db(self, path: str) -> None:
         """Initialize duplicate database.
 
         path specifies an SQLite database. It will be created if it does not
@@ -329,7 +330,7 @@ class CrashDatabase:
 
         return None
 
-    def duplicate_db_fixed(self, crash_id, version):
+    def duplicate_db_fixed(self, crash_id: int, version: str | None) -> None:
         """Mark given crash ID as fixed in the duplicate database.
 
         version specifies the package version the crash was fixed in (None for
@@ -347,7 +348,7 @@ class CrashDatabase:
         assert n.rowcount == 1
         self.duplicate_db.commit()
 
-    def duplicate_db_remove(self, crash_id):
+    def duplicate_db_remove(self, crash_id: int) -> None:
         """Remove crash from the duplicate database.
 
         This happens when a report got rejected or manually duplicated.
@@ -359,7 +360,7 @@ class CrashDatabase:
         cur.execute("DELETE FROM address_signatures WHERE crash_id = ?", [crash_id])
         self.duplicate_db.commit()
 
-    def duplicate_db_change_master_id(self, old_id, new_id):
+    def duplicate_db_change_master_id(self, old_id: int, new_id: int) -> None:
         """Change a crash ID."""
         assert self.duplicate_db, "init_duplicate_db() needs to be called before"
 
@@ -401,7 +402,7 @@ class CrashDatabase:
         if cur_file:
             cur_file.close()
 
-    def duplicate_db_publish(self, publish_dir):
+    def duplicate_db_publish(self, publish_dir: str) -> None:
         """Create text files suitable for www publishing.
 
         Create a number of text files in the given directory which Apport
@@ -440,7 +441,7 @@ class CrashDatabase:
         if os.path.exists(f"{publish_dir}.old"):
             shutil.rmtree(f"{publish_dir}.old")
 
-    def _duplicate_db_upgrade(self, cur_format):
+    def _duplicate_db_upgrade(self, cur_format: int) -> None:
         """Upgrade database to current format."""
         # Format 3 added a primary key which can't be done as an upgrade in
         # SQLite
@@ -454,7 +455,9 @@ class CrashDatabase:
 
         assert cur_format == self.format_version
 
-    def _duplicate_search_signature(self, sig, crash_id):
+    def _duplicate_search_signature(
+        self, sig: str | bytes, crash_id: int
+    ) -> list[tuple[int, str]]:
         """Look up signature in the duplicate db.
 
         Return [(crash_id, fixed_version)] tuple list.
@@ -490,7 +493,7 @@ class CrashDatabase:
 
         return existing
 
-    def _duplicate_search_address_signature(self, sig):
+    def _duplicate_search_address_signature(self, sig: str | bytes) -> int | None:
         """Return ID for crash address signature.
 
         Return None if signature is unknown.
@@ -509,7 +512,17 @@ class CrashDatabase:
             return existing_ids[0][0]
         return None
 
-    def duplicate_db_dump(self, with_timestamps=False):
+    @typing.overload
+    def duplicate_db_dump(
+        self, with_timestamps: Literal[False] = False
+    ) -> dict[int, tuple[str, int | None]]: ...
+
+    @typing.overload
+    def duplicate_db_dump(
+        self, with_timestamps: Literal[True]
+    ) -> dict[int, tuple[str, int | None, str]]: ...
+
+    def duplicate_db_dump(self, with_timestamps: bool = False) -> dict[int, tuple]:
         """Return the entire duplicate database as a dictionary.
 
         The returned dictionary maps "signature" to (crash_id, fixed_version)
@@ -522,7 +535,7 @@ class CrashDatabase:
         """
         assert self.duplicate_db, "init_duplicate_db() needs to be called before"
 
-        dump = {}
+        dump: dict[int, tuple] = {}
         cur = self.duplicate_db.cursor()
         cur.execute("SELECT * FROM crashes")
         for sig, crash_id, ver, last_change in cur:
@@ -532,7 +545,7 @@ class CrashDatabase:
                 dump[sig] = (crash_id, ver)
         return dump
 
-    def _duplicate_db_sync_status(self, crash_id):
+    def _duplicate_db_sync_status(self, crash_id: int) -> None:
         """Update the duplicate db to the reality of the report in the
         crash db.
 
@@ -575,7 +588,7 @@ class CrashDatabase:
             self.duplicate_db_fixed(crash_id, None)
             return
 
-    def _duplicate_db_add_address_signature(self, sig, crash_id):
+    def _duplicate_db_add_address_signature(self, sig: str, crash_id: int) -> None:
         # consistency check
         existing = self._duplicate_search_address_signature(sig)
         if existing:
@@ -591,7 +604,7 @@ class CrashDatabase:
             )
             self.duplicate_db.commit()
 
-    def _duplicate_db_merge_id(self, dup, master):
+    def _duplicate_db_merge_id(self, dup: int, master: int) -> None:
         """Merge two crash IDs.
 
         This is necessary when having to mark a bug as a duplicate if it
@@ -608,7 +621,7 @@ class CrashDatabase:
         self.duplicate_db.commit()
 
     @staticmethod
-    def duplicate_sig_hash(sig):
+    def duplicate_sig_hash(sig: str) -> str | None:
         """Create a www/URL proof hash for a duplicate signature."""
         # cannot hash multi-line custom duplicate signatures
         if "\n" in sig:
@@ -725,13 +738,13 @@ class CrashDatabase:
             ],
         )
 
-    def get_distro_release(self, crash_id):
+    def get_distro_release(self, crash_id: int) -> str:
         """Get 'DistroRelease: <release>' from the report ID."""
         raise NotImplementedError(
             "this method must be implemented by a concrete subclass"
         )
 
-    def get_unretraced(self):
+    def get_unretraced(self) -> set[int]:
         """Return set of crash IDs which have not been retraced yet.
 
         This should only include crashes which match the current host
@@ -741,7 +754,7 @@ class CrashDatabase:
             "this method must be implemented by a concrete subclass"
         )
 
-    def get_dup_unchecked(self):
+    def get_dup_unchecked(self) -> set[int]:
         """Return set of crash IDs which need duplicate checking.
 
         This is mainly useful for crashes of scripting languages such as
@@ -752,7 +765,7 @@ class CrashDatabase:
             "this method must be implemented by a concrete subclass"
         )
 
-    def get_unfixed(self):
+    def get_unfixed(self) -> set[int]:
         """Return an ID set of all crashes which are not yet fixed.
 
         The list must not contain bugs which were rejected or duplicate.
@@ -765,7 +778,7 @@ class CrashDatabase:
             "this method must be implemented by a concrete subclass"
         )
 
-    def get_fixed_version(self, crash_id):
+    def get_fixed_version(self, crash_id: int) -> str | None:
         """Return the package version that fixes a given crash.
 
         Return None if the crash is not yet fixed, or an empty string if the
@@ -781,19 +794,19 @@ class CrashDatabase:
             "this method must be implemented by a concrete subclass"
         )
 
-    def get_affected_packages(self, crash_id):
+    def get_affected_packages(self, crash_id: int) -> list[str]:
         """Return list of affected source packages for given ID."""
         raise NotImplementedError(
             "this method must be implemented by a concrete subclass"
         )
 
-    def is_reporter(self, crash_id):
+    def is_reporter(self, crash_id: int) -> bool:
         """Check whether the user is the reporter of given ID."""
         raise NotImplementedError(
             "this method must be implemented by a concrete subclass"
         )
 
-    def can_update(self, crash_id):
+    def can_update(self, crash_id: int) -> bool:
         """Check whether the user is eligible to update a report.
 
         A user should add additional information to an existing ID if (s)he is
@@ -805,7 +818,7 @@ class CrashDatabase:
             "this method must be implemented by a concrete subclass"
         )
 
-    def duplicate_of(self, crash_id):
+    def duplicate_of(self, crash_id: int) -> int | None:
         """Return master ID for a duplicate bug.
 
         If the bug is not a duplicate, return None.
@@ -823,7 +836,7 @@ class CrashDatabase:
             "this method must be implemented by a concrete subclass"
         )
 
-    def mark_regression(self, crash_id, master):
+    def mark_regression(self, crash_id: int, master: int) -> None:
         """Mark a crash id as reintroducing an earlier crash which is
         already marked as fixed (having ID 'master').
         """
@@ -831,13 +844,15 @@ class CrashDatabase:
             "this method must be implemented by a concrete subclass"
         )
 
-    def mark_retraced(self, crash_id):
+    def mark_retraced(self, crash_id: int) -> None:
         """Mark crash id as retraced."""
         raise NotImplementedError(
             "this method must be implemented by a concrete subclass"
         )
 
-    def mark_retrace_failed(self, crash_id, invalid_msg=None):
+    def mark_retrace_failed(
+        self, crash_id: int, invalid_msg: str | None = None
+    ) -> None:
         """Mark crash id as 'failed to retrace'.
 
         If invalid_msg is given, the bug should be closed as invalid with given
@@ -914,7 +929,7 @@ def get_crashdb(
     return load_crashdb(auth_file, settings["databases"][name])
 
 
-def load_crashdb(auth_file, spec):
+def load_crashdb(auth_file: str | None, spec: dict[str, Any]) -> CrashDatabase:
     """Return a CrashDatabase object for a given DB specification.
 
     spec is a crash db configuration dictionary as described in get_crashdb().

--- a/apport/crashdb_impl/github.py
+++ b/apport/crashdb_impl/github.py
@@ -15,7 +15,7 @@ import urllib.parse
 import urllib.request
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Self
 
 import apport.crashdb
 
@@ -25,9 +25,11 @@ class Github:
 
     __last_request: float = time.time()
 
-    def __init__(self, client_id, message_callback):
+    def __init__(
+        self, client_id: str, message_callback: Callable | None = None
+    ) -> None:
         self.__client_id = client_id
-        self.__authentication_data = None
+        self.__authentication_data: dict[str, str] | None = None
         self.__access_token = None
         self.__cooldown = 0.0
         self.__expiry = 0.0
@@ -65,7 +67,7 @@ class Github:
         url = f"https://api.github.com/repos/{owner}/{repo}/issues"
         return self._post(url, json.dumps(data))
 
-    def __enter__(self):
+    def __enter__(self) -> Self:
         """Enters login process. At exit, login process ends."""
         data = {"client_id": self.__client_id, "scope": "public_repo"}
         url = "https://github.com/login/device/code"
@@ -170,7 +172,7 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
             "labels": list(self.labels),
         }
 
-    def _github_login(self, user_message_callback):
+    def _github_login(self, user_message_callback: Callable | None = None) -> Github:
         with Github(self.app_id, user_message_callback) as github:
             while not github.authentication_complete():
                 pass
@@ -219,7 +221,7 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
             "This method is not relevant for Github database implementation."
         )
 
-    def can_update(self, crash_id):
+    def can_update(self, crash_id: int) -> bool:
         raise NotImplementedError(
             "This method is not relevant for Github database implementation."
         )
@@ -234,27 +236,27 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
             "This method is not relevant for Github database implementation."
         )
 
-    def duplicate_of(self, crash_id):
+    def duplicate_of(self, crash_id: int) -> int | None:
         raise NotImplementedError(
             "This method is not relevant for Github database implementation."
         )
 
-    def get_affected_packages(self, crash_id):
+    def get_affected_packages(self, crash_id: int) -> list[str]:
         raise NotImplementedError(
             "This method is not relevant for Github database implementation."
         )
 
-    def get_distro_release(self, crash_id):
+    def get_distro_release(self, crash_id: int) -> str:
         raise NotImplementedError(
             "This method is not relevant for Github database implementation."
         )
 
-    def get_dup_unchecked(self):
+    def get_dup_unchecked(self) -> set[int]:
         raise NotImplementedError(
             "This method is not relevant for Github database implementation."
         )
 
-    def get_fixed_version(self, crash_id):
+    def get_fixed_version(self, crash_id: int) -> str | None:
         raise NotImplementedError(
             "This method is not relevant for Github database implementation."
         )
@@ -264,32 +266,34 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
             "This method is not relevant for Github database implementation."
         )
 
-    def get_unfixed(self):
+    def get_unfixed(self) -> set[int]:
         raise NotImplementedError(
             "This method is not relevant for Github database implementation."
         )
 
-    def get_unretraced(self):
+    def get_unretraced(self) -> set[int]:
         raise NotImplementedError(
             "This method is not relevant for Github database implementation."
         )
 
-    def is_reporter(self, crash_id):
+    def is_reporter(self, crash_id: int) -> bool:
         raise NotImplementedError(
             "This method is not relevant for Github database implementation."
         )
 
-    def mark_regression(self, crash_id, master):
+    def mark_regression(self, crash_id: int, master: int) -> None:
         raise NotImplementedError(
             "This method is not relevant for Github database implementation."
         )
 
-    def mark_retrace_failed(self, crash_id, invalid_msg=None):
+    def mark_retrace_failed(
+        self, crash_id: int, invalid_msg: str | None = None
+    ) -> None:
         raise NotImplementedError(
             "This method is not relevant for Github database implementation."
         )
 
-    def mark_retraced(self, crash_id):
+    def mark_retraced(self, crash_id: int) -> None:
         raise NotImplementedError(
             "This method is not relevant for Github database implementation."
         )

--- a/apport/crashdb_impl/github.py
+++ b/apport/crashdb_impl/github.py
@@ -46,11 +46,12 @@ class Github:
             with urllib.request.urlopen(request, timeout=5.0) as response:
                 return json.loads(response.read())
         except urllib.error.URLError as err:
-            self.message_callback(
-                "Failed connection",
-                f"Failed connection to {url}.\n"
-                + "Please check your internet connection and try again.",
-            )
+            if self.message_callback:
+                self.message_callback(
+                    "Failed connection",
+                    f"Failed connection to {url}.\n"
+                    f"Please check your internet connection and try again.",
+                )
             raise err
         finally:
             self.__last_request = time.time()
@@ -83,7 +84,8 @@ class Github:
         url = response["verification_uri"]
         code = response["user_code"]
 
-        self.message_callback("Login required", prompt.format(url=url, code=code))
+        if self.message_callback:
+            self.message_callback("Login required", prompt.format(url=url, code=code))
 
         self.__authentication_data = {
             "client_id": self.__client_id,
@@ -112,9 +114,10 @@ class Github:
         current_time = time.time()
         waittime = self.__cooldown - (current_time - self.__last_request)
         if current_time + waittime > self.__expiry:
-            self.message_callback(
-                "Failed login", "Github authentication expired. Please try again."
-            )
+            if self.message_callback:
+                self.message_callback(
+                    "Failed login", "Github authentication expired. Please try again."
+                )
             raise RuntimeError("Github authentication expired")
         if waittime > 0:
             time.sleep(waittime)  # Avoids spamming the API

--- a/apport/crashdb_impl/github.py
+++ b/apport/crashdb_impl/github.py
@@ -29,8 +29,8 @@ class Github:
         self.__client_id = client_id
         self.__authentication_data = None
         self.__access_token = None
-        self.__cooldown = None
-        self.__expiry = None
+        self.__cooldown = 0.0
+        self.__expiry = 0.0
         self.message_callback = message_callback
 
     def _post(self, url: str, data: str) -> Any:
@@ -99,8 +99,8 @@ class Github:
 
     def __exit__(self, *_: Any) -> None:
         self.__authentication_data = None
-        self.__cooldown = 0
-        self.__expiry = 0
+        self.__cooldown = 0.0
+        self.__expiry = 0.0
 
     def authentication_complete(self) -> bool:
         """Asks Github if the user has logged in already.

--- a/apport/crashdb_impl/launchpad.py
+++ b/apport/crashdb_impl/launchpad.py
@@ -520,7 +520,7 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
 
         self._subscribe_triaging_team(bug, report)
 
-    def get_distro_release(self, crash_id):
+    def get_distro_release(self, crash_id: int) -> str:
         """Get 'DistroRelease: <release>' from the given report ID and return
         it."""
         bug = self.launchpad.bugs[crash_id]
@@ -529,7 +529,7 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
             return m.group(1)
         raise ValueError("URL does not contain DistroRelease: field")
 
-    def get_affected_packages(self, crash_id):
+    def get_affected_packages(self, crash_id: int) -> list[str]:
         """Return list of affected source packages for given ID."""
         bug_target_re = re.compile(
             rf"/{self.distro}/(?:(?P<suite>[^/]+)/)?\+source" rf"/(?P<source>[^/]+)$"
@@ -547,12 +547,12 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
             result.append(match.group("source"))
         return result
 
-    def is_reporter(self, crash_id):
+    def is_reporter(self, crash_id: int) -> bool:
         """Check whether the user is the reporter of given ID."""
         bug = self.launchpad.bugs[crash_id]
         return bug.owner.name == self.launchpad.me.name
 
-    def can_update(self, crash_id):
+    def can_update(self, crash_id: int) -> bool:
         """Check whether the user is eligible to update a report.
 
         A user should add additional information to an existing ID if (s)he is
@@ -575,7 +575,7 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
 
         return False
 
-    def get_unretraced(self):
+    def get_unretraced(self) -> set[int]:
         """Return an ID set of all crashes which have not been retraced yet and
         which happened on the current host architecture."""
         try:
@@ -587,7 +587,7 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
             apport.logging.error("connecting to Launchpad failed: %s", str(error))
             sys.exit(99)  # transient error
 
-    def get_dup_unchecked(self):
+    def get_dup_unchecked(self) -> set[int]:
         """Return an ID set of all crashes which have not been checked for
         being a duplicate.
 
@@ -604,7 +604,7 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
             apport.logging.error("connecting to Launchpad failed: %s", str(error))
             sys.exit(99)  # transient error
 
-    def get_unfixed(self):
+    def get_unfixed(self) -> set[int]:
         """Return an ID set of all crashes which are not yet fixed.
 
         The list must not contain bugs which were rejected or duplicate.
@@ -630,7 +630,7 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
         # first element is the latest one
         return sources[0].source_package_version
 
-    def get_fixed_version(self, crash_id):
+    def get_fixed_version(self, crash_id: int) -> str | None:
         # TODO: Split into smaller functions/methods
         # pylint: disable=too-many-branches,too-many-return-statements
         """Return the package version that fixes a given crash.
@@ -732,7 +732,7 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
 
         return None
 
-    def duplicate_of(self, crash_id):
+    def duplicate_of(self, crash_id: int) -> int | None:
         """Return master ID for a duplicate bug.
 
         If the bug is not a duplicate, return None.
@@ -901,7 +901,7 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
         if bug._dirty_attributes:  # LP#336866 workaround
             bug.lp_save()
 
-    def mark_regression(self, crash_id, master):
+    def mark_regression(self, crash_id: int, master: int) -> None:
         """Mark a crash id as reintroducing an earlier crash which is
         already marked as fixed (having ID 'master').
         """
@@ -919,7 +919,7 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
         bug.tags = bug.tags + ["regression-retracer"]  # LP#254901 workaround
         bug.lp_save()
 
-    def mark_retraced(self, crash_id):
+    def mark_retraced(self, crash_id: int) -> None:
         """Mark crash id as retraced."""
         bug = self.launchpad.bugs[crash_id]
         if self.arch_tag in bug.tags:
@@ -931,7 +931,9 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
             except HTTPError:
                 pass  # LP#336866 workaround
 
-    def mark_retrace_failed(self, crash_id, invalid_msg=None):
+    def mark_retrace_failed(
+        self, crash_id: int, invalid_msg: str | None = None
+    ) -> None:
         """Mark crash id as 'failed to retrace'."""
         bug = self.launchpad.bugs[crash_id]
         if invalid_msg:
@@ -1138,7 +1140,7 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
         return mime
 
     @staticmethod
-    def _filter_tag_names(tags):
+    def _filter_tag_names(tags: str) -> str:
         """Replace characters from tags which are not palatable to
         Launchpad."""
         res = ""

--- a/apport/crashdb_impl/memory.py
+++ b/apport/crashdb_impl/memory.py
@@ -96,15 +96,15 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
         """Download the problem report from given ID and return a Report."""
         return self.reports[crash_id]["report"]
 
-    def get_affected_packages(self, crash_id):
+    def get_affected_packages(self, crash_id: int) -> list[str]:
         """Return list of affected source packages for given ID."""
         return [self.reports[crash_id]["report"]["SourcePackage"]]
 
-    def is_reporter(self, crash_id):
+    def is_reporter(self, crash_id: int) -> bool:
         """Check whether the user is the reporter of given ID."""
         return True
 
-    def can_update(self, crash_id):
+    def can_update(self, crash_id: int) -> bool:
         """Check whether the user is eligible to update a report.
 
         A user should add additional information to an existing ID if (s)he is
@@ -149,12 +149,12 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
         else:
             r["report"].update(report)
 
-    def get_distro_release(self, crash_id):
+    def get_distro_release(self, crash_id: int) -> str:
         """Get 'DistroRelease: <release>' from the given report ID and return
         it."""
         return self.reports[crash_id]["report"]["DistroRelease"]
 
-    def get_unfixed(self):
+    def get_unfixed(self) -> set[int]:
         """Return an ID set of all crashes which are not yet fixed.
 
         The list must not contain bugs which were rejected or duplicate.
@@ -170,7 +170,7 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
 
         return result
 
-    def get_fixed_version(self, crash_id):
+    def get_fixed_version(self, crash_id: int) -> str | None:
         """Return the package version that fixes a given crash.
 
         Return None if the crash is not yet fixed, or an empty string if the
@@ -189,7 +189,7 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
         except IndexError:
             return "invalid"
 
-    def duplicate_of(self, crash_id):
+    def duplicate_of(self, crash_id: int) -> int | None:
         """Return master ID for a duplicate bug.
 
         If the bug is not a duplicate, return None.
@@ -203,7 +203,7 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
         """
         self.reports[crash_id]["dup_of"] = master_id
 
-    def mark_regression(self, crash_id, master):
+    def mark_regression(self, crash_id: int, master: int) -> None:
         """Mark a crash id as reintroducing an earlier crash which is
         already marked as fixed (having ID 'master').
         """
@@ -217,22 +217,24 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
         except KeyError:
             pass  # happens when trying to check for dup twice
 
-    def mark_retraced(self, crash_id):
+    def mark_retraced(self, crash_id: int) -> None:
         """Mark crash id as retraced."""
         self.unretraced.remove(crash_id)
 
-    def mark_retrace_failed(self, crash_id, invalid_msg=None):
+    def mark_retrace_failed(
+        self, crash_id: int, invalid_msg: str | None = None
+    ) -> None:
         """Mark crash id as 'failed to retrace'.
 
         This is a no-op since this crash DB is not interested in it.
         """
 
-    def get_unretraced(self):
+    def get_unretraced(self) -> set[int]:
         """Return an ID set of all crashes which have not been retraced yet and
         which happened on the current host architecture."""
         return self.unretraced
 
-    def get_dup_unchecked(self):
+    def get_dup_unchecked(self) -> set[int]:
         """Return an ID set of all crashes which have not been checked for
         being a duplicate.
 
@@ -242,11 +244,11 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
         """
         return self.dup_unchecked
 
-    def latest_id(self):
+    def latest_id(self) -> int:
         """Return the ID of the most recently filed report."""
         return len(self.reports) - 1
 
-    def add_sample_data(self):
+    def add_sample_data(self) -> None:
         """Add some sample crash reports.
 
         This is mostly useful for test suites.

--- a/tests/run-linters
+++ b/tests/run-linters
@@ -69,8 +69,9 @@ run_pycodestyle() {
     echo "Running pycodestyle..."
     # E101 causes false positive on tests/unit/test_hookutils.py,
     # see https://github.com/PyCQA/pycodestyle/issues/376
+    # E704 complains about "def f(): ..."
     # . catches all *.py modules; we explicitly need to specify the programs
-    pycodestyle --max-line-length=88 -r --ignore=E101,E203,W503 ${PYTHON_FILES} ${PYTHON_SCRIPTS}
+    pycodestyle --max-line-length=88 -r --ignore=E101,E203,E704,W503 ${PYTHON_FILES} ${PYTHON_SCRIPTS}
 }
 
 run_pydocstyle() {

--- a/tests/unit/test_crashdb.py
+++ b/tests/unit/test_crashdb.py
@@ -605,17 +605,15 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
 
             # addr DB should have both possible patterns on a
             # pylint: disable=protected-access
+            b_sig_addr = b.crash_signature_addresses()
+            assert b_sig_addr is not None
             self.assertEqual(
-                self.crashes._duplicate_search_address_signature(
-                    b.crash_signature_addresses()
-                ),
-                5,
+                self.crashes._duplicate_search_address_signature(b_sig_addr), 5
             )
+            s_sig_addr = s.crash_signature_addresses()
+            assert s_sig_addr is not None
             self.assertEqual(
-                self.crashes._duplicate_search_address_signature(
-                    s.crash_signature_addresses()
-                ),
-                5,
+                self.crashes._duplicate_search_address_signature(s_sig_addr), 5
             )
 
     def test_check_duplicate_reopen(self) -> None:


### PR DESCRIPTION
Add type hints to apport.crashdb except for functions/methods that involve `Report` since that would lead to cyclic imports:

```
Traceback:
apport/__init__.py:8: in <module>
    from apport.report import Report
apport/report.py:50: in <module>
    from apport.ui import HookUI, NoninteractiveHookUI
apport/ui.py:49: in <module>
    import apport.crashdb
apport/crashdb.py:27: in <module>
    from apport.report import Report
E   ImportError: cannot import name 'Report' from partially initialized module 'apport.report' (most likely due to a circular import) (apport/report.py)
```

There are preparation commits to fix mypy issues beforehand.