### PR TITLE
crashdb_impl: add type annotations to memory backend

### DIFF
--- a/apport/crashdb_impl/memory.py
+++ b/apport/crashdb_impl/memory.py
@@ -29,7 +29,6 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
 
         This class does not support bug patterns and authentication.
         """
-
         super().__init__(auth_file, options)
 
         # reports is a list of dictionaries with keys:

--- a/apport/crashdb_impl/memory.py
+++ b/apport/crashdb_impl/memory.py
@@ -201,7 +201,7 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
         return self.reports[crash_id]["dup_of"]
 
     def close_duplicate(
-        self, report: apport.report.Report, crash_id: int, master_id: int | None
+        self, report: Any, crash_id: int, master_id: int | None
     ) -> None:
         """Mark a crash id as duplicate of given master ID.
 

--- a/apport/crashdb_impl/memory.py
+++ b/apport/crashdb_impl/memory.py
@@ -10,6 +10,7 @@
 # the full text of the license.
 
 import time
+from collections.abc import Callable, Iterable
 from typing import Any
 
 import apport.crashdb
@@ -28,7 +29,8 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
 
         This class does not support bug patterns and authentication.
         """
-        apport.crashdb.CrashDatabase.__init__(self, auth_file, options)
+
+        super().__init__(auth_file, options)
 
         # reports is a list of dictionaries with keys:
         # report, fixed_version, dup_of, comment
@@ -36,13 +38,18 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
         self.unretraced: set[int] = set()
         self.dup_unchecked: set[int] = set()
 
-        self.upload_delay = 0.0
+        self.upload_delay: float = 0.0
         self.upload_msg: tuple[str, str] | None = None
 
         if "sample_data" in options:
             self.add_sample_data()
 
-    def upload(self, report, progress_callback=None, user_message_callback=None):
+    def upload(
+        self,
+        report: apport.report.Report,
+        progress_callback: Callable[[int, int], None] | None = None,
+        user_message_callback: Callable[[str, str], None] | None = None,
+    ) -> int:
         """Store the report and return a handle number (starting from 0).
 
         This does not support (nor need) progress callbacks.
@@ -71,7 +78,7 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
 
         return crash_id
 
-    def get_comment_url(self, report, handle):
+    def get_comment_url(self, report: apport.report.Report, handle: int | str) -> str:
         """Return http://<sourcepackage>.bugs.example.com/<handle> for package
         bugs or http://bugs.example.com/<handle> for reports without a
         SourcePackage.
@@ -80,7 +87,7 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
             return f"http://{report['SourcePackage']}.bugs.example.com/{handle}"
         return f"http://bugs.example.com/{handle}"
 
-    def get_id_url(self, report, crash_id):
+    def get_id_url(self, report: apport.report.Report, crash_id: int) -> str | None:
         """Return URL for a given report ID.
 
         The report is passed in case building the URL needs additional
@@ -90,7 +97,7 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
         """
         return self.get_comment_url(report, crash_id)
 
-    def download(self, crash_id):
+    def download(self, crash_id: int) -> apport.report.Report:
         """Download the problem report from given ID and return a Report."""
         return self.reports[crash_id]["report"]
 
@@ -115,13 +122,13 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
     # pylint: disable-next=too-many-arguments,too-many-positional-arguments
     def update(
         self,
-        crash_id,
-        report,
-        comment,
-        change_description=False,
-        attachment_comment=None,
-        key_filter=None,
-    ):
+        crash_id: int,
+        report: apport.report.Report,
+        comment: str,
+        change_description: bool = False,
+        attachment_comment: str | None = None,
+        key_filter: Iterable[str] | None = None,
+    ) -> None:
         """Update the given report ID with all data from report.
 
         This creates a text comment with the "short" data (see
@@ -194,7 +201,12 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
         """
         return self.reports[crash_id]["dup_of"]
 
-    def close_duplicate(self, report, crash_id, master_id):
+    def close_duplicate(
+        self,
+        report: apport.report.Report,
+        crash_id: int,
+        master_id: int | None,
+    ) -> None:
         """Mark a crash id as duplicate of given master ID.
 
         If master is None, id gets un-duplicated.
@@ -208,7 +220,7 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
         assert self.reports[master]["fixed_version"] is not None
         self.reports[crash_id]["comment"] = f"regression, already fixed in #{master}"
 
-    def _mark_dup_checked(self, crash_id, report):
+    def _mark_dup_checked(self, crash_id: int, report: apport.report.Report) -> None:
         """Mark crash id as checked for being a duplicate."""
         try:
             self.dup_unchecked.remove(crash_id)

--- a/apport/crashdb_impl/memory.py
+++ b/apport/crashdb_impl/memory.py
@@ -202,10 +202,7 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
         return self.reports[crash_id]["dup_of"]
 
     def close_duplicate(
-        self,
-        report: apport.report.Report,
-        crash_id: int,
-        master_id: int | None,
+        self, report: apport.report.Report, crash_id: int, master_id: int | None
     ) -> None:
         """Mark a crash id as duplicate of given master ID.
 

--- a/apport/crashdb_impl/memory.py
+++ b/apport/crashdb_impl/memory.py
@@ -10,10 +10,12 @@
 # the full text of the license.
 
 import time
+from collections.abc import Callable, Iterable
 from typing import Any
 
 import apport.crashdb
 import apport.report
+import problem_report
 
 
 class CrashDatabase(apport.crashdb.CrashDatabase):
@@ -36,13 +38,18 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
         self.unretraced: set[int] = set()
         self.dup_unchecked: set[int] = set()
 
-        self.upload_delay = 0.0
+        self.upload_delay: float = 0.0
         self.upload_msg: tuple[str, str] | None = None
 
         if "sample_data" in options:
             self.add_sample_data()
 
-    def upload(self, report, progress_callback=None, user_message_callback=None):
+    def upload(
+        self,
+        report: problem_report.ProblemReport,
+        progress_callback: Callable[[int, int], None] | None = None,
+        user_message_callback: Callable[[str, str], None] | None = None,
+    ) -> int:
         """Store the report and return a handle number (starting from 0).
 
         This does not support (nor need) progress callbacks.
@@ -71,7 +78,9 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
 
         return crash_id
 
-    def get_comment_url(self, report, handle):
+    def get_comment_url(
+        self, report: problem_report.ProblemReport, handle: int | str
+    ) -> str:
         """Return http://<sourcepackage>.bugs.example.com/<handle> for package
         bugs or http://bugs.example.com/<handle> for reports without a
         SourcePackage.
@@ -80,7 +89,7 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
             return f"http://{report['SourcePackage']}.bugs.example.com/{handle}"
         return f"http://bugs.example.com/{handle}"
 
-    def get_id_url(self, report, crash_id):
+    def get_id_url(self, report: problem_report.ProblemReport, crash_id: int) -> str:
         """Return URL for a given report ID.
 
         The report is passed in case building the URL needs additional
@@ -90,7 +99,7 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
         """
         return self.get_comment_url(report, crash_id)
 
-    def download(self, crash_id):
+    def download(self, crash_id: int) -> apport.report.Report:
         """Download the problem report from given ID and return a Report."""
         return self.reports[crash_id]["report"]
 
@@ -115,13 +124,13 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
     # pylint: disable-next=too-many-arguments,too-many-positional-arguments
     def update(
         self,
-        crash_id,
-        report,
-        comment,
-        change_description=False,
-        attachment_comment=None,
-        key_filter=None,
-    ):
+        crash_id: int,
+        report: problem_report.ProblemReport,
+        comment: str,
+        change_description: bool = False,
+        attachment_comment: str | None = None,
+        key_filter: Iterable[str] | None = None,
+    ) -> None:
         """Update the given report ID with all data from report.
 
         This creates a text comment with the "short" data (see
@@ -194,7 +203,9 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
         """
         return self.reports[crash_id]["dup_of"]
 
-    def close_duplicate(self, report, crash_id, master_id):
+    def close_duplicate(
+        self, report: Any, crash_id: int, master_id: int | None
+    ) -> None:
         """Mark a crash id as duplicate of given master ID.
 
         If master is None, id gets un-duplicated.
@@ -208,7 +219,9 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
         assert self.reports[master]["fixed_version"] is not None
         self.reports[crash_id]["comment"] = f"regression, already fixed in #{master}"
 
-    def _mark_dup_checked(self, crash_id, report):
+    def _mark_dup_checked(
+        self, crash_id: int, report: problem_report.ProblemReport
+    ) -> None:
         """Mark crash id as checked for being a duplicate."""
         try:
             self.dup_unchecked.remove(crash_id)

--- a/apport/crashdb_impl/memory.py
+++ b/apport/crashdb_impl/memory.py
@@ -30,7 +30,7 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
 
         This class does not support bug patterns and authentication.
         """
-        apport.crashdb.CrashDatabase.__init__(self, auth_file, options)
+        super().__init__(auth_file, options)
 
         # reports is a list of dictionaries with keys:
         # report, fixed_version, dup_of, comment


### PR DESCRIPTION
## Summary

This pull request adds type annotations to `apport/crashdb_impl/memory.py`.

### Changes

- Add type annotations throughout the module.
- Replace the explicit base class constructor call with `super()`.
- Minor formatting improvements.
- No functional behavior changes.

### Verification

I verified the changes with:

- `python -m py_compile apport/crashdb_impl/memory.py`
- `ruff check apport/crashdb_impl/memory.py`
- `black --check apport/crashdb_impl/memory.py`
- `mypy apport/crashdb_impl/memory.py`