### PR TITLE
report: let _build_proc_maps_cache return the cache

### DIFF
--- a/apport/report.py
+++ b/apport/report.py
@@ -380,7 +380,7 @@ class Report(problem_report.ProblemReport):
         """
         problem_report.ProblemReport.__init__(self, problem_type, date)
         self.pid: int | None = None
-        self._proc_maps_cache: list[tuple[int, int, str]] | None = None
+        self._proc_maps_cache: list[tuple[int, int, str]] = []
 
     @staticmethod
     def _customized_package_suffix(package: str) -> str:
@@ -1963,7 +1963,7 @@ class Report(problem_report.ProblemReport):
 
         return command, environ
 
-    def _address_to_offset(self, addr):
+    def _address_to_offset(self, addr: int) -> str | None:
         """Resolve a memory address to an ELF name and offset.
 
         This can be used for building duplicate signatures from non-symbolic

--- a/apport/report.py
+++ b/apport/report.py
@@ -1977,21 +1977,19 @@ class Report(problem_report.ProblemReport):
         Return 'path+offset' when found, or None if address is not in any
         mapped range.
         """
-        self._build_proc_maps_cache()
-
-        for start, end, elf in self._proc_maps_cache:
+        for start, end, elf in self._build_proc_maps_cache():
             if start <= addr <= end:
                 return f"{elf}+{addr - start:x}"
 
         return None
 
-    def _build_proc_maps_cache(self) -> None:
+    def _build_proc_maps_cache(self) -> list[tuple[int, int, str]]:
         """Generate self._proc_maps_cache from ProcMaps field.
 
         This only gets done once.
         """
         if self._proc_maps_cache:
-            return
+            return self._proc_maps_cache
 
         assert "ProcMaps" in self
         self._proc_maps_cache = []
@@ -2017,6 +2015,7 @@ class Report(problem_report.ProblemReport):
             self._proc_maps_cache.append(
                 (int(m.group(1), 16), int(m.group(2), 16), m.group(3))
             )
+        return self._proc_maps_cache
 
     def _add_str_from_coredump(
         self, coredump: dict[str, object], coredump_key: str, key: str

--- a/tests/integration/test_report.py
+++ b/tests/integration/test_report.py
@@ -1774,6 +1774,7 @@ int main() { return f(42); }
         pr.add_proc_info()
         self.assertIsNone(pr._address_to_offset(0))
         res = pr._address_to_offset(int(pr["ProcMaps"].split("-", 1)[0], 16) + 5)
+        assert res is not None
         self.assertEqual(res.split("+", 1)[1], "5")
         self.assertIn("python", res.split("+", 1)[0])
 


### PR DESCRIPTION
Let `_build_proc_maps_cache` return the proc maps cache. The caller in `_address_to_offset` can rely on it being not `None` then.