### PR TITLE
test: add riscv64 entry to archmap

### DIFF
--- a/tests/system/test_packaging_apt_dpkg.py
+++ b/tests/system/test_packaging_apt_dpkg.py
@@ -1054,6 +1054,7 @@ def assert_elf_arch(path: str, expected: str) -> None:
         "armhf": "ARM",
         "i386": "80386",
         "ppc64el": "PowerPC64",
+        "riscv64": "RISC-V",
         "s390x": "IBM S/390",
     }
 


### PR DESCRIPTION
The tests `test_install_packages_versioned` and
`test_install_packages_unversioned` fail in `assert_elf_arch` on riscv64:

```
>       assert archmap[expected] in machine
               ^^^^^^^^^^^^^^^^^
E       KeyError: 'riscv64'
```

Add `riscv64` to `archmap`.

Bug: https://launchpad.net/bugs/2159030