### PR TITLE
apt_dpkg: arm64 is available on http://archive.ubuntu.com since questing

### DIFF
--- a/apport/packaging_impl/apt_dpkg.py
+++ b/apport/packaging_impl/apt_dpkg.py
@@ -187,14 +187,22 @@ def _load_all_sources(apt_dir: str) -> list[Deb822SourceEntry | SourceEntry]:
     return sources
 
 
-def _map_mirror_to_arch(uri: str, target_arch: str) -> str:
+def _availabe_on_archive_ubuntu_com(arch: str, dist: str) -> bool:
+    """Check if arch plus dist is available on http://archive.ubuntu.com."""
+    if arch == "arm64":
+        # arm64 is available on http://archive.ubuntu.com starting from questing on
+        return dist not in {"trusty", "xenial", "bionic", "focal", "jammy", "noble"}
+    return arch in {"amd64", "i386"}
+
+
+def _map_mirror_to_arch(uri: str, target_arch: str, dist: str) -> str:
     """Map the givin archive mirror URI to a valid one for the givin architecture.
 
     The Ubuntu archive is split. The primary mirrors only has packages
     for the amd64 and i386 architectures. The ports mirrors host all
     remaining architectures.
     """
-    if target_arch in {"amd64", "i386"}:
+    if _availabe_on_archive_ubuntu_com(target_arch, dist):
         ports_match = re.match("http://([a-z.]*)ports.ubuntu.com/ubuntu-ports/?", uri)
         if ports_match:
             return f"http://{ports_match.group(1)}archive.ubuntu.com/ubuntu"
@@ -1613,7 +1621,7 @@ class _AptDpkgPackageInfo(PackageInfo):
             f" couldn't find configured source contains the `deb` type in {apt_dir}"
         )
 
-    def _get_mirror(self, arch: str) -> str:
+    def _get_mirror(self, arch: str, dist: str) -> str:
         """Return the distribution mirror URL.
 
         If it has not been set yet, it will be read from the system
@@ -1621,7 +1629,7 @@ class _AptDpkgPackageInfo(PackageInfo):
         """
         if not self._mirror:
             self._mirror = self._get_primary_mirror_from_apt_sources("/etc/apt")
-        return _map_mirror_to_arch(self._mirror, arch)
+        return _map_mirror_to_arch(self._mirror, arch, dist)
 
     def _ppa_archive_url(self, user: str, distro: str, ppa_name: str) -> str:
         return f"{self._launchpad_base}/~{user}/+archive/{distro}/{ppa_name}"
@@ -1642,7 +1650,7 @@ class _AptDpkgPackageInfo(PackageInfo):
         self, contents_filename: str, mtime: float | None, dist: str, arch: str
     ) -> bool:
         """Returns True on success (including when no update is needed)."""
-        url = f"{self._get_mirror(arch)}/dists/{dist}/Contents-{arch}.gz"
+        url = f"{self._get_mirror(arch, dist)}/dists/{dist}/Contents-{arch}.gz"
         if mtime:
             req = urllib.request.Request(url, method="HEAD")
             with contextlib.suppress(OSError):

--- a/tests/system/test_apport_retrace.py
+++ b/tests/system/test_apport_retrace.py
@@ -92,7 +92,7 @@ def setup_ubuntu_sandbox_config(
     sources_dir = config_release_dir / "sources.list.d"
     sources_file = sources_dir / "ubuntu.sources"
     # pylint: disable-next=protected-access
-    uri = impl._get_mirror(arch)
+    uri = impl._get_mirror(arch, release)
 
     sources_dir.mkdir(parents=True)
     codename_file.write_text(release)

--- a/tests/unit/test_packaging_apt_dpkg.py
+++ b/tests/unit/test_packaging_apt_dpkg.py
@@ -105,33 +105,48 @@ class TestPackagingAptDpkg(unittest.TestCase):
     def test_map_mirror_to_arch_ports_to_primary(self) -> None:
         """Test _map_mirror_to_arch() to map ports to primary."""
         self.assertEqual(
-            _map_mirror_to_arch("http://ports.ubuntu.com/ubuntu-ports/", "amd64"),
+            _map_mirror_to_arch(
+                "http://ports.ubuntu.com/ubuntu-ports/", "amd64", "resolute"
+            ),
             "http://archive.ubuntu.com/ubuntu",
         )
 
     def test_map_mirror_to_arch_country_ports_to_primary(self) -> None:
         """Test _map_mirror_to_arch() to map country ports to primary."""
         self.assertEqual(
-            _map_mirror_to_arch("http://de.ports.ubuntu.com/ubuntu-ports", "amd64"),
+            _map_mirror_to_arch(
+                "http://de.ports.ubuntu.com/ubuntu-ports", "amd64", "resolute"
+            ),
             "http://de.archive.ubuntu.com/ubuntu",
         )
 
     def test_map_mirror_to_arch_ports_unchanged(self) -> None:
         """Test _map_mirror_to_arch() to keep ports unchanged."""
         uri = "http://de.ports.ubuntu.com/ubuntu-ports"
-        self.assertEqual(_map_mirror_to_arch(uri, "ppc64el"), uri)
+        self.assertEqual(_map_mirror_to_arch(uri, "arm64", "noble"), uri)
 
     def test_map_mirror_to_arch_primary_to_ports(self) -> None:
         """Test _map_mirror_to_arch() to map primary to ports."""
         self.assertEqual(
-            _map_mirror_to_arch("http://de.archive.ubuntu.com/ubuntu/", "s390x"),
+            _map_mirror_to_arch(
+                "http://de.archive.ubuntu.com/ubuntu/", "s390x", "resolute"
+            ),
             "http://de.ports.ubuntu.com/ubuntu-ports",
         )
 
     def test_map_mirror_to_arch_primary_unchanged(self) -> None:
         """Test _map_mirror_to_arch() to keep ports unchanged."""
         uri = "http://de.archive.ubuntu.com/ubuntu"
-        self.assertEqual(_map_mirror_to_arch(uri, "amd64"), uri)
+        self.assertEqual(_map_mirror_to_arch(uri, "amd64", "resolute"), uri)
+
+    def test_map_mirror_to_arch_arm64_on_primary(self) -> None:
+        """Test _map_mirror_to_arch() for arm64 on archive.ubuntu.com since questing."""
+        self.assertEqual(
+            _map_mirror_to_arch(
+                "http://ports.ubuntu.com/ubuntu-ports/", "arm64", "resolute"
+            ),
+            "http://archive.ubuntu.com/ubuntu",
+        )
 
     @unittest.mock.patch(
         "builtins.open",


### PR DESCRIPTION
The arm64 package archive is available on archive.ubuntu.com since Ubuntu 25.10 "questing". So use this repository if available.

Bug: https://launchpad.net/bugs/2150685