### PR TITLE
report: Simplify and split big add_proc_info

### DIFF
--- a/apport/report.py
+++ b/apport/report.py
@@ -111,18 +111,13 @@ def _read_list_files_in_directory(directory: str) -> Iterator[str]:
         pass
 
 
-def _read_proc_file(
-    path: str, pid: int | None = None, dir_fd: int | None = None
-) -> str:
+def _read_proc_file(path: str, dir_fd: int) -> str:
     """Read file content.
 
     Return its content, or return a textual error if it failed.
     """
     try:
-        if dir_fd is None:
-            proc_file: int | str = f"/proc/{pid}/{path}"
-        else:
-            proc_file = os.open(path, os.O_RDONLY | os.O_CLOEXEC, dir_fd=dir_fd)
+        proc_file = os.open(path, os.O_RDONLY | os.O_CLOEXEC, dir_fd=dir_fd)
 
         with io.open(proc_file, "rb") as fd:
             return fd.read().strip().decode("UTF-8", errors="replace")
@@ -769,8 +764,8 @@ class Report(problem_report.ProblemReport):
         except OSError:
             pass
         self.add_proc_environ(pid=pid, proc_pid_fd=proc_pid_fd, extraenv=extraenv)
-        self["ProcStatus"] = _read_proc_file("status", pid, proc_pid_fd)
-        self["ProcCmdline"] = _read_proc_file("cmdline", pid, proc_pid_fd).rstrip("\0")
+        self["ProcStatus"] = _read_proc_file("status", proc_pid_fd)
+        self["ProcCmdline"] = _read_proc_file("cmdline", proc_pid_fd).rstrip("\0")
         self["ProcMaps"] = _read_maps(proc_pid_fd)
         if "ExecutablePath" not in self:
             try:
@@ -807,7 +802,7 @@ class Report(problem_report.ProblemReport):
             # On Linux 2.6.28+, 'current' is world readable, but read() gives
             # EPERM; Python 2.5.3+ crashes on that (LP: #314065)
             if os.getuid() == 0:
-                val = _read_proc_file("attr/current", pid, proc_pid_fd)
+                val = _read_proc_file("attr/current", proc_pid_fd)
                 if val != "unconfined":
                     self["ProcAttrCurrent"] = val
         except OSError:

--- a/apport/report.py
+++ b/apport/report.py
@@ -720,8 +720,6 @@ class Report(problem_report.ProblemReport):
         proc_pid_fd: int | None = None,
         extraenv: Iterable[str] | None = None,
     ) -> None:
-        # TODO: Split into smaller functions/methods
-        # pylint: disable=too-complex
         """Add /proc/pid information.
 
         If neither pid nor self.pid are given, it defaults to the process'
@@ -759,11 +757,14 @@ class Report(problem_report.ProblemReport):
                     raise ValueError("invalid process") from error
                 raise
 
+        self.add_proc_environ(pid=pid, proc_pid_fd=proc_pid_fd, extraenv=extraenv)
+        self._add_proc_info(proc_pid_fd)
+
+    def _add_proc_info(self, proc_pid_fd: int) -> None:
         try:
             self["ProcCwd"] = os.readlink("cwd", dir_fd=proc_pid_fd)
         except OSError:
             pass
-        self.add_proc_environ(pid=pid, proc_pid_fd=proc_pid_fd, extraenv=extraenv)
         self["ProcStatus"] = _read_proc_file("status", proc_pid_fd)
         self["ProcCmdline"] = _read_proc_file("cmdline", proc_pid_fd).rstrip("\0")
         self["ProcMaps"] = _read_maps(proc_pid_fd)


### PR DESCRIPTION
I was working on https://launchpad.net/bugs/2098792 and reading the code `add_proc_info` for that. This PR is the result of making the code more readable. Then I noticed that `_add_executable_timestamp` was not called by `add_proc_info` in these crashes.

See individual commits for details.