### PR TITLE
Deprecate logging functions in base apport module

### DIFF
--- a/apport/__init__.py
+++ b/apport/__init__.py
@@ -3,7 +3,6 @@
 # for faster module loading and avoiding circular dependencies
 # pylint: disable=import-outside-toplevel
 
-from apport.logging import error, fatal, log, memdbg, warning
 from apport.packaging_impl import impl as packaging
 from apport.report import Report
 
@@ -17,6 +16,22 @@ __all__ = [
     "unicode_gettext",
     "warning",
 ]
+
+
+def _logging_function(function_name):
+    def _wrapped_logging_function(*args, **kwargs):
+        import apport.logging
+
+        return getattr(apport.logging, function_name)(*args, **kwargs)
+
+    return _wrapped_logging_function
+
+
+error = _logging_function("error")
+fatal = _logging_function("fatal")
+log = _logging_function("log")
+memdbg = _logging_function("memdbg")
+warning = _logging_function("warning")
 
 
 def unicode_gettext(message):

--- a/apport/__init__.py
+++ b/apport/__init__.py
@@ -20,8 +20,16 @@ __all__ = [
 
 def _logging_function(function_name):
     def _wrapped_logging_function(*args, **kwargs):
+        import warnings
+
         import apport.logging
 
+        warnings.warn(
+            f"apport.{function_name}() is deprecated."
+            f" Please use apport.logging.{function_name}() directly instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return getattr(apport.logging, function_name)(*args, **kwargs)
 
     return _wrapped_logging_function

--- a/tests/unit/test_deprecation.py
+++ b/tests/unit/test_deprecation.py
@@ -7,18 +7,24 @@
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
 
-"""Unit tests for apport.unicode_gettext."""
+"""Unit tests for deprecated functions in apport."""
 
 import unittest
 import unittest.mock
 
-from apport import unicode_gettext
+from apport import fatal, unicode_gettext
 
 
 class TestDeprecation(unittest.TestCase):
-    """Unit tests for apport.unicode_gettext."""
+    """Unit tests for deprecated functions in apport."""
 
     def test_unicode_gettext(self) -> None:
         """unicode_gettext() throws a deprecation warning."""
         with self.assertWarns(PendingDeprecationWarning):
             self.assertEqual(unicode_gettext("untranslated"), "untranslated")
+
+    def test_deprecated_logging_function(self) -> None:
+        """apport.fatal() throws a deprecation warning."""
+        with self.assertRaisesRegex(SystemExit, "^1$"):
+            with self.assertWarns(DeprecationWarning):
+                fatal("fatal error")


### PR DESCRIPTION
Deprecate using the logging functions directly from the base `apport` module. Users should import the logging functions from `apport.logging` instead.