### PR TITLE
test: drop running pyflakes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
           apt-get update
           && apt-get install --no-install-recommends --yes
           black gir1.2-gtk-3.0 gir1.2-wnck-3.0 isort mypy pycodestyle
-          pydocstyle pyflakes3 pylint python3 python3-apt python3-dbus
+          pydocstyle pylint python3 python3-apt python3-dbus
           python3-distutils-extra python3-gi python3-launchpadlib
           python3-psutil python3-pyqt5 python3-pytest python3-rpm
           python3-typeshed python3-yaml python3-systemd python3-zstandard

--- a/tests/README.md
+++ b/tests/README.md
@@ -11,8 +11,12 @@ Linter tests
 The script [run-linters](./run-linters) runs following linters on the source
 code:
 
+ * black
+ * isort
+ * mypy
  * pycodestyle
- * pyflakes
+ * pydocstyle
+ * pylint
 
 Unit tests
 ----------

--- a/tests/run-linters
+++ b/tests/run-linters
@@ -89,15 +89,6 @@ run_pydocstyle() {
     pydocstyle ${PYTHON_FILES} ${PYTHON_SCRIPTS}
 }
 
-run_pyflakes() {
-    if ! type pyflakes3 >/dev/null 2>&1; then
-        echo "Skipping pyflakes3 tests, pyflakes3 is not installed"
-        return
-    fi
-    echo "Running pyflakes3..."
-    pyflakes3 ${PYTHON_FILES} ${PYTHON_SCRIPTS}
-}
-
 run_pylint() {
     if ! type pylint >/dev/null 2>&1; then
         echo "Skipping pylint tests, pylint is not installed"
@@ -116,7 +107,6 @@ else
     run_isort
     run_pycodestyle
     run_pydocstyle
-    run_pyflakes
     run_mypy
     run_pylint
     check_hardcoded_names


### PR DESCRIPTION
There is no way for overriding complaints from pyflakes (like unused imports). Drop pyflakes and rely on the other tools (like pylint) instead.

This PR is split from https://github.com/canonical/apport/pull/475 and https://github.com/canonical/apport/pull/477.