### PR TITLE
problem_report: assert correct value type in _write_ascii_item

### DIFF
--- a/problem_report.py
+++ b/problem_report.py
@@ -687,9 +687,10 @@ class ProblemReport(collections.UserDict):
 
     def _write_ascii_item(self, file: typing.IO[bytes], key: str) -> None:
         v = self.data[key]
+        assert not isinstance(v, (CompressedFile, CompressedValue))
 
         # if it's a tuple, we have a file reference; read the contents
-        if not isinstance(v, bytes | str):
+        if isinstance(v, tuple):
             if len(v) >= 3 and v[2] is not None:
                 limit = v[2]
             else:


### PR DESCRIPTION
mypy will complain if `ProblemReport` will get type hints:

```
error: Argument 1 to "len" has incompatible type "CompressedFile | CompressedValue | tuple[Any, ...]"; expected "Sized"  [arg-type]
error: Value of type "CompressedFile | CompressedValue | tuple[Any, ...]" is not indexable  [index]
```

`ProblemReport._write_ascii_item` is only called on ASCII keys. Those keys cannot have values of type `CompressedFile` or `CompressedValue` according to `_get_sorted_keys`.

So add a `isinstance` assertion to make mypy happy.