### PR TITLE
Fix ProcMaps bytes/str crash from trailing NULs

### DIFF
--- a/apport/report.py
+++ b/apport/report.py
@@ -1855,7 +1855,10 @@ class Report(problem_report.ProblemReport):
         """
         if "ProcMaps" not in self or "Stacktrace" not in self or "Signal" not in self:
             return None
-        if self["ProcMaps"].startswith("Error: "):
+        proc_maps = self["ProcMaps"]
+        if isinstance(proc_maps, bytes):
+            proc_maps = proc_maps.decode("UTF-8", errors="replace")
+        if proc_maps.startswith("Error: "):
             return None
 
         stack = []
@@ -2083,6 +2086,9 @@ class Report(problem_report.ProblemReport):
             return self._proc_maps_cache
 
         assert "ProcMaps" in self
+        proc_maps = self["ProcMaps"]
+        if isinstance(proc_maps, bytes):
+            proc_maps = proc_maps.decode("UTF-8", errors="replace")
         self._proc_maps_cache = []
         # library paths might have spaces, so we need to make some assumptions
         # about the intermediate fields. But we know that in between the
@@ -2092,7 +2098,7 @@ class Report(problem_report.ProblemReport):
         fmt = re.compile(r"^([0-9a-fA-F]+)-([0-9a-fA-F]+).*\s{2,}(\S.*$)")
         fmt_unknown = re.compile(r"^([0-9a-fA-F]+)-([0-9a-fA-F]+)\s")
 
-        for line in self["ProcMaps"].splitlines():
+        for line in proc_maps.splitlines():
             if not line.strip():
                 continue
             m = fmt.match(line)

--- a/apport/sandboxutils.py
+++ b/apport/sandboxutils.py
@@ -85,7 +85,10 @@ def needed_runtime_packages(report, pkgmap_cache_dir, pkg_versions, verbose=Fals
     pkgs = set()
     libs = set()
     if "ProcMaps" in report:
-        for line in report["ProcMaps"].splitlines():
+        proc_maps = report["ProcMaps"]
+        if isinstance(proc_maps, bytes):
+            proc_maps = proc_maps.decode("UTF-8", errors="replace")
+        for line in proc_maps.splitlines():
             if not line.strip():
                 continue
             cols = line.split()

--- a/data/general-hooks/generic.py
+++ b/data/general-hooks/generic.py
@@ -67,7 +67,10 @@ def add_info(report: ProblemReport, ui: apport.hook_ui.HookUI) -> None:
     # using local libraries?
     if "ProcMaps" in report:
         local_libs = set()
-        for lib in re.finditer(r"\s(/[^ ]+\.so[.0-9]*)$", report["ProcMaps"], re.M):
+        proc_maps = report["ProcMaps"]
+        if isinstance(proc_maps, bytes):
+            proc_maps = proc_maps.decode("UTF-8", errors="replace")
+        for lib in re.finditer(r"\s(/[^ ]+\.so[.0-9]*)$", proc_maps, re.M):
             if not apport.fileutils.likely_packaged(lib.group(1)):
                 local_libs.add(lib.group(1))
         if ui and local_libs:


### PR DESCRIPTION
Title: Root Cause Analysis and proposed fix for bytes/ProcMaps null-termination

We traced the apport TypeError to ProcMaps values being left as bytes when '\x00' is present. This happens because `_try_unicode()` in apport 2.33.1 for Ubuntu does not force decoding for certain keys; upstream apport has `_STRING_KEYS` which avoids this. I prepared a patch that either centralizes null-stripping in `ProblemReport._try_unicode()` or adds defensive decoding+null-stripping in the four locations that parse ProcMaps. Unit tests pass locally and I've exercised the change against representative systemd-coredump outputs. Patch: lp2146806-bytes-procmaps.patch

Proposed action:
- Attach patch and request review from apport maintainers.
- If accepted upstream, request SRU to the Ubuntu apport packages and link the SRU to this bug.

Patch location: /tmp/lp2146806-bytes-procmaps.patch

