### PR TITLE
apt_dpkg: split install_packages into two methods

### DIFF
--- a/apport/packaging_impl/apt_dpkg.py
+++ b/apport/packaging_impl/apt_dpkg.py
@@ -1286,6 +1286,14 @@ class _AptDpkgPackageInfo(PackageInfo):
             real_pkgs.add(pkg)
             return pkg_found
 
+        def is_transitional_package(package: str) -> bool:
+            """Checks if the package has "transitional" in the description.
+
+            Returns False in case no candidate version could be found.
+            """
+            candidate = apt_cache[package].candidate
+            return candidate is not None and "transitional" in candidate.description
+
         for pkg, ver in packages:
             try:
                 cache_pkg = apt_cache[pkg]
@@ -1335,7 +1343,7 @@ class _AptDpkgPackageInfo(PackageInfo):
                             for p in src_records.binaries
                             if p.endswith("-dbg")
                             and p in apt_cache
-                            and "transitional" not in apt_cache[p].candidate.description
+                            and not is_transitional_package(p)
                         ]
                         # if a specific version of a package was requested
                         # only install dbg pkgs whose version matches

--- a/apport/packaging_impl/apt_dpkg.py
+++ b/apport/packaging_impl/apt_dpkg.py
@@ -432,7 +432,9 @@ class _AptDpkgPackageInfo(PackageInfo):
 
     def get_available_version(self, package: str) -> str:
         """Return the latest available version of a package."""
-        return self._apt_pkg(package).candidate.version
+        candidate = self._apt_pkg(package).candidate
+        assert candidate is not None
+        return candidate.version
 
     def get_dependencies(self, package: str) -> list[str]:
         """Return a list of packages a package depends on."""
@@ -1278,6 +1280,7 @@ class _AptDpkgPackageInfo(PackageInfo):
                     package.candidate = package.versions[candidate.version]
                 except KeyError:
                     if base_pkg:
+                        assert package.candidate is not None
                         obsolete.append(
                             f"outdated debug symbol package for {base_pkg}:"
                             f" package version {ver} or {candidate.version}"
@@ -1309,6 +1312,7 @@ class _AptDpkgPackageInfo(PackageInfo):
                     cache_pkg.candidate = cache_pkg.versions[ver]
             except KeyError:
                 if not get_package_from_launchpad(pkg, ver):
+                    assert cache_pkg.candidate is not None
                     obsolete.append(
                         f"{pkg} version {ver} required,"
                         f" but {cache_pkg.candidate.version} is available\n"
@@ -1316,6 +1320,7 @@ class _AptDpkgPackageInfo(PackageInfo):
                     ver = cache_pkg.candidate.version
 
             candidate = cache_pkg.candidate
+            assert candidate is not None
             real_pkgs.add(pkg)
 
             if permanent_rootdir:
@@ -1349,7 +1354,8 @@ class _AptDpkgPackageInfo(PackageInfo):
                         # only install dbg pkgs whose version matches
                         if ver:
                             for dbg in dbgs:
-                                if apt_cache[dbg].candidate.version != ver:
+                                dbg_candidate = apt_cache[dbg].candidate
+                                if dbg_candidate and dbg_candidate.version != ver:
                                     dbgs.remove(dbg)
                     else:
                         dbgs = []


### PR DESCRIPTION
Split `install_packages` into two methods and address the mypy complains triggered by that.