### PR TITLE
test: avoid type change of key variables

### DIFF
--- a/tests/integration/test_hooks.py
+++ b/tests/integration/test_hooks.py
@@ -156,9 +156,9 @@ class T(unittest.TestCase):
         with open(reps[0], "rb") as f:
             r.load(f)
 
-        filekey = None
-        log1key = None
-        log2key = None
+        filekey = ""
+        log1key = ""
+        log2key = ""
         for k in r.keys():
             if k.endswith("Testhookspy"):
                 filekey = k

--- a/tests/integration/test_hooks.py
+++ b/tests/integration/test_hooks.py
@@ -156,9 +156,9 @@ class T(unittest.TestCase):
         with open(reps[0], "rb") as f:
             r.load(f)
 
-        filekey = None
-        log1key = None
-        log2key = None
+        filekey = ""
+        log1key = ""
+        log2key = ""
         for k in r:
             if k.endswith("Testhookspy"):
                 filekey = k


### PR DESCRIPTION
The `ProblemReport` keys must be of type `str`. Avoid setting those keys initially to `None` to avoid mypy to complain.