### PR TITLE
Check type of ErrorMessage value to be a string

### DIFF
--- a/apport/report.py
+++ b/apport/report.py
@@ -1620,8 +1620,9 @@ class Report(problem_report.ProblemReport):
         # package problem
         if self.get("ProblemType") == "Package" and "Package" in self:
             title = f"package {self['Package']} failed to install/upgrade"
-            if self.get("ErrorMessage"):
-                title += ": " + self["ErrorMessage"].splitlines()[-1]
+            error_message = self.get("ErrorMessage")
+            if error_message and isinstance(error_message, str):
+                title += ": " + error_message.splitlines()[-1]
 
             return title
 

--- a/data/general-hooks/generic.py
+++ b/data/general-hooks/generic.py
@@ -104,8 +104,10 @@ Do you want to continue the report process anyway?
             " which the crashed program expected to use."
         )
     # filter out package install failures due to a segfault
+    error_message = report.get("ErrorMessage")
     if (
-        "Segmentation fault" in report.get("ErrorMessage", "")
+        isinstance(error_message, str)
+        and "Segmentation fault" in error_message
         and report["ProblemType"] == "Package"
     ):
         report["UnreportableReason"] = (


### PR DESCRIPTION
mypy will complain about the value of `ErrorMessage` if `ProblemReport` will get type hints. `data/package_hook` might set the value of `ErrorMessage` to an tuple.

Therefore check that the value for `ErrorMessage` is a string before operating on it.