### PR TITLE
ci: add Ubuntu 26.04 LTS "Resolute Raccoon"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,6 +54,7 @@ jobs:
           - debian:testing-slim
           - ubuntu:noble
           - ubuntu:questing
+          - ubuntu:resolute
     container:
       image: ${{ matrix.container }}
       options: --cap-add=SYS_PTRACE --security-opt seccomp=unconfined
@@ -142,6 +143,7 @@ jobs:
         container:
           - ubuntu:noble
           - ubuntu:questing
+          - ubuntu:resolute
     container:
       image: ${{ matrix.container }}
     steps:
@@ -174,6 +176,8 @@ jobs:
         container:
           - ubuntu:noble
           - ubuntu:questing
+          # resolute skipped due to https://launchpad.net/bugs/2147544
+          # - ubuntu:resolute
     container:
       image: ${{ matrix.container }}
       options: --cap-add=SYS_PTRACE --security-opt seccomp=unconfined


### PR DESCRIPTION
Ubuntu 26.04 LTS "Resolute Raccoon" has been released today.

Skip the system tests on resolute for now, because running the GTK and KDE test together crashes:

```
GDK_BACKEND=x11 xvfb-run python3 -m pytest tests/system/test_ui_gtk.py tests/system/test_ui_kde.py
```