### PR TITLE
general-hooks/generic: drop main code

### DIFF
--- a/data/general-hooks/generic.py
+++ b/data/general-hooks/generic.py
@@ -117,10 +117,3 @@ Do you want to continue the report process anyway?
     # log errors
     if report["ProblemType"] == "Crash":
         apport.hookutils.attach_journal_errors(report)
-
-
-if __name__ == "__main__":
-    r = ProblemReport()
-    add_info(r, apport.hook_ui.NoninteractiveHookUI())
-    for key, value in r.items():
-        print(f"{key}: {value}")

--- a/tests/integration/test_hooks.py
+++ b/tests/integration/test_hooks.py
@@ -14,12 +14,14 @@ import os
 import pathlib
 import shutil
 import subprocess
-import sys
 import tempfile
 import unittest
 
 import apport.fileutils
+import apport.hook_ui
 import apport.report
+from problem_report import ProblemReport
+from tests.helper import import_module_from_file
 from tests.paths import get_data_directory, local_test_environment
 
 
@@ -47,15 +49,12 @@ class T(unittest.TestCase):
         shutil.rmtree(self.workdir)
 
     def test_general_hook_generic(self) -> None:
-        """Test running general-hooks/generic.py."""
-        process = subprocess.run(
-            [sys.executable, str(self.data_dir / "general-hooks" / "generic.py")],
-            check=True,
-            env=self.env,
-            encoding="utf-8",
-            stdout=subprocess.PIPE,
+        """Test running add_info() from general-hooks/generic.py."""
+        generic_hook = import_module_from_file(
+            self.data_dir / "general-hooks" / "generic.py"
         )
-        self.assertIn("ProblemType: Crash", process.stdout)
+        report = ProblemReport()
+        generic_hook.add_info(report, apport.hook_ui.NoninteractiveHookUI())
 
     def test_package_hook_nologs(self) -> None:
         """package_hook without any log files."""


### PR DESCRIPTION
mypy will complain if `ProblemReport` will get type hints:

```
data/general-hooks/generic.py:126: error: If x = b'abc' then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x). Otherwise, decode the bytes  [str-bytes-safe]
```

This code in the generic general hook is only there for testing. Drop this code and test `add_info` directly.