### PR TITLE
Remove unused import apport.fileutils

### DIFF
--- a/bin/apport-retrace
+++ b/bin/apport-retrace
@@ -30,7 +30,6 @@ from argparse import Namespace
 from gettext import gettext as _
 
 import apport
-import apport.fileutils
 import apport.sandboxutils
 from apport import Report
 from apport.crashdb import CrashDatabase, get_crashdb

--- a/bin/apport-valgrind
+++ b/bin/apport-valgrind
@@ -26,7 +26,6 @@ import sys
 from gettext import gettext as _
 
 import apport
-import apport.fileutils
 import apport.sandboxutils
 
 #


### PR DESCRIPTION
Remove unused import of apport.fileutils. No idea why no linter complained about that.