### PR TITLE
test: use true from GNU coreutils

### DIFF
--- a/tests/system/test_apport_valgrind.py
+++ b/tests/system/test_apport_valgrind.py
@@ -15,7 +15,7 @@ import subprocess
 import tempfile
 import unittest
 
-from tests.helper import skip_if_command_is_missing
+from tests.helper import get_gnu_coreutils_cmd, skip_if_command_is_missing
 from tests.paths import local_test_environment
 
 with open("/proc/meminfo", encoding="utf-8") as f:
@@ -55,7 +55,7 @@ class TestApportValgrind(unittest.TestCase):
             sandbox,
             "--cache",
             cache,
-            "/usr/bin/true",
+            get_gnu_coreutils_cmd("true"),
         ]
         subprocess.check_call(cmd, env=self.env)
 


### PR DESCRIPTION
Several test cases use the sleep command as test case. Some kill the sleep command while it is sleeping and expect a certain stack trace. So enforce using the GNU coreutils implementation of the sleep command.

Since Ubuntu 25.10 (questing) the GNU implementation is shipped by gnu-coreutils and the commands are prefixed with `gnu`.

Bug-Ubuntu: https://launchpad.net/bugs/2111595
Fixes: 6830e0cbd423 ("test: use cat and sleep from GNU coreutils")