### PR TITLE
crashdb: Import sqlite3 without giving it a different name

### DIFF
--- a/apport/crashdb.py
+++ b/apport/crashdb.py
@@ -81,7 +81,8 @@ class CrashDatabase:
         path specifies an SQLite database. It will be created if it does not
         exist yet.
         """
-        import sqlite3  # pylint: disable=import-outside-toplevel
+        # for faster Python startup time: pylint: disable-next=import-outside-toplevel
+        import sqlite3
 
         assert (
             sqlite3.paramstyle == "qmark"

--- a/apport/crashdb.py
+++ b/apport/crashdb.py
@@ -81,10 +81,10 @@ class CrashDatabase:
         path specifies an SQLite database. It will be created if it does not
         exist yet.
         """
-        import sqlite3 as dbapi2  # pylint: disable=import-outside-toplevel
+        import sqlite3  # pylint: disable=import-outside-toplevel
 
         assert (
-            dbapi2.paramstyle == "qmark"
+            sqlite3.paramstyle == "qmark"
         ), "this module assumes qmark dbapi parameter style"
 
         self.format_version = 3
@@ -92,7 +92,7 @@ class CrashDatabase:
         init = (
             not os.path.exists(path) or path == ":memory:" or os.path.getsize(path) == 0
         )
-        self.duplicate_db = dbapi2.connect(path, timeout=7200)
+        self.duplicate_db = sqlite3.connect(path, timeout=7200)
 
         if init:
             cur = self.duplicate_db.cursor()


### PR DESCRIPTION
The Python module `sqlite3` is part of the Python standard library and not naming it `dbapi2` makes the code more readable.