### PR TITLE
apport: defer imports for unicode_gettext

### DIFF
--- a/apport/__init__.py
+++ b/apport/__init__.py
@@ -1,7 +1,7 @@
 """Apport Python module."""
 
-import gettext
-import warnings
+# for faster module loading and avoiding circular dependencies
+# pylint: disable=import-outside-toplevel
 
 from apport.logging import error, fatal, log, memdbg, warning
 from apport.packaging_impl import impl as packaging
@@ -21,6 +21,9 @@ __all__ = [
 
 def unicode_gettext(message):
     """Return the localized translation of message."""
+    import gettext
+    import warnings
+
     warnings.warn(
         "apport.unicode_gettext() is deprecated."
         " Please use gettext.gettext() directly instead.",


### PR DESCRIPTION
For faster module loading defer the imports needed for the deprecated and hopefully unused `unicode_gettext`.