### PR TITLE
Import Report from apport.report directly

### DIFF
--- a/apport/crashdb_impl/github.py
+++ b/apport/crashdb_impl/github.py
@@ -19,6 +19,7 @@ from dataclasses import dataclass
 from typing import Any, Self
 
 import apport.crashdb
+import apport.report
 
 
 class Github:
@@ -211,7 +212,7 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
 
         return IssueHandle(url=response["html_url"])
 
-    def get_comment_url(self, report: apport.Report, handle: IssueHandle) -> str:
+    def get_comment_url(self, report: apport.report.Report, handle: IssueHandle) -> str:
         """Return a URL that should be opened after report has been uploaded
         and upload() returned handle.
         """

--- a/apport/crashdb_impl/launchpad.py
+++ b/apport/crashdb_impl/launchpad.py
@@ -1069,7 +1069,7 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
         ]:
             bug.subscribe(person=person)
 
-    def _generate_upload_headers(self, report: apport.Report) -> dict[str, str]:
+    def _generate_upload_headers(self, report: apport.report.Report) -> dict[str, str]:
         """Generate the headers for the multipart/MIME temporary file."""
         # set reprocessing tags
         hdr = {"Tags": f"apport-{report['ProblemType'].lower()}"}
@@ -1108,7 +1108,7 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
             hdr["HWDB-Submission"] = report["CheckboxSubmission"]
         return hdr
 
-    def _generate_upload_blob(self, report: apport.Report) -> IO[bytes]:
+    def _generate_upload_blob(self, report: apport.report.Report) -> IO[bytes]:
         """Generate a multipart/MIME temporary file for uploading.
 
         You have to close the returned file object after you are done with it.

--- a/apport/sandboxutils.py
+++ b/apport/sandboxutils.py
@@ -18,6 +18,7 @@ import tempfile
 
 import apport.fileutils
 import apport.logging
+import apport.report
 from apport.packaging_impl import impl as packaging
 
 
@@ -131,7 +132,7 @@ def _move_base_files_first(pkgs: list[tuple[str, None | str]]) -> None:
 
 # pylint: disable-next=too-many-arguments,too-many-positional-arguments
 def make_sandbox(
-    report: apport.Report,
+    report: apport.report.Report,
     config_dir: str | None,
     cache_dir: str | None = None,
     sandbox_dir: str | None = None,
@@ -152,8 +153,8 @@ def make_sandbox(
     For unpackaged executables, there are no Dependencies. Packages for shared
     libraries are unpacked.
 
-    report is an apport.Report object to build a sandbox for. Presence of the
-    Package field determines whether to determine dependencies through
+    report is an apport.report.Report object to build a sandbox for. Presence
+    of the Package field determines whether to determine dependencies through
     packaging (via the optional report['Dependencies'] field), or through ldd
     via needed_runtime_packages() -> shared_libraries().  Usually
     report['Architecture'] and report['Uname'] are present.

--- a/apport/ui.py
+++ b/apport/ui.py
@@ -47,6 +47,7 @@ from typing import Any
 import apport.crashdb
 import apport.fileutils
 import apport.logging
+import apport.report
 import apport.REThread
 from apport.hook_ui import HookUI, NoninteractiveHookUI
 from apport.packaging_impl import impl as packaging
@@ -558,7 +559,7 @@ class UserInterface:
         noninteractive processes will collect the remaining information and
         mark the report for uploading.
         """
-        self.report = apport.Report("Hang")
+        self.report = apport.report.Report("Hang")
 
         if not self.args.pid:
             self.ui_error_message(
@@ -643,7 +644,7 @@ class UserInterface:
             )
             return False
 
-        self.report = apport.Report("Bug")
+        self.report = apport.report.Report("Bug")
 
         # if PID is given, add info
         if self.args.pid:
@@ -777,7 +778,7 @@ class UserInterface:
                 return False
 
         # list of affected source packages
-        self.report = apport.Report("Bug")
+        self.report = apport.report.Report("Bug")
         if self.args.package:
             pkgs = [self.args.package.strip()]
         else:
@@ -1820,7 +1821,7 @@ class UserInterface:
         returned.
         """
         try:
-            self.report = apport.Report()
+            self.report = apport.report.Report()
             with open(path, "rb") as f:
                 self.report.load(f, binary="compressed")
             if "ProblemType" not in self.report:

--- a/bin/apport-retrace
+++ b/bin/apport-retrace
@@ -32,8 +32,8 @@ from gettext import gettext as _
 import apport
 import apport.logging
 import apport.sandboxutils
-from apport import Report
 from apport.crashdb import CrashDatabase, get_crashdb
+from apport.report import Report
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
@@ -336,7 +336,7 @@ def load_report(
     # load the report
     if os.path.exists(options.report):
         try:
-            report = apport.Report()
+            report = Report()
             with open(options.report, "rb") as f:
                 report.load(f, binary="compressed")
             apport.logging.memdbg("loaded report from file")
@@ -492,7 +492,7 @@ def main(argv):
                 gdb_sandbox = sandbox
         else:
             gdb_packages = ["gdb", "gdb-multiarch"]
-            fake_report = apport.Report()
+            fake_report = Report()
             # if the report has no Architecture the host one will be used
             fake_report["DistroRelease"] = report["DistroRelease"]
             # use a empty ProcMaps so needed_runtimes packages won't want

--- a/bin/apport-valgrind
+++ b/bin/apport-valgrind
@@ -28,8 +28,8 @@ import subprocess
 import sys
 from gettext import gettext as _
 
-import apport
 import apport.logging
+import apport.report
 import apport.sandboxutils
 
 #
@@ -140,7 +140,7 @@ except (KeyboardInterrupt, SystemExit):
 try:
     if not options.no_sandbox:
         # create report unless in no-sandbox mode
-        report = apport.Report()
+        report = apport.report.Report()
 
         report["ExecutablePath"] = exepath
         report.add_os_info()

--- a/data/gcc_ice_hook
+++ b/data/gcc_ice_hook
@@ -13,9 +13,9 @@
 
 import sys
 
-import apport
 import apport.fileutils
 import apport.logging
+import apport.report
 
 # parse command line arguments
 if len(sys.argv) != 3:
@@ -29,7 +29,7 @@ if len(sys.argv) != 3:
 (exename, sourcefile) = sys.argv[1:3]
 
 # create report
-pr = apport.Report()
+pr = apport.report.Report()
 pr["ExecutablePath"] = exename
 if sourcefile == "-":
     pr["PreprocessedSource"] = (sys.stdin, False)

--- a/data/iwlwifi_error_dump
+++ b/data/iwlwifi_error_dump
@@ -18,6 +18,7 @@ import sys
 import apport
 import apport.fileutils
 import apport.logging
+import apport.report
 from apport.hookutils import command_output
 
 
@@ -31,7 +32,7 @@ def main() -> None:
     if not os.path.exists(sysfs_path):
         sys.exit(1)
 
-    pr = apport.Report("KernelCrash")
+    pr = apport.report.Report("KernelCrash")
     pr.add_package(apport.packaging.get_kernel_package())
     pr["Title"] = "iwlwifi firmware error"
     pr.add_os_info()

--- a/data/kernel_crashdump
+++ b/data/kernel_crashdump
@@ -15,16 +15,16 @@ import glob
 import os
 import re
 
-import apport
 import apport.fileutils
 import apport.logging
+import apport.report
 
 
 # TODO: Split into smaller functions/methods
 # pylint: disable-next=too-complex
 def main() -> None:
     """Collect information about a kernel oops."""
-    pr = apport.Report("KernelCrash")
+    pr = apport.report.Report("KernelCrash")
     package = apport.packaging.get_kernel_package()
     pr.add_package(package)
 

--- a/data/kernel_oops
+++ b/data/kernel_oops
@@ -19,6 +19,7 @@ import sys
 from gettext import gettext as _
 
 import apport.fileutils
+import apport.report
 
 checksum = None
 if len(sys.argv) > 1:
@@ -26,7 +27,7 @@ if len(sys.argv) > 1:
 
 oops = sys.stdin.read()
 
-pr = apport.Report("KernelOops")
+pr = apport.report.Report("KernelOops")
 pr["Failure"] = "oops"
 pr["Tags"] = "kernel-oops"
 pr["Annotation"] = _(

--- a/data/package_hook
+++ b/data/package_hook
@@ -19,6 +19,7 @@ import sys
 import apport
 import apport.fileutils
 import apport.logging
+import apport.report
 
 
 def mkattrname(path):
@@ -68,7 +69,7 @@ def main():
     options = parse_args()
 
     # create report
-    report = apport.Report("Package")
+    report = apport.report.Report("Package")
     report.add_package(options.package)
     # get_source can fail on distribution upgrades where the package in question has
     # been removed from the newer release. See https://launchpad.net/bugs/2078695

--- a/data/unkillable_shutdown
+++ b/data/unkillable_shutdown
@@ -18,10 +18,10 @@ import errno
 import os
 from collections.abc import Container, Iterable
 
-import apport
 import apport.fileutils
 import apport.hookutils
 import apport.logging
+import apport.report
 
 
 def parse_argv():
@@ -85,7 +85,7 @@ def orphaned_processes(omit_pids: Container[str]) -> Iterable[int]:
 def do_report(pid: int, omit_pids: Iterable[str]) -> None:
     """Create a report for a particular PID."""
 
-    report = apport.Report("Bug")
+    report = apport.report.Report("Bug")
     try:
         report.add_proc_info(pid)
     except (ValueError, AssertionError):

--- a/data/whoopsie-upload-all
+++ b/data/whoopsie-upload-all
@@ -27,8 +27,8 @@ import sys
 import time
 import zlib
 
-import apport
 import apport.fileutils
+import apport.report
 from problem_report import MalformedProblemReport
 
 
@@ -70,7 +70,7 @@ def process_report(report):
 
     report_stat = None
 
-    r = apport.Report()
+    r = apport.report.Report()
     # make sure we're actually on the hook to write this updated report
     # before we start doing expensive collection operations
     try:

--- a/tests/integration/test_python_crashes.py
+++ b/tests/integration/test_python_crashes.py
@@ -187,7 +187,7 @@ func(42)
         # load report for this
         reports = apport.fileutils.get_new_reports()
         self.assertEqual(len(reports), 1, "crashed Python program produced a report")
-        pr1 = apport.Report()
+        pr1 = apport.report.Report()
         with open(reports[0], "rb") as f:
             pr1.load(f)
         for f in apport.fileutils.get_all_reports():
@@ -211,7 +211,7 @@ func(42)
         # get report for symlinked crash
         reports = apport.fileutils.get_new_reports()
         self.assertEqual(len(reports), 1, "crashed Python program produced a report")
-        pr2 = apport.Report()
+        pr2 = apport.report.Report()
         with open(reports[0], "rb") as f:
             pr2.load(f)
 
@@ -525,11 +525,11 @@ func(42)
         exe = pr["ExecutablePath"]
         self.assertEqual(pr.crash_signature(), f"{exe}:FileNotFoundError:{exe}@11:g")
 
-    def _load_report(self) -> apport.Report:
+    def _load_report(self) -> apport.report.Report:
         """Ensure that there is exactly one crash report and load it."""
         reports = apport.fileutils.get_new_reports()
         self.assertEqual(len(reports), 1, "crashed Python program produced a report")
-        pr = apport.Report()
+        pr = apport.report.Report()
         with open(reports[0], "rb") as f:
             pr.load(f)
         return pr

--- a/tests/integration/test_signal_crashes.py
+++ b/tests/integration/test_signal_crashes.py
@@ -254,7 +254,7 @@ class T(unittest.TestCase):
         st2 = os.stat(test_report)
         self.assertNotEqual(st, st2, "original seen report gets overwritten")
 
-        pr = apport.Report()
+        pr = apport.report.Report()
         with open(test_report, "rb") as f:
             pr.load(f)
         self.assertTrue(
@@ -445,7 +445,7 @@ class T(unittest.TestCase):
         leak = os.path.join(
             apport.fileutils.report_dir, f"_usr_bin_perl.{os.getuid()}.crash"
         )
-        pr = apport.Report()
+        pr = apport.report.Report()
         with open(leak, "rb") as f:
             pr.load(f)
         # On a leak, no report is created since the executable path will be
@@ -592,7 +592,7 @@ class T(unittest.TestCase):
         """Ignore executables."""
         test_report = self.do_crash()
 
-        pr = apport.Report()
+        pr = apport.report.Report()
         with open(test_report, "rb") as f:
             pr.load(f)
         os.unlink(test_report)
@@ -682,7 +682,7 @@ class T(unittest.TestCase):
         self.assertNotIn("Traceback", logged)
 
         self._check_report()
-        pr = apport.Report()
+        pr = apport.report.Report()
         assert self.test_report
         with open(self.test_report, "rb") as f:
             pr.load(f)
@@ -728,7 +728,7 @@ class T(unittest.TestCase):
         self.assertNotIn("Traceback", app.stderr)
 
         self._check_report()
-        pr = apport.Report()
+        pr = apport.report.Report()
         assert self.test_report
         with open(self.test_report, "rb") as f:
             pr.load(f)
@@ -811,7 +811,7 @@ class T(unittest.TestCase):
         """
         test_report = self.do_crash(via_socket=True)
 
-        pr = apport.Report()
+        pr = apport.report.Report()
         with open(test_report, "rb") as f:
             pr.load(f)
         self.assertEqual(pr["Signal"], "11")
@@ -842,7 +842,7 @@ class T(unittest.TestCase):
             )
 
             # check crash report
-            report = apport.Report()
+            report = apport.report.Report()
             with open(test_report, "rb") as report_file:
                 report.load(report_file)
             self.assertEqual(report["Signal"], "11")
@@ -940,7 +940,7 @@ class T(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         reader_mock.assert_called_once_with()
         self._check_report()
-        report = apport.Report()
+        report = apport.report.Report()
         with open(self.test_report, "rb") as report_file:
             report.load(report_file, binary="compressed")
         self.assertEqual(report["CoreDump"].compressed_value, b"mocked core")
@@ -1345,7 +1345,7 @@ class T(unittest.TestCase):
 
     def check_report_coredump(self, report_path):
         """Check that given report file has a valid core dump."""
-        r = apport.Report()
+        r = apport.report.Report()
         with open(report_path, "rb") as f:
             r.load(f)
         self.assertIn("CoreDump", r)

--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -228,7 +228,7 @@ class T(unittest.TestCase):
         os.mknod(apport.report._ignore_file)
 
         # demo report
-        self.report = apport.Report()
+        self.report = apport.report.Report()
         self.report["ExecutablePath"] = "/bin/bash"
         self.report["Package"] = "libfoo1 1-1"
         self.report["SourcePackage"] = "foo"
@@ -331,7 +331,7 @@ class T(unittest.TestCase):
     def test_get_size_constructed(self) -> None:
         """get_complete_size() and get_reduced_size() for on-the-fly Reports"""
         ui = UserInterfaceMock()
-        ui.report = apport.Report("Bug")
+        ui.report = apport.report.Report("Bug")
         ui.report["Hello"] = "World"
 
         s = ui.get_complete_size()
@@ -412,7 +412,7 @@ class T(unittest.TestCase):
         """collect_info() on report without information (distro bug)"""
         ui = UserInterfaceMock()
         # report without any information (distro bug)
-        ui.report = apport.Report("Bug")
+        ui.report = apport.report.Report("Bug")
         ui.collect_info()
         assert ui.report
         self.assertTrue(
@@ -430,7 +430,7 @@ class T(unittest.TestCase):
         """collect_info() on report with only ExecutablePath"""
         ui = UserInterfaceMock()
         # report with only package information
-        self.report = apport.Report("Bug")
+        self.report = apport.report.Report("Bug")
         self.report["ExecutablePath"] = "/bin/bash"
         self.update_report_file()
         ui.load_report(self.report_file.name)
@@ -467,7 +467,7 @@ class T(unittest.TestCase):
         """collect_info() on report with a package"""
         ui = UserInterfaceMock()
         # report with only package information
-        ui.report = apport.Report("Bug")
+        ui.report = apport.report.Report("Bug")
         ui.cur_package = "bash"
 
         def search_bug_patterns(url: str) -> str | None:
@@ -510,7 +510,7 @@ class T(unittest.TestCase):
     def test_collect_info_permissions(self) -> None:
         """collect_info() leaves the report accessible to the group"""
         ui = UserInterfaceMock()
-        ui.report = apport.Report("Bug")
+        ui.report = apport.report.Report("Bug")
         ui.cur_package = "bash"
         ui.report_file = self.report_file.name
         ui.collect_info()
@@ -538,7 +538,7 @@ class T(unittest.TestCase):
         """collect_info() with package hook that defines a CrashDB"""
         ui = UserInterfaceMock()
         self._write_crashdb_config_hook("{ 'impl': 'memory', 'local_opt': '1' }", "Moo")
-        ui.report = apport.Report("Bug")
+        ui.report = apport.report.Report("Bug")
         ui.cur_package = "bash"
         ui.collect_info()
         assert ui.report
@@ -551,7 +551,7 @@ class T(unittest.TestCase):
         """collect_info() with package hook that chooses a different CrashDB"""
         ui = UserInterfaceMock()
         self._write_crashdb_config_hook("debug", "Moo")
-        ui.report = apport.Report("Bug")
+        ui.report = apport.report.Report("Bug")
         ui.cur_package = "bash"
         ui.collect_info()
         assert ui.report
@@ -564,7 +564,7 @@ class T(unittest.TestCase):
         ui = UserInterfaceMock()
         # nonexisting implementation
         self._write_crashdb_config_hook("{ 'impl': 'nonexisting', 'local_opt': '1' }")
-        ui.report = apport.Report("Bug")
+        ui.report = apport.report.Report("Bug")
         ui.cur_package = "bash"
         ui.collect_info()
         assert ui.report
@@ -572,7 +572,7 @@ class T(unittest.TestCase):
 
         # invalid syntax
         self._write_crashdb_config_hook("{ 'impl': 'memory', 'local_opt'")
-        ui.report = apport.Report("Bug")
+        ui.report = apport.report.Report("Bug")
         ui.cur_package = "bash"
         ui.collect_info()
         assert ui.report
@@ -580,7 +580,7 @@ class T(unittest.TestCase):
 
         # nonexisting name
         self._write_crashdb_config_hook("nonexisting")
-        ui.report = apport.Report("Bug")
+        ui.report = apport.report.Report("Bug")
         ui.cur_package = "bash"
         ui.collect_info()
         assert ui.report
@@ -591,7 +591,7 @@ class T(unittest.TestCase):
             """{'impl': 'memory',"""
             """ 'trap': exec('open("/tmp/pwned", "w").close()')}"""
         )
-        ui.report = apport.Report("Bug")
+        ui.report = apport.report.Report("Bug")
         ui.cur_package = "bash"
         ui.collect_info()
         assert ui.report
@@ -887,7 +887,7 @@ class T(unittest.TestCase):
 
         self.assertTrue(ui.ic_progress_pulses > 0)
 
-        r = apport.Report()
+        r = apport.report.Report()
         with open(reportfile, "rb") as f:
             r.load(f)
 
@@ -905,7 +905,7 @@ class T(unittest.TestCase):
         self.assertIsNone(ui.msg_severity)
         self.assertTrue(ui.present_details_shown)
 
-    def _gen_test_crash(self) -> apport.Report:
+    def _gen_test_crash(self) -> apport.report.Report:
         """Generate a Report with real crash data."""
         core_path = os.path.join(self.workdir, "core")
         try:
@@ -932,7 +932,7 @@ class T(unittest.TestCase):
                         timeout=10.0,
                     )
                     # generate crash report
-                    r = apport.Report()
+                    r = apport.report.Report()
                     r["ExecutablePath"] = self.TEST_EXECUTABLE
                     r["Signal"] = "11"
                     r.add_proc_info(pid)
@@ -1051,7 +1051,7 @@ class T(unittest.TestCase):
         """run_crash() for an invalid core dump"""
         ui = UserInterfaceMock()
         # generate broken crash report
-        r = apport.Report()
+        r = apport.report.Report()
         r["ExecutablePath"] = self.TEST_EXECUTABLE
         r["Signal"] = "11"
         r["CoreDump"] = problem_report.CompressedValue(compressed_value=b"AAAAAAAA")
@@ -1195,7 +1195,7 @@ class T(unittest.TestCase):
         # create a test executable
         with run_test_executable() as pid:
             # generate crash report
-            r = apport.Report()
+            r = apport.report.Report()
             r["ExecutablePath"] = self.TEST_EXECUTABLE
             r["Signal"] = "42"
             r.add_proc_info(pid)
@@ -1282,7 +1282,7 @@ class T(unittest.TestCase):
         """run_crash() on various error conditions"""
         ui = UserInterfaceMock()
         # crash report with invalid Package name
-        r = apport.Report()
+        r = apport.report.Report()
         r["ExecutablePath"] = "/bin/bash"
         r["Package"] = "foobarbaz"
         report_file = os.path.join(apport.fileutils.report_dir, "test.crash")
@@ -1314,7 +1314,7 @@ class T(unittest.TestCase):
         self.assertIn("not installed any more", ui.msg_text)
 
         # interpreted program got uninstalled between crash and report
-        r = apport.Report()
+        r = apport.report.Report()
         r["ExecutablePath"] = "/bin/nonexisting"
         r["InterpreterPath"] = "/usr/bin/python"
         r["Traceback"] = "ZeroDivisionError: integer division or modulo by zero"
@@ -1326,7 +1326,7 @@ class T(unittest.TestCase):
         self.assertIn("not installed any more", ui.msg_text)
 
         # interpreter got uninstalled between crash and report
-        r = apport.Report()
+        r = apport.report.Report()
         r["ExecutablePath"] = "/bin/sh"
         r["InterpreterPath"] = "/usr/bin/nonexisting"
         r["Traceback"] = "ZeroDivisionError: integer division or modulo by zero"
@@ -1361,7 +1361,7 @@ class T(unittest.TestCase):
     def test_run_crash_package(self) -> None:
         """run_crash() for a package error"""
         # generate crash report
-        r = apport.Report("Package")
+        r = apport.report.Report("Package")
         r["Package"] = "bash"
         r["SourcePackage"] = "bash"
         r["ErrorMessage"] = "It broke"
@@ -1429,7 +1429,7 @@ class T(unittest.TestCase):
             )
 
         # generate crash report
-        r = apport.Report("KernelCrash")
+        r = apport.report.Report("KernelCrash")
         r["Package"] = package
         r["SourcePackage"] = src_pkg
 

--- a/tests/system/test_python_crashes.py
+++ b/tests/system/test_python_crashes.py
@@ -230,7 +230,7 @@ func(42)
         """Ensure that there is exactly one crash report and load it."""
         reports = apport.fileutils.get_new_reports()
         self.assertEqual(len(reports), 1, "crashed Python program produced a report")
-        pr = apport.Report()
+        pr = apport.report.Report()
         with open(reports[0], "rb") as f:
             pr.load(f)
         return pr

--- a/tests/system/test_signal_crashes.py
+++ b/tests/system/test_signal_crashes.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock, patch
 import psutil
 
 import apport.fileutils
+import apport.report
 from tests.helper import (
     get_gnu_coreutils_cmd,
     get_init_system,
@@ -158,7 +159,7 @@ class T(unittest.TestCase):
         assert self.apport_path is not None
         # determine how much data we have to pump into apport in order to make
         # sure that it will refuse the core dump
-        r = apport.Report()
+        r = apport.report.Report()
         with open("/proc/meminfo", "rb") as f:
             r.load(f)
         totalmb = int(r["MemFree"].split()[0]) + int(r["Cached"].split()[0])
@@ -211,7 +212,7 @@ class T(unittest.TestCase):
         reports = apport.fileutils.get_all_reports()
         self.assertEqual(reports, [self.test_report])
 
-        pr = apport.Report()
+        pr = apport.report.Report()
         with open(reports[0], "rb") as f:
             pr.load(f)
         os.unlink(reports[0])

--- a/tests/unit/test_hookutils.py
+++ b/tests/unit/test_hookutils.py
@@ -9,6 +9,7 @@ import unittest.mock
 from unittest.mock import MagicMock, Mock
 
 import apport.hookutils
+import apport.report
 from problem_report import ProblemReport
 
 IW_REG_LIST_DE = b"""\
@@ -242,7 +243,7 @@ class TestHookutils(unittest.TestCase):
         )
         now = datetime.datetime.now()
 
-        report = apport.Report(date=now.strftime("%a %b %d %H:%M:%S %Y"))
+        report = apport.report.Report(date=now.strftime("%a %b %d %H:%M:%S %Y"))
         apport.hookutils.attach_journal_errors(report)
 
         self.assertEqual(run_mock.call_count, 1)
@@ -264,7 +265,7 @@ class TestHookutils(unittest.TestCase):
             args=MagicMock(), returncode=0, stdout=b"journalctl output", stderr=b""
         )
 
-        report = apport.Report()
+        report = apport.report.Report()
         del report["Date"]
         apport.hookutils.attach_journal_errors(report)
 
@@ -490,7 +491,7 @@ class TestHookutils(unittest.TestCase):
             ),
         ]
 
-        report = apport.Report()
+        report = apport.report.Report()
         apport.hookutils.attach_wifi(report)
 
         self.assertEqual(report["WifiSyslog"], "some recent logs")
@@ -531,7 +532,7 @@ class TestHookutils(unittest.TestCase):
             args=MagicMock(), returncode=0, stdout=b"rfkill output", stderr=b""
         )
 
-        report = apport.Report()
+        report = apport.report.Report()
         apport.hookutils.attach_wifi(report)
 
         self.assertEqual(report["WifiSyslog"], "some recent logs")


### PR DESCRIPTION
Import `Report` from `apport.report` directly as one step to lazy load the code in `apport/__init__.py` itself (and maybe deprecate it in the future).