### PR TITLE
test: add type hint to _CACHE

### DIFF
--- a/tests/integration/test_crashdb_launchpad.py
+++ b/tests/integration/test_crashdb_launchpad.py
@@ -41,7 +41,7 @@ from apport.crashdb_impl.launchpad import CrashDatabase
 from apport.packaging_impl import impl as packaging
 from apport.report import Report
 
-_CACHE = {}
+_CACHE: dict[str, Callable] = {}
 
 
 def cache(func: Callable) -> Callable:


### PR DESCRIPTION
mypy 2.1.0 will complain:

```
tests/integration/test_crashdb_launchpad.py:42: error: Need type annotation for "_CACHE" (hint: "_CACHE: dict[<type>, <type>] = ...")  [var-annotated]
```

So add a type hint to `_CACHE`.