### PR TITLE
report: get value for VmCore only once

### DIFF
--- a/apport/report.py
+++ b/apport/report.py
@@ -971,13 +971,14 @@ class Report(problem_report.ProblemReport):
 
         This needs a VmCore in the Report.
         """
-        if "VmCore" not in self:
+        vm_core = self.get("VmCore")
+        if vm_core is None:
             return False
         with tempfile.NamedTemporaryFile(prefix="apport_vmcore_") as core:
-            if hasattr(self["VmCore"], "write"):
-                self["VmCore"].write(core)
+            if hasattr(vm_core, "write"):
+                vm_core.write(core)
             else:
-                core.write(self["VmCore"])
+                core.write(vm_core)
             core.flush()
 
             kver = self["Uname"].split()[1]


### PR DESCRIPTION
Ease mypy to determine the type of `self["VmCore"]` by getting the value of `VmCore` only once and store it in a `vm_core` variable.