### PR TITLE
test: use cat and sleep from GNU coreutils

### DIFF
--- a/tests/helper.py
+++ b/tests/helper.py
@@ -19,6 +19,14 @@ from unittest.mock import MagicMock
 import psutil
 
 
+def get_gnu_coreutils_cmd(cmd: str) -> str:
+    """Determine path to GNU coreutils command."""
+    path = shutil.which(f"gnu{cmd}")
+    if path is not None:
+        return path
+    return os.path.realpath(f"/bin/{cmd}")
+
+
 def get_init_system() -> str:
     """Return the name of the running init system (PID 1)."""
     with open("/proc/1/comm", encoding="utf-8") as comm:
@@ -106,10 +114,11 @@ def restore_os_environ() -> Generator[None]:
 
 @contextlib.contextmanager
 def run_test_executable(
-    args: Sequence[str] = (os.path.realpath("/bin/sleep"), "86400"),
-    env: dict[str, str] | None = None,
+    args: Sequence[str] | None = None, env: dict[str, str] | None = None
 ) -> Iterator[int]:
     """Run test executable and yield the process ID. Kill process afterwards."""
+    if args is None:
+        args = (get_gnu_coreutils_cmd("sleep"), "86400")
     with subprocess.Popen(args, env=env) as test_process:
         try:
             yield test_process.pid

--- a/tests/integration/test_report.py
+++ b/tests/integration/test_report.py
@@ -22,7 +22,7 @@ from unittest.mock import MagicMock
 import apport.packaging
 import apport.report
 import problem_report
-from tests.helper import skip_if_command_is_missing
+from tests.helper import get_gnu_coreutils_cmd, skip_if_command_is_missing
 from tests.paths import patch_data_dir, restore_data_dir
 
 
@@ -186,8 +186,9 @@ class T(unittest.TestCase):
         self.assertNotIn("InterpreterPath", pr)
 
         # check escaping of ProcCmdline
+        catcmd = get_gnu_coreutils_cmd("cat")
         with subprocess.Popen(
-            ["cat", "/foo bar", "\\h", "\\ \\", "-"],
+            [catcmd, "/foo bar", "\\h", "\\ \\", "-"],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -197,8 +198,8 @@ class T(unittest.TestCase):
             pr.add_proc_info(pid=cat.pid)
             self.assertEqual(pr.pid, cat.pid)
             cat.communicate(b"\n")
-        self.assertEqual(pr["ProcCmdline"], "cat /foo\\ bar \\\\h \\\\\\ \\\\ -")
-        self.assertRegex(pr["ExecutablePath"], "/usr/bin/.*cat")
+        self.assertEqual(pr["ProcCmdline"], f"{catcmd} /foo\\ bar \\\\h \\\\\\ \\\\ -")
+        self.assertEqual(pr["ExecutablePath"], catcmd)
         self.assertNotIn("InterpreterPath", pr)
         self.assertIn(pr["ExecutablePath"], pr["ProcMaps"])
         self.assertIn("[stack]", pr["ProcMaps"])

--- a/tests/integration/test_signal_crashes.py
+++ b/tests/integration/test_signal_crashes.py
@@ -42,6 +42,7 @@ import pytest
 import apport.fileutils
 import apport.report
 from tests.helper import (
+    get_gnu_coreutils_cmd,
     import_module_from_file,
     pidfd_open,
     read_shebang,
@@ -111,7 +112,7 @@ def compile_c_code(name: str, c_code: str, tmpdir: str = "/var/tmp") -> Iterator
 @contextlib.contextmanager
 def create_suid(tmpdir: str = "/var/tmp") -> Iterator[str]:
     """Creates a `sleep` suid binary in a subdirectory of `tmpdir`."""
-    src_bin = os.path.realpath("/bin/sleep")
+    src_bin = get_gnu_coreutils_cmd("sleep")
     with tempfile.TemporaryDirectory(dir=tmpdir) as tempdir:
         binary = f"{tempdir}/sleep"
         shutil.copy(src_bin, binary)
@@ -142,7 +143,7 @@ required_fields = [
 class T(unittest.TestCase):
     # pylint: disable=missing-class-docstring,missing-function-docstring
     # pylint: disable=protected-access,too-many-public-methods
-    TEST_EXECUTABLE = os.path.realpath("/bin/sleep")
+    TEST_EXECUTABLE = get_gnu_coreutils_cmd("sleep")
     TEST_ARGS = ["86400"]
     maxDiff = None
     orig_core_dir: str

--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -30,6 +30,7 @@ import problem_report
 from apport.packaging_impl import impl as packaging
 from apport.ui import _, run_as_real_user
 from tests.helper import (
+    get_gnu_coreutils_cmd,
     pids_of,
     run_test_executable,
     skip_if_command_is_missing,
@@ -198,7 +199,7 @@ class T(unittest.TestCase):
     # pylint: disable=too-many-public-methods
     """Integration tests for apport.ui."""
 
-    TEST_EXECUTABLE = os.path.realpath("/bin/sleep")
+    TEST_EXECUTABLE = get_gnu_coreutils_cmd("sleep")
     TEST_ARGS = ["86400"]
 
     def setUp(self) -> None:

--- a/tests/integration/test_unkillable_shutdown.py
+++ b/tests/integration/test_unkillable_shutdown.py
@@ -19,6 +19,7 @@ import tempfile
 import unittest
 from collections.abc import Generator
 
+from tests.helper import get_gnu_coreutils_cmd
 from tests.paths import get_data_directory, local_test_environment
 
 
@@ -26,7 +27,7 @@ class TestUnkillableShutdown(unittest.TestCase):
     """Test unkillable_shutdown"""
 
     maxDiff = None
-    TEST_EXECUTABLE = os.path.realpath("/bin/sleep")
+    TEST_EXECUTABLE = get_gnu_coreutils_cmd("sleep")
     TEST_ARGS = ["86400"]
 
     def setUp(self) -> None:

--- a/tests/system/test_packaging_apt_dpkg.py
+++ b/tests/system/test_packaging_apt_dpkg.py
@@ -313,12 +313,12 @@ def test_install_packages_system(
         rootdir,
         None,
         release,
-        [("coreutils", impl.get_version("coreutils")), ("tzdata", "1.1")],
+        [("gzip", impl.get_version("gzip")), ("tzdata", "1.1")],
         False,
         cachedir,
     )
 
-    assert os.path.exists(os.path.join(rootdir, "usr/bin/stat"))
+    assert os.path.exists(os.path.join(rootdir, "/usr/bin/gzip"))
     assert os.path.exists(os.path.join(rootdir, "usr/share/zoneinfo/zone.tab"))
 
     # complains about obsolete packages
@@ -331,22 +331,20 @@ def test_install_packages_system(
         os.path.join(cachedir, "system", "apt", "var", "cache", "apt", "archives")
     )
     cache_names = [p.split("_")[0] for p in cache]
-    assert "coreutils" in cache_names
-    assert "coreutils-dbgsym" in cache_names
+    assert "gzip" in cache_names
+    assert "gzip-dbgsym" in cache_names
     assert "tzdata" in cache_names
 
     # works with relative paths and existing cache
-    os.unlink(os.path.join(rootdir, "usr/bin/stat"))
+    os.unlink(os.path.join(rootdir, "usr/bin/gzip"))
     os.unlink(os.path.join(rootdir, "packages.txt"))
     orig_cwd = os.getcwd()
     try:
         os.chdir(workdir)
-        impl.install_packages(
-            "root", None, release, [("coreutils", None)], False, "cache"
-        )
+        impl.install_packages("root", None, release, [("gzip", None)], False, "cache")
     finally:
         os.chdir(orig_cwd)
-        assert os.path.exists(os.path.join(rootdir, "usr/bin/stat"))
+        assert os.path.exists(os.path.join(rootdir, "usr/bin/gzip"))
 
 
 @pytest.mark.skipif(not has_internet(), reason="online test")

--- a/tests/system/test_signal_crashes.py
+++ b/tests/system/test_signal_crashes.py
@@ -17,6 +17,7 @@ import psutil
 
 import apport.fileutils
 from tests.helper import (
+    get_gnu_coreutils_cmd,
     get_init_system,
     pids_of,
     skip_if_command_is_missing,
@@ -33,7 +34,7 @@ from tests.paths import (
 class T(unittest.TestCase):
     # pylint: disable=missing-class-docstring,missing-function-docstring
     # pylint: disable=protected-access
-    TEST_EXECUTABLE = os.path.realpath("/bin/sleep")
+    TEST_EXECUTABLE = get_gnu_coreutils_cmd("sleep")
     TEST_ARGS = ["86400"]
     apport_path: pathlib.Path | str | None
     all_reports: list[str]


### PR DESCRIPTION
Several test cases use the sleep command as test case. Some kill the sleep command while it is sleeping and expect a certain stack trace. So enforce using the GNU coreutils implementation of the sleep command.

Since Ubuntu 25.10 (questing) the GNU implementation is shipped by gnu-coreutils and the commands are prefixed with `gnu`.

Bug-Ubuntu: https://launchpad.net/bugs/2111595