### PR TITLE
report: use list comprehension to check for interpreters

### DIFF
--- a/apport/report.py
+++ b/apport/report.py
@@ -670,7 +670,7 @@ class Report(problem_report.ProblemReport):
         # check if we consider ExecutablePath an interpreter; we have to do
         # this, otherwise 'gedit /tmp/foo.txt' would be detected as interpreted
         # script as well
-        if not any(filter(lambda i: fnmatch.fnmatch(exebasename, i), interpreters)):
+        if not any(fnmatch.fnmatch(exebasename, i) for i in interpreters):
             return
 
         # first, determine process name


### PR DESCRIPTION
mypy will complain if `ProblemReport` will get type hints:

```
error: Argument 1 to "filter" has incompatible type "Callable[[Any], bool]"; expected "Callable[[str], TypeGuard[object]]"  [arg-type]
error: Value of type variable "AnyStr" of "fnmatch" cannot be "object"  [type-var]
```

Use a list comprehension instead to make mypy happy and the code more readable.