### PR TITLE
apt_dpkg: use str for contents mapping

### DIFF
--- a/apport/packaging_impl/apt_dpkg.py
+++ b/apport/packaging_impl/apt_dpkg.py
@@ -317,7 +317,7 @@ class _AptDpkgPackageInfo(PackageInfo):
         self._contents_dir: str | None = None
         self._mirror: str | None = None
         self._virtual_mapping_obj: dict[str, set[str]] | None = None
-        self._contents_mapping_obj: dict[bytes, bytes] | None = None
+        self._contents_mapping_obj: dict[str, str] | None = None
         self._launchpad_base = "https://api.launchpad.net/devel"
         self._contents_update = False
 
@@ -350,11 +350,11 @@ class _AptDpkgPackageInfo(PackageInfo):
 
     def _contents_mapping(
         self, configdir: str, release: str, arch: str
-    ) -> dict[bytes, bytes]:
+    ) -> dict[str, str]:
         if (
             self._contents_mapping_obj
-            and self._contents_mapping_obj[b"release"] == release.encode()
-            and self._contents_mapping_obj[b"arch"] == arch.encode()
+            and self._contents_mapping_obj["release"] == release
+            and self._contents_mapping_obj["arch"] == arch
         ):
             return self._contents_mapping_obj
 
@@ -367,11 +367,10 @@ class _AptDpkgPackageInfo(PackageInfo):
             with open(mapping_file, "rb") as fp:
                 self._contents_mapping_obj = pickle.load(fp)
             assert isinstance(self._contents_mapping_obj, dict)
+            # Discard files from Apport < 2.35.0
+            assert isinstance(next(iter(self._contents_mapping_obj)), str)
         except (AssertionError, FileNotFoundError):
-            self._contents_mapping_obj = {
-                b"release": release.encode(),
-                b"arch": arch.encode(),
-            }
+            self._contents_mapping_obj = {"release": release, "arch": arch}
 
         return self._contents_mapping_obj
 
@@ -1698,10 +1697,10 @@ class _AptDpkgPackageInfo(PackageInfo):
 
     @staticmethod
     def _update_given_file2pkg_mapping(
-        file2pkg: dict[bytes, bytes], contents_filename: str, dist: str
+        file2pkg: dict[str, str], contents_filename: str, dist: str
     ) -> None:
-        path_exclude_pattern = re.compile(_EXCLUDED_PATHS.encode())
-        with gzip.open(contents_filename, "rb") as contents:
+        path_exclude_pattern = re.compile(_EXCLUDED_PATHS)
+        with gzip.open(contents_filename, "rt") as contents:
             if dist in {"trusty", "xenial"}:
                 # the first 32 lines are descriptive only for these
                 # releases
@@ -1712,7 +1711,7 @@ class _AptDpkgPackageInfo(PackageInfo):
                 if path_exclude_pattern.match(line):
                     continue
                 path, column2 = line.rsplit(maxsplit=1)
-                package = column2.split(b",")[0].split(b"/")[-1]
+                package = column2.split(",")[0].split("/")[-1]
                 if path in file2pkg:
                     if package == file2pkg[path]:
                         continue
@@ -1723,7 +1722,7 @@ class _AptDpkgPackageInfo(PackageInfo):
 
     def _get_file2pkg_mapping(
         self, map_cachedir: str, release: str, arch: str
-    ) -> dict[bytes, bytes]:
+    ) -> dict[str, str]:
         # this is ordered by likelihood of installation with the most common
         # last
         # XXX - maybe we shouldn't check -security and -updates if it is the
@@ -1768,13 +1767,13 @@ class _AptDpkgPackageInfo(PackageInfo):
 
         if file[0] != "/":
             file = f"/{file}"
-        files = [file[1:].encode()]
+        files = [file[1:]]
         usrmerge_file = _usr_merge_alternative(file)
         if usrmerge_file:
-            files.append(usrmerge_file[1:].encode())
+            files.append(usrmerge_file[1:])
         for filename in files:
             try:
-                pkg = contents_mapping[filename].decode()
+                pkg = contents_mapping[filename]
                 return pkg
             except KeyError:
                 pass

--- a/apport/packaging_impl/apt_dpkg.py
+++ b/apport/packaging_impl/apt_dpkg.py
@@ -326,7 +326,7 @@ class _AptDpkgPackageInfo(PackageInfo):
         self._contents_dir: str | None = None
         self._mirror: str | None = None
         self._virtual_mapping_obj: dict[str, set[str]] | None = None
-        self._contents_mapping_obj: dict[bytes, bytes] | None = None
+        self._contents_mapping_obj: dict[str, str] | None = None
         self._launchpad_base = "https://api.launchpad.net/devel"
         self._contents_update = False
 
@@ -359,11 +359,11 @@ class _AptDpkgPackageInfo(PackageInfo):
 
     def _contents_mapping(
         self, configdir: str, release: str, arch: str
-    ) -> dict[bytes, bytes]:
+    ) -> dict[str, str]:
         if (
             self._contents_mapping_obj
-            and self._contents_mapping_obj[b"release"] == release.encode()
-            and self._contents_mapping_obj[b"arch"] == arch.encode()
+            and self._contents_mapping_obj["release"] == release
+            and self._contents_mapping_obj["arch"] == arch
         ):
             return self._contents_mapping_obj
 
@@ -376,11 +376,10 @@ class _AptDpkgPackageInfo(PackageInfo):
             with open(mapping_file, "rb") as fp:
                 self._contents_mapping_obj = pickle.load(fp)
             assert isinstance(self._contents_mapping_obj, dict)
+            # Discard files from Apport < 2.35.0
+            assert isinstance(next(iter(self._contents_mapping_obj)), str)
         except (AssertionError, FileNotFoundError):
-            self._contents_mapping_obj = {
-                b"release": release.encode(),
-                b"arch": arch.encode(),
-            }
+            self._contents_mapping_obj = {"release": release, "arch": arch}
 
         return self._contents_mapping_obj
 
@@ -1705,10 +1704,10 @@ class _AptDpkgPackageInfo(PackageInfo):
 
     @staticmethod
     def _update_given_file2pkg_mapping(
-        file2pkg: dict[bytes, bytes], contents_filename: str, dist: str
+        file2pkg: dict[str, str], contents_filename: str, dist: str
     ) -> None:
-        path_exclude_pattern = re.compile(_EXCLUDED_PATHS.encode())
-        with gzip.open(contents_filename, "rb") as contents:
+        path_exclude_pattern = re.compile(_EXCLUDED_PATHS)
+        with gzip.open(contents_filename, "rt") as contents:
             if dist in {"trusty", "xenial"}:
                 # the first 32 lines are descriptive only for these
                 # releases
@@ -1719,7 +1718,7 @@ class _AptDpkgPackageInfo(PackageInfo):
                 if path_exclude_pattern.match(line):
                     continue
                 path, column2 = line.rsplit(maxsplit=1)
-                package = column2.split(b",")[0].split(b"/")[-1]
+                package = column2.split(",")[0].split("/")[-1]
                 if path in file2pkg:
                     if package == file2pkg[path]:
                         continue
@@ -1730,7 +1729,7 @@ class _AptDpkgPackageInfo(PackageInfo):
 
     def _get_file2pkg_mapping(
         self, map_cachedir: str, release: str, arch: str
-    ) -> dict[bytes, bytes]:
+    ) -> dict[str, str]:
         # this is ordered by likelihood of installation with the most common
         # last
         # XXX - maybe we shouldn't check -security and -updates if it is the
@@ -1775,13 +1774,13 @@ class _AptDpkgPackageInfo(PackageInfo):
 
         if file[0] != "/":
             file = f"/{file}"
-        files = [file[1:].encode()]
+        files = [file[1:]]
         usrmerge_file = _usr_merge_alternative(file)
         if usrmerge_file:
-            files.append(usrmerge_file[1:].encode())
+            files.append(usrmerge_file[1:])
         for filename in files:
             try:
-                pkg = contents_mapping[filename].decode()
+                pkg = contents_mapping[filename]
                 return pkg
             except KeyError:
                 pass

--- a/tests/unit/test_packaging_apt_dpkg.py
+++ b/tests/unit/test_packaging_apt_dpkg.py
@@ -9,6 +9,8 @@
 
 """Unit tests for apport.packaging_impl.apt_dpkg."""
 
+import pathlib
+import pickle
 import tempfile
 import unittest
 import unittest.mock
@@ -182,9 +184,9 @@ Components: main
         """get_file_package() on uninstalled usrmerge packages."""
         # Data from Ubuntu 24.04 (noble)
         _get_file2pkg_mapping_mock.return_value = {
-            b"usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2": b"libc6",
-            b"usr/lib/x86_64-linux-gnu/libc.so.6": b"libc6",
-            b"usr/libx32/libc.so.6": b"libc6-x32",
+            "usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2": "libc6",
+            "usr/lib/x86_64-linux-gnu/libc.so.6": "libc6",
+            "usr/libx32/libc.so.6": "libc6-x32",
         }
 
         pkg = impl.get_file_package(
@@ -196,11 +198,29 @@ Components: main
             "/map_cachedir", impl.get_distro_codename(), "amd64"
         )
 
+    def test_contents_mapping_load_legacy_resolute(self) -> None:
+        """Test _contents_mapping() discarding cache file from Apport 2.34.0."""
+        with tempfile.TemporaryDirectory() as workdir:
+            legacy_file2pkg = {
+                b"release": b"resolute",
+                b"arch": b"amd64",
+                b"path/to/file": b"package1",
+            }
+            mapping_path = (
+                pathlib.Path(workdir) / "contents_mapping-resolute-amd64.pickle"
+            )
+            with mapping_path.open("wb") as mapping_file:
+                pickle.dump(legacy_file2pkg, mapping_file)
+
+            # pylint: disable-next=protected-access
+            file2pkg = impl._contents_mapping(workdir, "resolute", "amd64")
+            self.assertEqual(file2pkg, {"release": "resolute", "arch": "amd64"})
+
     def test_contents_skip_xenial_header(self) -> None:
         """Test _update_given_file2pkg_mapping skipping xenial Contents header."""
         # Header taken from
         # http://archive.ubuntu.com/ubuntu/dists/xenial/Contents-amd64.gz
-        contents = b"""\
+        contents = """\
 This file maps each file available in the Ubuntu
 system to the package from which it originates.  It includes packages
 from the DIST distribution for the ARCH architecture.
@@ -237,7 +257,7 @@ FILE                                                    LOCATION
 bin/afio						    multiverse/utils/afio
 bin/archdetect						    utils/archdetect-deb
 """
-        file2pkg: dict[bytes, bytes] = {}
+        file2pkg: dict[str, str] = {}
         open_mock = unittest.mock.mock_open(read_data=contents)
         with unittest.mock.patch("gzip.open", open_mock):
             # pylint: disable-next=protected-access
@@ -246,18 +266,18 @@ bin/archdetect						    utils/archdetect-deb
         self.assertEqual(
             file2pkg,
             {
-                b":sexsend:sexget:": b"fex",
-                b"bin/afio": b"afio",
-                b"bin/archdetect": b"archdetect-deb",
+                ":sexsend:sexget:": "fex",
+                "bin/afio": "afio",
+                "bin/archdetect": "archdetect-deb",
             },
         )
-        open_mock.assert_called_once_with("/fake_Contents", "rb")
+        open_mock.assert_called_once_with("/fake_Contents", "rt")
 
     def test_contents_path_filering(self) -> None:
         """Test _update_given_file2pkg_mapping to ignore unrelevant files."""
         # Test content taken from
         # http://archive.ubuntu.com/ubuntu/dists/noble/Contents-amd64.gz
-        contents = b"""\
+        contents = """\
 bin/ip							    net/iproute2
 boot/ipxe.efi						    admin/grub-ipxe
 etc/dput.cf						    devel/dput
@@ -293,14 +313,14 @@ usr/src/broadcom-sta.tar.xz				    restricted/admin/broadcom-sta-source
 var/lib/ieee-data/iab.txt				    net/ieee-data
 """
 
-        file2pkg: dict[bytes, bytes] = {}
+        file2pkg: dict[str, str] = {}
         open_mock = unittest.mock.mock_open(read_data=contents)
         with unittest.mock.patch("gzip.open", open_mock):
             # pylint: disable-next=protected-access
             impl._update_given_file2pkg_mapping(file2pkg, "Contents-amd64", "noble")
 
         self.assertEqual(
-            {k.decode(): v.decode() for k, v in file2pkg.items()},
+            file2pkg,
             {
                 "bin/ip": "iproute2",
                 "boot/ipxe.efi": "grub-ipxe",
@@ -321,7 +341,7 @@ var/lib/ieee-data/iab.txt				    net/ieee-data
                 "var/lib/ieee-data/iab.txt": "ieee-data",
             },
         )
-        open_mock.assert_called_once_with("Contents-amd64", "rb")
+        open_mock.assert_called_once_with("Contents-amd64", "rt")
 
     def test_contents_parse_path_with_spaces(self) -> None:
         """Test _update_given_file2pkg_mapping to parse Contents file correctly."""
@@ -334,21 +354,21 @@ var/lib/ieee-data/iab.txt				    net/ieee-data
             "/__init__.py universe/python/ilorest\n"
         )
 
-        file2pkg: dict[bytes, bytes] = {}
-        open_mock = unittest.mock.mock_open(read_data=contents.encode())
+        file2pkg: dict[str, str] = {}
+        open_mock = unittest.mock.mock_open(read_data=contents)
         with unittest.mock.patch("gzip.open", open_mock):
             # pylint: disable-next=protected-access
             impl._update_given_file2pkg_mapping(file2pkg, "Contents-amd64", "noble")
 
         self.assertEqual(
-            {k.decode(): v.decode() for k, v in file2pkg.items()},
+            file2pkg,
             {
                 "usr/lib/iannix/Tools/JavaScript Library.js": "iannix",
                 "usr/lib/python3/dist-packages/ilorest/extensions/BIOS COMMANDS"
                 "/__init__.py": "ilorest",
             },
         )
-        open_mock.assert_called_once_with("Contents-amd64", "rb")
+        open_mock.assert_called_once_with("Contents-amd64", "rt")
 
 
 class TestPackaging(unittest.TestCase):

--- a/tests/unit/test_packaging_apt_dpkg.py
+++ b/tests/unit/test_packaging_apt_dpkg.py
@@ -9,6 +9,8 @@
 
 """Unit tests for apport.packaging_impl.apt_dpkg."""
 
+import pathlib
+import pickle
 import tempfile
 import unittest
 import unittest.mock
@@ -194,9 +196,9 @@ Components: main
         """get_file_package() on uninstalled usrmerge packages."""
         # Data from Ubuntu 24.04 (noble)
         _get_file2pkg_mapping_mock.return_value = {
-            b"usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2": b"libc6",
-            b"usr/lib/x86_64-linux-gnu/libc.so.6": b"libc6",
-            b"usr/libx32/libc.so.6": b"libc6-x32",
+            "usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2": "libc6",
+            "usr/lib/x86_64-linux-gnu/libc.so.6": "libc6",
+            "usr/libx32/libc.so.6": "libc6-x32",
         }
 
         pkg = impl.get_file_package(
@@ -208,11 +210,29 @@ Components: main
             "/map_cachedir", impl.get_distro_codename(), "amd64"
         )
 
+    def test_contents_mapping_load_legacy_resolute(self) -> None:
+        """Test _contents_mapping() discarding cache file from Apport 2.34.0."""
+        with tempfile.TemporaryDirectory() as workdir:
+            legacy_file2pkg = {
+                b"release": b"resolute",
+                b"arch": b"amd64",
+                b"path/to/file": b"package1",
+            }
+            mapping_path = (
+                pathlib.Path(workdir) / "contents_mapping-resolute-amd64.pickle"
+            )
+            with mapping_path.open("wb") as mapping_file:
+                pickle.dump(legacy_file2pkg, mapping_file)
+
+            # pylint: disable-next=protected-access
+            file2pkg = impl._contents_mapping(workdir, "resolute", "amd64")
+            self.assertEqual(file2pkg, {"release": "resolute", "arch": "amd64"})
+
     def test_contents_skip_xenial_header(self) -> None:
         """Test _update_given_file2pkg_mapping skipping xenial Contents header."""
         # Header taken from
         # http://archive.ubuntu.com/ubuntu/dists/xenial/Contents-amd64.gz
-        contents = b"""\
+        contents = """\
 This file maps each file available in the Ubuntu
 system to the package from which it originates.  It includes packages
 from the DIST distribution for the ARCH architecture.
@@ -249,7 +269,7 @@ FILE                                                    LOCATION
 bin/afio						    multiverse/utils/afio
 bin/archdetect						    utils/archdetect-deb
 """
-        file2pkg: dict[bytes, bytes] = {}
+        file2pkg: dict[str, str] = {}
         open_mock = unittest.mock.mock_open(read_data=contents)
         with unittest.mock.patch("gzip.open", open_mock):
             # pylint: disable-next=protected-access
@@ -258,18 +278,18 @@ bin/archdetect						    utils/archdetect-deb
         self.assertEqual(
             file2pkg,
             {
-                b":sexsend:sexget:": b"fex",
-                b"bin/afio": b"afio",
-                b"bin/archdetect": b"archdetect-deb",
+                ":sexsend:sexget:": "fex",
+                "bin/afio": "afio",
+                "bin/archdetect": "archdetect-deb",
             },
         )
-        open_mock.assert_called_once_with("/fake_Contents", "rb")
+        open_mock.assert_called_once_with("/fake_Contents", "rt")
 
     def test_contents_path_filering(self) -> None:
         """Test _update_given_file2pkg_mapping to ignore unrelevant files."""
         # Test content taken from
         # http://archive.ubuntu.com/ubuntu/dists/noble/Contents-amd64.gz
-        contents = b"""\
+        contents = """\
 bin/ip							    net/iproute2
 boot/ipxe.efi						    admin/grub-ipxe
 etc/dput.cf						    devel/dput
@@ -305,14 +325,14 @@ usr/src/broadcom-sta.tar.xz				    restricted/admin/broadcom-sta-source
 var/lib/ieee-data/iab.txt				    net/ieee-data
 """
 
-        file2pkg: dict[bytes, bytes] = {}
+        file2pkg: dict[str, str] = {}
         open_mock = unittest.mock.mock_open(read_data=contents)
         with unittest.mock.patch("gzip.open", open_mock):
             # pylint: disable-next=protected-access
             impl._update_given_file2pkg_mapping(file2pkg, "Contents-amd64", "noble")
 
         self.assertEqual(
-            {k.decode(): v.decode() for k, v in file2pkg.items()},
+            file2pkg,
             {
                 "bin/ip": "iproute2",
                 "boot/ipxe.efi": "grub-ipxe",
@@ -333,7 +353,7 @@ var/lib/ieee-data/iab.txt				    net/ieee-data
                 "var/lib/ieee-data/iab.txt": "ieee-data",
             },
         )
-        open_mock.assert_called_once_with("Contents-amd64", "rb")
+        open_mock.assert_called_once_with("Contents-amd64", "rt")
 
     def test_contents_parse_path_with_spaces(self) -> None:
         """Test _update_given_file2pkg_mapping to parse Contents file correctly."""
@@ -346,21 +366,21 @@ var/lib/ieee-data/iab.txt				    net/ieee-data
             "/__init__.py universe/python/ilorest\n"
         )
 
-        file2pkg: dict[bytes, bytes] = {}
-        open_mock = unittest.mock.mock_open(read_data=contents.encode())
+        file2pkg: dict[str, str] = {}
+        open_mock = unittest.mock.mock_open(read_data=contents)
         with unittest.mock.patch("gzip.open", open_mock):
             # pylint: disable-next=protected-access
             impl._update_given_file2pkg_mapping(file2pkg, "Contents-amd64", "noble")
 
         self.assertEqual(
-            {k.decode(): v.decode() for k, v in file2pkg.items()},
+            file2pkg,
             {
                 "usr/lib/iannix/Tools/JavaScript Library.js": "iannix",
                 "usr/lib/python3/dist-packages/ilorest/extensions/BIOS COMMANDS"
                 "/__init__.py": "ilorest",
             },
         )
-        open_mock.assert_called_once_with("Contents-amd64", "rb")
+        open_mock.assert_called_once_with("Contents-amd64", "rt")
 
 
 class TestPackaging(unittest.TestCase):


### PR DESCRIPTION
Use `str` instead of `bytes` for the contents mapping. This speeds up the creation of the contents cache. On a Raspberry Pi 5 (running resolute) the creation time of a jammy contents mapping reduces by 16 % from 101 seconds to 85 seconds. The creation time on amd64 reduces by some percentage as well.