### PR TITLE
ci: ensure bash is updated for integration tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ env:
   kde_deps: procps pyqt6-dev-tools python3-pyqt6
   unit_deps: locales python3-systemd python3-zstandard
   integration_deps: >
-    binutils dpkg-dev gcc gdb kmod libc6-dev libglib2.0-dev libxml2-utils
+    bash binutils dpkg-dev gcc gdb kmod libc6-dev libglib2.0-dev libxml2-utils
     polkitd python3-systemd valgrind xterm
   system_deps: >
     chaos-marmosets dbus dbus-x11 dirmngr dpkg-dev gcc gdb gvfs-daemons psmisc


### PR DESCRIPTION
`get_package_origin("bash")` in `test_get_package_origin` might return `None` in case a version is installed that is not part of the archive any more.

Therefore ensure that `bash` is upgraded before running the integration tests. See also commit 9f68c5ff8e55 ("CI: Upgrade bash for integration tests").

Fixes: c6506e9856b9 ("ci: use environment variables for dependencies")