### PR TITLE
problem_report: add CompressedFile.write()

### DIFF
--- a/problem_report.py
+++ b/problem_report.py
@@ -257,6 +257,10 @@ class CompressedFile:
         """Check if the compressed file is readable by the effective user."""
         return os.access(self.filename, os.R_OK, effective_ids=True)
 
+    def write(self, file: typing.IO[bytes]) -> None:
+        """Write uncompressed value into given file-like object."""
+        file.writelines(_decode_compressed_stream(self.iter_compressed()))
+
 
 class CompressedValue:
     """Represent a ProblemReport value which is gzip or zstandard compressed.

--- a/tests/unit/test_problem_report.py
+++ b/tests/unit/test_problem_report.py
@@ -10,6 +10,7 @@ import io
 import json
 import locale
 import sys
+import tempfile
 import textwrap
 import time
 import unittest
@@ -346,6 +347,26 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
             b"fake core dump data for testing purposes"
             b" which is long enough to be compressed\n",
         )
+
+    @unittest.skipUnless(zstandard, "zstandard Python module not available")
+    def test_writing_zstd_compressed_file(self) -> None:
+        """Test writing zstd-compressed CompressedFile."""
+        with tempfile.NamedTemporaryFile() as temp:
+            temp.write(
+                base64.b64decode(
+                    b"KLUv/SRCvQEAIsQMEMC3AbLcS0WaZ8rvf69jyw3ghpXr6pBr5i7HiCKroc60"
+                    b"3+tB4rC/4TV1osHyJUXme6IIAD6PTiM="
+                )
+            )
+            temp.flush()
+            compressed_file = problem_report.CompressedFile(temp.name)
+
+            output = io.BytesIO()
+            compressed_file.write(output)
+            self.assertEqual(
+                output.getvalue(),
+                b"Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam\n",
+            )
 
     @unittest.skipUnless(zstandard, "zstandard Python module not available")
     def test_writing_zstd_compressed_value(self) -> None:


### PR DESCRIPTION
Add a `CompressedFile.write()` method to support this problem report value type in `Report.add_kernel_crash_info()`.