### PR TITLE
test: replace SKIP_ONLINE_TESTS by requires_internet marker

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -162,8 +162,8 @@ jobs:
       - uses: actions/checkout@v6
       - name: Run all tests (to check if they are skipped or succeed)
         run: >
-          SKIP_ONLINE_TESTS=1 python3 -m pytest -v -ra --cov=$(pwd)
-          --cov-report=xml --durations=0 tests/
+          python3 -m pytest -v -ra --cov=$(pwd)
+          --cov-report=xml --durations=0 -m "not requires_internet" tests/
       - name: Upload coverage
         uses: actions/upload-artifact@v7
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,9 @@ score = false
 
 [tool.pytest.ini_options]
 addopts = "--cov-branch"
+markers = [
+    "requires_internet: marks tests that require internet connection (deselect with '-m \"not requires_internet\"')",
+]
 
 [tool.ruff]
 include = [

--- a/tests/README.md
+++ b/tests/README.md
@@ -51,8 +51,8 @@ The [system directory](./system) contains system tests. It also contains
 integration tests that need special environment setup or have a long execution
 time. The GTK and KDE UI integration tests need a window system, which can be
 provided by `xvfb-run`. Some integration tests query https://launchpad.net/.
-These tests can be skipped by setting the environment variable
-`SKIP_ONLINE_TESTS` to something non empty. The test in
+These tests can be filtered out with the pytest marker expression
+`-m "not requires_internet"`. The test in
 [test_python_crashes.py](./system/test_python_crashes.py) need a running D-Bus
 daemon. Whit a D-Bus daemon running, the system tests can be run from the top
 directory by calling:

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -1,7 +1,6 @@
 """Helper functions for the test cases."""
 
 import contextlib
-import functools
 import importlib.machinery
 import importlib.util
 import os
@@ -10,8 +9,6 @@ import shutil
 import subprocess
 import time
 import unittest.mock
-import urllib.error
-import urllib.request
 from collections.abc import Callable, Generator, Iterator, Sequence, Set
 from typing import Any
 from unittest.mock import MagicMock
@@ -31,24 +28,6 @@ def get_init_system() -> str:
     """Return the name of the running init system (PID 1)."""
     with open("/proc/1/comm", encoding="utf-8") as comm:
         return comm.read().rstrip()
-
-
-@functools.lru_cache(maxsize=1)
-def has_internet() -> bool:
-    """Return if there is sufficient network connection for the tests.
-
-    This checks if https://api.launchpad.net/devel/ubuntu/ can be downloaded
-    from, to check if we can run the online tests.
-    """
-    if os.environ.get("SKIP_ONLINE_TESTS"):
-        return False
-    try:
-        with urllib.request.urlopen(
-            "https://api.launchpad.net/devel/ubuntu/", timeout=30
-        ) as url:
-            return b"web_link" in url.readline()
-    except urllib.error.URLError:
-        return False
 
 
 def import_module_from_file(path: pathlib.Path) -> Any:

--- a/tests/integration/test_crashdb_launchpad.py
+++ b/tests/integration/test_crashdb_launchpad.py
@@ -25,6 +25,8 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock
 
+import pytest
+
 try:
     from launchpadlib.errors import HTTPError
 
@@ -58,6 +60,7 @@ def cache(func: Callable) -> Callable:
     return try_to_get_from_cache
 
 
+@pytest.mark.requires_internet
 @unittest.skipIf(IMPORT_ERROR, f"Python module not available: {IMPORT_ERROR}")
 @unittest.skipUnless(
     "TEST_LAUNCHPAD" in os.environ,

--- a/tests/system/test_apport_retrace.py
+++ b/tests/system/test_apport_retrace.py
@@ -14,7 +14,6 @@ import pytest
 
 from apport.packaging_impl.apt_dpkg import impl
 from apport.report import Report
-from tests.helper import has_internet
 from tests.paths import get_test_data_directory, local_test_environment
 
 CODENAME_DISTRO_RELEASE_MAP = {"jammy": "Ubuntu 22.04"}
@@ -195,7 +194,7 @@ def _assert_cache_has_content(
     assert list((aptroot / "var/cache/apt/archives").iterdir())
 
 
-@pytest.mark.skipif(not has_internet(), reason="online test")
+@pytest.mark.requires_internet
 @pytest.mark.skipif(
     impl.get_system_architecture() == "s390x",
     reason="GDB has issues with divide-by-zero on s390x (LP: #2075204)",
@@ -224,7 +223,7 @@ def test_retrace_system_sandbox(
     _assert_divide_by_zero_retrace(report)
 
 
-@pytest.mark.skipif(not has_internet(), reason="online test")
+@pytest.mark.requires_internet
 @pytest.mark.skipif(
     impl.get_system_architecture() == "amd64",
     reason="GDB sandbox is only available on amd64",
@@ -252,7 +251,7 @@ def test_retrace_system_sandbox_gdb_sandbox_nonamd64(
     assert "gdb sandboxes are only implemented for amd64 hosts" in ret.stderr
 
 
-@pytest.mark.skipif(not has_internet(), reason="online test")
+@pytest.mark.requires_internet
 @pytest.mark.skipif(
     impl.get_system_architecture() != "amd64",
     reason="Testing the GDB sandbox erroring out on non-AMD64",
@@ -282,7 +281,7 @@ def test_retrace_system_sandbox_gdb_sandbox(
     _assert_divide_by_zero_retrace(report)
 
 
-@pytest.mark.skipif(not has_internet(), reason="online test")
+@pytest.mark.requires_internet
 @pytest.mark.skipif(
     impl.get_system_architecture() != "amd64" and shutil.which("gdb-multiarch") is None,
     reason="gdb-multiarch is needed for proper retracing on foreign architectures",
@@ -315,7 +314,7 @@ def test_retrace_jammy_sandbox(
     _assert_cache_has_content(module_cachedir, "amd64", "jammy")
 
 
-@pytest.mark.skipif(not has_internet(), reason="online test")
+@pytest.mark.requires_internet
 @pytest.mark.skipif(
     impl.get_system_architecture() != "amd64",
     reason="GDB sandbox only available on amd64",

--- a/tests/system/test_apport_valgrind.py
+++ b/tests/system/test_apport_valgrind.py
@@ -15,6 +15,8 @@ import subprocess
 import tempfile
 import unittest
 
+import pytest
+
 from tests.helper import get_gnu_coreutils_cmd, skip_if_command_is_missing
 from tests.paths import local_test_environment
 
@@ -43,6 +45,7 @@ class TestApportValgrind(unittest.TestCase):
         shutil.rmtree(self.workdir)
         os.chdir(self.pwd)
 
+    @pytest.mark.requires_internet
     @unittest.skipIf(MEM_TOTAL_MiB < 2000, f"{MEM_TOTAL_MiB} MiB is not enough memory")
     def test_sandbox_cache_options(self) -> None:
         """apport-valgrind creates a user specified sandbox and cache"""

--- a/tests/system/test_github_query.py
+++ b/tests/system/test_github_query.py
@@ -3,6 +3,8 @@
 import unittest
 from unittest.mock import Mock
 
+import pytest
+
 import apport.crashdb_impl.github
 
 SOME_ID = "a654870577ad2a2ab5b1"
@@ -18,6 +20,7 @@ class TestGitHubQuery(unittest.TestCase):
             self.crashdb.app_id, self.message_cb
         )
 
+    @pytest.mark.requires_internet
     def test_api_authentication(self) -> None:
         """Test if we can contact Github authentication service."""
         with self.github as github:

--- a/tests/system/test_packaging_apt_dpkg.py
+++ b/tests/system/test_packaging_apt_dpkg.py
@@ -17,7 +17,6 @@ import apt_pkg
 import pytest
 
 from apport.packaging_impl.apt_dpkg import _parse_deb822_sources, impl
-from tests.helper import has_internet
 from tests.paths import get_test_data_directory
 
 if shutil.which("dpkg") is None:
@@ -75,7 +74,7 @@ def reset_impl() -> Iterator[None]:
     impl.configuration = orig_conf
 
 
-@pytest.mark.skipif(not has_internet(), reason="online test")
+@pytest.mark.requires_internet
 def test_install_packages_versioned(
     configdir: str, cachedir: str, rootdir: str, apt_style: AptStyle
 ) -> None:
@@ -217,7 +216,7 @@ def test_install_packages_versioned(
     assert os.path.exists(os.path.join(rootdir, "usr/bin/dpkg"))
 
 
-@pytest.mark.skipif(not has_internet(), reason="online test")
+@pytest.mark.requires_internet
 def test_install_packages_unversioned(
     configdir: str, cachedir: str, rootdir: str, apt_style: AptStyle
 ) -> None:
@@ -267,7 +266,7 @@ def test_install_packages_unversioned(
     assert len(pkglist), str(pkglist) == 3
 
 
-@pytest.mark.skipif(not has_internet(), reason="online test")
+@pytest.mark.requires_internet
 def test_install_packages_dependencies(
     configdir: str, rootdir: str, apt_style: AptStyle
 ) -> None:
@@ -294,7 +293,7 @@ def test_install_packages_dependencies(
     assert "libc6" not in result
 
 
-@pytest.mark.skipif(not has_internet(), reason="online test")
+@pytest.mark.requires_internet
 def test_install_packages_system(
     cachedir: str, workdir: str, rootdir: str, apt_style: AptStyle
 ) -> None:
@@ -347,7 +346,7 @@ def test_install_packages_system(
         assert os.path.exists(os.path.join(rootdir, "usr/bin/gzip"))
 
 
-@pytest.mark.skipif(not has_internet(), reason="online test")
+@pytest.mark.requires_internet
 def test_install_packages_error(
     configdir: str, cachedir: str, rootdir: str, apt_style: AptStyle
 ) -> None:
@@ -381,7 +380,7 @@ def test_install_packages_error(
     )
 
 
-@pytest.mark.skipif(not has_internet(), reason="online test")
+@pytest.mark.requires_internet
 def test_install_packages_permanent_sandbox(
     configdir: str, cachedir: str, rootdir: str, apt_style: AptStyle
 ) -> None:
@@ -490,7 +489,7 @@ def test_install_packages_permanent_sandbox(
     apt_pkg.config.set("Acquire::http::Proxy", orig_apt_proxy)
 
 
-@pytest.mark.skipif(not has_internet(), reason="online test")
+@pytest.mark.requires_internet
 def test_install_packages_permanent_sandbox_repack(
     configdir: str, cachedir: str, rootdir: str, apt_style: AptStyle
 ) -> None:
@@ -532,7 +531,7 @@ def test_install_packages_permanent_sandbox_repack(
     assert os.readlink(curl_library) == "libcurl-gnutls.so"
 
 
-@pytest.mark.skipif(not has_internet(), reason="online test")
+@pytest.mark.requires_internet
 @pytest.mark.skipif(
     impl.get_system_architecture() == "armhf", reason="native armhf architecture"
 )
@@ -570,7 +569,7 @@ def test_install_packages_armhf(
     assert f"libc6_{got_version}_armhf.deb" in cache
 
 
-@pytest.mark.skipif(not has_internet(), reason="online test")
+@pytest.mark.requires_internet
 def test_install_packages_from_launchpad(
     configdir: str, cachedir: str, rootdir: str, apt_style: AptStyle
 ) -> None:
@@ -634,7 +633,7 @@ def test_install_packages_from_launchpad(
     assert ("qemu-utils-dbgsym", _strip_epoch(wanted["qemu-utils"])) in cache_versions
 
 
-@pytest.mark.skipif(not has_internet(), reason="online test")
+@pytest.mark.requires_internet
 def test_install_old_packages(
     configdir: str, cachedir: str, rootdir: str, apt_style: AptStyle
 ) -> None:
@@ -678,7 +677,7 @@ def test_install_old_packages(
     assert f"{wanted_package} {wanted_version}" in pkglist
 
 
-@pytest.mark.skipif(not has_internet(), reason="online test")
+@pytest.mark.requires_internet
 def test_get_source_tree_sandbox(
     configdir: str, workdir: str, rootdir: str, apt_style: AptStyle
 ) -> None:
@@ -697,7 +696,7 @@ def test_get_source_tree_sandbox(
     assert res.endswith("/base-files-12ubuntu4")
 
 
-@pytest.mark.skipif(not has_internet(), reason="online test")
+@pytest.mark.requires_internet
 def test_get_source_tree_lp_sandbox(
     configdir: str, workdir: str, rootdir: str, apt_style: AptStyle
 ) -> None:
@@ -721,7 +720,7 @@ def test_get_source_tree_lp_sandbox(
     assert res.endswith(f"/{wanted_package}-{upstream_version}")
 
 
-@pytest.mark.skipif(not has_internet(), reason="online test")
+@pytest.mark.requires_internet
 def test_create_sources_for_a_named_ppa(
     configdir: str, rootdir: str, apt_style: AptStyle
 ) -> None:
@@ -760,7 +759,7 @@ def test_create_sources_for_a_named_ppa(
     assert expected_key == actual_key
 
 
-@pytest.mark.skipif(not has_internet(), reason="online test")
+@pytest.mark.requires_internet
 def test_create_sources_for_an_unnamed_ppa(
     configdir: str, rootdir: str, apt_style: AptStyle
 ) -> None:
@@ -844,7 +843,7 @@ def test_use_sources_for_a_ppa(
         ]
 
 
-@pytest.mark.skipif(not has_internet(), reason="online test")
+@pytest.mark.requires_internet
 def test_install_package_from_a_ppa(
     configdir: str, cachedir: str, rootdir: str, apt_style: AptStyle
 ) -> None:


### PR DESCRIPTION
Replace the use of `has_internet()` by a pytest marker, called `requires_internet`. All tests that require Internet access can now be easily skipped with `pytest -m 'not requires_internet'`.

This PR depends on https://github.com/canonical/apport/pull/621.