### PR TITLE
test: mark Internet requiring tests as such

### DIFF
--- a/tests/integration/test_crashdb_launchpad.py
+++ b/tests/integration/test_crashdb_launchpad.py
@@ -38,6 +38,7 @@ except ImportError as error:
 from apport.crashdb_impl.launchpad import CrashDatabase
 from apport.packaging_impl import impl as packaging
 from apport.report import Report
+from tests.helper import has_internet
 
 _CACHE = {}
 
@@ -58,6 +59,7 @@ def cache(func: Callable) -> Callable:
     return try_to_get_from_cache
 
 
+@unittest.skipIf(not has_internet(), reason="online test")
 @unittest.skipIf(IMPORT_ERROR, f"Python module not available: {IMPORT_ERROR}")
 @unittest.skipUnless(
     "TEST_LAUNCHPAD" in os.environ,

--- a/tests/system/test_apport_valgrind.py
+++ b/tests/system/test_apport_valgrind.py
@@ -15,7 +15,7 @@ import subprocess
 import tempfile
 import unittest
 
-from tests.helper import get_gnu_coreutils_cmd, skip_if_command_is_missing
+from tests.helper import get_gnu_coreutils_cmd, has_internet, skip_if_command_is_missing
 from tests.paths import local_test_environment
 
 with open("/proc/meminfo", encoding="utf-8") as f:
@@ -43,6 +43,7 @@ class TestApportValgrind(unittest.TestCase):
         shutil.rmtree(self.workdir)
         os.chdir(self.pwd)
 
+    @unittest.skipIf(not has_internet(), reason="online test")
     @unittest.skipIf(MEM_TOTAL_MiB < 2000, f"{MEM_TOTAL_MiB} MiB is not enough memory")
     def test_sandbox_cache_options(self) -> None:
         """apport-valgrind creates a user specified sandbox and cache"""

--- a/tests/system/test_github_query.py
+++ b/tests/system/test_github_query.py
@@ -4,6 +4,7 @@ import unittest
 from unittest.mock import Mock
 
 import apport.crashdb_impl.github
+from tests.helper import has_internet
 
 SOME_ID = "a654870577ad2a2ab5b1"
 
@@ -18,6 +19,7 @@ class TestGitHubQuery(unittest.TestCase):
             self.crashdb.app_id, self.message_cb
         )
 
+    @unittest.skipIf(not has_internet(), reason="online test")
     def test_api_authentication(self) -> None:
         """Test if we can contact Github authentication service."""
         with self.github as github:


### PR DESCRIPTION
Some tests require Internet access, but do not declare that:

* `test_crashdb_launchpad` accesses Launchpad
* apport-valgrind fetches debug packages from http://ddebs.ubuntu.com
* `test_api_authentication` accesses github.com