### PR TITLE
report: check for errors in ProcMaps in crash_signature_addresses

### DIFF
--- a/apport/report.py
+++ b/apport/report.py
@@ -1788,7 +1788,7 @@ class Report(problem_report.ProblemReport):
         """
         if "ProcMaps" not in self or "Stacktrace" not in self or "Signal" not in self:
             return None
-        if "Errno 13" in self["ProcMaps"]:
+        if self["ProcMaps"].startswith("Error: "):
             return None
 
         stack = []

--- a/tests/unit/test_report.py
+++ b/tests/unit/test_report.py
@@ -1363,6 +1363,20 @@ No symbol table info available.
 """
         self.assertIsNone(pr.crash_signature_addresses())
 
+    def test_crash_signature_addresses_error_in_proc_maps(self) -> None:
+        """crash_signature_addresses() with error in ProcMaps"""
+        report = apport.report.Report()
+        report["ExecutablePath"] = "/usr/bin/sleep"
+        report["Signal"] = "42"
+        with tempfile.TemporaryDirectory() as proc_pid_dir:
+            pid_fd = os.open(proc_pid_dir, os.O_RDONLY | os.O_PATH | os.O_DIRECTORY)
+            report.add_proc_info(proc_pid_fd=pid_fd)
+            os.close(pid_fd)
+            self.assertIn("[Errno ", report["ProcMaps"])
+        report["Stacktrace"] = "mocked stack trace"
+
+        self.assertIsNone(report.crash_signature_addresses())
+
     @staticmethod
     @unittest.mock.patch("os.geteuid")
     def test_missing_uid(geteuid_mock: MagicMock) -> None:


### PR DESCRIPTION
There are several crashes reported on https://errors.ubuntu.com with:

```
Traceback (most recent call last):
  File "/usr/share/apport/whoopsie-upload-all", line 246, in <module>
    main()
  File "/usr/share/apport/whoopsie-upload-all", line 228, in main
    stamps = collect_info()
             ^^^^^^^^^^^^^^
  File "/usr/share/apport/whoopsie-upload-all", line 162, in collect_info
    res = process_report(r)
          ^^^^^^^^^^^^^^^^^
  File "/usr/share/apport/whoopsie-upload-all", line 112, in process_report
    r.add_gdb_info()
  File "/usr/lib/python3/dist-packages/apport/report.py", line 1022, in add_gdb_info
    addr_signature = self.crash_signature_addresses()
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/apport/report.py", line 1761, in crash_signature_addresses
    offset = self._address_to_offset(addr)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/apport/report.py", line 1969, in _address_to_offset
    self._build_proc_maps_cache()
  File "/usr/lib/python3/dist-packages/apport/report.py", line 2005, in _build_proc_maps_cache
    assert m, "cannot parse ProcMaps line: " + line
           ^
AssertionError: cannot parse ProcMaps line: Error: [Errno 3] No such process: 'maps'
```

The function `_read_maps` reads `/proc/pid/maps` but will return a string starting with `Error: ` in case of an `OSError`.

Catch all cases of errors in `ProcMaps` in the
`crash_signature_addresses` method.

Bug: https://launchpad.net/bugs/2114171