### PR TITLE
apt_dpkg: import used modules explicitly

### DIFF
--- a/apport/packaging_impl/apt_dpkg.py
+++ b/apport/packaging_impl/apt_dpkg.py
@@ -47,6 +47,10 @@ import urllib.request
 from collections.abc import Iterable, Iterator
 
 import apt
+import apt.cache
+import apt.package
+import apt.progress.base
+import apt.progress.text
 import apt_pkg
 from aptsources.sourceslist import Deb822SourceEntry, SourceEntry
 

--- a/apport/packaging_impl/apt_dpkg.py
+++ b/apport/packaging_impl/apt_dpkg.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import contextlib
 import datetime
+import fnmatch
 import functools
 import glob
 import gzip
@@ -1397,7 +1398,7 @@ class _AptDpkgPackageInfo(PackageInfo):
 
     def package_name_glob(self, nameglob):
         """Return known package names which match given glob."""
-        return glob.fnmatch.filter(self._cache().keys(), nameglob)
+        return fnmatch.filter(self._cache().keys(), nameglob)
 
     #
     # Internal helper methods


### PR DESCRIPTION
Make Pyright happier about `apt_dpkg` by importing the used modules from `apt` explicitly.