### PR TITLE
problem_report: avoid double .txt file extension

### DIFF
--- a/problem_report.py
+++ b/problem_report.py
@@ -111,6 +111,13 @@ def _create_compressed_attachment(name: str, value: bytes) -> email.mime.base.MI
     return attachment
 
 
+def _create_text_attachment(name: str, value: str) -> email.mime.base.MIMEBase:
+    filename = f"{name}.txt"
+    attachment = email.mime.text.MIMEText(value, _charset="UTF-8")
+    attachment.add_header("Content-Disposition", "attachment", filename=filename)
+    return attachment
+
+
 def _derive_compression(name: str, value: bytes) -> tuple[str, str]:
     if value.startswith(GZIP_HEADER_START):
         return ("gzip", ".gz")
@@ -903,11 +910,7 @@ class ProblemReport(collections.UserDict):
                     text += v.strip().replace("\n", "\n ") + "\n"
                 else:
                     # too large, separate attachment
-                    att = email.mime.text.MIMEText(v, _charset="UTF-8")
-                    att.add_header(
-                        "Content-Disposition", "attachment", filename=k + ".txt"
-                    )
-                    attachments.append(att)
+                    attachments.append(_create_text_attachment(k, v))
 
         # create initial text attachment
         att = email.mime.text.MIMEText(text, _charset="UTF-8")

--- a/problem_report.py
+++ b/problem_report.py
@@ -112,7 +112,7 @@ def _create_compressed_attachment(name: str, value: bytes) -> email.mime.base.MI
 
 
 def _create_text_attachment(name: str, value: str) -> email.mime.base.MIMEBase:
-    filename = f"{name}.txt"
+    filename = _add_extension_if_missing(name, ".txt")
     attachment = email.mime.text.MIMEText(value, _charset="UTF-8")
     attachment.add_header("Content-Disposition", "attachment", filename=filename)
     return attachment

--- a/problem_report.py
+++ b/problem_report.py
@@ -114,7 +114,7 @@ def _create_compressed_attachment(name: str, value: bytes) -> email.mime.base.MI
 
 
 def _create_text_attachment(name: str, value: str) -> email.mime.base.MIMEBase:
-    filename = f"{name}.txt"
+    filename = _add_extension_if_missing(name, ".txt")
     attachment = email.mime.text.MIMEText(value, _charset="UTF-8")
     attachment.add_header("Content-Disposition", "attachment", filename=filename)
     return attachment

--- a/problem_report.py
+++ b/problem_report.py
@@ -113,6 +113,13 @@ def _create_compressed_attachment(name: str, value: bytes) -> email.mime.base.MI
     return attachment
 
 
+def _create_text_attachment(name: str, value: str) -> email.mime.base.MIMEBase:
+    filename = f"{name}.txt"
+    attachment = email.mime.text.MIMEText(value, _charset="UTF-8")
+    attachment.add_header("Content-Disposition", "attachment", filename=filename)
+    return attachment
+
+
 def _derive_compression(name: str, value: bytes) -> tuple[str, str]:
     if value.startswith(GZIP_HEADER_START):
         return ("gzip", ".gz")
@@ -964,11 +971,7 @@ class ProblemReport(collections.UserDict):
                     text += v.strip().replace("\n", "\n ") + "\n"
                 else:
                     # too large, separate attachment
-                    att = email.mime.text.MIMEText(v, _charset="UTF-8")
-                    att.add_header(
-                        "Content-Disposition", "attachment", filename=k + ".txt"
-                    )
-                    attachments.append(att)
+                    attachments.append(_create_text_attachment(k, v))
 
         # create initial text attachment
         att = email.mime.text.MIMEText(text, _charset="UTF-8")

--- a/tests/unit/test_problem_report.py
+++ b/tests/unit/test_problem_report.py
@@ -668,7 +668,7 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
         pr["SimpleLineEnd"] = "bar\n"
         pr["TwoLine"] = "first\nsecond\n"
         pr["InlineMargin"] = "first\nsecond\nthird\nfourth\nfifth\n"
-        pr["Multiline"] = " foo   bar\nbaz\n  blip  \nline4\nline♥5!!\nłıµ€ ⅝\n"
+        pr["Multiline.txt"] = " foo   bar\nbaz\n  blip  \nline4\nline♥5!!\nłıµ€ ⅝\n"
 
         # still small enough for inline text
         pr["Largeline"] = "A" * 999

--- a/tests/unit/test_problem_report.py
+++ b/tests/unit/test_problem_report.py
@@ -682,7 +682,7 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
         pr["SimpleLineEnd"] = "bar\n"
         pr["TwoLine"] = "first\nsecond\n"
         pr["InlineMargin"] = "first\nsecond\nthird\nfourth\nfifth\n"
-        pr["Multiline"] = " foo   bar\nbaz\n  blip  \nline4\nline♥5!!\nłıµ€ ⅝\n"
+        pr["Multiline.txt"] = " foo   bar\nbaz\n  blip  \nline4\nline♥5!!\nłıµ€ ⅝\n"
 
         # still small enough for inline text
         pr["Largeline"] = "A" * 999


### PR DESCRIPTION
Some bug reports like bug #2147517 have an attachment with double file extension: `CurrentDmesg.txt.txt`

Do not add `.txt` in case the key name already contains the file extension.

This PR is stacked on top of https://github.com/canonical/apport/pull/576

Bug: https://launchpad.net/bugs/2149892