### PR TITLE
packaging: drop lsb_release support from get_os_version()

### DIFF
--- a/apport/packaging.py
+++ b/apport/packaging.py
@@ -11,8 +11,6 @@
 
 import platform
 import re
-import subprocess
-import sys
 from collections.abc import Iterable
 
 
@@ -349,30 +347,13 @@ class PackageInfo:
     def get_os_version(self) -> tuple[str, str]:
         """Return (osname, osversion) tuple.
 
-        This is read from /etc/os-release, or if that doesn't exist,
-        'lsb_release -sir' output.
+        This is read from /etc/os-release.
         """
         if self._os_version:
             return self._os_version
 
-        try:
-            info = platform.freedesktop_os_release()
-            name = self._sanitize_operating_system_name(info["NAME"])
-            version = info.get("VERSION_ID")
-            if name and version:
-                self._os_version = (name, version)
-                return self._os_version
-        except OSError as error:
-            sys.stderr.write(f"{error}. Falling back to calling 'lsb_release -sir'.")
-
-        # fall back to lsb_release
-        lsb_release = subprocess.run(
-            ["lsb_release", "-sir"],
-            check=False,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-        )
-        (name, version) = lsb_release.stdout.strip().replace("\n", " ").split()
-        self._os_version = (name.strip(), version.strip())
+        info = platform.freedesktop_os_release()
+        name = self._sanitize_operating_system_name(info["NAME"])
+        version = info.get("VERSION_ID", "n/a")
+        self._os_version = (name, version)
         return self._os_version

--- a/tests/unit/test_packaging_apt_dpkg.py
+++ b/tests/unit/test_packaging_apt_dpkg.py
@@ -327,3 +327,31 @@ var/lib/ieee-data/iab.txt				    net/ieee-data
             },
         )
         open_mock.assert_called_once_with("Contents-amd64", "rb")
+
+
+class TestPackaging(unittest.TestCase):
+    """Unit tests for apport.packaging.PackageInfo class."""
+
+    def setUp(self) -> None:
+        # pylint: disable-next=protected-access
+        impl._os_version = None
+
+    def tearDown(self) -> None:
+        # pylint: disable-next=protected-access
+        impl._os_version = None
+
+    @unittest.mock.patch("platform.freedesktop_os_release")
+    def test_get_os_version_debian_testing(self, os_release_mock: MagicMock) -> None:
+        """Test get_os_version() for Debian testing (no VERSION_ID set)."""
+        # platform.freedesktop_os_release() data from base-files 13.7
+        os_release_mock.return_value = {
+            "NAME": "Debian GNU/Linux",
+            "ID": "debian",
+            "PRETTY_NAME": "Debian GNU/Linux trixie/sid",
+            "VERSION_CODENAME": "trixie",
+            "HOME_URL": "https://www.debian.org/",
+            "SUPPORT_URL": "https://www.debian.org/support",
+            "BUG_REPORT_URL": "https://bugs.debian.org/",
+        }
+        self.assertEqual(impl.get_os_version(), ("Debian", "n/a"))
+        os_release_mock.assert_called_once_with()

--- a/tests/unit/test_packaging_apt_dpkg.py
+++ b/tests/unit/test_packaging_apt_dpkg.py
@@ -15,6 +15,7 @@ import unittest.mock
 from unittest.mock import MagicMock
 
 import apt
+import apt.package
 
 from apport.packaging_impl.apt_dpkg import (
     _map_mirror_to_arch,


### PR DESCRIPTION
`PackageInfo.get_os_version()` uses `lsb_release` as fallback in case `NAME` and/or `VERSION_ID` is not set in `/etc/os-release`. This may only be the case for Debian testing/unstable.

Debian testing/unstable with base-files 13.7 has following `/etc/os-release`:

```
PRETTY_NAME="Debian GNU/Linux trixie/sid"
NAME="Debian GNU/Linux"
VERSION_CODENAME=trixie
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
```

`lsb_release -s --release` will return `n/a` in this case and therefore does not provide any benefit.

So drop the `lsb_release` fallback from `PackageInfo.get_os_version()`.