### PR TITLE
problem_report: make input type of _try_unicode stricter

### DIFF
--- a/problem_report.py
+++ b/problem_report.py
@@ -492,9 +492,9 @@ class ProblemReport(collections.UserDict):
         return False
 
     @classmethod
-    def _try_unicode(cls, value: bytes | str) -> bytes | str:
+    def _try_unicode(cls, value: bytes) -> bytes | str:
         """Try to convert bytearray value to Unicode."""
-        if isinstance(value, bytes) and not cls.is_binary(value):
+        if not cls.is_binary(value):
             try:
                 return value.decode("UTF-8")
             except UnicodeDecodeError:


### PR DESCRIPTION
The method `_try_unicode()` is private and only called with values of type `bytes`. So drop supporting `str` there.