### PR TITLE
ci: run the tests in verbose mode

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,7 +76,7 @@ jobs:
           && python3 -m coverage xml -o coverage-setup.xml
       - name: Run unit and integration tests
         run: >
-          python3 -m pytest -ra --cov=$(pwd) --cov-report=xml
+          python3 -m pytest -v -ra --cov=$(pwd) --cov-report=xml
           --durations=0 tests/unit/ tests/integration/
       - name: Upload coverage
         uses: actions/upload-artifact@v4
@@ -117,7 +117,7 @@ jobs:
           WORKDIR=$(mktemp -d -t apport.XXXXXXXXXX)
           && cp -r tests "$WORKDIR"
           && cd "$WORKDIR"
-          && python3 -m pytest -ra --cov=$(pwd) --cov-report=xml
+          && python3 -m pytest -v -ra --cov=$(pwd) --cov-report=xml
           --durations=0 tests/unit/ tests/integration/
           && cd -
           && cp "$WORKDIR/coverage.xml" .
@@ -152,7 +152,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run all tests (to check if they are skipped or succeed)
         run: >
-          SKIP_ONLINE_TESTS=1 python3 -m pytest -ra --cov=$(pwd)
+          SKIP_ONLINE_TESTS=1 python3 -m pytest -v -ra --cov=$(pwd)
           --cov-report=xml --durations=0 tests/
       - name: Upload coverage
         uses: actions/upload-artifact@v4
@@ -200,7 +200,7 @@ jobs:
         env:
           GDK_BACKEND: x11
         run: >
-          xvfb-run python3 -m pytest -ra --cov=$(pwd)
+          xvfb-run python3 -m pytest -v -ra --cov=$(pwd)
           --cov-report=xml --durations=0 tests/system/
       - name: Stop D-Bus daemon
         run: kill $(cat /run/dbus/pid)
@@ -251,7 +251,7 @@ jobs:
           WORKDIR=$(mktemp -d -t apport.XXXXXXXXXX)
           && cp -r tests "$WORKDIR"
           && cd "$WORKDIR"
-          && sudo xvfb-run python3 -m pytest -ra --cov=$(pwd)
+          && sudo xvfb-run python3 -m pytest -v -ra --cov=$(pwd)
           --cov-report=xml --durations=0 tests/system/
           && cd -
           && cp "$WORKDIR/coverage.xml" .


### PR DESCRIPTION
This does not *completely* work around GHA's line buffering, but at least now when a test is hanging we have a better chance of knowing in which module that test is.