### PR TITLE
test: do not assign None on tear-down

### DIFF
--- a/tests/integration/test_fileutils.py
+++ b/tests/integration/test_fileutils.py
@@ -33,12 +33,11 @@ class T(unittest.TestCase):
         apport.fileutils.report_dir = tempfile.mkdtemp()
         self.orig_config_file = apport.fileutils._CONFIG_FILE
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         shutil.rmtree(apport.fileutils.core_dir)
         apport.fileutils.core_dir = self.orig_core_dir
         shutil.rmtree(apport.fileutils.report_dir)
         apport.fileutils.report_dir = self.orig_report_dir
-        self.orig_report_dir = None
         apport.fileutils._CONFIG_FILE = self.orig_config_file
 
     @staticmethod

--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -257,11 +257,9 @@ class T(unittest.TestCase):
         self.report.write(self.report_file)
         self.report_file.flush()
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         apport.fileutils.report_dir = self.orig_report_dir
-        self.orig_report_dir = None
         apport.ui.symptom_script_dir = self.orig_symptom_script_dir
-        self.orig_symptom_script_dir = None
 
         # pylint: disable=protected-access
         os.unlink(apport.report._ignore_file)


### PR DESCRIPTION
Setting the `orig_*` properties to `None` on tear-down is not needed and only causes mypy/Pyright to be unhappy.