### PR TITLE
po: Import translation updates from Ubuntu

### DIFF
--- a/po/ca.po
+++ b/po/ca.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-02-20 14:20+0100\n"
-"PO-Revision-Date: 2023-03-30 12:04+0000\n"
+"PO-Revision-Date: 2025-03-12 15:20+0000\n"
 "Last-Translator: Walter Garcia-Fontes <walter.garcia@upf.edu>\n"
 "Language-Team: Ubuntu Catalan Translators list <Ubuntu-l10n-ca@lists.ubuntu."
 "com>\n"
@@ -16,8 +16,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2023-04-11 15:04+0000\n"
-"X-Generator: Launchpad (build ce6856af661dea2cdabcc7883eecafbc1fccc4ad)\n"
+"X-Launchpad-Export-Date: 2025-06-04 11:20+0000\n"
+"X-Generator: Launchpad (build c425d5702ce6a53fe8d94ca38038ac108957fda2)\n"
 
 #: ../apport/com.ubuntu.apport.policy.in.h:1
 msgid "Collect system information"
@@ -620,11 +620,11 @@ msgstr ""
 
 #: ../bin/apport-cli.py:312
 msgid "&Yes"
-msgstr ""
+msgstr "&Sí"
 
 #: ../bin/apport-cli.py:313
 msgid "&No"
-msgstr ""
+msgstr "&No"
 
 #: ../bin/apport-cli.py:349
 msgid "&Done"

--- a/po/cs.po
+++ b/po/cs.po
@@ -8,15 +8,15 @@ msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-02-20 14:20+0100\n"
-"PO-Revision-Date: 2022-12-07 23:42+0000\n"
-"Last-Translator: Croolman <croolman@gmail.com>\n"
+"PO-Revision-Date: 2025-04-10 10:02+0000\n"
+"Last-Translator: Tomáš Marný <tomik.marny@gmail.com>\n"
 "Language-Team: Czech <cs@li.org>\n"
 "Language: cs\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2024-02-21 18:08+0000\n"
-"X-Generator: Launchpad (build 9643586c585856148a18782148972ae9c1179d06)\n"
+"X-Launchpad-Export-Date: 2025-06-04 11:20+0000\n"
+"X-Generator: Launchpad (build c425d5702ce6a53fe8d94ca38038ac108957fda2)\n"
 
 #: ../apport/com.ubuntu.apport.policy.in.h:1
 msgid "Collect system information"
@@ -597,11 +597,11 @@ msgstr ""
 
 #: ../bin/apport-cli.py:312
 msgid "&Yes"
-msgstr ""
+msgstr "&Ano"
 
 #: ../bin/apport-cli.py:313
 msgid "&No"
-msgstr ""
+msgstr "&Ne"
 
 #: ../bin/apport-cli.py:349
 msgid "&Done"

--- a/po/da.po
+++ b/po/da.po
@@ -8,15 +8,15 @@ msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-02-20 14:20+0100\n"
-"PO-Revision-Date: 2022-10-08 21:37+0000\n"
+"PO-Revision-Date: 2025-03-11 18:04+0000\n"
 "Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Language-Team: Danish <dansk@dansk-gruppen.dk>\n"
 "Language: da\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2022-12-07 14:36+0000\n"
-"X-Generator: Launchpad (build 41e7553f8097ce3a683f90e835708cbe7bf0006c)\n"
+"X-Launchpad-Export-Date: 2025-06-04 11:20+0000\n"
+"X-Generator: Launchpad (build c425d5702ce6a53fe8d94ca38038ac108957fda2)\n"
 
 #: ../apport/com.ubuntu.apport.policy.in.h:1
 msgid "Collect system information"
@@ -601,11 +601,11 @@ msgstr ""
 
 #: ../bin/apport-cli.py:312
 msgid "&Yes"
-msgstr ""
+msgstr "&Ja"
 
 #: ../bin/apport-cli.py:313
 msgid "&No"
-msgstr ""
+msgstr "&Nej"
 
 #: ../bin/apport-cli.py:349
 msgid "&Done"

--- a/po/en_CA.po
+++ b/po/en_CA.po
@@ -8,15 +8,15 @@ msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-02-20 14:20+0100\n"
-"PO-Revision-Date: 2024-07-23 19:30+0000\n"
-"Last-Translator: Dawid Wiktor <Unknown>\n"
+"PO-Revision-Date: 2025-03-14 18:05+0000\n"
+"Last-Translator: Luke Hollins <Unknown>\n"
 "Language-Team: English (Canada) <en_CA@li.org>\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2024-08-08 15:00+0000\n"
-"X-Generator: Launchpad (build e3ace39cea497a5ecb83e8fb6dd8e7e169f02939)\n"
+"X-Launchpad-Export-Date: 2025-06-04 11:20+0000\n"
+"X-Generator: Launchpad (build c425d5702ce6a53fe8d94ca38038ac108957fda2)\n"
 
 #: ../apport/com.ubuntu.apport.policy.in.h:1
 msgid "Collect system information"
@@ -597,11 +597,11 @@ msgstr ""
 
 #: ../bin/apport-cli.py:312
 msgid "&Yes"
-msgstr ""
+msgstr "&Yes"
 
 #: ../bin/apport-cli.py:313
 msgid "&No"
-msgstr ""
+msgstr "&No"
 
 #: ../bin/apport-cli.py:349
 msgid "&Done"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -8,15 +8,15 @@ msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-02-20 14:20+0100\n"
-"PO-Revision-Date: 2024-03-30 17:12+0000\n"
-"Last-Translator: Anthony Harrington <Unknown>\n"
+"PO-Revision-Date: 2025-02-22 19:17+0000\n"
+"Last-Translator: Andi Chandler <Unknown>\n"
 "Language-Team: English (United Kingdom) <en_GB@li.org>\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2024-04-17 09:08+0000\n"
-"X-Generator: Launchpad (build 67d34a19aaa1df7be4dd8bf498cbc5bbd785067b)\n"
+"X-Launchpad-Export-Date: 2025-06-04 11:20+0000\n"
+"X-Generator: Launchpad (build c425d5702ce6a53fe8d94ca38038ac108957fda2)\n"
 
 #: ../apport/com.ubuntu.apport.policy.in.h:1
 msgid "Collect system information"
@@ -597,11 +597,11 @@ msgstr ""
 
 #: ../bin/apport-cli.py:312
 msgid "&Yes"
-msgstr ""
+msgstr "&Yes"
 
 #: ../bin/apport-cli.py:313
 msgid "&No"
-msgstr ""
+msgstr "&No"
 
 #: ../bin/apport-cli.py:349
 msgid "&Done"

--- a/po/hu.po
+++ b/po/hu.po
@@ -1,22 +1,23 @@
-# Hungarian translation for apport
-# Copyright (c) (c) 2006 Canonical Ltd, and Rosetta Contributors 2006
+# Hungarian translation for apport.
+# Copyright (C) 2006, 2023 Canonical Ltd, and Rosetta Contributors 2006
 # This file is distributed under the same license as the apport package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2006.
 #
+# Balázs Úr <ur.balazs at fsf dot hu>, 2023.
 msgid ""
 msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-02-20 14:20+0100\n"
-"PO-Revision-Date: 2020-04-03 16:38+0000\n"
+"PO-Revision-Date: 2025-04-24 11:14+0000\n"
 "Last-Translator: Balázs Úr <Unknown>\n"
-"Language-Team: Hungarian <hu@li.org>\n"
+"Language-Team: Hungarian <https://translations.launchpad.net/ubuntu/+source/"
+"apport>\n"
 "Language: hu\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2024-02-21 18:08+0000\n"
-"X-Generator: Launchpad (build 9643586c585856148a18782148972ae9c1179d06)\n"
+"X-Launchpad-Export-Date: 2025-06-04 11:20+0000\n"
+"X-Generator: Launchpad (build c425d5702ce6a53fe8d94ca38038ac108957fda2)\n"
 
 #: ../apport/com.ubuntu.apport.policy.in.h:1
 msgid "Collect system information"
@@ -614,11 +615,11 @@ msgstr ""
 
 #: ../bin/apport-cli.py:312
 msgid "&Yes"
-msgstr ""
+msgstr "&Igen"
 
 #: ../bin/apport-cli.py:313
 msgid "&No"
-msgstr ""
+msgstr "&Nem"
 
 #: ../bin/apport-cli.py:349
 msgid "&Done"

--- a/po/ia.po
+++ b/po/ia.po
@@ -8,15 +8,15 @@ msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-02-20 14:20+0100\n"
-"PO-Revision-Date: 2018-05-09 23:32+0000\n"
+"PO-Revision-Date: 2025-04-10 19:37+0000\n"
 "Last-Translator: karm <melo@carmu.com>\n"
 "Language-Team: Interlingua <ia@li.org>\n"
 "Language: ia\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2022-12-07 14:36+0000\n"
-"X-Generator: Launchpad (build 41e7553f8097ce3a683f90e835708cbe7bf0006c)\n"
+"X-Launchpad-Export-Date: 2025-06-04 11:20+0000\n"
+"X-Generator: Launchpad (build c425d5702ce6a53fe8d94ca38038ac108957fda2)\n"
 
 #: ../apport/com.ubuntu.apport.policy.in.h:1
 msgid "Collect system information"
@@ -51,6 +51,9 @@ msgid ""
 "the indexes of available packages, if that does not work then remove related "
 "third party packages and try again."
 msgstr ""
+"Isto non sembla esser un pacchetto %s official. Retenta post le "
+"actualisation del indices de pacchettos disponibile, si illo non functiona "
+"alora remove le pacchettos de tertie partes associate e retenta."
 
 #: ../apport/ui.py:303
 #, python-format
@@ -108,11 +111,11 @@ msgstr ""
 
 #: ../apport/ui.py:566
 msgid "No PID specified"
-msgstr ""
+msgstr "Necun PID specificate"
 
 #: ../apport/ui.py:567
 msgid "You need to specify a PID. See --help for more information."
-msgstr ""
+msgstr "Tu debe specificar un PID. Vide --help pro altere informationes."
 
 #: ../apport/ui.py:576 ../apport/ui.py:681
 msgid "Invalid PID"
@@ -120,15 +123,15 @@ msgstr "PID invalide"
 
 #: ../apport/ui.py:576
 msgid "The specified process ID does not exist."
-msgstr ""
+msgstr "Le ID de processo specificate non existe."
 
 #: ../apport/ui.py:581
 msgid "Not your PID"
-msgstr ""
+msgstr "Non tu PID"
 
 #: ../apport/ui.py:582
 msgid "The specified process ID does not belong to you."
-msgstr ""
+msgstr "Le ID de processo specificate non pertine a te."
 
 #: ../apport/ui.py:639
 msgid "No package specified"
@@ -236,6 +239,15 @@ msgid ""
 "the Processes tab, scroll until you find the correct application. The "
 "process ID is the number listed in the ID column."
 msgstr ""
+"Le option del fenestra non pote esser usate sur Wayland.\n"
+"\n"
+"Trova le ID de processo del fenestra e pois exeque 'ubuntu-bug <process "
+"ID>'.\n"
+"\n"
+"Le ID de processo pote esser trovate exequente le application de "
+"Surveliantia de systema. In le scheda Processos, rola usque tu trova le "
+"application correcte. Le ID de processo es le numero in le lista in le "
+"columna ID."
 
 #: ../apport/ui.py:954
 msgid ""
@@ -252,7 +264,7 @@ msgstr "xprop ha mancate a determinar le ID de processo del fenestra"
 #: ../apport/ui.py:992
 #, python-format
 msgid "%(prog)s <report number>"
-msgstr ""
+msgstr "%(prog)s <numero de reporto>"
 
 #: ../apport/ui.py:993
 msgid "Specify package name."
@@ -267,6 +279,8 @@ msgstr "Adder un tag extra al reporto. Pote esser specificate multiple vices."
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
+"%(prog)s [optiones] [symptoma|pid|pacchetto|route de programma|"
+"file .apport/.crash]"
 
 #: ../apport/ui.py:1046
 msgid ""
@@ -367,10 +381,12 @@ msgstr "Ajornar %s con le tracia del pila plenmente symbolic"
 msgid ""
 "Saving crash reporting state failed. Can't set auto or never reporting mode."
 msgstr ""
+"Le reservation del stato de reporto de crash falleva. Impossibile predefinir "
+"modo de reportar automatic o jammais."
 
 #: ../apport/ui.py:1357
 msgid "Can't remember send report status settings"
-msgstr ""
+msgstr "Impossibile rememorar parametros del stato de invio reportos"
 
 #: ../apport/ui.py:1438 ../apport/ui.py:1451
 msgid ""
@@ -407,21 +423,24 @@ msgid ""
 "You have two versions of this application installed, which one do you want "
 "to report a bug against?"
 msgstr ""
+"Tu ha duo versiones installate de iste application, contra qual vole tu "
+"reportar un error?"
 
 #: ../apport/ui.py:1565
 #, python-format
 msgid "%s snap"
-msgstr ""
+msgstr "%s snap"
 
 #: ../apport/ui.py:1566
 #, python-format
 msgid "%s deb package"
-msgstr ""
+msgstr "%s pacchetto deb"
 
 #: ../apport/ui.py:1604
 #, python-format
 msgid "%s is provided by a snap published by %s. Contact them via %s for help."
 msgstr ""
+"%s es fornite per un snap publicate per %s. Contacta illes via %s pro adjuta."
 
 #: ../apport/ui.py:1609
 #, python-format
@@ -429,6 +448,8 @@ msgid ""
 "%s is provided by a snap published by %s. No contact address has been "
 "provided; visit the forum at https://forum.snapcraft.io/ for help."
 msgstr ""
+"%s es fornite per un snap publicate per %s. Nulle adresse de contacto ha "
+"essite fornite; visita le forum a https://forum.snapcraft.io/ pro le adjuta."
 
 #: ../apport/ui.py:1695
 msgid "Could not determine the package or source package name."
@@ -594,11 +615,11 @@ msgstr ""
 
 #: ../bin/apport-cli.py:312
 msgid "&Yes"
-msgstr ""
+msgstr "Si &Y"
 
 #: ../bin/apport-cli.py:313
 msgid "&No"
-msgstr ""
+msgstr "&No"
 
 #: ../bin/apport-cli.py:349
 msgid "&Done"
@@ -795,15 +816,15 @@ msgstr "OK a inviar istes como attaccamentos? [s/n]"
 #: ../bin/apport-unpack.py:35
 #, python-format
 msgid "%(prog)s <report> <target directory>"
-msgstr ""
+msgstr "%(prog)s <report> <directorio de destination>"
 
 #: ../bin/apport-unpack.py:36
 msgid "Report file to unpack"
-msgstr ""
+msgstr "File de reporto a dispacchettar"
 
 #: ../bin/apport-unpack.py:37
 msgid "directory to unpack report to"
-msgstr ""
+msgstr "directorio  pro dispacchettar le reporto"
 
 #: ../bin/apport-unpack.py:86
 msgid "Destination directory exists and is not empty."
@@ -852,6 +873,8 @@ msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
 msgstr ""
+"le executabile que es exequite sub le application memcheck de valgrind pro "
+"le detection del perdita de memoria"
 
 #: ../bin/apport-valgrind.py:130
 #, python-format
@@ -989,7 +1012,7 @@ msgstr "<big><b>Displacente, ha occurrite un error interne.</b></big>"
 
 #: ../gtk/apport-gtk.ui.h:8
 msgid "Remember this in future"
-msgstr ""
+msgstr "Rememorar isto in futuro"
 
 #: ../gtk/apport-gtk.ui.h:9
 msgid "Ignore future problems of this program version"
@@ -997,7 +1020,7 @@ msgstr "Ignorar le futur problema de iste version del programma"
 
 #: ../gtk/apport-gtk.ui.h:10
 msgid "Relaunch this application"
-msgstr ""
+msgstr "Relancear iste application"
 
 #: ../gtk/apport-gtk.ui.h:12
 msgid "_Examine locally"
@@ -1005,7 +1028,7 @@ msgstr "_Examinar localmente"
 
 #: ../gtk/apport-gtk.ui.h:13
 msgid "Don't send"
-msgstr ""
+msgstr "non inviar"
 
 #: ../gtk/apport-gtk.ui.h:15
 msgid "<big><b>Collecting problem information</b></big>"

--- a/po/id.po
+++ b/po/id.po
@@ -8,15 +8,15 @@ msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-02-20 14:20+0100\n"
-"PO-Revision-Date: 2023-06-14 11:27+0000\n"
-"Last-Translator: Ajam Jamaludin <Unknown>\n"
+"PO-Revision-Date: 2025-03-19 10:35+0000\n"
+"Last-Translator: Andika Triwidada <andika@gmail.com>\n"
 "Language-Team: Indonesian <id@li.org>\n"
 "Language: id\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2023-07-21 14:36+0000\n"
-"X-Generator: Launchpad (build 2bfac4503c7b6a57e9a8acd782035a16f97e2ddb)\n"
+"X-Launchpad-Export-Date: 2025-06-04 11:20+0000\n"
+"X-Generator: Launchpad (build c425d5702ce6a53fe8d94ca38038ac108957fda2)\n"
 
 #: ../apport/com.ubuntu.apport.policy.in.h:1
 msgid "Collect system information"
@@ -607,11 +607,11 @@ msgstr ""
 
 #: ../bin/apport-cli.py:312
 msgid "&Yes"
-msgstr ""
+msgstr "&Ya"
 
 #: ../bin/apport-cli.py:313
 msgid "&No"
-msgstr ""
+msgstr "&Tidak"
 
 #: ../bin/apport-cli.py:349
 msgid "&Done"

--- a/po/ko.po
+++ b/po/ko.po
@@ -8,15 +8,15 @@ msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-02-20 14:20+0100\n"
-"PO-Revision-Date: 2021-01-23 02:37+0000\n"
-"Last-Translator: Catry <Unknown>\n"
+"PO-Revision-Date: 2025-03-22 07:38+0000\n"
+"Last-Translator: Jung Hoehyeong <hothead.jung@ubuntu-kr.org>\n"
 "Language-Team: Korean <ko@li.org>\n"
 "Language: ko\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2022-12-07 14:36+0000\n"
-"X-Generator: Launchpad (build 41e7553f8097ce3a683f90e835708cbe7bf0006c)\n"
+"X-Launchpad-Export-Date: 2025-06-04 11:20+0000\n"
+"X-Generator: Launchpad (build c425d5702ce6a53fe8d94ca38038ac108957fda2)\n"
 
 #: ../apport/com.ubuntu.apport.policy.in.h:1
 msgid "Collect system information"
@@ -229,6 +229,13 @@ msgid ""
 "the Processes tab, scroll until you find the correct application. The "
 "process ID is the number listed in the ID column."
 msgstr ""
+"창 옵션이 Wayland에서 사용 불가능합니다.\n"
+"\n"
+"창의 프로세스 ID를 찾아서 'ubuntu-bug <프로세스 ID>' 명령어를 실행하십시오.\n"
+"\n"
+"프로세스 ID는 시스템 모니터 어플리케이션을 열어 확인할 수 있습니다. 프로세스 "
+"탭에서 해당하는 어플리케이션을 찾을 때까지 스크롤을 내리십시오. ID 열에 표시"
+"된 숫자가 프로세스 ID입니다."
 
 #: ../apport/ui.py:954
 msgid ""
@@ -576,11 +583,11 @@ msgstr ""
 
 #: ../bin/apport-cli.py:312
 msgid "&Yes"
-msgstr ""
+msgstr "예(&Y)"
 
 #: ../bin/apport-cli.py:313
 msgid "&No"
-msgstr ""
+msgstr "아니오(&N)"
 
 #: ../bin/apport-cli.py:349
 msgid "&Done"
@@ -763,11 +770,11 @@ msgstr ""
 
 #: ../bin/apport-unpack.py:36
 msgid "Report file to unpack"
-msgstr ""
+msgstr "압축을 해제할 제보 파일"
 
 #: ../bin/apport-unpack.py:37
 msgid "directory to unpack report to"
-msgstr ""
+msgstr "제보 파일을 압축 해제할 디렉토리"
 
 #: ../bin/apport-unpack.py:86
 msgid "Destination directory exists and is not empty."

--- a/po/my.po
+++ b/po/my.po
@@ -8,15 +8,15 @@ msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-02-20 14:20+0100\n"
-"PO-Revision-Date: 2012-09-04 12:14+0000\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"PO-Revision-Date: 2025-04-12 13:33+0000\n"
+"Last-Translator: Wint Theingi Aung <Unknown>\n"
 "Language-Team: Burmese <my@li.org>\n"
 "Language: my\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2024-02-21 18:08+0000\n"
-"X-Generator: Launchpad (build 9643586c585856148a18782148972ae9c1179d06)\n"
+"X-Launchpad-Export-Date: 2025-06-04 11:20+0000\n"
+"X-Generator: Launchpad (build c425d5702ce6a53fe8d94ca38038ac108957fda2)\n"
 
 #: ../apport/com.ubuntu.apport.policy.in.h:1
 msgid "Collect system information"
@@ -582,11 +582,11 @@ msgstr ""
 
 #: ../bin/apport-cli.py:312
 msgid "&Yes"
-msgstr ""
+msgstr "&ဟုတ်"
 
 #: ../bin/apport-cli.py:313
 msgid "&No"
-msgstr ""
+msgstr "&မဟုတ်"
 
 #: ../bin/apport-cli.py:349
 msgid "&Done"

--- a/po/tr.po
+++ b/po/tr.po
@@ -8,15 +8,15 @@ msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-02-20 14:20+0100\n"
-"PO-Revision-Date: 2023-02-08 11:17+0000\n"
-"Last-Translator: Sabri Ünal <Unknown>\n"
+"PO-Revision-Date: 2025-04-12 23:11+0000\n"
+"Last-Translator: yokki <Unknown>\n"
 "Language-Team: Turkish <tr@li.org>\n"
 "Language: tr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2023-02-10 11:56+0000\n"
-"X-Generator: Launchpad (build 76fbbe3960b74b1bf6aa937d9f415c99a6b083f0)\n"
+"X-Launchpad-Export-Date: 2025-06-04 11:20+0000\n"
+"X-Generator: Launchpad (build c425d5702ce6a53fe8d94ca38038ac108957fda2)\n"
 
 #: ../apport/com.ubuntu.apport.policy.in.h:1
 msgid "Collect system information"
@@ -603,11 +603,11 @@ msgstr ""
 
 #: ../bin/apport-cli.py:312
 msgid "&Yes"
-msgstr ""
+msgstr "&Evet"
 
 #: ../bin/apport-cli.py:313
 msgid "&No"
-msgstr ""
+msgstr "&Hayır"
 
 #: ../bin/apport-cli.py:349
 msgid "&Done"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -8,15 +8,15 @@ msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-02-20 14:20+0100\n"
-"PO-Revision-Date: 2024-03-20 05:21+0000\n"
+"PO-Revision-Date: 2025-04-30 17:35+0000\n"
 "Last-Translator: 爽自由 <coby2023t@gmail.com>\n"
 "Language-Team: Chinese (Taiwan) <zh_TW@li.org>\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2024-04-17 09:08+0000\n"
-"X-Generator: Launchpad (build 67d34a19aaa1df7be4dd8bf498cbc5bbd785067b)\n"
+"X-Launchpad-Export-Date: 2025-06-04 11:20+0000\n"
+"X-Generator: Launchpad (build c425d5702ce6a53fe8d94ca38038ac108957fda2)\n"
 
 #: ../apport/com.ubuntu.apport.policy.in.h:1
 msgid "Collect system information"
@@ -223,6 +223,9 @@ msgid ""
 "the Processes tab, scroll until you find the correct application. The "
 "process ID is the number listed in the ID column."
 msgstr ""
+"視窗選項無法用於 Wayland。\n"
+"請找出視窗程序 ID 後再執行 'ubuntu-bug <程序 ID>'.\n"
+"程序ID 可在系統監控程式找到。在程序欄找到應用程式名即可找到。"
 
 #: ../apport/ui.py:954
 msgid ""
@@ -786,7 +789,7 @@ msgstr "當軟體包安裝至沙箱時回報下載/安裝進度"
 msgid ""
 "the executable that is run under valgrind's memcheck tool for memory leak "
 "detection"
-msgstr ""
+msgstr "可執行碼在 valgrind 的記憶體外洩偵測工具 memcheck 下執行。"
 
 #: ../bin/apport-valgrind.py:130
 #, python-format


### PR DESCRIPTION
Import translation updates from Launchpad for languages that have updates. Do not update translations that have no
changes except for updated metadata (POT-Creation-Date, X-Launchpad-Export-Date, and X-Generator). Do not import languages that have zero translated messages.