### PR TITLE
apport: Do not change report group to report owners primary group

### DIFF
--- a/data/apport
+++ b/data/apport
@@ -1173,7 +1173,7 @@ def process_crash(
             gid = pwd.getpwnam("whoopsie").pw_gid
             os.fchown(fd, report_owner.uid, gid)
         except (OSError, KeyError):
-            os.fchown(fd, report_owner.uid, report_owner.gid)
+            os.fchown(fd, report_owner.uid, -1)
     except OSError as error:
         logger.error("Could not create report file: %s", str(error))
         return 1


### PR DESCRIPTION
When a low privileged processes crashes, an apport crash report file is written to /var/crash which contains various technical details including the raw base64 encoded core dump. A core file could potentially include sensitive data such as passwords and encryption keys. The issue is the report file has group read permissions by default. If there is no `whoopsie` group, any user that is a member of the same primary group can read the crash reports of another user which could lead to the disclosure of sensitive information.

In case there is no `whoopsie` group, leave the group ownership untouched and rely on the configuration of `/var/crash`. In case whoopsie is not installed, the default for `/var/crash` will be mode 3777 and (group) owned by root.

Bug: https://launchpad.net/bugs/2106338