### PR TITLE
apport: check the exe mtime within the proc root mount (LP: #2112272)

### DIFF
--- a/data/apport
+++ b/data/apport
@@ -580,10 +580,11 @@ def forward_crash_to_container(
 
     # Validate that the crashed binary is owned
     # by the user namespace of the process
-    task_uid = proc_pid.stat("exe").st_uid
+    exe_path = f"root{proc_pid.readlink('exe')}"
+    exe_stat = proc_pid.stat(exe_path)
     try:
         with proc_pid.open("uid_map") as fd:
-            if not apport.fileutils.search_map(fd, task_uid):
+            if not apport.fileutils.search_map(fd, exe_stat.st_uid):
                 logger.error(
                     "host pid %s crashed in a container"
                     " with no access to the binary",
@@ -593,10 +594,9 @@ def forward_crash_to_container(
     except FileNotFoundError:
         pass
 
-    task_gid = proc_pid.stat("exe").st_gid
     try:
         with proc_pid.open("gid_map") as fd:
-            if not apport.fileutils.search_map(fd, task_gid):
+            if not apport.fileutils.search_map(fd, exe_stat.st_gid):
                 logger.error(
                     "host pid %s crashed in a container"
                     " with no access to the binary",
@@ -914,11 +914,11 @@ def consistency_checks(
 
     # check if the executable was modified after the process started (e. g.
     # package got upgraded in between).
-    exe_mtime = os.stat("exe", dir_fd=proc_pid.fd).st_mtime
+    exe_path = f"root{proc_pid.readlink('exe')}"
     process_mtime = os.lstat("cmdline", dir_fd=proc_pid.fd).st_mtime
     if (
-        not os.path.exists(os.readlink("exe", dir_fd=proc_pid.fd))
-        or exe_mtime > process_mtime
+        not proc_pid.exists(exe_path)
+        or proc_pid.stat(exe_path).st_mtime > process_mtime
     ):
         logger.error("executable was modified after program start, ignoring")
         return False

--- a/tests/unit/test_signal_crashes.py
+++ b/tests/unit/test_signal_crashes.py
@@ -186,6 +186,10 @@ class TestApport(unittest.TestCase):
             status.write_text("Name:\tname\nUid:\t0\t0\t0\t0\nGid:\t0\t0\t0\t0\n")
             exe = pathlib.Path(tmpdir) / "exe"
             os.symlink(sys.executable, exe)
+            root = pathlib.Path(tmpdir) / "root"
+            container_exe = root / pathlib.Path(sys.executable).relative_to("/")
+            container_exe.parent.mkdir(parents=True)
+            container_exe.touch(mode=0o755)
             cmdline = pathlib.Path(tmpdir) / "cmdline"
             cmdline.write_text("name\0")
             with apport_binary.ProcPid(fake_pid, tmpdir) as proc_pid:


### PR DESCRIPTION
If the binary is in a container, our check will be looking at the binary OUTSIDE that container, which is rather problematic. We take advantage of the /proc/pid/root facility to avoid that.

Bug-Ubuntu: https://bugs.launchpad.net/ubuntu/+source/apport/+bug/2112272
Fixes: a806cac1fa13 ("apport: do consistency check before forwarding crashes")