### PR TITLE
crashdb/memory: use float for upload_delay

### DIFF
--- a/apport/crashdb_impl/memory.py
+++ b/apport/crashdb_impl/memory.py
@@ -35,7 +35,7 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
         self.unretraced = set()
         self.dup_unchecked = set()
 
-        self.upload_delay = 0
+        self.upload_delay = 0.0
         self.upload_msg = None
 
         if "sample_data" in options:


### PR DESCRIPTION
`time.sleep` takes a `float`.