### PR TITLE
ci: fix branch coverage for *-installed tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -126,7 +126,7 @@ jobs:
       - name: Run unit and integration tests
         run: >
           WORKDIR=$(mktemp -d -t apport.XXXXXXXXXX)
-          && cp -r tests "$WORKDIR"
+          && cp -r tests pyproject.toml "$WORKDIR"
           && cd "$WORKDIR"
           && python3 -m pytest -v -ra --cov=$(pwd) --cov-report=xml
           --durations=0 tests/unit/ tests/integration/
@@ -250,7 +250,7 @@ jobs:
           GDK_BACKEND: x11
         run: >
           WORKDIR=$(mktemp -d -t apport.XXXXXXXXXX)
-          && cp -r tests "$WORKDIR"
+          && cp -r tests pyproject.toml "$WORKDIR"
           && cd "$WORKDIR"
           && sudo xvfb-run python3 -m pytest -v -ra --cov=$(pwd)
           --cov-report=xml --durations=0 tests/system/


### PR DESCRIPTION
The branch coverage setting is specified in `pyproject.toml`. The out-of-tree `*-installed` tests do not have access to this config and therefore lack the branch coverage setting.

So copy the `pyproject.toml` to the out-of-tree location as well.

Fixes: a65d62efdc95 ("test: set branch code coverage in pyproject.toml")