### PR TITLE
test: explicitly import apport.fileutils

### DIFF
--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -23,6 +23,7 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 import apport.crashdb_impl.memory
+import apport.fileutils
 import apport.packaging
 import apport.report
 import apport.ui


### PR DESCRIPTION
Make Pyright happy by explicitly importing `apport.fileutils`.