### PR TITLE
setuptools/java: use snakecase for option name

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,4 +2,4 @@
 domain=apport
 
 [build_java_subdir]
-minimum-java-release=8
+minimum_java_release=8

--- a/setuptools_apport/java.py
+++ b/setuptools_apport/java.py
@@ -16,7 +16,7 @@ class build_java(Command):
     """Compile Java components of Apport"""
 
     description = __doc__
-    user_options = [("minimum-java-release=", "r", "Specify minimum Java release.")]
+    user_options = [("minimum_java_release=", "r", "Specify minimum Java release.")]
 
     def __init__(self, dist: Distribution, **kwargs: dict[str, typing.Any]) -> None:
         Command.__init__(self, dist, **kwargs)


### PR DESCRIPTION
We're the sole users of that plugin so the migration is fairly easy, and setuptools has apparently deprecated (and actually broken) the use of kebab-case option names in setup.cfg, see

https://github.com/pypa/setuptools/blob/main/NEWS.rst#v7800