### PR TITLE
increase waiting timeout from 5/10 to 30 seconds

### DIFF
--- a/apport/crashdb_impl/github.py
+++ b/apport/crashdb_impl/github.py
@@ -47,7 +47,7 @@ class Github:
             url, data=data.encode("utf-8"), headers=headers, method="POST"
         )
         try:
-            with urllib.request.urlopen(request, timeout=5.0) as response:
+            with urllib.request.urlopen(request, timeout=30.0) as response:
                 return json.loads(response.read())
         except urllib.error.URLError:
             if self.message_callback:

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -15,6 +15,8 @@ from unittest.mock import MagicMock
 
 import psutil
 
+WAITING_TIMEOUT = 30.0
+
 
 def get_gnu_coreutils_cmd(cmd: str) -> str:
     """Determine path to GNU coreutils command."""
@@ -149,7 +151,7 @@ def wrap_object(
         yield mock
 
 
-def wait_for_sleeping_state(pid: int, timeout: float = 5.0) -> None:
+def wait_for_sleeping_state(pid: int, timeout: float = WAITING_TIMEOUT) -> None:
     """Wait for sleep command to enter sleeping state."""
     proc = psutil.Process(pid)
     waited = 0.0
@@ -169,7 +171,7 @@ def wait_for_sleeping_state(pid: int, timeout: float = 5.0) -> None:
 
 
 def wait_for_process_to_appear(
-    process: str, already_running: Set[int], timeout: float = 5.0
+    process: str, already_running: Set[int], timeout: float = WAITING_TIMEOUT
 ) -> int:
     """Wait for process to appear and return its PID."""
     waited = 0.0

--- a/tests/integration/test_recoverable_problem.py
+++ b/tests/integration/test_recoverable_problem.py
@@ -19,6 +19,7 @@ import unittest.mock
 from unittest.mock import MagicMock
 
 import apport.report
+from tests.helper import WAITING_TIMEOUT
 from tests.paths import get_data_directory, local_test_environment
 
 
@@ -34,7 +35,7 @@ class TestRecoverableProblem(unittest.TestCase):
 
     def _wait_for_report(self) -> str:
         seconds = 0.0
-        while seconds < 10:
+        while seconds < WAITING_TIMEOUT:
             crashes = os.listdir(self.report_dir)
             if crashes:
                 assert len(crashes) == 1
@@ -58,7 +59,7 @@ class TestRecoverableProblem(unittest.TestCase):
             self._wait_for_report()
         fail_mock.assert_called_once()
         sleep_mock.assert_called_with(0.1)
-        self.assertEqual(sleep_mock.call_count, 101)
+        self.assertEqual(sleep_mock.call_count, 300)
 
     def _call_recoverable_problem(self, data: str) -> None:
         cmd = [self.datadir / "recoverable_problem"]

--- a/tests/integration/test_report.py
+++ b/tests/integration/test_report.py
@@ -22,7 +22,11 @@ from unittest.mock import MagicMock
 import apport.packaging
 import apport.report
 import problem_report
-from tests.helper import get_gnu_coreutils_cmd, skip_if_command_is_missing
+from tests.helper import (
+    WAITING_TIMEOUT,
+    get_gnu_coreutils_cmd,
+    skip_if_command_is_missing,
+)
 from tests.paths import patch_data_dir, restore_data_dir
 
 
@@ -41,7 +45,9 @@ class T(unittest.TestCase):
     def tearDownClass(cls) -> None:
         restore_data_dir(apport.report, cls.orig_data_dir)
 
-    def wait_for_proc_cmdline(self, pid: int, timeout_sec: float = 10.0) -> None:
+    def wait_for_proc_cmdline(
+        self, pid: int, timeout_sec: float = WAITING_TIMEOUT
+    ) -> None:
         assert pid
         elapsed_time = 0.0
         while elapsed_time < timeout_sec:

--- a/tests/integration/test_signal_crashes.py
+++ b/tests/integration/test_signal_crashes.py
@@ -42,6 +42,7 @@ import pytest
 import apport.fileutils
 import apport.report
 from tests.helper import (
+    WAITING_TIMEOUT,
     get_gnu_coreutils_cmd,
     import_module_from_file,
     pidfd_open,
@@ -1355,7 +1356,7 @@ class T(unittest.TestCase):
         case of an failure or timeout, let the test case fail.
         """
         timeout = 0.0
-        while timeout < 5:
+        while timeout < WAITING_TIMEOUT:
             if os.path.exists(core_file):
                 break
             time.sleep(0.1)
@@ -1392,7 +1393,7 @@ class T(unittest.TestCase):
         with self.assertRaises(AssertionError):
             self.wait_for_core_file(123456789, "core")
         sleep_mock.assert_called_with(0.1)
-        self.assertEqual(sleep_mock.call_count, 51)
+        self.assertEqual(sleep_mock.call_count, 300)
 
     @unittest.mock.patch("os.path.exists")
     @unittest.mock.patch("psutil.Process", spec=psutil.Process)
@@ -1416,7 +1417,7 @@ class T(unittest.TestCase):
         """Wait until GDB execv()ed the child process."""
         gdb_process = psutil.Process(gdb_pid)
         timeout = 0.0
-        while timeout < 5:
+        while timeout < WAITING_TIMEOUT:
             gdb_children = gdb_process.children(recursive=True)
             for process in gdb_children:
                 try:
@@ -1472,4 +1473,4 @@ class T(unittest.TestCase):
             self.wait_for_gdb_child_process(123456789, self.TEST_EXECUTABLE)
         fail_mock.assert_called_once()
         sleep_mock.assert_called_with(0.1)
-        self.assertEqual(sleep_mock.call_count, 51)
+        self.assertEqual(sleep_mock.call_count, 300)

--- a/tests/integration/test_ui.py
+++ b/tests/integration/test_ui.py
@@ -966,9 +966,7 @@ class T(unittest.TestCase):
 
                 try:
                     pid = wait_for_process_to_appear(
-                        self.TEST_EXECUTABLE,
-                        self.running_test_executables,
-                        timeout=10.0,
+                        self.TEST_EXECUTABLE, self.running_test_executables
                     )
                     # generate crash report
                     r = apport.report.Report()

--- a/tests/system/test_signal_crashes.py
+++ b/tests/system/test_signal_crashes.py
@@ -19,6 +19,7 @@ import apport.fileutils
 import apport.report
 from apport.procutils import parse_meminfo
 from tests.helper import (
+    WAITING_TIMEOUT,
     get_gnu_coreutils_cmd,
     get_init_system,
     pids_of,
@@ -334,12 +335,12 @@ class T(unittest.TestCase):
 
         wait_sleep_mock.assert_not_called()
 
-    def wait_for_apport_to_finish(self, timeout_sec: float = 10.0) -> None:
+    def wait_for_apport_to_finish(self, timeout_sec: float = WAITING_TIMEOUT) -> None:
         assert self.apport_path is not None
         self.wait_for_no_instance_running(self.apport_path, timeout_sec)
 
     def wait_for_no_instance_running(
-        self, program: pathlib.Path | str, timeout_sec: float = 10.0
+        self, program: pathlib.Path | str, timeout_sec: float = WAITING_TIMEOUT
     ) -> None:
         while timeout_sec > 0:
             if not pids_of(str(program)) - self.running_test_executables:


### PR DESCRIPTION
Some tests run into the waiting timeout on the slow and emulated riscv64 architecture, for example:

```
=================================== FAILURES ===================================
__________________________ T.test_crash_system_slice ___________________________

self = <tests.system.test_signal_crashes.T testMethod=test_crash_system_slice>

    @unittest.skipIf(
        get_init_system() != "systemd", "running init system is not systemd"
    )
    @skip_if_command_is_missing("systemd-run")
    @unittest.skipIf(os.geteuid() != 0, "this test needs to be run as root")
    def test_crash_system_slice(self) -> None:
        """Report generation for a protected process running in the system
        slice"""
        apport.fileutils.report_dir = self.orig_report_dir
        self.test_report = os.path.join(
            apport.fileutils.report_dir,
            f"{self.TEST_EXECUTABLE.replace('/', '_')}.{os.getuid()}.crash",
        )

        system_run = self.create_test_process(
            command="/usr/bin/systemd-run",
            args=[
                "-t",
                "-q",
                "--slice=system.slice",
                "-p",
                "ProtectSystem=true",
                self.TEST_EXECUTABLE,
            ]
            + self.TEST_ARGS,
        )
        try:
            sleep_pid = wait_for_process_to_appear(
                self.TEST_EXECUTABLE, self.running_test_executables
            )
            wait_for_sleeping_state(sleep_pid)
            os.kill(sleep_pid, signal.SIGSEGV)

>           self.wait_for_no_instance_running(self.TEST_EXECUTABLE)

/tmp/autopkgtest.RQrDHF/autopkgtest_tmp/tests/system/test_signal_crashes.py:261:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
/tmp/autopkgtest.RQrDHF/autopkgtest_tmp/tests/system/test_signal_crashes.py:350: in wait_for_no_instance_running
    self.fail(f"Timeout exceeded, but {program} is still running.")
E   AssertionError: Timeout exceeded, but /usr/bin/gnusleep is still running.
```

So increase the waiting timeout from 5 and 10 seconds to 30 seconds.

There are multiple waiting functions but all have different conditions to wait for. Therefore is no easy way to unify them (while keeping them simple).

This PR should wait for https://github.com/canonical/apport/pull/640 to land.

Bug: https://launchpad.net/bugs/2159030