### PR TITLE
apport-unpack: fix mypy complaint in unpack_report_to_directory

### DIFF
--- a/bin/apport-unpack
+++ b/bin/apport-unpack
@@ -70,6 +70,7 @@ def unpack_report_to_directory(
             if isinstance(value, str):
                 key_file.write(value.encode("UTF-8"))
             else:
+                assert isinstance(value, bytes)
                 key_file.write(value)
     return missing_keys
 


### PR DESCRIPTION
mypy will complain if `ProblemReport` will get type hints:

```
error: Argument 1 to "write" of "BufferedWriter" has incompatible type "bytes | CompressedFile | CompressedValue | tuple[Any, ...]"; expected "Buffer"  [arg-type]
```

The problem report is loaded with `binary=True` or `binary=False`. In both cases this should result in the values to be either `str` or `bytes`. So add an `isinstance` assertion for that.