### PR TITLE
test: use pwd and ls from GNU coreutils in apport-valgrind tests

### DIFF
--- a/tests/integration/test_apport_valgrind.py
+++ b/tests/integration/test_apport_valgrind.py
@@ -15,7 +15,7 @@ import subprocess
 import tempfile
 import unittest
 
-from tests.helper import skip_if_command_is_missing
+from tests.helper import get_gnu_coreutils_cmd, skip_if_command_is_missing
 from tests.paths import local_test_environment
 
 
@@ -43,7 +43,12 @@ class TestApportValgrind(unittest.TestCase):
 
     def test_valgrind_min_installed(self) -> None:
         """Valgrind is installed and recent enough."""
-        cmd = ["valgrind", "-q", "--extra-debuginfo-path=./", "ls"]
+        cmd = [
+            "valgrind",
+            "-q",
+            "--extra-debuginfo-path=./",
+            get_gnu_coreutils_cmd("ls"),
+        ]
         ret, out, err = self._call(cmd)
         self.assertEqual(err, "")
         self.assertEqual(ret, 0)
@@ -70,7 +75,7 @@ class TestApportValgrind(unittest.TestCase):
 
     def test_invalid_args(self) -> None:
         """Return code is not 0 when invalid args are passed."""
-        cmd = ["apport-valgrind", "-k", "pwd"]
+        cmd = ["apport-valgrind", "-k", get_gnu_coreutils_cmd("pwd")]
         ret, out, err = self._call(cmd)
         self.assertEqual(out, "")
         self.assertNotEqual(ret, 0)
@@ -144,7 +149,7 @@ void makeleak(void){
     def test_unpackaged_exe(self) -> None:
         """apport-valgrind creates valgrind log on unpackaged executable."""
         exepath = os.path.join(self.workdir, "pwd")
-        shutil.copy("/bin/pwd", exepath)
+        shutil.copy(get_gnu_coreutils_cmd("pwd"), exepath)
         logpath = os.path.join(self.workdir, "unpackaged-exe.log")
 
         cmd = ["apport-valgrind", "--no-sandbox", "-l", logpath, exepath]


### PR DESCRIPTION
apport-valgrind fails on `ls` and `pwd` from uutils. The valgrind error output contains:

```
==868049== Invalid read of size 1
==868049==    at 0x532A166: strlen (vg_replace_strmem.c:506)
==868049==    by 0x41C323C: ??? (in /usr/lib/cargo/bin/coreutils/ls)
==868049==    by 0x417E2C6: ??? (in /usr/lib/cargo/bin/coreutils/ls)
==868049==    by 0x417E215: ??? (in /usr/lib/cargo/bin/coreutils/ls)
==868049==    by 0x4318F5C: ??? (in /usr/lib/cargo/bin/coreutils/ls)
==868049==    by 0x417E203: ??? (in /usr/lib/cargo/bin/coreutils/ls)
==868049==    by 0x550E600: (below main) (libc_start_call_main.h:59)
==868049==  Address 0x7fff1a1eafcd is not stack'd, malloc'd or (recently) free'd
==868049==
==868049== Invalid read of size 1
==868049==    at 0x532A174: strlen (vg_replace_strmem.c:506)
==868049==    by 0x41C323C: ??? (in /usr/lib/cargo/bin/coreutils/ls)
==868049==    by 0x417E2C6: ??? (in /usr/lib/cargo/bin/coreutils/ls)
==868049==    by 0x417E215: ??? (in /usr/lib/cargo/bin/coreutils/ls)
==868049==    by 0x4318F5C: ??? (in /usr/lib/cargo/bin/coreutils/ls)
==868049==    by 0x417E203: ??? (in /usr/lib/cargo/bin/coreutils/ls)
==868049==    by 0x550E600: (below main) (libc_start_call_main.h:59)
==868049==  Address 0x7fff1a1eafce is not stack'd, malloc'd or (recently) free'd
==868049==
==868049== Invalid read of size 1
==868049==    at 0x41C329D: ??? (in /usr/lib/cargo/bin/coreutils/ls)
==868049==    by 0x417E2C6: ??? (in /usr/lib/cargo/bin/coreutils/ls)
==868049==    by 0x417E215: ??? (in /usr/lib/cargo/bin/coreutils/ls)
==868049==    by 0x4318F5C: ??? (in /usr/lib/cargo/bin/coreutils/ls)
==868049==    by 0x417E203: ??? (in /usr/lib/cargo/bin/coreutils/ls)
==868049==    by 0x550E600: (below main) (libc_start_call_main.h:59)
==868049==  Address 0x7fff1a1eaff6 is not stack'd, malloc'd or (recently) free'd
==868049==
==868049== Invalid read of size 1
==868049==    at 0x532E12D: bcmp (vg_replace_strmem.c:1234)
==868049==    by 0x410814F: ??? (in /usr/lib/cargo/bin/coreutils/ls)
==868049==    by 0x41C3325: ??? (in /usr/lib/cargo/bin/coreutils/ls)
==868049==    by 0x417E2C6: ??? (in /usr/lib/cargo/bin/coreutils/ls)
==868049==    by 0x417E215: ??? (in /usr/lib/cargo/bin/coreutils/ls)
==868049==    by 0x4318F5C: ??? (in /usr/lib/cargo/bin/coreutils/ls)
==868049==    by 0x417E203: ??? (in /usr/lib/cargo/bin/coreutils/ls)
==868049==    by 0x550E600: (below main) (libc_start_call_main.h:59)
==868049==  Address 0x7fff1a1eafcd is not stack'd, malloc'd or (recently) free'd
==868049==
==868049== Invalid read of size 1
==868049==    at 0x532EBB0: memmove (vg_replace_strmem.c:1415)
==868049==    by 0x432558F: ??? (in /usr/lib/cargo/bin/coreutils/ls)
==868049==    by 0x4335255: ??? (in /usr/lib/cargo/bin/coreutils/ls)
==868049==    by 0x4311950: ??? (in /usr/lib/cargo/bin/coreutils/ls)
==868049==    by 0x425C268: ??? (in /usr/lib/cargo/bin/coreutils/ls)
==868049==    by 0x41C335D: ??? (in /usr/lib/cargo/bin/coreutils/ls)
==868049==    by 0x417E2C6: ??? (in /usr/lib/cargo/bin/coreutils/ls)
==868049==    by 0x417E215: ??? (in /usr/lib/cargo/bin/coreutils/ls)
==868049==    by 0x4318F5C: ??? (in /usr/lib/cargo/bin/coreutils/ls)
==868049==    by 0x417E203: ??? (in /usr/lib/cargo/bin/coreutils/ls)
==868049==    by 0x550E600: (below main) (libc_start_call_main.h:59)
==868049==  Address 0x7fff1a1eafcd is not stack'd, malloc'd or (recently) free'd
==868049==
==868049== Invalid read of size 1
==868049==    at 0x532EBBD: memmove (vg_replace_strmem.c:1415)
==868049==    by 0x432558F: ??? (in /usr/lib/cargo/bin/coreutils/ls)
==868049==    by 0x4335255: ??? (in /usr/lib/cargo/bin/coreutils/ls)
==868049==    by 0x4311950: ??? (in /usr/lib/cargo/bin/coreutils/ls)
==868049==    by 0x425C268: ??? (in /usr/lib/cargo/bin/coreutils/ls)
==868049==    by 0x41C335D: ??? (in /usr/lib/cargo/bin/coreutils/ls)
==868049==    by 0x417E2C6: ??? (in /usr/lib/cargo/bin/coreutils/ls)
==868049==    by 0x417E215: ??? (in /usr/lib/cargo/bin/coreutils/ls)
==868049==    by 0x4318F5C: ??? (in /usr/lib/cargo/bin/coreutils/ls)
==868049==    by 0x417E203: ??? (in /usr/lib/cargo/bin/coreutils/ls)
==868049==    by 0x550E600: (below main) (libc_start_call_main.h:59)
==868049==  Address 0x7fff1a1eafcf is not stack'd, malloc'd or (recently) free'd
==868049==
==868049== Invalid read of size 1
==868049==    at 0x532EBB0: memmove (vg_replace_strmem.c:1415)
==868049==    by 0x41BB20E: ??? (in /usr/lib/cargo/bin/coreutils/ls)
==868049==    by 0x41C33DD: ??? (in /usr/lib/cargo/bin/coreutils/ls)
==868049==    by 0x417E2C6: ??? (in /usr/lib/cargo/bin/coreutils/ls)
==868049==    by 0x417E215: ??? (in /usr/lib/cargo/bin/coreutils/ls)
==868049==    by 0x4318F5C: ??? (in /usr/lib/cargo/bin/coreutils/ls)
==868049==    by 0x417E203: ??? (in /usr/lib/cargo/bin/coreutils/ls)
==868049==    by 0x550E600: (below main) (libc_start_call_main.h:59)
==868049==  Address 0x7fff1a1eafcd is not stack'd, malloc'd or (recently) free'd
==868049==
==868049== Invalid read of size 1
==868049==    at 0x532EBBD: memmove (vg_replace_strmem.c:1415)
==868049==    by 0x41BB20E: ??? (in /usr/lib/cargo/bin/coreutils/ls)
==868049==    by 0x41C33DD: ??? (in /usr/lib/cargo/bin/coreutils/ls)
==868049==    by 0x417E2C6: ??? (in /usr/lib/cargo/bin/coreutils/ls)
==868049==    by 0x417E215: ??? (in /usr/lib/cargo/bin/coreutils/ls)
==868049==    by 0x4318F5C: ??? (in /usr/lib/cargo/bin/coreutils/ls)
==868049==    by 0x417E203: ??? (in /usr/lib/cargo/bin/coreutils/ls)
==868049==    by 0x550E600: (below main) (libc_start_call_main.h:59)
==868049==  Address 0x7fff1a1eafcf is not stack'd, malloc'd or (recently) free'd
==868049==
coreutils: unknown program 'memcheck-amd64-linux'
```

Use the GNU coreutils implementation for `ls` and `pwd` to test with C code instead of Rust code.