### PR TITLE
test: skip system tests if divide-by-zero is not present

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -160,7 +160,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Run all tests (to check if they are skipped or succeed)
         run: >
-          SKIP_ONLINE_TESTS=1 python3 -m pytest -v -ra --cov=$(pwd)
+          python3 -m pytest -v -ra --cov=$(pwd)
           --cov-report=xml --durations=0 tests/
       - name: Upload coverage
         uses: actions/upload-artifact@v7

--- a/tests/system/test_apport_retrace.py
+++ b/tests/system/test_apport_retrace.py
@@ -38,7 +38,8 @@ def fixture_module_cachedir(module_workdir: pathlib.Path) -> pathlib.Path:
 def fixture_divide_by_zero_crash(module_workdir: pathlib.Path) -> str:
     """Generate a Report with a crash of divide-by-zero."""
     executable = "/usr/bin/divide-by-zero"
-    assert pathlib.Path(executable).exists()
+    if not pathlib.Path(executable).exists():
+        pytest.skip("divide-by-zero from chaos-marmosets not installed")
     core_path = module_workdir / "divide-by-zero.core"
     gdb = subprocess.run(
         [


### PR DESCRIPTION
Skip apport-retrace system tests in case `divide-by-zero` is not present in the system.