### PR TITLE
use apport.logging directly

### DIFF
--- a/bin/apport-retrace
+++ b/bin/apport-retrace
@@ -30,6 +30,7 @@ from argparse import Namespace
 from gettext import gettext as _
 
 import apport
+import apport.logging
 import apport.sandboxutils
 from apport import Report
 from apport.crashdb import CrashDatabase, get_crashdb
@@ -338,20 +339,20 @@ def load_report(
             report = apport.Report()
             with open(options.report, "rb") as f:
                 report.load(f, binary="compressed")
-            apport.memdbg("loaded report from file")
+            apport.logging.memdbg("loaded report from file")
             return report, None
         except (MemoryError, TypeError, ValueError, OSError, zlib.error) as error:
-            apport.fatal("Cannot open report file: %s", str(error))
+            apport.logging.fatal("Cannot open report file: %s", str(error))
     elif options.report.isdigit():
         # crash ID
         try:
             crashid = int(options.report)
             report = crashdb.download(crashid)
-            apport.memdbg("downloaded report from crash DB")
+            apport.logging.memdbg("downloaded report from crash DB")
             return report, crashid
         except AssertionError as error:
             if "apport format data" in str(error):
-                apport.error("Broken report: %s", str(error))
+                apport.logging.error("Broken report: %s", str(error))
                 raise _LoadReportException(2) from None
             raise
         except (
@@ -367,7 +368,9 @@ def load_report(
             # close it with an informative message and exit cleanly
             # to not break crash-digger
             if options.auth and not options.output and not options.stdout:
-                apport.error("Broken report: %s, closing as invalid", str(error))
+                apport.logging.error(
+                    "Broken report: %s, closing as invalid", str(error)
+                )
                 crashdb.mark_retrace_failed(
                     options.report,
                     f"""Thank you for your report!
@@ -386,7 +389,7 @@ Thank you for your understanding, and sorry for the inconvenience!
                 raise _LoadReportException(0) from None
             raise
     else:
-        apport.fatal(
+        apport.logging.fatal(
             '"%s" is neither an existing report file nor a crash ID', options.report
         )
 
@@ -396,14 +399,14 @@ def main(argv):
     # TODO: Split into smaller functions/methods
     # pylint: disable=too-many-branches,too-many-locals,too-many-nested-blocks
     # pylint: disable=too-many-return-statements,too-many-statements
-    apport.memdbg("start")
+    apport.logging.memdbg("start")
 
     gettext.textdomain("apport")
 
     options = parse_args(argv)
 
     crashdb = get_crashdb(options.auth)
-    apport.memdbg("got crash DB")
+    apport.logging.memdbg("got crash DB")
 
     # load the report
     try:
@@ -421,7 +424,7 @@ def main(argv):
     if options.rebuild_package_info and "ExecutablePath" in report:
         report.add_package_info()
 
-    apport.memdbg("processed extra options from command line")
+    apport.logging.memdbg("processed extra options from command line")
 
     # consistency checks
     required_fields = set(
@@ -429,27 +432,27 @@ def main(argv):
     )
     if report["ProblemType"] == "KernelCrash":
         if not set(["Package", "VmCore"]).issubset(set(report.keys())):
-            apport.error("report file does not contain the required fields")
+            apport.logging.error("report file does not contain the required fields")
             return 2
-        apport.error("KernelCrash processing not implemented yet")
+        apport.logging.error("KernelCrash processing not implemented yet")
         return 3
     if not required_fields.issubset(set(report.keys())):
         missing_fields = []
         for required_field in required_fields:
             if required_field not in set(report.keys()):
                 missing_fields.append(required_field)
-        apport.error(
+        apport.logging.error(
             "report file does not contain one of the required fields: %s",
             " ".join(sorted(missing_fields)),
         )
         return 2
 
-    apport.memdbg("consistency checks passed")
+    apport.logging.memdbg("consistency checks passed")
 
     if options.gdb_sandbox:
         system_arch = apport.packaging.get_system_architecture()
         if system_arch != "amd64":
-            apport.error("gdb sandboxes are only implemented for amd64 hosts")
+            apport.logging.error("gdb sandboxes are only implemented for amd64 hosts")
             return 3
         # Create a .dwz directory if it doesn't exist
         if not os.path.exists("/usr/lib/debug/.dwz"):
@@ -565,17 +568,17 @@ def main(argv):
                     cmd += f"'{w}'"
                 else:
                     cmd += w
-            apport.log(f"Calling gdb command: {cmd}", options.timestamps)
-        apport.memdbg("before calling gdb")
+            apport.logging.log(f"Calling gdb command: {cmd}", options.timestamps)
+        apport.logging.memdbg("before calling gdb")
         subprocess.call(gdb_cmd, env=os.environ | environ)
     else:
         # regenerate gdb info
-        apport.memdbg("before collecting gdb info")
+        apport.logging.memdbg("before collecting gdb info")
         try:
             report.add_gdb_info(sandbox, gdb_sandbox)
         except OSError as error:
             if not options.auth:
-                apport.fatal("%s", str(error))
+                apport.logging.fatal("%s", str(error))
             if not options.confirm or confirm_traces(report):
                 invalid_msg = """Thank you for your report!
 
@@ -587,7 +590,7 @@ transit.
 Thank you for your understanding, and sorry for the inconvenience!
 """
                 crashdb.mark_retrace_failed(crashid, invalid_msg)
-            apport.fatal("%s", str(error))
+            apport.logging.fatal("%s", str(error))
         if options.sandbox == "system":
             apt_root = os.path.join(cache, "system", "apt")
         elif options.sandbox:
@@ -607,7 +610,7 @@ Thank you for your understanding, and sorry for the inconvenience!
 
     modified = False
 
-    apport.memdbg("information collection done")
+    apport.logging.memdbg("information collection done")
 
     if options.remove_core:
         del report["CoreDump"]
@@ -621,7 +624,7 @@ Thank you for your understanding, and sorry for the inconvenience!
     if modified:
         if crashid is not None and not options.output:
             if not options.auth:
-                apport.fatal(
+                apport.logging.fatal(
                     "You need to specify --auth for uploading retraced results"
                     " back to the crash database."
                 )
@@ -638,25 +641,29 @@ Thank you for your understanding, and sorry for the inconvenience!
                             version = "fixed in latest version"
                         else:
                             version = f"fixed in version {res[1]}"
-                        apport.log(
+                        apport.logging.log(
                             f"Report is a duplicate of #{res[0]} ({version})",
                             options.timestamps,
                         )
                         update_bug = False
                     else:
-                        apport.log("Duplicate check negative", options.timestamps)
+                        apport.logging.log(
+                            "Duplicate check negative", options.timestamps
+                        )
 
                 if update_bug:
                     if "Stacktrace" in report:
                         crashdb.update_traces(crashid, report)
-                        apport.log(
+                        apport.logging.log(
                             f"New attachments uploaded to crash database"
                             f" LP: #{crashid}",
                             options.timestamps,
                         )
                     else:
                         # this happens when gdb crashes
-                        apport.log("No stack trace, invalid report", options.timestamps)
+                        apport.logging.log(
+                            "No stack trace, invalid report", options.timestamps
+                        )
 
                     if not report.has_useful_stacktrace():
                         if outdated_msg:
@@ -674,14 +681,14 @@ encounter the crash, please file a new report.
 
 Thank you for your understanding, and sorry for the inconvenience!
 """
-                            apport.log(
+                            apport.logging.log(
                                 "No crash signature and outdated packages,"
                                 " invalidating report",
                                 options.timestamps,
                             )
                             crashdb.mark_retrace_failed(crashid, invalid_msg)
                         else:
-                            apport.log(
+                            apport.logging.log(
                                 "Report has no crash signature,"
                                 " so retrace is flawed",
                                 options.timestamps,

--- a/bin/apport-unpack
+++ b/bin/apport-unpack
@@ -27,7 +27,7 @@ from gettext import gettext as _
 from typing import BinaryIO
 
 import problem_report
-from apport import fatal
+from apport.logging import fatal
 
 
 def parse_args() -> argparse.Namespace:

--- a/bin/apport-valgrind
+++ b/bin/apport-valgrind
@@ -26,6 +26,7 @@ import sys
 from gettext import gettext as _
 
 import apport
+import apport.logging
 import apport.sandboxutils
 
 #
@@ -116,9 +117,9 @@ def _exit_on_interrupt():
 options = parse_options()
 
 try:
-    apport.memdbg("start")
-    apport.memdbg(f"Executable: {options.exe}")
-    apport.memdbg(f"Command arguments: {str(options)}")
+    apport.logging.memdbg("start")
+    apport.logging.memdbg(f"Executable: {options.exe}")
+    apport.logging.memdbg(f"Command arguments: {str(options)}")
 
     gettext.textdomain("apport")
 
@@ -142,13 +143,13 @@ try:
         report.add_os_info()
         report.add_package_info()
 
-        apport.memdbg("\nCreated report")
+        apport.logging.memdbg("\nCreated report")
 except (KeyboardInterrupt, SystemExit):
     sys.stderr.write("\nInterrupted during report creation\n")
     _exit_on_interrupt()
 
 
-apport.memdbg("About to handle sandbox")
+apport.logging.memdbg("About to handle sandbox")
 
 cache = None
 
@@ -168,7 +169,7 @@ except (KeyboardInterrupt, SystemExit):
     sys.stderr.write("\nInterrupted while creating sandbox\n")
     _exit_on_interrupt()
 
-apport.memdbg("About to get path to sandbox")
+apport.logging.memdbg("About to get path to sandbox")
 
 debugrootdir = None
 
@@ -197,7 +198,7 @@ try:
         argv += [f"--extra-debuginfo-path={debugrootdir}/usr/lib/debug/"]
     argv += [exepath]
 
-    apport.memdbg("before calling valgrind")
+    apport.logging.memdbg("before calling valgrind")
 except (KeyboardInterrupt, SystemExit):
     sys.stderr.write("\nInterrupted while preparing to create sandbox\n")
     _exit_on_interrupt()
@@ -210,4 +211,4 @@ except (KeyboardInterrupt, SystemExit):
     sys.stderr.write("\nInterrupted while running valgrind\n")
     _exit_on_interrupt()
 
-apport.memdbg("information collection done")
+apport.logging.memdbg("information collection done")

--- a/bin/crash-digger
+++ b/bin/crash-digger
@@ -22,7 +22,7 @@ import subprocess
 import sys
 import zlib
 
-import apport
+import apport.logging
 from apport.crashdb import get_crashdb
 
 
@@ -58,7 +58,7 @@ class CrashDigger:  # pylint: disable=too-many-instance-attributes
         try:
             self.crashdb = get_crashdb(auth_file, name=crash_db)
         except KeyError:
-            apport.error("Crash database %s does not exist", crash_db)
+            apport.logging.error("Crash database %s does not exist", crash_db)
             sys.exit(1)
         self.lp = False
         try:
@@ -71,7 +71,7 @@ class CrashDigger:  # pylint: disable=too-many-instance-attributes
         if config_dir:
             self.releases = os.listdir(config_dir)
             self.releases.sort()
-            apport.log(f"Available releases: {str(self.releases)}", True)
+            apport.logging.log(f"Available releases: {str(self.releases)}", True)
         else:
             self.releases = None
 
@@ -85,18 +85,20 @@ class CrashDigger:  # pylint: disable=too-many-instance-attributes
 
         if self.dupcheck_mode:
             self.dupcheck_pool.update(self.crashdb.get_dup_unchecked())
-            apport.log(
+            apport.logging.log(
                 f"fill_pool: dup check pool now: {str(self.dupcheck_pool)}", True
             )
         else:
             self.retrace_pool.update(self.crashdb.get_unretraced())
-            apport.log(f"fill_pool: retrace pool now: {str(self.retrace_pool)}", True)
+            apport.logging.log(
+                f"fill_pool: retrace pool now: {str(self.retrace_pool)}", True
+            )
 
     def retrace_next(self):
         """Grab an ID from the retrace pool and retrace it."""
 
         crash_id = self.retrace_pool.pop()
-        apport.log(
+        apport.logging.log(
             f"retracing {'LP: ' if self.lp else ''}#{crash_id}"
             f" (left in pool: {len(self.retrace_pool)})",
             True,
@@ -105,11 +107,13 @@ class CrashDigger:  # pylint: disable=too-many-instance-attributes
         try:
             rel = self.crashdb.get_distro_release(crash_id)
         except ValueError:
-            apport.log("could not determine release -- no DistroRelease field?", True)
+            apport.logging.log(
+                "could not determine release -- no DistroRelease field?", True
+            )
             self.crashdb.mark_retraced(crash_id)
             return
         if rel not in self.releases:
-            apport.log(
+            apport.logging.log(
                 f"crash is release {rel} which does not have a config"
                 f" available, skipping",
                 True,
@@ -138,14 +142,14 @@ class CrashDigger:  # pylint: disable=too-many-instance-attributes
 
         result = subprocess.call(argv, stdout=sys.stdout, stderr=subprocess.STDOUT)
         if result != 0:
-            apport.log(
+            apport.logging.log(
                 f"retracing {'LP: ' if self.lp else ''}#{crash_id} failed"
                 f" with status: {result}",
                 True,
             )
             if result == 99:
                 self.retrace_pool = set()
-                apport.log("transient error reported; halting", True)
+                apport.logging.log("transient error reported; halting", True)
                 return
 
         self.crashdb.mark_retraced(crash_id)
@@ -154,7 +158,7 @@ class CrashDigger:  # pylint: disable=too-many-instance-attributes
         """Grab an ID from the dupcheck pool and process it."""
 
         crash_id = self.dupcheck_pool.pop()
-        apport.log(
+        apport.logging.log(
             f"checking {'LP: ' if self.lp else ''}#{crash_id} for duplicate"
             f" (left in pool: {len(self.dupcheck_pool)})",
             True,
@@ -171,11 +175,13 @@ class CrashDigger:  # pylint: disable=too-many-instance-attributes
             zlib.error,
         ) as error:
             if str(error) == "bug description must contain standard apport format data":
-                apport.log(f"Cannot download report: {str(error)}", True)
-                apport.error("Cannot download report %s: %s", crash_id, str(error))
+                apport.logging.log(f"Cannot download report: {str(error)}", True)
+                apport.logging.error(
+                    "Cannot download report %s: %s", crash_id, str(error)
+                )
                 return
-            apport.log(f"Cannot download report: {str(error)}", True)
-            apport.error("Cannot download report %i: %s", crash_id, str(error))
+            apport.logging.log(f"Cannot download report: {str(error)}", True)
+            apport.logging.error("Cannot download report %i: %s", crash_id, str(error))
             return
 
         res = self.crashdb.check_duplicate(crash_id, report)
@@ -186,9 +192,9 @@ class CrashDigger:  # pylint: disable=too-many-instance-attributes
                 version = "fixed in latest version"
             else:
                 version = f"fixed in version {res[1]}"
-            apport.log(f"Report is a duplicate of #{res[0]} ({version})", True)
+            apport.logging.log(f"Report is a duplicate of #{res[0]} ({version})", True)
         else:
-            apport.log("Duplicate check negative", True)
+            apport.logging.log("Duplicate check negative", True)
 
     def run(self):
         """Process the work pools until they are empty."""
@@ -288,9 +294,9 @@ def parse_options():
     args = parser.parse_args()
 
     if not args.config_dir and not args.dupcheck_mode:
-        apport.fatal("Error: --config-dir or --dupcheck needs to be given")
+        apport.logging.fatal("Error: --config-dir or --dupcheck needs to be given")
     if not args.auth_file:
-        apport.fatal("Error: -a/--auth needs to be given")
+        apport.logging.fatal("Error: -a/--auth needs to be given")
 
     return args
 

--- a/bin/dupdb-admin
+++ b/bin/dupdb-admin
@@ -18,8 +18,8 @@ import argparse
 import os.path
 import sys
 
-import apport
 import apport.crashdb_impl.memory
+import apport.logging
 
 
 def command_dump(crashdb, _):
@@ -98,7 +98,7 @@ def main():
     args = parse_args()
 
     if not os.path.exists(args.db_file):
-        apport.fatal("file does not exist: %s", args.db_file)
+        apport.logging.fatal("file does not exist: %s", args.db_file)
 
     # pure DB operations don't need a real backend, and thus no crashdb.conf
     crashdb = apport.crashdb_impl.memory.CrashDatabase(None, {})

--- a/data/gcc_ice_hook
+++ b/data/gcc_ice_hook
@@ -15,6 +15,7 @@ import sys
 
 import apport
 import apport.fileutils
+import apport.logging
 
 # parse command line arguments
 if len(sys.argv) != 3:
@@ -40,4 +41,4 @@ try:
     with apport.fileutils.make_report_file(pr) as f:
         pr.write(f)
 except OSError as error:
-    apport.fatal("Cannot create report: %s", str(error))
+    apport.logging.fatal("Cannot create report: %s", str(error))

--- a/data/iwlwifi_error_dump
+++ b/data/iwlwifi_error_dump
@@ -17,6 +17,7 @@ import sys
 
 import apport
 import apport.fileutils
+import apport.logging
 from apport.hookutils import command_output
 
 
@@ -68,7 +69,7 @@ def main() -> None:
         with apport.fileutils.make_report_file(pr) as f:
             pr.write(f)
     except OSError as error:
-        apport.fatal("Cannot create report: %s", str(error))
+        apport.logging.fatal("Cannot create report: %s", str(error))
 
 
 if __name__ == "__main__":

--- a/data/kernel_crashdump
+++ b/data/kernel_crashdump
@@ -17,6 +17,7 @@ import re
 
 import apport
 import apport.fileutils
+import apport.logging
 
 
 def main() -> None:
@@ -36,7 +37,7 @@ def main() -> None:
             pr["VmCoreLog"] = (os.fdopen(log_fd, "rb"),)
             os.unlink(f"{vmcore_path}.log")
         except OSError as error:
-            apport.fatal("Cannot open vmcore log: %s", str(error))
+            apport.logging.fatal("Cannot open vmcore log: %s", str(error))
 
     if os.path.exists(vmcore_path):
         try:
@@ -45,7 +46,7 @@ def main() -> None:
             with apport.fileutils.make_report_file(pr) as f:
                 pr.write(f)
         except OSError as error:
-            apport.fatal("Cannot create report: %s", str(error))
+            apport.logging.fatal("Cannot create report: %s", str(error))
 
         try:
             os.unlink(vmcore_path)
@@ -63,7 +64,7 @@ def main() -> None:
                 # creating a symlink to someplace else and disclosing data; we just
                 # compare against euid here so that we can test this as non-root
                 if os.lstat(timedir).st_uid != os.geteuid():
-                    apport.fatal("%s has unsafe permissions, ignoring", timedir)
+                    apport.logging.fatal("%s has unsafe permissions, ignoring", timedir)
                 report_name = f"{package}-{timestamp}.crash"
                 try:
                     crash_report = os.path.join(
@@ -74,7 +75,7 @@ def main() -> None:
                     with open(crash_report, "xb") as f:
                         pr.write(f)
                 except OSError as error:
-                    apport.fatal("Cannot create report: %s", str(error))
+                    apport.logging.fatal("Cannot create report: %s", str(error))
 
 
 if __name__ == "__main__":

--- a/data/package_hook
+++ b/data/package_hook
@@ -18,6 +18,7 @@ import sys
 
 import apport
 import apport.fileutils
+import apport.logging
 
 
 def mkattrname(path):
@@ -92,7 +93,7 @@ def main():
         with apport.fileutils.make_report_file(report) as report_file:
             report.write(report_file)
     except OSError as error:
-        apport.fatal("Cannot create report: %s", str(error))
+        apport.logging.fatal("Cannot create report: %s", str(error))
 
 
 if __name__ == "__main__":

--- a/data/unkillable_shutdown
+++ b/data/unkillable_shutdown
@@ -21,6 +21,7 @@ from collections.abc import Container, Iterable
 import apport
 import apport.fileutils
 import apport.hookutils
+import apport.logging
 
 
 def parse_argv():
@@ -53,7 +54,7 @@ def orphaned_processes(omit_pids: Container[str]) -> Iterable[int]:
         except ValueError:
             continue
         if pid == 1 or pid == my_pid or process in omit_pids:
-            apport.warning("ignoring: %s", process)
+            apport.logging.warning("ignoring: %s", process)
             continue
 
         try:
@@ -64,7 +65,7 @@ def orphaned_processes(omit_pids: Container[str]) -> Iterable[int]:
             continue
 
         if sid == my_sid:
-            apport.warning("ignoring same sid: %s", process)
+            apport.logging.warning("ignoring same sid: %s", process)
             continue
 
         try:
@@ -73,7 +74,7 @@ def orphaned_processes(omit_pids: Container[str]) -> Iterable[int]:
             if error.errno == errno.ENOENT:
                 # kernel thread or similar, silently ignore
                 continue
-            apport.warning(
+            apport.logging.warning(
                 "Could not read information about pid %s: %s", process, str(error)
             )
             continue
@@ -106,9 +107,11 @@ def do_report(pid: int, omit_pids: Iterable[str]) -> None:
         with apport.fileutils.make_report_file(report) as report_file:
             report.write(report_file)
     except FileExistsError as error:
-        apport.warning("Cannot create report: %s already exists", error.filename)
+        apport.logging.warning(
+            "Cannot create report: %s already exists", error.filename
+        )
     except OSError as error:
-        apport.fatal("Cannot create report: %s", str(error))
+        apport.logging.fatal("Cannot create report: %s", str(error))
 
 
 #

--- a/gtk/apport-gtk
+++ b/gtk/apport-gtk
@@ -20,7 +20,7 @@ import subprocess
 import sys
 from gettext import gettext as _
 
-import apport
+import apport.logging
 import apport.ui
 
 try:
@@ -651,7 +651,7 @@ def text_to_markup(text: str) -> str:
 def main(argv: list[str]) -> None:
     """GTK Apport user interface."""
     if not apport.ui.has_display() or Gdk.Display.get_default() is None:
-        apport.fatal(
+        apport.logging.fatal(
             "This program needs a running display server session. Please see"
             ' "man apport-cli" for a command line version of Apport.'
         )


### PR DESCRIPTION
Use `apport.logging` instead of using the logging functions imported via the `apport` base module. This step is done as preparation for deprecation (to speed up the `apport` module loading).