### PR TITLE
test: fix C warning about implicit int

### DIFF
--- a/tests/integration/test_crashdb_launchpad.py
+++ b/tests/integration/test_crashdb_launchpad.py
@@ -994,7 +994,7 @@ NameError: global name 'weird' is not defined"""
             with open("crash.c", "w", encoding="utf-8") as fd:
                 fd.write(
                     """
-int f(x) {
+int f(int x) {
     int* p = 0; *p = x;
     return x+1;
 }


### PR DESCRIPTION
gcc will complain:

```
crash.c: In function ‘f’:
crash.c:2:5: error: type of ‘x’ defaults to ‘int’ [-Wimplicit-int]
    2 | int f(x) {
      |     ^
```

This is equivalent to commit a730657a2f8d
("test/test_report.py: Fix C warnings").