### PR TITLE
ui: avoid crashing when restart command is unavailable

### DIFF
--- a/apport/ui.py
+++ b/apport/ui.py
@@ -1270,6 +1270,10 @@ class UserInterface:
 
         return self.ui_has_terminal()
 
+    def can_restart(self) -> bool:
+        """Return whether the crashed application can be restarted."""
+        return bool(self.offer_restart and self.report and "ProcCmdline" in self.report)
+
     def restart(self) -> None:
         """Reopen the crashed application."""
         assert self.report and "ProcCmdline" in self.report

--- a/gtk/apport-gtk
+++ b/gtk/apport-gtk
@@ -229,8 +229,9 @@ class GTKUserInterface(apport.ui.UserInterface):
         if report_type == "Hang" and self.offer_restart:
             self.w("ignore_future_problems").set_active(False)
             self.w("ignore_future_problems").hide()
-            self.w("relaunch_app").set_active(True)
-            self.w("relaunch_app").show()
+            if self.can_restart():
+                self.w("relaunch_app").set_active(True)
+                self.w("relaunch_app").show()
             self.w("subtitle_label").show()
             self.w("subtitle_label").set_label(
                 "You can wait to see if it wakes up, or close or relaunch it."
@@ -285,11 +286,7 @@ class GTKUserInterface(apport.ui.UserInterface):
 
                 pid = apport.ui.get_pid(self.report)
                 still_running = pid and apport.ui.still_running(pid)
-                if (
-                    "ProcCmdline" in self.report
-                    and not still_running
-                    and self.offer_restart
-                ):
+                if self.can_restart() and not still_running:
                     self.w("relaunch_app").set_active(True)
                     self.w("relaunch_app").show()
             else:
@@ -388,7 +385,7 @@ class GTKUserInterface(apport.ui.UserInterface):
             if (
                 self.w("relaunch_app").get_active()
                 and self.desktop_info
-                and self.offer_restart
+                and self.can_restart()
             ):
                 return_value.restart = True
 

--- a/kde/apport-kde
+++ b/kde/apport-kde
@@ -257,11 +257,7 @@ class ReportDialog(Dialog):  # pylint: disable=too-many-instance-attributes
 
                 pid = apport.ui.get_pid(report)
                 still_running = pid and apport.ui.still_running(pid)
-                if (
-                    "ProcCmdline" not in report
-                    or still_running
-                    or not self.ui.offer_restart
-                ):
+                if not self.ui.can_restart() or still_running:
                     self.closed_button.hide()
                     self.continue_button.setText(_("Continue"))
                 else:
@@ -437,7 +433,7 @@ class MainUserInterface(apport.ui.UserInterface):
             return return_value
 
         text = self.dialog.continue_button.text().replace("&", "")
-        if response == 1 and text == _("Relaunch") and self.offer_restart:
+        if response == 1 and text == _("Relaunch") and self.can_restart():
             return_value.restart = True
         if self.dialog.send_error_report.isChecked():
             return_value.report = True

--- a/tests/system/test_ui_gtk.py
+++ b/tests/system/test_ui_gtk.py
@@ -403,6 +403,46 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
         self.assertTrue(self.app.w("subtitle_label").get_property("visible"))
         self.assertFalse(self.app.w("ignore_future_problems").get_property("visible"))
 
+    def test_hang_layout_without_proc_cmdline(self) -> None:
+        """Hide the relaunch checkbox for hangs when ProcCmdline is missing.
+
+        Without a known command line we cannot restart the application, so the
+        UI must not offer "Relaunch this application" and must not request a
+        restart from ``UserInterface.restart()`` (which would fail its
+        ``"ProcCmdline" in self.report`` assertion). See LP: #956173 for the
+        equivalent fix on the regular crash branch.
+
+        +-----------------------------------------------------------------+
+        | [ apport ] The application Apport has stopped responding.       |
+        |            Send problem report to the developers?               |
+        |            You can wait to see if it wakes up, or close or      |
+        |            relaunch it.                                         |
+        |                                                                 |
+        |            [ ] Remember this in future                          |
+        |                                                                 |
+        | [ Show Details ]                      [ Don't send ]   [ Send ] |
+        +-----------------------------------------------------------------+
+        """
+        # pretend we got called through run_crashes() which sets offer_restart
+        self.app.offer_restart = True
+        self.app.report["ProblemType"] = "Hang"
+        # deliberately no ProcCmdline (e.g. stripped by a package hook)
+        self.app.report["Package"] = "apport 1.2.3~0ubuntu1"
+        with tempfile.NamedTemporaryFile(mode="w+") as fp:
+            fp.write(textwrap.dedent("""\
+                [Desktop Entry]
+                Version=1.0
+                Name=Apport
+                Type=Application
+                """))
+            fp.flush()
+            self.app.report["DesktopFile"] = fp.name
+            GLib.idle_add(Gtk.main_quit)
+            response = self.app.ui_present_report_details(True)
+        self.assertFalse(self.app.w("relaunch_app").get_property("visible"))
+        self.assertFalse(self.app.w("relaunch_app").get_active())
+        self.assertFalse(response.restart)
+
     def test_system_crash_layout(self) -> None:
         """Display crash dialog for a system application crash.
 

--- a/tests/unit/test_ui.py
+++ b/tests/unit/test_ui.py
@@ -8,6 +8,7 @@ import unittest.mock
 from gettext import gettext as _
 from unittest.mock import MagicMock
 
+import apport.report
 import apport.ui
 
 
@@ -49,6 +50,34 @@ class TestUI(unittest.TestCase):
     def tearDown(self) -> None:
         os.environ.clear()
         os.environ.update(self.orig_environ)
+
+    def test_can_restart_without_report(self) -> None:
+        """Do not allow restarting without a loaded report."""
+        self.ui.offer_restart = True
+
+        self.assertFalse(self.ui.can_restart())
+
+    def test_can_restart_requires_restart_offer(self) -> None:
+        """Do not allow restarting if the UI was not asked to offer it."""
+        self.ui.report = apport.report.Report()
+        self.ui.report["ProcCmdline"] = "example"
+
+        self.assertFalse(self.ui.can_restart())
+
+    def test_can_restart_requires_proc_cmdline(self) -> None:
+        """Do not allow restarting when ProcCmdline is missing."""
+        self.ui.offer_restart = True
+        self.ui.report = apport.report.Report()
+
+        self.assertFalse(self.ui.can_restart())
+
+    def test_can_restart_with_proc_cmdline_and_restart_offer(self) -> None:
+        """Allow restarting when the UI offers it and ProcCmdline is present."""
+        self.ui.offer_restart = True
+        self.ui.report = apport.report.Report()
+        self.ui.report["ProcCmdline"] = "example"
+
+        self.assertTrue(self.ui.can_restart())
 
     @unittest.mock.patch("subprocess.run")
     @unittest.mock.patch("webbrowser.open")


### PR DESCRIPTION
## Summary

Fix the GTK Hang dialog so it does not offer "Relaunch this application"
when the report has no `ProcCmdline`.

The regular crash dialog already has this guard, but the Hang-specific
path did not. If the checkbox was selected, apport later called
`UserInterface.restart()`, which asserts that `ProcCmdline` exists.

## Notes

`Report.add_proc_info()` normally sets `ProcCmdline`, but reports can still
lack it if the field is removed by hooks or if the report was generated
outside the normal collection path. In that case the UI should not offer a
restart.

## Changes

- Only show the GTK Hang relaunch checkbox when `ProcCmdline` is present.
- Also require `ProcCmdline` before setting `response.restart`.
- Add a GTK system test covering a Hang report without `ProcCmdline`.
- Keep `UserInterface.restart()`'s assertion unchanged.

## Test

- `python3 -m unittest tests.unit.test_ui`
- `python3 -m unittest tests.system.test_ui_gtk`
- `git diff --check`
