### PR TITLE
problem_report: add get_on_disk_size() to CompressedFile

### DIFF
--- a/problem_report.py
+++ b/problem_report.py
@@ -223,6 +223,10 @@ class CompressedFile:
         if hasattr(self, "_compressed_file"):
             self._compressed_file.close()
 
+    def get_on_disk_size(self) -> int:
+        """Return the size on disk."""
+        return os.fstat(self._compressed_file.fileno()).st_size
+
     def iter_compressed(self) -> Iterator[bytes]:
         """Iterate over the compressed content of the file in chunks."""
         while True:

--- a/tests/unit/test_problem_report.py
+++ b/tests/unit/test_problem_report.py
@@ -7,6 +7,7 @@ import email
 import io
 import locale
 import sys
+import tempfile
 import textwrap
 import time
 import unittest
@@ -904,6 +905,15 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
         assert compressed_value.compressed_value is not None
         base64_encoded = base64.b64encode(compressed_value.compressed_value)
         self.assertEqual(compressed_value.get_on_disk_size(), len(base64_encoded))
+
+    def test_compressed_file_get_on_disk_size(self) -> None:
+        """Test CompressedFile.get_on_disk_size()."""
+        with tempfile.NamedTemporaryFile() as gzip_file:
+            gzip_file.write(GZIP_BIN_DATA)
+            gzip_file.flush()
+            compressed_file = problem_report.CompressedFile(gzip_file.name)
+            self.assertTrue(compressed_file.is_readable())
+            self.assertEqual(compressed_file.get_on_disk_size(), len(GZIP_BIN_DATA))
 
 
 class TestEntryParser(unittest.TestCase):


### PR DESCRIPTION
`UserInterface.get_complete_size` and `UserInterface.get_reduced_size` need to determine the on-disk size of the problem report values. `CompressedFile` does not support `len()`.

Add a `get_on_disk_size()` method to `CompressedFile`.