### PR TITLE
problem_report: enforce some keys to always have str values in load()

### DIFF
--- a/problem_report.py
+++ b/problem_report.py
@@ -9,6 +9,8 @@
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
 
+# pylint: disable=too-many-lines
+
 import base64
 import binascii
 import collections
@@ -352,6 +354,64 @@ class CompressedValue:
 
 
 ProblemReportValue: TypeAlias = bytes | CompressedFile | CompressedValue | str | tuple
+_STRING_KEYS = {
+    "Annotation",
+    "Architecture",
+    "AssertionMessage",
+    "AuditLog",
+    "CheckboxSubmission",
+    "CrashCounter",
+    "CrashDB",
+    "Date",
+    "DbusErrorAnalysis",
+    "Dependencies",
+    "DesktopFile",
+    "DialogBody",
+    "Disassembly",
+    "DistroRelease",
+    "DuplicateSignature",
+    "ExecutablePath",
+    "ExecutableTimestamp",
+    "Failure",
+    "GLibAssertionMessage",
+    "InterpreterPath",
+    "KernLog",
+    "MachineType",
+    "MainClassUrl",
+    "NonfreeKernelModules",
+    "OopsText",
+    "OpenFds",
+    "Package",
+    "PackageArchitecture",
+    "ProblemType",
+    "ProcCmdline",
+    "ProcCwd",
+    "ProcEnviron",
+    "ProcMaps",
+    "ProcStatus",
+    "Registers",
+    "RespawnCommand",
+    "SegvAnalysis",
+    "SegvAnalysisError",
+    "Signal",
+    "SignalName",
+    "SnapTags",
+    "SourcePackage",
+    "StackTrace",
+    "Stacktrace",
+    "StacktraceSource",
+    "StacktraceTop",
+    "Tags",
+    "ThreadStacktrace",
+    "Title",
+    "Traceback",
+    "Uname",
+    "UnreportableReason",
+    "UserGroups",
+    "_KnownReport",
+    "_PythonExceptionQualifier",
+    "dmi.bios.version",
+}
 
 
 class ProblemReport(collections.UserDict):
@@ -419,12 +479,11 @@ class ProblemReport(collections.UserDict):
                         name=key, compressed_value=b"".join(iterator)
                     )
                 else:
-                    self.data[key] = self._try_unicode(
-                        b"".join(CompressedValue.decode_compressed_stream(iterator))
-                    )
+                    value = b"".join(CompressedValue.decode_compressed_stream(iterator))
+                    self.data[key] = self._try_unicode(key, value)
 
             else:
-                self.data[key] = self._try_unicode(b"".join(iterator))
+                self.data[key] = self._try_unicode(key, b"".join(iterator))
 
             if remaining_keys is not None:
                 remaining_keys.remove(key)
@@ -516,8 +575,10 @@ class ProblemReport(collections.UserDict):
         return False
 
     @classmethod
-    def _try_unicode(cls, value: bytes) -> bytes | str:
+    def _try_unicode(cls, key: str, value: bytes) -> bytes | str:
         """Try to convert bytearray value to Unicode."""
+        if key in _STRING_KEYS:
+            return value.decode("UTF-8")
         if not cls.is_binary(value):
             try:
                 return value.decode("UTF-8")

--- a/tests/unit/test_problem_report.py
+++ b/tests/unit/test_problem_report.py
@@ -229,6 +229,20 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
         pr.load(io.BytesIO(b"ProblemType: Crash"))
         self.assertEqual(list(pr.keys()), ["ProblemType"])
 
+    def test_load_string_with_null(self) -> None:
+        """Test load() with a NULL character in a string key.
+
+        Test case for https://launchpad.net/bugs/2146806
+        """
+        proc_maps = "7f8e5d61f000-7f8e5d620000 r--p 00005000 fc:00 190815U\0\0"
+        content = f"ProblemType: Crash\n" f"Date: now!\n" f"ProcMaps: {proc_maps}\n"
+        report = problem_report.ProblemReport()
+        report.load(io.BytesIO(content.encode()))
+
+        self.assertEqual(report["ProblemType"], "Crash")
+        self.assertEqual(report["Date"], "now!")
+        self.assertEqual(report["ProcMaps"], proc_maps)
+
     def test_load_binary_blob(self) -> None:
         """Throw exception when binary file (e.g. core) is loaded."""
         report = problem_report.ProblemReport()


### PR DESCRIPTION
plasmashell crashed on the system, and when Apport tried to upload the problem report, whoopsie-upload-all crashed:

```
INFO:root:Collecting info for /var/crash/_usr_bin_plasmashell.1000.crash...
ERROR: hook /usr/share/apport/general-hooks/generic.py crashed:
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/apport/report.py", line 314, in _run_hook
    symb["add_info"](report, ui)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^
  File "/usr/share/apport/general-hooks/generic.py", line 70, in add_info
    for lib in re.finditer(r"\s(/[^ ]+\.so[.0-9]*)$", report["ProcMaps"], re.M):
               ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.14/re/__init__.py", line 285, in finditer
    return _compile(pattern, flags).finditer(string)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^
TypeError: cannot use a string pattern on a bytes-like object
Traceback (most recent call last):
  File "/usr/share/apport/whoopsie-upload-all", line 246, in <module>
    main()
    ~~~~^^
  File "/usr/share/apport/whoopsie-upload-all", line 228, in main
    stamps = collect_info()
  File "/usr/share/apport/whoopsie-upload-all", line 162, in collect_info
    res = process_report(r)
  File "/usr/share/apport/whoopsie-upload-all", line 112, in process_report
    r.add_gdb_info()
    ~~~~~~~~~~~~~~^^
  File "/usr/lib/python3/dist-packages/apport/report.py", line 1057, in add_gdb_info
    addr_signature = self.crash_signature_addresses()
  File "/usr/lib/python3/dist-packages/apport/report.py", line 1797, in crash_signature_addresses
    if self["ProcMaps"].startswith("Error: "):
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
TypeError: startswith first arg must be bytes or a tuple of bytes, not str
```

The `ProcMaps` field in the crash report has following last lines:

```
 7f8e5d61b000-7f8e5d61e000 r-xp 00002000 fc:00 19081540                   /usr/lib/x86_64-linux-gnu/qt6/plugins/kf6/packagestructure/plasma_wallpaper.so
 7f8e5d61e000-7f8e5d61f000 r--p 00005000 fc:00 19081540                   /usr/lib/x86_64-linux-gnu/qt6/plugins/kf6/packagestructure/plasma_wallpaper.so
 7f8e5d61f000-7f8e5d620000 r--p 00005000 fc:00 190815U\0\0
```

So string value for `ProcMaps` seems to be truncated. whoopsie-upload-all opens the crash file and keeps the value as `bytes` because it contains null characters at the end.

The value for `ProcMaps` should always be a string. There are other fields that are expected to be string as well.

Enforce decoding those fields when reading the crash report and prevent setting those keys to non-string values. This should result in more consistent `ProblemReport` object instances. This can be accompanied by type hints in a future commit.

Bug: https://launchpad.net/bugs/2146806