### PR TITLE
test: use true from GNU coreutils in apport-valgrind tests

### DIFF
--- a/tests/integration/test_apport_valgrind.py
+++ b/tests/integration/test_apport_valgrind.py
@@ -83,7 +83,7 @@ class TestApportValgrind(unittest.TestCase):
 
     def test_vlog_created(self) -> None:
         """apport-valgrind creates valgrind.log with expected content."""
-        cmd = ["apport-valgrind", "--no-sandbox", "true"]
+        cmd = ["apport-valgrind", "--no-sandbox", get_gnu_coreutils_cmd("true")]
         os.chdir(self.workdir)
         self.assertEqual(self._call(cmd), (0, "", ""))
         self.assertTrue(


### PR DESCRIPTION
apport-valgrind fails on `true` from uutils:

```
_____________________ TestApportValgrind.test_vlog_created _____________________

self = <tests.integration.test_apport_valgrind.TestApportValgrind testMethod=test_vlog_created>

    def test_vlog_created(self) -> None:
        """apport-valgrind creates valgrind.log with expected content."""
        cmd = ["apport-valgrind", "--no-sandbox", "true"]
        os.chdir(self.workdir)
> self.assertEqual(self._call(cmd), (0, "", ""))
E AssertionError: Tuples differ: (0, '', "coreutils: unknown program 'memcheck-amd64-linux'\n") != (0, '', '')
E
E First differing element 2:
E "coreutils: unknown program 'memcheck-amd64-linux'\n"
E ''
E
E - (0, '', "coreutils: unknown program 'memcheck-amd64-linux'\n")
E + (0, '', '')

tests/integration/test_apport_valgrind.py:83: AssertionError
```

Use the GNU coreutils implementation for `true` to test with C code instead of the multi-call Rust binary.

Bug: https://launchpad.net/bugs/2158973