### PR TITLE
packaging: add type hints to all PackageInfo methods

### DIFF
--- a/apport/packaging.py
+++ b/apport/packaging.py
@@ -20,7 +20,7 @@ class PackageInfo:
     # default global configuration file
     configuration = "/etc/default/apport"
 
-    def get_version(self, package):
+    def get_version(self, package: str) -> str:
         """Return the installed version of a package.
 
         Throw ValueError if package does not exist.
@@ -87,7 +87,7 @@ class PackageInfo:
             "this method must be implemented by a concrete subclass"
         )
 
-    def get_files(self, package):
+    def get_files(self, package: str) -> list[str]:
         """Return list of files shipped by a package.
 
         Throw ValueError if package does not exist.
@@ -102,7 +102,7 @@ class PackageInfo:
             "this method must be implemented by a concrete subclass"
         )
 
-    def get_modified_conffiles(self, package):
+    def get_modified_conffiles(self, package: str) -> dict[str, bytes | str]:
         """Return modified configuration files of a package.
 
         Return a file name -> file contents map of all configuration files of
@@ -180,7 +180,13 @@ class PackageInfo:
             "this method must be implemented by a concrete subclass"
         )
 
-    def get_source_tree(self, srcpackage, output_dir, version=None, sandbox=None):
+    def get_source_tree(
+        self,
+        srcpackage: str,
+        output_dir: str,
+        version: str | None = None,
+        sandbox: str | None = None,
+    ) -> str | None:
         """Download source package and unpack it into output_dir.
 
         This also has to care about applying patches etc., so that output_dir
@@ -299,7 +305,7 @@ class PackageInfo:
             "this method must be implemented by a concrete subclass"
         )
 
-    def package_name_glob(self, nameglob):
+    def package_name_glob(self, nameglob: str) -> list[str]:
         """Return known package names which match given glob."""
         raise NotImplementedError(
             "this method must be implemented by a concrete subclass"

--- a/apport/packaging_impl/apt_dpkg.py
+++ b/apport/packaging_impl/apt_dpkg.py
@@ -422,7 +422,7 @@ class _AptDpkgPackageInfo(PackageInfo):
         except KeyError:
             raise ValueError(f"package {package} does not exist") from None
 
-    def get_version(self, package):
+    def get_version(self, package: str) -> str:
         """Return the installed version of a package."""
         pkg = self._apt_pkg(package)
         inst = pkg.installed
@@ -638,7 +638,7 @@ class _AptDpkgPackageInfo(PackageInfo):
             return pkg.candidate.architecture or "unknown"
         raise ValueError(f"package {package} does not exist")
 
-    def get_files(self, package):
+    def get_files(self, package: str) -> list[str]:
         """Return list of files shipped by a package."""
         output = self._call_dpkg(["-L", package])
         return [f for f in output.splitlines() if not f.startswith("diverted")]
@@ -697,7 +697,7 @@ class _AptDpkgPackageInfo(PackageInfo):
             return self._check_files_md5(sums)
         return []
 
-    def get_modified_conffiles(self, package):
+    def get_modified_conffiles(self, package: str) -> dict[str, bytes | str]:
         """Return modified configuration files of a package.
 
         Return a file name -> file contents map of all configuration files of
@@ -714,7 +714,7 @@ class _AptDpkgPackageInfo(PackageInfo):
         if dpkg.returncode != 0:
             return {}
 
-        modified = {}
+        modified: dict[str, bytes | str] = {}
         for line in dpkg.stdout.decode().splitlines():
             if not line:
                 continue
@@ -879,7 +879,13 @@ class _AptDpkgPackageInfo(PackageInfo):
         except AttributeError:
             pass
 
-    def get_source_tree(self, srcpackage, output_dir, version=None, sandbox=None):
+    def get_source_tree(
+        self,
+        srcpackage: str,
+        output_dir: str,
+        version: str | None = None,
+        sandbox: str | None = None,
+    ) -> str | None:
         # TODO: Split into smaller functions/methods
         # pylint: disable=too-complex,too-many-branches,too-many-locals
         """Download source package and unpack it into output_dir.
@@ -935,8 +941,11 @@ class _AptDpkgPackageInfo(PackageInfo):
                     fetcher = apt_pkg.Acquire(fetch_progress)
                     af_queue = []
                     for sf in sf_urls:
+                        # False positive: "hash" not needed in call to "AcquireFile"
                         af_queue.append(
-                            apt_pkg.AcquireFile(fetcher, sf, destdir=output_dir)
+                            apt_pkg.AcquireFile(
+                                fetcher, sf, destdir=output_dir
+                            )  # type: ignore
                         )
                     result = fetcher.run()
                     if result != fetcher.RESULT_CONTINUE:
@@ -1457,7 +1466,7 @@ class _AptDpkgPackageInfo(PackageInfo):
 
         return obsolete
 
-    def package_name_glob(self, nameglob):
+    def package_name_glob(self, nameglob: str) -> list[str]:
         """Return known package names which match given glob."""
         return fnmatch.filter(self._cache().keys(), nameglob)
 

--- a/apport/packaging_impl/apt_dpkg.py
+++ b/apport/packaging_impl/apt_dpkg.py
@@ -641,8 +641,6 @@ class _AptDpkgPackageInfo(PackageInfo):
     def get_files(self, package):
         """Return list of files shipped by a package."""
         output = self._call_dpkg(["-L", package])
-        if output is None:
-            return None
         return [f for f in output.splitlines() if not f.startswith("diverted")]
 
     # TODO: Split into smaller functions/methods

--- a/apport/packaging_impl/rpm.py
+++ b/apport/packaging_impl/rpm.py
@@ -44,16 +44,16 @@ class RPMPackageInfo:
         self.ts = rpm.TransactionSet()  # connect to the rpmdb
         self._mirror: str | None = None
 
-    def get_version(self, package):
+    def get_version(self, package: str) -> str:
         """Return the installed version of a package."""
         hdr = self._get_header(package)
         if hdr is None:
-            raise ValueError
+            raise ValueError(f"package {package} does not exist")
         # Note - "version" here seems to refer to the full EVR, so..
         if not hdr["e"]:
             return f"{hdr['v']}-{hdr['r']}"
         if not hdr["v"] or not hdr["r"]:
-            return None
+            raise ValueError(f"package {package} misses version information")
         return f"{hdr['e']}:{hdr['v']}-{hdr['r']}"
 
     def get_available_version(self, package: str) -> str:
@@ -97,7 +97,7 @@ class RPMPackageInfo:
         hdr = self._get_header(package)
         return hdr["arch"]
 
-    def get_files(self, package):
+    def get_files(self, package: str) -> list[str]:
         """Return list of files shipped by a package."""
         hdr = self._get_header(package)
         files = []
@@ -204,7 +204,13 @@ class RPMPackageInfo:
         # FIXME C&P from apt-dpkg implementation, might move to subclass
         self._mirror = url
 
-    def get_source_tree(self, srcpackage, output_dir, version=None, sandbox=None):
+    def get_source_tree(
+        self,
+        srcpackage: str,
+        output_dir: str,
+        version: str | None = None,
+        sandbox: str | None = None,
+    ) -> str | None:
         """Download source package and unpack it into output_dir.
 
         This also has to care about applying patches etc., so that output_dir
@@ -240,7 +246,7 @@ class RPMPackageInfo:
             "method must be implemented by distro-specific RPMPackageInfo subclass"
         )
 
-    def package_name_glob(self, nameglob):
+    def package_name_glob(self, nameglob: str) -> list[str]:
         """Return known package names which match given glob."""
         raise NotImplementedError("TODO")
 

--- a/tests/integration/test_fileutils.py
+++ b/tests/integration/test_fileutils.py
@@ -71,10 +71,10 @@ class T(unittest.TestCase):
 
             display_num = 0
             no_display_num = 0
-            for desktop_file in apport.packaging.get_files(pkg):
-                if not desktop_path_re.match(desktop_file):
+            for desktop_filename in apport.packaging.get_files(pkg):
+                if not desktop_path_re.match(desktop_filename):
                     continue
-                with open(desktop_file, "rb") as desktop_file:
+                with open(desktop_filename, "rb") as desktop_file:
                     if b"NoDisplay=true" in desktop_file.read():
                         no_display_num += 1
                     else:

--- a/tests/system/test_packaging_apt_dpkg.py
+++ b/tests/system/test_packaging_apt_dpkg.py
@@ -692,6 +692,7 @@ def test_get_source_tree_sandbox(
         rootdir, os.path.join(configdir, release), "ubuntu", "jammy", origins=None
     )
     res = impl.get_source_tree("base-files", out_dir, sandbox=rootdir)
+    assert res is not None
     assert os.path.isdir(os.path.join(res, "debian"))
     # this needs to be updated when the release in _setup_foonux_config
     # changes
@@ -714,6 +715,7 @@ def test_get_source_tree_lp_sandbox(
     res = impl.get_source_tree(
         wanted_package, out_dir, version=wanted_version, sandbox=rootdir
     )
+    assert res is not None
     assert os.path.isdir(os.path.join(res, "debian"))
     # this needs to be updated when the release in _setup_foonux_config
     # changes


### PR DESCRIPTION
Add type hints to all methods of `PackageInfo` and address mypy's complaints.