### PR TITLE
ui: add type hint for desktop_file

### DIFF
--- a/apport/ui.py
+++ b/apport/ui.py
@@ -1887,7 +1887,7 @@ class UserInterface:
         """
         assert self.report
         if "DesktopFile" in self.report and os.path.exists(self.report["DesktopFile"]):
-            desktop_file = self.report["DesktopFile"]
+            desktop_file: str | None = self.report["DesktopFile"]
         else:
             try:
                 desktop_file = apport.fileutils.find_package_desktopfile(


### PR DESCRIPTION
mypy will complain if `ProblemReport` will get type hints:

```
error: Incompatible types in assignment (expression has type "str | None", variable has type "str")  [assignment]
```