### PR TITLE
Check cyclomatic complexity

### DIFF
--- a/apport/crashdb.py
+++ b/apport/crashdb.py
@@ -145,7 +145,7 @@ class CrashDatabase:
 
     def check_duplicate(self, crash_id, report=None):
         # TODO: Split into smaller functions/methods
-        # pylint: disable=too-many-branches,too-many-statements
+        # pylint: disable=too-complex,too-many-branches,too-many-statements
         """Check whether a crash is already known.
 
         If the crash is new, it will be added to the duplicate database and the
@@ -259,7 +259,7 @@ class CrashDatabase:
 
     def known(self, report):
         # TODO: Split into smaller functions/methods
-        # pylint: disable=too-many-branches
+        # pylint: disable=too-complex,too-many-branches
         """Check if the crash db already knows about the crash signature.
 
         Check if the report has a DuplicateSignature, crash_signature(), or

--- a/apport/crashdb_impl/launchpad.py
+++ b/apport/crashdb_impl/launchpad.py
@@ -283,7 +283,7 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
 
     def download(self, crash_id):
         # TODO: Split into smaller functions/methods
-        # pylint: disable=too-many-branches,too-many-statements
+        # pylint: disable=too-complex,too-many-branches,too-many-statements
         """Download the problem report from given ID and return a Report."""
         report = apport.report.Report()
         b = self.launchpad.bugs[crash_id]
@@ -632,7 +632,7 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
 
     def get_fixed_version(self, crash_id: int) -> str | None:
         # TODO: Split into smaller functions/methods
-        # pylint: disable=too-many-branches,too-many-return-statements
+        # pylint: disable=too-complex,too-many-branches,too-many-return-statements
         """Return the package version that fixes a given crash.
 
         Return None if the crash is not yet fixed, or an empty string if the
@@ -744,7 +744,7 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
 
     def close_duplicate(self, report, crash_id, master_id):
         # TODO: Split into smaller functions/methods
-        # pylint: disable=too-many-branches,too-many-statements
+        # pylint: disable=too-complex,too-many-branches,too-many-statements
         """Mark a crash id as duplicate of given master ID.
 
         If master is None, id gets un-duplicated.

--- a/apport/crashdb_impl/launchpad.py
+++ b/apport/crashdb_impl/launchpad.py
@@ -469,6 +469,8 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
                     is_patch=False,
                 )
 
+    # TODO: Split into smaller functions/methods
+    # pylint: disable-next=too-complex
     def update_traces(self, crash_id, report, comment=""):
         """Update the given report ID for retracing results.
 

--- a/apport/hookutils.py
+++ b/apport/hookutils.py
@@ -901,6 +901,8 @@ def attach_printing(report):
     )
 
 
+# TODO: Split into smaller functions/methods
+# pylint: disable-next=too-complex
 def attach_mac_events(
     report: ProblemReport, profiles: Iterable[str] | str | None = None
 ) -> None:

--- a/apport/packaging_impl/apt_dpkg.py
+++ b/apport/packaging_impl/apt_dpkg.py
@@ -629,6 +629,8 @@ class __AptDpkgPackageInfo(PackageInfo):
             return None
         return [f for f in output.splitlines() if not f.startswith("diverted")]
 
+    # TODO: Split into smaller functions/methods
+    # pylint: disable-next=too-complex
     def get_modified_files(self, package: str) -> list[str]:
         """Return list of all modified files of a package."""
         # get the maximum mtime of package files that we consider unmodified

--- a/apport/packaging_impl/apt_dpkg.py
+++ b/apport/packaging_impl/apt_dpkg.py
@@ -865,7 +865,7 @@ class __AptDpkgPackageInfo(PackageInfo):
 
     def get_source_tree(self, srcpackage, output_dir, version=None, sandbox=None):
         # TODO: Split into smaller functions/methods
-        # pylint: disable=too-many-branches,too-many-locals
+        # pylint: disable=too-complex,too-many-branches,too-many-locals
         """Download source package and unpack it into output_dir.
 
         This also has to care about applying patches etc., so that output_dir
@@ -993,7 +993,7 @@ class __AptDpkgPackageInfo(PackageInfo):
         pkg_versions: dict[str, str],
     ) -> None:
         # TODO: Split into smaller functions/methods
-        # pylint: disable=too-many-branches,too-many-locals
+        # pylint: disable=too-complex,too-many-branches,too-many-locals
         virtual_mapping = self._virtual_mapping(aptroot)
         # Remember all the virtual packages that this package provides,
         # so that if we encounter that virtual package as a
@@ -1068,7 +1068,8 @@ class __AptDpkgPackageInfo(PackageInfo):
         install_deps: bool = False,
     ) -> str:
         # TODO: Split into smaller functions/methods
-        # pylint: disable=too-many-branches,too-many-locals,too-many-statements
+        # pylint: disable=too-complex,too-many-branches,too-many-locals
+        # pylint: disable=too-many-statements
         """Install packages into a sandbox (for apport-retrace).
 
         In order to work without any special permissions and without touching
@@ -1809,7 +1810,8 @@ class __AptDpkgPackageInfo(PackageInfo):
         origins: Iterable[str] | None,
     ) -> None:
         # TODO: Split into smaller functions/methods
-        # pylint: disable=too-many-branches,too-many-locals,too-many-statements
+        # pylint: disable=too-complex,too-many-branches,too-many-locals
+        # pylint: disable=too-many-statements
 
         # pre-create directories, to avoid apt.Cache() printing "creating..."
         # messages on stdout

--- a/apport/report.py
+++ b/apport/report.py
@@ -201,6 +201,8 @@ def _command_output(
     )
 
 
+# TODO: Split into smaller functions/methods
+# pylint: disable-next=too-complex
 def _check_bug_pattern(report, pattern):
     """Check if given report matches the given bug pattern XML DOM node.
 
@@ -1035,6 +1037,8 @@ class Report(problem_report.ProblemReport):
             if addr_signature:
                 self["StacktraceAddressSignature"] = addr_signature
 
+    # TODO: Split into smaller functions/methods
+    # pylint: disable-next=too-complex
     def _gen_stacktrace_top(self):
         """Build field StacktraceTop as the top five functions of Stacktrace.
 
@@ -1307,6 +1311,8 @@ class Report(problem_report.ProblemReport):
         except ValueError:
             return f"signal {signal_number}"
 
+    # TODO: Split into smaller functions/methods
+    # pylint: disable-next=too-complex
     def check_ignored(self) -> bool:
         """Check if current report should not be presented.
 
@@ -1807,6 +1813,8 @@ class Report(problem_report.ProblemReport):
 
         return f"{self['ExecutablePath']}:{self['Signal']}:{':'.join(stack)}"
 
+    # TODO: Split into smaller functions/methods
+    # pylint: disable-next=too-complex
     def anonymize(self) -> None:
         """Remove user identifying strings from the report.
 

--- a/apport/report.py
+++ b/apport/report.py
@@ -598,7 +598,7 @@ class Report(problem_report.ProblemReport):
 
     def _check_interpreted(self) -> None:
         # TODO: Split into smaller functions/methods
-        # pylint: disable=too-many-branches
+        # pylint: disable=too-complex,too-many-branches
         """Check if process is a script.
 
         Use ExecutablePath, ProcStatus and ProcCmdline to determine if
@@ -722,7 +722,7 @@ class Report(problem_report.ProblemReport):
         extraenv: Iterable[str] | None = None,
     ) -> None:
         # TODO: Split into smaller functions/methods
-        # pylint: disable=too-many-branches
+        # pylint: disable=too-complex,too-many-branches
         """Add /proc/pid information.
 
         If neither pid nor self.pid are given, it defaults to the process'
@@ -918,7 +918,7 @@ class Report(problem_report.ProblemReport):
         self, rootdir: str | None = None, gdb_sandbox: str | None = None
     ) -> None:
         # TODO: Split into smaller functions/methods
-        # pylint: disable=too-many-branches,too-many-locals
+        # pylint: disable=too-complex,too-many-branches,too-many-locals
         """Add information from gdb.
 
         This requires that the report has a CoreDump and an
@@ -1141,7 +1141,7 @@ class Report(problem_report.ProblemReport):
         self, ui: HookUI, package: str | None, srcpackage: str | None
     ) -> bool:
         # TODO: Split into smaller functions/methods
-        # pylint: disable=too-many-branches
+        # pylint: disable=too-complex,too-many-branches
 
         # determine package names, unless already given as arguments
         # avoid path traversal

--- a/apport/sandboxutils.py
+++ b/apport/sandboxutils.py
@@ -141,7 +141,7 @@ def make_sandbox(
     dynamic_origins: bool = False,
 ) -> tuple[str, str, str]:
     # TODO: Split into smaller functions/methods
-    # pylint: disable=too-many-branches,too-many-locals,too-many-statements
+    # pylint: disable=too-complex,too-many-branches,too-many-locals,too-many-statements
     """Build a sandbox with the packages that belong to a particular report.
 
     This downloads and unpacks all packages from the report's Package and

--- a/apport/ui.py
+++ b/apport/ui.py
@@ -178,7 +178,7 @@ def thread_collect_info(
     report, reportfile, package, ui, symptom_script=None, ignore_uninstalled=False
 ):
     # TODO: Split into smaller functions/methods
-    # pylint: disable=too-many-branches,too-many-statements
+    # pylint: disable=too-complex,too-many-branches,too-many-statements
     """Collect information about report.
 
     Encapsulate calls to add_*_info() and update given report, so that this
@@ -415,7 +415,7 @@ class UserInterface:
 
     def run_crash(self, report_file: str) -> None:
         # TODO: Split into smaller functions/methods
-        # pylint: disable=too-many-branches,too-many-return-statements
+        # pylint: disable=too-complex,too-many-branches,too-many-return-statements
         # pylint: disable=too-many-statements
         """Present and report a particular crash.
 
@@ -618,7 +618,7 @@ class UserInterface:
 
     def run_report_bug(self, symptom_script: str | None = None) -> bool:
         # TODO: Split into smaller functions/methods
-        # pylint: disable=too-many-branches,too-many-return-statements
+        # pylint: disable=too-complex,too-many-branches,too-many-return-statements
         # pylint: disable=too-many-statements
         """Report a bug.
 
@@ -903,7 +903,7 @@ class UserInterface:
 
     def run_argv(self) -> bool:
         # TODO: Split into smaller functions/methods
-        # pylint: disable=too-many-return-statements
+        # pylint: disable=too-complex,too-many-return-statements
         """Call appropriate run_* method according to command line arguments.
 
         Return True if at least one report has been processed, and False
@@ -1008,7 +1008,7 @@ class UserInterface:
 
     def parse_argv(self, argv: list[str]) -> argparse.Namespace:
         # TODO: Split into smaller functions/methods
-        # pylint: disable=too-many-branches,too-many-statements
+        # pylint: disable=too-complex,too-many-branches,too-many-statements
         """Parse command line options.
 
         If a single argument is given without any options, this tries to "do
@@ -1403,7 +1403,8 @@ class UserInterface:
         on_finished: Callable[[], None] | None = None,
     ) -> None:
         # TODO: Split into smaller functions/methods
-        # pylint: disable=too-many-branches,too-many-locals,too-many-statements
+        # pylint: disable=too-complex,too-many-branches,too-many-locals
+        # pylint: disable=too-many-statements
         """Collect additional information.
 
         Call all the add_*_info() methods and display a progress dialog during

--- a/apport/ui.py
+++ b/apport/ui.py
@@ -743,6 +743,8 @@ class UserInterface:
 
         return True
 
+    # TODO: Split into smaller functions/methods
+    # pylint: disable-next=too-complex
     def run_update_report(self) -> bool:
         """Update an existing bug with locally collected information."""
         # avoid irrelevant noise
@@ -1726,6 +1728,8 @@ class UserInterface:
         message = _("Unable to start web browser to open %s.") % url
         self.ui_error_message(title, message + error_details)
 
+    # TODO: Split into smaller functions/methods
+    # pylint: disable-next=too-complex
     def file_report(self) -> None:
         """Upload the current report and guide the user to the reporting
         web page."""

--- a/apport_python_hook.py
+++ b/apport_python_hook.py
@@ -39,7 +39,7 @@ def apport_excepthook(
     exc_tb: types.TracebackType | None,
 ) -> None:
     # TODO: Split into smaller functions/methods
-    # pylint: disable=too-many-branches,too-many-locals
+    # pylint: disable=too-complex,too-many-branches,too-many-locals
     # pylint: disable=too-many-return-statements,too-many-statements
     """Catch an uncaught exception and make a traceback."""
     # create and save a problem report. Note that exceptions in this code

--- a/bin/apport-retrace
+++ b/bin/apport-retrace
@@ -398,7 +398,7 @@ Thank you for your understanding, and sorry for the inconvenience!
 def main(argv):
     # TODO: Split into smaller functions/methods
     # pylint: disable=too-many-branches,too-many-locals,too-many-nested-blocks
-    # pylint: disable=too-many-return-statements,too-many-statements
+    # pylint: disable=too-many-return-statements,too-many-statements,too-complex
     apport.logging.memdbg("start")
 
     gettext.textdomain("apport")

--- a/data/apport
+++ b/data/apport
@@ -1043,7 +1043,7 @@ def process_crash(
 ) -> int:
     """Process crash and return exit code."""
     # TODO: Split into smaller functions/methods
-    # pylint: disable=too-many-branches,too-many-statements
+    # pylint: disable=too-complex,too-many-branches,too-many-statements
     logger = logging.getLogger()
 
     report = (

--- a/data/apport
+++ b/data/apport
@@ -503,6 +503,8 @@ def is_same_ns(pid: int, ns: str) -> bool:
     return False
 
 
+# TODO: Split into smaller functions/methods
+# pylint: disable-next=too-complex
 def forward_crash_to_container(
     options: argparse.Namespace, coredump_fd: int = 0, has_cap_sys_admin: bool = True
 ) -> None:

--- a/data/general-hooks/generic.py
+++ b/data/general-hooks/generic.py
@@ -23,7 +23,7 @@ from problem_report import ProblemReport
 def add_info(report: ProblemReport, ui: apport.ui.HookUI) -> None:
     """Add generic, general information to the problem report."""
     # TODO: Split into smaller functions/methods
-    # pylint: disable=too-many-branches,too-many-locals
+    # pylint: disable=too-complex,too-many-branches,too-many-locals
     nonfree_modules = apport.hookutils.nonfree_kernel_modules()
     if nonfree_modules:
         report["NonfreeKernelModules"] = " ".join(nonfree_modules)

--- a/data/general-hooks/parse_segv.py
+++ b/data/general-hooks/parse_segv.py
@@ -73,7 +73,7 @@ class ParseSegv:
 
     def parse_disassembly(self, disassembly):
         # TODO: Split into smaller functions/methods
-        # pylint: disable=too-many-branches
+        # pylint: disable=too-complex,too-many-branches
         if not self.regs:
             raise ValueError("Registers not loaded yet!?")
         lines = disassembly.splitlines()
@@ -214,7 +214,7 @@ class ParseSegv:
 
     def calculate_arg(self, arg):
         # TODO: Split into smaller functions/methods
-        # pylint: disable=too-many-branches
+        # pylint: disable=too-complex,too-many-branches
 
         # Check for and pre-remove segment offset
         segment = 0
@@ -280,7 +280,7 @@ class ParseSegv:
 
     def report(self):
         # TODO: Split into smaller functions/methods
-        # pylint: disable=too-many-branches,too-many-statements
+        # pylint: disable=too-complex,too-many-branches,too-many-statements
         understood = False
         reason = []
         details = [f"Segfault happened at: {self.line}"]

--- a/data/kernel_crashdump
+++ b/data/kernel_crashdump
@@ -20,6 +20,8 @@ import apport.fileutils
 import apport.logging
 
 
+# TODO: Split into smaller functions/methods
+# pylint: disable-next=too-complex
 def main() -> None:
     """Collect information about a kernel oops."""
     pr = apport.Report("KernelCrash")

--- a/data/whoopsie-upload-all
+++ b/data/whoopsie-upload-all
@@ -34,7 +34,7 @@ from problem_report import MalformedProblemReport
 
 def process_report(report):
     # TODO: Split into smaller functions/methods
-    # pylint: disable=too-many-branches,too-many-return-statements
+    # pylint: disable=too-complex,too-many-branches,too-many-return-statements
     # pylint: disable=too-many-statements
     """Collect information for a report and mark for whoopsie upload
 

--- a/gtk/apport-gtk
+++ b/gtk/apport-gtk
@@ -196,7 +196,8 @@ class GTKUserInterface(apport.ui.UserInterface):
         self, allowed_to_report: bool = True, modal_for: int | None = None
     ) -> apport.ui.Action:
         # TODO: Split into smaller functions/methods
-        # pylint: disable=too-many-branches,too-many-locals,too-many-statements
+        # pylint: disable=too-complex,too-complex,too-many-branches,too-many-locals
+        # pylint: disable=too-many-statements
         assert self.report
         icon = None
         self.collect_called = False

--- a/kde/apport-kde
+++ b/kde/apport-kde
@@ -136,7 +136,7 @@ class ReportDialog(Dialog):  # pylint: disable=too-many-instance-attributes
 
     def __init__(self, report, allowed_to_report, ui, desktop_info):
         # TODO: Split into smaller functions/methods
-        # pylint: disable=too-many-branches,too-many-statements
+        # pylint: disable=too-complex,too-many-branches,too-many-statements
         if "DistroRelease" not in report:
             report.add_os_info()
         distro = report["DistroRelease"]

--- a/problem_report.py
+++ b/problem_report.py
@@ -664,7 +664,7 @@ class ProblemReport(collections.UserDict):
         size limit, in which case it will also remove the value from self.data entirely.
         """
         # TODO: split into smaller subgenerators
-        # pylint: disable=too-many-branches
+        # pylint: disable=too-complex,too-many-branches
         value = self.data[key]
         if isinstance(value, (CompressedFile, CompressedValue)):
             yield from value.iter_compressed()
@@ -770,7 +770,8 @@ class ProblemReport(collections.UserDict):
         priority_fields=None,
     ):
         # TODO: Split into smaller functions/methods
-        # pylint: disable=too-many-branches,too-many-locals,too-many-statements
+        # pylint: disable=too-complex,too-many-branches,too-many-locals
+        # pylint: disable=too-many-statements
         """Write MIME/Multipart RFC 2822 formatted data into file.
 
         file must be a file-like object, not a path.  It needs to be opened in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ load-plugins = [
     "pylint.extensions.docstyle",
     "pylint.extensions.dunder",
     "pylint.extensions.eq_without_hash",
+    "pylint.extensions.mccabe",
     "pylint.extensions.no_self_use",
     "pylint.extensions.overlapping_exceptions",
     "pylint.extensions.private_import",
@@ -69,6 +70,9 @@ max-args = 6
 
 # Maximum number of attributes for a class (see R0902).
 max-attributes = 9
+
+# McCabe complexity cyclomatic threshold
+max-complexity = 11
 
 # Maximum number of positional arguments for function / method.
 max-positional-arguments=6

--- a/tests/integration/test_signal_crashes.py
+++ b/tests/integration/test_signal_crashes.py
@@ -1120,7 +1120,8 @@ class T(unittest.TestCase):
         **kwargs: typing.Any,
     ) -> str:
         # TODO: Split into smaller functions/methods
-        # pylint: disable=too-many-branches,too-many-locals,too-many-statements
+        # pylint: disable=too-complex,too-many-branches,too-many-locals
+        # pylint: disable=too-many-statements
         """Generate a test crash.
 
         This runs command (by default TEST_EXECUTABLE) in cwd, lets it crash,


### PR DESCRIPTION
To prevent introducing too complex functions, add `TODO`s for functions/methods that should be split and check cyclomatic complexity with a slightly relaxed maximum of 11 instead of 10.