### PR TITLE
po: Import translation updates from Ubuntu

### DIFF
--- a/po/sl.po
+++ b/po/sl.po
@@ -8,15 +8,15 @@ msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-06-06 11:55+0200\n"
-"PO-Revision-Date: 2015-04-27 21:46+0000\n"
-"Last-Translator: Andrej Znidarsic <andrej.znidarsic@gmail.com>\n"
+"PO-Revision-Date: 2025-06-29 11:04+0000\n"
+"Last-Translator: Martin Srebotnjak <miles@filmsi.net>\n"
 "Language-Team: Slovenian <sl@li.org>\n"
 "Language: sl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2024-02-21 18:08+0000\n"
-"X-Generator: Launchpad (build 9643586c585856148a18782148972ae9c1179d06)\n"
+"X-Launchpad-Export-Date: 2025-07-04 10:48+0000\n"
+"X-Generator: Launchpad (build b5a18a1fb2c651898dbb3172b738994271938569)\n"
 
 #: ../apport/com.ubuntu.apport.policy.in.h:1
 msgid "Collect system information"
@@ -595,11 +595,11 @@ msgstr ""
 
 #: ../bin/apport-cli.py:315
 msgid "&Yes"
-msgstr ""
+msgstr "&Da"
 
 #: ../bin/apport-cli.py:316
 msgid "&No"
-msgstr ""
+msgstr "&Ne"
 
 #: ../bin/apport-cli.py:352
 msgid "&Done"

--- a/po/uk.po
+++ b/po/uk.po
@@ -8,15 +8,15 @@ msgstr ""
 "Project-Id-Version: apport\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-06-06 11:55+0200\n"
-"PO-Revision-Date: 2023-08-09 04:56+0000\n"
-"Last-Translator: Yura <Unknown>\n"
+"PO-Revision-Date: 2025-07-04 08:53+0000\n"
+"Last-Translator: Volodymyr Shypovych <Unknown>\n"
 "Language-Team: Ukrainian <uk@li.org>\n"
 "Language: uk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2024-02-22 10:04+0000\n"
-"X-Generator: Launchpad (build 9643586c585856148a18782148972ae9c1179d06)\n"
+"X-Launchpad-Export-Date: 2025-07-04 10:48+0000\n"
+"X-Generator: Launchpad (build b5a18a1fb2c651898dbb3172b738994271938569)\n"
 
 #: ../apport/com.ubuntu.apport.policy.in.h:1
 msgid "Collect system information"
@@ -260,7 +260,7 @@ msgstr "Помилка xprop: не вдалося визначити ID проц
 #: ../apport/ui.py:992
 #, python-format
 msgid "%(prog)s <report number>"
-msgstr ""
+msgstr "%(prog)s <report number>"
 
 #: ../apport/ui.py:993
 msgid "Specify package name."
@@ -275,6 +275,7 @@ msgstr "Додати додаткову мітку до звіту. Може б�
 msgid ""
 "%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 msgstr ""
+"%(prog)s [options] [symptom|pid|package|program path|.apport/.crash file]"
 
 #: ../apport/ui.py:1046
 msgid ""
@@ -605,11 +606,11 @@ msgstr ""
 
 #: ../bin/apport-cli.py:315
 msgid "&Yes"
-msgstr ""
+msgstr "&Так"
 
 #: ../bin/apport-cli.py:316
 msgid "&No"
-msgstr ""
+msgstr "&Ні"
 
 #: ../bin/apport-cli.py:352
 msgid "&Done"


### PR DESCRIPTION
Import translation updates from https://translations.launchpad.net/ubuntu/noble/+source/apport and https://translations.launchpad.net/ubuntu/plucky/+source/apport for languages that have updates. Do not update translations that have no changes except for updated metadata (POT-Creation-Date, X-Launchpad-Export-Date, and X-Generator). Do not import languages that have zero translated messages.