### PR TITLE
test: assert that ui.report is not None

### DIFF
--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -415,6 +415,7 @@ class T(unittest.TestCase):
         # report without any information (distro bug)
         ui.report = apport.Report("Bug")
         ui.collect_info()
+        assert ui.report
         self.assertTrue(
             set(["Date", "Uname", "DistroRelease", "ProblemType"]).issubset(
                 set(ui.report.keys())
@@ -484,6 +485,7 @@ class T(unittest.TestCase):
             ui.collect_info()
 
         search_bug_patterns_mock.assert_called_once()
+        assert ui.report
         self.assertTrue(
             set(
                 [
@@ -540,6 +542,7 @@ class T(unittest.TestCase):
         ui.report = apport.Report("Bug")
         ui.cur_package = "bash"
         ui.collect_info()
+        assert ui.report
         self.assertIn("CrashDB", ui.report)
         self.assertNotIn("UnreportableReason", ui.report)
         self.assertEqual(ui.report["BashHook"], "Moo")
@@ -552,6 +555,7 @@ class T(unittest.TestCase):
         ui.report = apport.Report("Bug")
         ui.cur_package = "bash"
         ui.collect_info()
+        assert ui.report
         self.assertNotIn("UnreportableReason", ui.report)
         self.assertEqual(ui.report["BashHook"], "Moo")
         self.assertEqual(ui.crashdb.options["distro"], "debug")
@@ -564,6 +568,7 @@ class T(unittest.TestCase):
         ui.report = apport.Report("Bug")
         ui.cur_package = "bash"
         ui.collect_info()
+        assert ui.report
         self.assertIn("nonexisting", ui.report["UnreportableReason"])
 
         # invalid syntax
@@ -571,6 +576,7 @@ class T(unittest.TestCase):
         ui.report = apport.Report("Bug")
         ui.cur_package = "bash"
         ui.collect_info()
+        assert ui.report
         self.assertIn("package hook", ui.report["UnreportableReason"])
 
         # nonexisting name
@@ -578,6 +584,7 @@ class T(unittest.TestCase):
         ui.report = apport.Report("Bug")
         ui.cur_package = "bash"
         ui.collect_info()
+        assert ui.report
         self.assertIn("nonexisting", ui.report["UnreportableReason"])
 
         # string with unsafe contents
@@ -588,6 +595,7 @@ class T(unittest.TestCase):
         ui.report = apport.Report("Bug")
         ui.cur_package = "bash"
         ui.collect_info()
+        assert ui.report
         self.assertIn("package hook", ui.report["UnreportableReason"])
         self.assertFalse(os.path.exists("/tmp/pwned"))
 
@@ -1247,6 +1255,7 @@ class T(unittest.TestCase):
 
         # now pretend to move it to a machine where the package is not
         # installed
+        assert ui.report
         ui.report["Package"] = "uninstalled_pkg 1"
         ui.report["ExecutablePath"] = "/usr/bin/uninstalled_program"
         ui.report["InterpreterPath"] = "/usr/bin/uninstalled_interpreter"


### PR DESCRIPTION
Make Pyright happy by asserting that `ui.report` is not `None` before accessing it.