### PR TITLE
test: fix running tests as non-root system user

### DIFF
--- a/tests/integration/test_apport_checkreports.py
+++ b/tests/integration/test_apport_checkreports.py
@@ -16,7 +16,12 @@ import tempfile
 import unittest
 
 import apport.report
+from apport.fileutils import get_sys_uid_max
 from tests.paths import get_data_directory, local_test_environment
+
+
+def _is_system_user_but_not_root() -> bool:
+    return os.geteuid() != 0 and os.geteuid() <= get_sys_uid_max()
 
 
 class TestApportCheckreports(unittest.TestCase):
@@ -63,6 +68,7 @@ class TestApportCheckreports(unittest.TestCase):
         if user and os.geteuid() == 0:
             os.chown(path, 1000, -1)
 
+    @unittest.skipIf(_is_system_user_but_not_root(), "needs to run as root or user")
     def test_has_no_system_report(self) -> None:
         self._write_report("_bin_sleep.1000.crash")
         self._call(args=["--system"], expected_returncode=1)

--- a/tests/integration/test_fileutils.py
+++ b/tests/integration/test_fileutils.py
@@ -220,7 +220,7 @@ class T(unittest.TestCase):
         """get_all_system_reports() and get_new_system_reports()"""
         self.assertEqual(apport.fileutils.get_all_reports(), [])
         self.assertEqual(apport.fileutils.get_all_system_reports(), [])
-        if os.getuid() == 0:
+        if os.getuid() <= apport.fileutils.get_sys_uid_max():
             tr = self._create_reports(True)
             self.assertEqual(set(apport.fileutils.get_all_system_reports()), set(tr))
             self.assertEqual(set(apport.fileutils.get_new_system_reports()), set(tr))


### PR DESCRIPTION
sbuild with the unshare backend will run as system user (but not root). This causes these two tests to fail:

```
=================================== FAILURES ===================================
_______________ TestApportCheckreports.test_has_no_system_report _______________

self = <tests.integration.test_apport_checkreports.TestApportCheckreports testMethod=test_has_no_system_report>

    def test_has_no_system_report(self) -> None:
        self._write_report("_bin_sleep.1000.crash")
> self._call(args=["--system"], expected_returncode=1)

tests/integration/test_apport_checkreports.py:68:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests/integration/test_apport_checkreports.py:53: in _call
    self.assertEqual(process.returncode, expected_returncode)
E AssertionError: 0 != 1
__________________________ T.test_get_system_reports ___________________________

self = <tests.integration.test_fileutils.T testMethod=test_get_system_reports>

    def test_get_system_reports(self) -> None:
        """get_all_system_reports() and get_new_system_reports()"""
        self.assertEqual(apport.fileutils.get_all_reports(), [])
        self.assertEqual(apport.fileutils.get_all_system_reports(), [])
        if os.getuid() == 0:
            tr = self._create_reports(True)
            self.assertEqual(set(apport.fileutils.get_all_system_reports()), set(tr))
            self.assertEqual(set(apport.fileutils.get_new_system_reports()), set(tr))

            # now mark them as seen and check again
            for r in tr:
                apport.fileutils.mark_report_seen(r)

            self.assertEqual(set(apport.fileutils.get_all_system_reports()), set(tr))
            self.assertEqual(set(apport.fileutils.get_new_system_reports()), set([]))
        else:
            tr = [r for r in self._create_reports(True) if "inaccessible" not in r]
> self.assertEqual(set(apport.fileutils.get_all_system_reports()), set([]))
E AssertionError: Items in the first set but not the second:
E '/tmp/tmp0l5zfk3h/rep2.crash'
E '/tmp/tmp0l5zfk3h/inaccessible.crash'
E '/tmp/tmp0l5zfk3h/rep1.crash'

tests/integration/test_fileutils.py:236: AssertionError
=============================== warnings summary ===============================
```

Skip `test_has_no_system_report` in this case, because the test would require to call `os.chown(path, 1000, -1)` which will fail with an permission error.

Bug: https://launchpad.net/bugs/2153134