### PR TITLE
apport: catch ProcessLookupError in forward_crash_to_container

### DIFF
--- a/data/apport
+++ b/data/apport
@@ -519,7 +519,7 @@ def forward_crash_to_container(
             "root/run/apport.socket", os.O_RDONLY | os.O_PATH, dir_fd=proc_host_pid_fd
         )
         socket_uid = os.fstat(sock_fd).st_uid
-    except FileNotFoundError:
+    except (FileNotFoundError, ProcessLookupError):
         logger.error(
             "host pid %s crashed in a container without apport support",
             options.global_pid,


### PR DESCRIPTION
Crashes in the Chrome snap can crash Apport:

```
Traceback (most recent call last):
  File "/usr/share/apport/apport", line 1248, in <module>
    sys.exit(main(sys.argv[1:]))
             ^^^^^^^^^^^^^^^^^^
  File "/usr/share/apport/apport", line 773, in main
    if _check_global_pid_and_forward(options):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/apport/apport", line 732, in _check_global_pid_and_forward
    forward_crash_to_container(options)
  File "/usr/share/apport/apport", line 531, in forward_crash_to_container
    sock_fd = os.open(
              ^^^^^^^^
ProcessLookupError: [Errno 3] No such process: 'root/run/apport.socket'
```

Example /proc/cmdline:

```
/usr/bin/python3 /usr/share/apport/apport -p1 -s4 -c0 -d1 -P570846 -u1000 -g1000 -- !snap!chromium!2934!usr!lib!chromium-browser!chrome
/usr/bin/python3 /usr/share/apport/apport -p1 -s4 -c0 -d1 -P22550 -u1001 -g1001 -- !snap!brave!438!opt!brave.com!brave!brave
```

The Snap container does neither have `/run` nor `/run/apport.socket`. Python throws `ProcessLookupError` instead of `FileNotFoundError`. So catch this exception type as well. Writing a test case for this use case is tricky unless you want to setup snaps in your test environment.

Bug-Ubuntu: https://launchpad.net/bugs/2080499