### PR TITLE
apt_dpkg: fix mapping primary ports.ubuntu.com to archive.ubuntu.com

### DIFF
--- a/apport/packaging_impl/apt_dpkg.py
+++ b/apport/packaging_impl/apt_dpkg.py
@@ -195,12 +195,12 @@ def _map_mirror_to_arch(uri: str, target_arch: str) -> str:
     remaining architectures.
     """
     if target_arch in {"amd64", "i386"}:
-        ports_match = re.match("http://([a-z.]+)?ports.ubuntu.com/ubuntu-ports/?", uri)
+        ports_match = re.match("http://([a-z.]*)ports.ubuntu.com/ubuntu-ports/?", uri)
         if ports_match:
             return f"http://{ports_match.group(1)}archive.ubuntu.com/ubuntu"
         return uri
 
-    primary_match = re.match("http://([a-z.]+)?archive.ubuntu.com/ubuntu/?$", uri)
+    primary_match = re.match("http://([a-z.]*)archive.ubuntu.com/ubuntu/?$", uri)
     if primary_match:
         return f"http://{primary_match.group(1)}ports.ubuntu.com/ubuntu-ports"
     return uri

--- a/tests/unit/test_packaging_apt_dpkg.py
+++ b/tests/unit/test_packaging_apt_dpkg.py
@@ -105,6 +105,13 @@ class TestPackagingAptDpkg(unittest.TestCase):
     def test_map_mirror_to_arch_ports_to_primary(self) -> None:
         """Test _map_mirror_to_arch() to map ports to primary."""
         self.assertEqual(
+            _map_mirror_to_arch("http://ports.ubuntu.com/ubuntu-ports/", "amd64"),
+            "http://archive.ubuntu.com/ubuntu",
+        )
+
+    def test_map_mirror_to_arch_country_ports_to_primary(self) -> None:
+        """Test _map_mirror_to_arch() to map country ports to primary."""
+        self.assertEqual(
             _map_mirror_to_arch("http://de.ports.ubuntu.com/ubuntu-ports", "amd64"),
             "http://de.archive.ubuntu.com/ubuntu",
         )


### PR DESCRIPTION
`test_retrace_jammy_sandbox` fails on arm64 when the APT sources URI is http://ports.ubuntu.com/ubuntu-ports. Log on stdout:

```
Err http://Nonearchive.ubuntu.com/ubuntu jammy InRelease

  Could not resolve 'Nonearchive.ubuntu.com'
```

Bug: https://launchpad.net/bugs/2150427