### PR TITLE
test: add type hints to has_click_event_connected

### DIFF
--- a/tests/system/test_ui_gtk.py
+++ b/tests/system/test_ui_gtk.py
@@ -1210,7 +1210,7 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
         self.app.ui_update_view()
 
     @staticmethod
-    def has_click_event_connected(widget):
+    def has_click_event_connected(widget: "Gtk.Widget") -> None:
         signal_id = GObject.signal_lookup("clicked", widget)
         signal_handler_id = GObject.signal_handler_find(
             widget,


### PR DESCRIPTION
Add type hints to `has_click_event_connected`. A forward reference is needed to avoid the "skip" CI tests fail:

```
==================================== ERRORS ====================================
_________________ ERROR collecting tests/system/test_ui_gtk.py _________________
tests/system/test_ui_gtk.py:56: in <module>
    class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
tests/system/test_ui_gtk.py:1213: in T
    def has_click_event_connected(widget: Gtk.Widget) -> None:
E   NameError: name 'Gtk' is not defined
```