### PR TITLE
test: set locale for test_install_packages_error

### DIFF
--- a/tests/helper.py
+++ b/tests/helper.py
@@ -4,6 +4,7 @@ import contextlib
 import functools
 import importlib.machinery
 import importlib.util
+import locale
 import os
 import pathlib
 import shutil
@@ -101,6 +102,14 @@ def read_shebang(command: str) -> str | None:
     if not first_line.startswith(b"#!"):
         return None
     return first_line.decode().split(" ", 1)[0][2:]
+
+
+@contextlib.contextmanager
+def restore_locale(category: int) -> Generator[None]:
+    """Restore locale after leaving this context manager."""
+    orig_locale = locale.getlocale(category)
+    yield
+    locale.setlocale(category, orig_locale)
 
 
 @contextlib.contextmanager

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -3,13 +3,14 @@
 import contextlib
 import importlib.machinery
 import importlib.util
+import locale
 import os
 import pathlib
 import shutil
 import subprocess
 import time
 import unittest.mock
-from collections.abc import Callable, Generator, Iterator, Sequence, Set
+from collections.abc import Callable, Generator, Iterable, Iterator, Sequence, Set
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -107,6 +108,17 @@ def run_test_executable(
 
 def _id(obj: Any) -> Any:
     return obj
+
+
+@contextlib.contextmanager
+def set_locale(
+    category: int, new_locale: Iterable[str | None] | None
+) -> Generator[None]:
+    """Set locale and restore it after leaving this context manager."""
+    orig_locale = locale.getlocale(category)
+    locale.setlocale(category, new_locale)
+    yield
+    locale.setlocale(category, orig_locale)
 
 
 def skip_if_command_is_missing(cmd: str) -> Callable:

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -3,13 +3,14 @@
 import contextlib
 import importlib.machinery
 import importlib.util
+import locale
 import os
 import pathlib
 import shutil
 import subprocess
 import time
 import unittest.mock
-from collections.abc import Callable, Generator, Iterator, Sequence, Set
+from collections.abc import Callable, Generator, Iterable, Iterator, Sequence, Set
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -110,6 +111,17 @@ def run_test_executable(
 
 def _id(obj: Any) -> Any:
     return obj
+
+
+@contextlib.contextmanager
+def set_locale(
+    category: int, new_locale: Iterable[str | None] | None
+) -> Generator[None]:
+    """Set locale and restore it after leaving this context manager."""
+    orig_locale = locale.getlocale(category)
+    locale.setlocale(category, new_locale)
+    yield
+    locale.setlocale(category, orig_locale)
 
 
 def skip_if_command_is_missing(cmd: str) -> Callable:

--- a/tests/system/test_packaging_apt_dpkg.py
+++ b/tests/system/test_packaging_apt_dpkg.py
@@ -4,6 +4,7 @@
 
 import glob
 import gzip
+import locale
 import os
 import pathlib
 import shutil
@@ -17,7 +18,7 @@ import apt_pkg
 import pytest
 
 from apport.packaging_impl.apt_dpkg import _parse_deb822_sources, impl
-from tests.helper import has_internet
+from tests.helper import has_internet, restore_locale
 from tests.paths import get_test_data_directory
 
 if shutil.which("dpkg") is None:
@@ -348,10 +349,12 @@ def test_install_packages_system(
 
 
 @pytest.mark.skipif(not has_internet(), reason="online test")
+@restore_locale(locale.LC_MESSAGES)
 def test_install_packages_error(
     configdir: str, cachedir: str, rootdir: str, apt_style: AptStyle
 ) -> None:
     """install_packages() with errors"""
+    locale.setlocale(locale.LC_MESSAGES, "C.UTF-8")
     # sources.list with invalid format
     release = _setup_foonux_config(configdir, apt_style)
     with open(

--- a/tests/system/test_packaging_apt_dpkg.py
+++ b/tests/system/test_packaging_apt_dpkg.py
@@ -4,6 +4,7 @@
 
 import glob
 import gzip
+import locale
 import os
 import pathlib
 import shutil
@@ -17,6 +18,7 @@ import apt_pkg
 import pytest
 
 from apport.packaging_impl.apt_dpkg import _parse_deb822_sources, impl
+from tests.helper import set_locale
 from tests.paths import get_test_data_directory
 
 if shutil.which("dpkg") is None:
@@ -347,6 +349,7 @@ def test_install_packages_system(
 
 
 @pytest.mark.requires_internet
+@set_locale(locale.LC_MESSAGES, "C.UTF-8")
 def test_install_packages_error(
     configdir: str, cachedir: str, rootdir: str, apt_style: AptStyle
 ) -> None:


### PR DESCRIPTION
The test `test_install_packages_error` will fail on systems where the locale is not set to C (english):

```
$ python3 -m pytest tests/integration/test_ui_gtk.py tests/system/test_packaging_apt_dpkg.py::test_install_packages_error
[...]
>       exc_info.match("E:Type 'bogus' is not known .* sources could not be read.$")
E       AssertionError: Regex pattern did not match.
E         Expected regex: "E:Type 'bogus' is not known .* sources could not be read.$"
E         Actual message: 'E:Typ »bogus« in Zeile 1 der Quellliste /tmp/tmp4erzi0jq/cache/Foonux 22.04/apt/etc/apt/sources.list ist unbekannt., E:Die Liste der Quellen konnte nicht gelesen werden.'
```

Set the locale explicitly for this test.