### PR TITLE
test: relax check for Package field

### DIFF
--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -908,8 +908,8 @@ class T(unittest.TestCase):
         assert ui.report
 
         kernel_package = packaging.get_kernel_package()
-        self.assertEqual(
-            ui.report["Package"], f"{kernel_package} {get_version_mock.return_value}"
+        self.assertRegex(
+            ui.report["Package"], f"^{kernel_package} {get_version_mock.return_value}"
         )
         get_version_mock.assert_any_call(kernel_package)
 


### PR DESCRIPTION
`test_run_report_bug_kernel_thread` might failed in a autopkgtest VM:

```
=================================== FAILURES ===================================
_____________________ T.test_run_report_bug_kernel_thread ______________________

self = <tests.integration.test_ui.T testMethod=test_run_report_bug_kernel_thread>
get_version_mock = <MagicMock name='get_version' id='130971739753504'>

    @unittest.mock.patch("apport.packaging_impl.impl.get_version")
    def test_run_report_bug_kernel_thread(self, get_version_mock: MagicMock) -> None:
        """run_report_bug() for a pid of a kernel thread"""
        # The kernel package might not be installed in chroot environments.
        # Therefore mock get_version for the kernel package.
        get_version_mock.return_value = "5.15.0-33.34"

        for path in glob.glob("/proc/[0-9]*/stat"):
            with open(path, encoding="utf-8") as f:
                proc_stat = f.read().split()
            flags = int(proc_stat[8])
            if flags & apport.ui.PF_KTHREAD:
                pid = int(proc_stat[0])
                break
        else:
            self.skipTest("no kernel thread found")

        ui = UserInterfaceMock(["ui-test", "-f", "-P", str(pid)])
        ui.present_details_response = apport.ui.Action(report=True)
        ui.run_argv()
        assert ui.report

        kernel_package = packaging.get_kernel_package()
>       self.assertEqual(
            ui.report["Package"], f"{kernel_package} {get_version_mock.return_value}"
        )
E       AssertionError: 'linux-image-7.0.0-12-generic 5.15.0-33.34 [origin: unknown]' != 'linux-image-7.0.0-12-generic 5.15.0-33.34'
E       - linux-image-7.0.0-12-generic 5.15.0-33.34 [origin: unknown]
E       ?                                          ------------------
E       + linux-image-7.0.0-12-generic 5.15.0-33.34

tests/integration/test_ui.py:911: AssertionError
=============================== warnings summary ===============================
```

Bug: https://launchpad.net/bugs/2149909