### PR TITLE
Stop importing from base apport module directly

### DIFF
--- a/bin/apport-retrace
+++ b/bin/apport-retrace
@@ -29,10 +29,10 @@ import zlib
 from argparse import Namespace
 from gettext import gettext as _
 
-import apport
 import apport.logging
 import apport.sandboxutils
 from apport.crashdb import CrashDatabase, get_crashdb
+from apport.packaging_impl import impl as packaging
 from apport.report import Report
 
 
@@ -288,7 +288,7 @@ def gen_source_stacktrace(report, sandbox):
             version = report["Package"].split()[1]
         except (IndexError, KeyError):
             version = None
-        srcdir = apport.packaging.get_source_tree(
+        srcdir = packaging.get_source_tree(
             report["SourcePackage"], workdir, version, sandbox=sandbox
         )
         if not srcdir:
@@ -450,7 +450,7 @@ def main(argv):
     apport.logging.memdbg("consistency checks passed")
 
     if options.gdb_sandbox:
-        system_arch = apport.packaging.get_system_architecture()
+        system_arch = packaging.get_system_architecture()
         if system_arch != "amd64":
             apport.logging.error("gdb sandboxes are only implemented for amd64 hosts")
             return 3

--- a/data/apport-checkreports
+++ b/data/apport-checkreports
@@ -18,8 +18,8 @@ reports are available, or with 1 if not."""
 import argparse
 import sys
 
-import apport
 from apport.fileutils import get_new_reports, get_new_system_reports
+from apport.packaging_impl import impl as packaging
 
 
 def parse_args():
@@ -43,7 +43,7 @@ else:
 if len(reports) > 0:
     for report in reports:
         print(report.split(".")[0].split("_")[-1])
-    if apport.packaging.enabled():
+    if packaging.enabled():
         sys.exit(0)
     else:
         print("new reports but apport disabled")

--- a/data/iwlwifi_error_dump
+++ b/data/iwlwifi_error_dump
@@ -15,11 +15,11 @@ import os
 import re
 import sys
 
-import apport
 import apport.fileutils
 import apport.logging
 import apport.report
 from apport.hookutils import command_output
+from apport.packaging_impl import impl as packaging
 
 
 def main() -> None:
@@ -33,7 +33,7 @@ def main() -> None:
         sys.exit(1)
 
     pr = apport.report.Report("KernelCrash")
-    pr.add_package(apport.packaging.get_kernel_package())
+    pr.add_package(packaging.get_kernel_package())
     pr["Title"] = "iwlwifi firmware error"
     pr.add_os_info()
 

--- a/data/kernel_crashdump
+++ b/data/kernel_crashdump
@@ -18,6 +18,7 @@ import re
 import apport.fileutils
 import apport.logging
 import apport.report
+from apport.packaging_impl import impl as packaging
 
 
 # TODO: Split into smaller functions/methods
@@ -25,7 +26,7 @@ import apport.report
 def main() -> None:
     """Collect information about a kernel oops."""
     pr = apport.report.Report("KernelCrash")
-    package = apport.packaging.get_kernel_package()
+    package = packaging.get_kernel_package()
     pr.add_package(package)
 
     pr.add_os_info()

--- a/data/package_hook
+++ b/data/package_hook
@@ -16,10 +16,10 @@ import contextlib
 import os
 import sys
 
-import apport
 import apport.fileutils
 import apport.logging
 import apport.report
+from apport.packaging_impl import impl as packaging
 
 
 def mkattrname(path):
@@ -74,7 +74,7 @@ def main():
     # get_source can fail on distribution upgrades where the package in question has
     # been removed from the newer release. See https://launchpad.net/bugs/2078695
     with contextlib.suppress(ValueError):
-        report["SourcePackage"] = apport.packaging.get_source(options.package)
+        report["SourcePackage"] = packaging.get_source(options.package)
     report["ErrorMessage"] = (sys.stdin, False)
 
     if options.tags:


### PR DESCRIPTION
Import the packaging implementation from `apport.packaging_impl` directly as one step to lazy load the code in `apport/__init__.py` itself (and maybe deprecate it in the future).