### PR TITLE
report: remove dead code from internal helper functions

### DIFF
--- a/apport/report.py
+++ b/apport/report.py
@@ -111,18 +111,13 @@ def _read_list_files_in_directory(directory: str) -> Iterator[str]:
         pass
 
 
-def _read_proc_file(
-    path: str, pid: int | None = None, dir_fd: int | None = None
-) -> str:
+def _read_proc_file(path: str, dir_fd: int) -> str:
     """Read file content.
 
     Return its content, or return a textual error if it failed.
     """
     try:
-        if dir_fd is None:
-            proc_file: int | str = f"/proc/{pid}/{path}"
-        else:
-            proc_file = os.open(path, os.O_RDONLY | os.O_CLOEXEC, dir_fd=dir_fd)
+        proc_file = os.open(path, os.O_RDONLY | os.O_CLOEXEC, dir_fd=dir_fd)
 
         with io.open(proc_file, "rb") as fd:
             return fd.read().strip().decode("UTF-8", errors="replace")
@@ -769,8 +764,8 @@ class Report(problem_report.ProblemReport):
         except OSError:
             pass
         self.add_proc_environ(pid=pid, proc_pid_fd=proc_pid_fd, extraenv=extraenv)
-        self["ProcStatus"] = _read_proc_file("status", pid, proc_pid_fd)
-        self["ProcCmdline"] = _read_proc_file("cmdline", pid, proc_pid_fd).rstrip("\0")
+        self["ProcStatus"] = _read_proc_file("status", proc_pid_fd)
+        self["ProcCmdline"] = _read_proc_file("cmdline", proc_pid_fd).rstrip("\0")
         self["ProcMaps"] = _read_maps(proc_pid_fd)
         if "ExecutablePath" not in self:
             try:
@@ -807,7 +802,7 @@ class Report(problem_report.ProblemReport):
             # On Linux 2.6.28+, 'current' is world readable, but read() gives
             # EPERM; Python 2.5.3+ crashes on that (LP: #314065)
             if os.getuid() == 0:
-                val = _read_proc_file("attr/current", pid, proc_pid_fd)
+                val = _read_proc_file("attr/current", proc_pid_fd)
                 if val != "unconfined":
                     self["ProcAttrCurrent"] = val
         except OSError:


### PR DESCRIPTION
`Report.add_proc_info` will always set `proc_pid_fd`. So the helper function `_read_proc_link` is not needed any more. The case for `dir_fd` being `None` in `_read_proc_file` can be dropped and the parameter `pid` will not be needed any more.