### PR TITLE
ci: drop testing on Ubuntu 24.04 LTS "Noble Numbat"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,7 +72,7 @@ jobs:
           - ubuntu:resolute
         architecture:
           - ubuntu-latest
-          - ubuntu-24.04-arm
+          - ubuntu-26.04-arm
     container:
       image: ${{ matrix.container }}
       options: --cap-add=SYS_PTRACE --security-opt seccomp=unconfined
@@ -106,7 +106,7 @@ jobs:
           path: ./coverage*.xml
 
   unit-and-integration-installed:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     strategy:
       fail-fast: false
     steps:
@@ -185,7 +185,7 @@ jobs:
           - ubuntu:resolute
         architecture:
           - ubuntu-latest
-          - ubuntu-24.04-arm
+          - ubuntu-26.04-arm
     container:
       image: ${{ matrix.container }}
     steps:
@@ -218,7 +218,7 @@ jobs:
           path: ./coverage.xml
 
   system-installed:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     strategy:
       fail-fast: false
     steps:
@@ -270,7 +270,7 @@ jobs:
           - ubuntu:resolute
         architecture:
           - ubuntu-latest
-          - ubuntu-24.04-arm
+          - ubuntu-26.04-arm
     container:
       image: ${{ matrix.container }}
     steps:
@@ -323,7 +323,7 @@ jobs:
           path: ./coverage.xml
 
   system-internet-installed:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     strategy:
       fail-fast: false
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,7 +68,6 @@ jobs:
         container:
           - debian:stable-slim
           - debian:testing-slim
-          - ubuntu:noble
           - ubuntu:resolute
         architecture:
           - ubuntu-latest
@@ -150,7 +149,6 @@ jobs:
       fail-fast: false
       matrix:
         container:
-          - ubuntu:noble
           - ubuntu:resolute
     container:
       image: ${{ matrix.container }}
@@ -181,7 +179,6 @@ jobs:
       fail-fast: false
       matrix:
         container:
-          - ubuntu:noble
           - ubuntu:resolute
         architecture:
           - ubuntu-latest
@@ -266,7 +263,6 @@ jobs:
       fail-fast: false
       matrix:
         container:
-          - ubuntu:noble
           - ubuntu:resolute
         architecture:
           - ubuntu-latest


### PR DESCRIPTION
Ubuntu 26.04 LTS "Resolute Raccoon" is the latest Ubuntu LTS version. Since the main branch targets the Ubuntu development release, drop testing on Ubuntu 24.04 LTS "Noble Numbat".