### PR TITLE
apport-cli: fix rounding printed upload percentage

### DIFF
--- a/bin/apport-cli
+++ b/bin/apport-cli
@@ -22,6 +22,7 @@
 # pylint: disable=missing-function-docstring
 
 import errno
+import math
 import os
 import re
 import subprocess
@@ -140,7 +141,7 @@ class CLIProgressDialog(CLIDialog):
             return
 
         if progress is not None:
-            sys.stdout.write(f"\r{progress * 100}%")
+            sys.stdout.write(f"\r{math.floor(progress * 100)}%")
         else:
             sys.stdout.write(".")
         sys.stdout.flush()


### PR DESCRIPTION
Using `%u` on a float will truncate the decimals. So the percentage used to be rounded down to the next integer.

Fix the f-string to round the floating point down to an integer.

Fixes: 5a504336b2f6 ("refactor: Use f-strings everywhere")