### PR TITLE
ci: use dynamic container image names

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
     container:
-      image: ubuntu:plucky
+      image: ubuntu:devel
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
@@ -44,11 +44,11 @@ jobs:
       fail-fast: false
       matrix:
         container:
-          - debian:bookworm-slim
+          - debian:stable-slim
           - debian:testing-slim
-          - ubuntu:noble
-          - ubuntu:oracular
-          - ubuntu:plucky
+          - ubuntu:latest
+          - ubuntu:rolling
+          - ubuntu:devel
     container:
       image: ${{ matrix.container }}
       options: --cap-add=SYS_PTRACE --security-opt seccomp=unconfined
@@ -133,9 +133,9 @@ jobs:
       fail-fast: false
       matrix:
         container:
-          - ubuntu:noble
-          - ubuntu:oracular
-          - ubuntu:plucky
+          - ubuntu:latest
+          - ubuntu:rolling
+          - ubuntu:devel
     container:
       image: ${{ matrix.container }}
     steps:
@@ -166,9 +166,9 @@ jobs:
       fail-fast: false
       matrix:
         container:
-          - ubuntu:noble
-          - ubuntu:oracular
-          - ubuntu:plucky
+          - ubuntu:latest
+          - ubuntu:rolling
+          - ubuntu:devel
     container:
       image: ${{ matrix.container }}
       options: --cap-add=SYS_PTRACE --security-opt seccomp=unconfined


### PR DESCRIPTION
Instead of using hard-coded codenames for the container images, use the tags that will update on their own. The current mapping is:

* debian:stable-slim -> bookworm
* ubuntu:latest -> noble
* ubuntu:rolling -> plucky
* ubuntu:devel -> questing

So this commit drops Ubuntu 24.10 "oracular" and adds Ubuntu 25.10 "questing".