### PR TITLE
apt_dpkg: exclude {usr/,}lib/modules and more from Contents-*.gz cache

### DIFF
--- a/apport/packaging_impl/apt_dpkg.py
+++ b/apport/packaging_impl/apt_dpkg.py
@@ -57,6 +57,35 @@ from aptsources.sourceslist import Deb822SourceEntry, SourceEntry
 import apport.logging
 from apport.package_info import PackageInfo
 
+# The Contents-*.gz files are huge. Loading all data into memory would result in a
+# dictionary with millions of entries consuming several gigabytes of memory.
+# Therefore exclude unneeded paths with 100k entries or more.
+# Data from 2026-04-23 on amd64:
+#
+# | Path                       |      jammy |      noble |   questing |   resolute |
+# |----------------------------|------------|------------|------------|------------|
+# | lib/modules                | 10,206,350 |  5,492,830 |    475,055 |      9,120 |
+# | usr/include                |    278,938 |    271,587 |    295,470 |    298,389 |
+# | usr/src                    | 39,533,381 | 21,538,896 |  2,201,315 |    420,916 |
+# | usr/[^/]+/include          |    107,568 |    170,800 |    103,340 |    127,294 |
+# | usr/lib/modules            |          0 |          0 |          0 |     73,589 |
+# | usr/share/cargo/registry   |     28,202 |     74,721 |    102,428 |    127,537 |
+# | usr/share/doc              |  3,025,577 |  2,938,577 |  2,636,718 |  2,766,784 |
+# | usr/share/gimp/.../help    |     38,220 |     73,845 |     78,120 |     85,216 |
+# | usr/share/gocode           |    112,802 |    168,941 |    199,405 |    227,626 |
+# | usr/share/help             |    121,470 |    124,824 |    118,948 |    119,346 |
+# | usr/share/icons            |    605,862 |    659,375 |    715,984 |    753,986 |
+# | usr/share/libreoffice/help |     93,359 |     98,690 |    100,540 |    100,580 |
+# | usr/share/locale           |     95,312 |    110,122 |    123,230 |    123,842 |
+# | usr/share/man              |    149,353 |    165,310 |    175,262 |    177,041 |
+# | usr/share/texlive          |    145,420 |    168,740 |    170,265 |    171,546 |
+# | **remaining paths**        |  3,365,393 |  3,839,911 |  3,725,751 |  3,909,851 |
+_EXCLUDED_PATHS = (
+    "^(lib/modules|usr/(include|src|[^/]+/include|lib/modules|share/"
+    "(cargo/registry|doc|gimp/.../help|gocode|help"
+    "|icons|libreoffice/help|locale|man|texlive)))/"
+)
+
 
 # pylint: disable-next=too-many-arguments,too-many-positional-arguments
 def _extract_downloaded_debs(
@@ -1671,10 +1700,7 @@ class _AptDpkgPackageInfo(PackageInfo):
     def _update_given_file2pkg_mapping(
         file2pkg: dict[bytes, bytes], contents_filename: str, dist: str
     ) -> None:
-        path_exclude_pattern = re.compile(
-            rb"^:|(boot|var|usr/(include|src|[^/]+/include"
-            rb"|share/(doc|gocode|help|icons|locale|man|texlive)))/"
-        )
+        path_exclude_pattern = re.compile(_EXCLUDED_PATHS.encode())
         with gzip.open(contents_filename, "rb") as contents:
             if dist in {"trusty", "xenial"}:
                 # the first 32 lines are descriptive only for these

--- a/tests/unit/test_packaging_apt_dpkg.py
+++ b/tests/unit/test_packaging_apt_dpkg.py
@@ -244,7 +244,12 @@ bin/archdetect						    utils/archdetect-deb
             impl._update_given_file2pkg_mapping(file2pkg, "/fake_Contents", "xenial")
 
         self.assertEqual(
-            file2pkg, {b"bin/afio": b"afio", b"bin/archdetect": b"archdetect-deb"}
+            file2pkg,
+            {
+                b":sexsend:sexget:": b"fex",
+                b"bin/afio": b"afio",
+                b"bin/archdetect": b"archdetect-deb",
+            },
         )
         open_mock.assert_called_once_with("/fake_Contents", "rb")
 
@@ -256,6 +261,8 @@ bin/archdetect						    utils/archdetect-deb
 bin/ip							    net/iproute2
 boot/ipxe.efi						    admin/grub-ipxe
 etc/dput.cf						    devel/dput
+lib/modules/6.8.0-31-generic/kernel/crypto/lz4.ko.zst	\
+    kernel/linux-modules-6.8.0-31-generic
 lib/nut/clone						    admin/nut-server
 sbin/hdparm						    admin/hdparm
 usr/Brother/inf/braddprinter				    multiverse/text/brother-lpr-drivers-laser
@@ -270,12 +277,15 @@ usr/lib/debug/.build-id/31/1c9c9b30d6991fb903ab459173c66eb8e7e895.debug debug/li
 usr/libexec/coreutils/libstdbuf.so			    utils/coreutils
 usr/libx32/ld.so					    libs/libc6-x32
 usr/sbin/zic						    libs/libc-bin
+usr/share/cargo/registry/libc-0.2.152/src/lib.rs	    universe/rust/librust-libc-dev
 usr/share/dicom3tools/gen.so				    universe/graphics/dicom3tools
 usr/share/doc/0install					    universe/admin/0install
+usr/share/gimp/2.0/help/de/glossary.html		    universe/doc/gimp-help-de
 usr/share/gocode/src/launchpad.net/mgo			    universe/devel/golang-gopkg-mgo.v2-dev
 usr/share/help/C/eog/default.page			    gnome/eog
 usr/share/icons/gnome-colors-common/32x32/apps/konsole.png\
   universe/gnome/gnome-colors-common
+usr/share/libreoffice/help/en-US/noscript.html		    doc/libreoffice-help-en-us
 usr/share/locale/de/LC_MESSAGES/apt.mo			    admin/apt
 usr/share/man/de/man1/man.1.gz				    doc/man-db
 usr/share/texlive/index.html				    universe/tex/texlive-base
@@ -293,6 +303,7 @@ var/lib/ieee-data/iab.txt				    net/ieee-data
             {k.decode(): v.decode() for k, v in file2pkg.items()},
             {
                 "bin/ip": "iproute2",
+                "boot/ipxe.efi": "grub-ipxe",
                 "etc/dput.cf": "dput",
                 "lib/nut/clone": "nut-server",
                 "sbin/hdparm": "hdparm",
@@ -307,6 +318,7 @@ var/lib/ieee-data/iab.txt				    net/ieee-data
                 "usr/libx32/ld.so": "libc6-x32",
                 "usr/sbin/zic": "libc-bin",
                 "usr/share/dicom3tools/gen.so": "dicom3tools",
+                "var/lib/ieee-data/iab.txt": "ieee-data",
             },
         )
         open_mock.assert_called_once_with("Contents-amd64", "rb")


### PR DESCRIPTION
The Contents-*.gz cache becomes bigger and bigger the longer a stable release ages (due to more and more kernel package versions in the archive).

| Path                       |      jammy |      noble |   questing |   resolute |
|----------------------------|------------|------------|------------|------------|
| :                          |          0 |          0 |          0 |          0 |
| boot                       |      4,654 |      2,647 |        366 |        137 |
| lib/modules                | 10,206,350 |  5,492,830 |    475,055 |      9,120 |
| usr/[^/]+/include          |    107,568 |    170,800 |    103,340 |    127,294 |
| usr/include                |    278,938 |    271,587 |    295,470 |    298,389 |
| usr/lib/modules            |          0 |          0 |          0 |     73,589 |
| usr/share/cargo/registry   |     28,202 |     74,721 |    102,428 |    127,537 |
| usr/share/doc              |  3,025,577 |  2,938,577 |  2,636,718 |  2,766,784 |
| usr/share/gimp/.../help    |     38,220 |     73,845 |     78,120 |     85,216 |
| usr/share/gocode           |    112,802 |    168,941 |    199,405 |    227,626 |
| usr/share/help             |    121,470 |    124,824 |    118,948 |    119,346 |
| usr/share/icons            |    605,862 |    659,375 |    715,984 |    753,986 |
| usr/share/libreoffice/help |     93,359 |     98,690 |    100,540 |    100,580 |
| usr/share/locale           |     95,312 |    110,122 |    123,230 |    123,842 |
| usr/share/man              |    149,353 |    165,310 |    175,262 |    177,041 |
| usr/share/texlive          |    145,420 |    168,740 |    170,265 |    171,546 |
| usr/src                    | 39,533,381 | 21,538,896 |  2,201,315 |    420,916 |
| var                        |     15,759 |     35,438 |     37,204 |     37,552 |
| **current**                | 13,711,111 |  9,541,912 |  4,444,324 |  4,268,204 |
| **new**                    |  3,365,393 |  3,839,911 |  3,725,751 |  3,909,851 |

This causes the cache to contain 13 million entries for jammy and to need more than 5 GiB of memory to retrace crashes.

Exclude the kernel directories `usr/lib/modules` and `lib/modules`, the help directories `usr/share/libreoffice/help` and `usr/share/gimp/.../help`, and the source code directory `usr/share/cargo/registry` from the cache. Simplify the exclusion rule by dropping `:`, `boot`, and `var` since those directory do not contain many entries. Note: The package fex in xenial contains a file named `/:sexsend:sexget:`.

This change reduced the cache creation time from 35.1 seconds down to 25.4 seconds for jammy amd64 on my Intel Core Ultra 9 285K desktop machine. The size reported by `sys.getsizeof()` reduced from 671 MB to 167 MB.

Bug: https://launchpad.net/bugs/2073787