### PR TITLE
problem_report: use iterator in CompressedValue.write

### DIFF
--- a/problem_report.py
+++ b/problem_report.py
@@ -150,6 +150,11 @@ def _decode_compressed_stream(entry: Iterator[bytes]) -> Iterator[bytes]:
         yield decompressor.decompress(block)
     yield decompressor.flush()
 
+    if not decompressor.eof:
+        raise EOFError(
+            "Compressed file ended before the end-of-stream marker was reached"
+        )
+
 
 def _derive_compression(name: str, value: bytes) -> tuple[str, str]:
     if value.startswith(GZIP_HEADER_START):

--- a/problem_report.py
+++ b/problem_report.py
@@ -137,15 +137,14 @@ def _decode_compressed_stream(entry: Iterator[bytes]) -> Iterator[bytes]:
     if block.startswith(ZSTANDARD_MAGIC_NUMBER):
         yield from _zstandard_decoder(entry, block)
         return
-    # skip gzip header, if present
     if block.startswith(GZIP_HEADER_START):
-        decompressor = zlib.decompressobj(-zlib.MAX_WBITS)
-        yield decompressor.decompress(_strip_gzip_header(block))
+        # Enable native gzip header & trailer processing
+        decompressor = zlib.decompressobj(16 + zlib.MAX_WBITS)
     else:
         # legacy zlib-only format used default block size
         decompressor = zlib.decompressobj()
-        yield decompressor.decompress(block)
 
+    yield decompressor.decompress(block)
     for block in entry:
         yield decompressor.decompress(block)
     yield decompressor.flush()
@@ -162,26 +161,6 @@ def _derive_compression(name: str, value: bytes) -> tuple[str, str]:
     if value.startswith(ZSTANDARD_MAGIC_NUMBER):
         return ("zstd", ".zst")
     raise ValueError(f"Unknown compression for {name}")
-
-
-def _strip_gzip_header(line: bytes) -> bytes:
-    """Strip gzip header from line and return the rest."""
-    flags = line[3]
-    offset = 10
-    if flags & 4:  # FLG.FEXTRA
-        offset += line[offset] + 1
-    if flags & 8:  # FLG.FNAME
-        while line[offset] != 0:
-            offset += 1
-        offset += 1
-    if flags & 16:  # FLG.FCOMMENT
-        while line[offset] != 0:
-            offset += 1
-        offset += 1
-    if flags & 2:  # FLG.FHCRC
-        offset += 2
-
-    return line[offset:]
 
 
 def _text_decoder(entry: Iterator[bytes], first_line: bytes) -> Iterator[bytes]:

--- a/problem_report.py
+++ b/problem_report.py
@@ -129,6 +129,28 @@ def _create_text_attachment(name: str, value: str) -> email.mime.base.MIMEBase:
     return attachment
 
 
+def _decode_compressed_stream(entry: Iterator[bytes]) -> Iterator[bytes]:
+    """Decode the given compressed value (iterator version)."""
+    block = next(entry, None)
+    if block is None:
+        return
+    if block.startswith(ZSTANDARD_MAGIC_NUMBER):
+        yield from _zstandard_decoder(entry, block)
+        return
+    # skip gzip header, if present
+    if block.startswith(GZIP_HEADER_START):
+        decompressor = zlib.decompressobj(-zlib.MAX_WBITS)
+        yield decompressor.decompress(_strip_gzip_header(block))
+    else:
+        # legacy zlib-only format used default block size
+        decompressor = zlib.decompressobj()
+        yield decompressor.decompress(block)
+
+    for block in entry:
+        yield decompressor.decompress(block)
+    yield decompressor.flush()
+
+
 def _derive_compression(name: str, value: bytes) -> tuple[str, str]:
     if value.startswith(GZIP_HEADER_START):
         return ("gzip", ".gz")
@@ -292,28 +314,6 @@ class CompressedValue:
         """
         return ((self.get_compressed_size() + 2) // 3) * 4
 
-    @staticmethod
-    def decode_compressed_stream(entry: Iterator[bytes]) -> Iterator[bytes]:
-        """Decode the given compressed value (iterator version)."""
-        block = next(entry, None)
-        if block is None:
-            return
-        if block.startswith(ZSTANDARD_MAGIC_NUMBER):
-            yield from _zstandard_decoder(entry, block)
-            return
-        # skip gzip header, if present
-        if block.startswith(GZIP_HEADER_START):
-            decompressor = zlib.decompressobj(-zlib.MAX_WBITS)
-            yield decompressor.decompress(_strip_gzip_header(block))
-        else:
-            # legacy zlib-only format used default block size
-            decompressor = zlib.decompressobj()
-            yield decompressor.decompress(block)
-
-        for block in entry:
-            yield decompressor.decompress(block)
-        yield decompressor.flush()
-
     def get_value(self) -> bytes:
         """Return uncompressed value."""
         assert self.compressed_value is not None
@@ -360,7 +360,7 @@ class CompressedValue:
 
         # legacy zlib format and zstandard
         length = 0
-        for block in self.decode_compressed_stream(self.iter_compressed()):
+        for block in _decode_compressed_stream(self.iter_compressed()):
             length += len(block)
         return length
 
@@ -500,7 +500,7 @@ class ProblemReport(collections.UserDict):
                         name=key, compressed_value=b"".join(iterator)
                     )
                 else:
-                    value = b"".join(CompressedValue.decode_compressed_stream(iterator))
+                    value = b"".join(_decode_compressed_stream(iterator))
                     self[key] = self._try_unicode(key, value)
 
             else:
@@ -545,7 +545,7 @@ class ProblemReport(collections.UserDict):
             key_path = os.path.join(directory, key)
             try:
                 with open(key_path, "wb") as out:
-                    out.writelines(CompressedValue.decode_compressed_stream(iterator))
+                    out.writelines(_decode_compressed_stream(iterator))
             except OSError as error:
                 raise OSError(f"unable to open {key_path}") from error
 

--- a/problem_report.py
+++ b/problem_report.py
@@ -312,23 +312,7 @@ class CompressedValue:
     def write(self, file: typing.IO[bytes]) -> None:
         """Write uncompressed value into given file-like object."""
         assert self.compressed_value
-
-        if self.compressed_value.startswith(ZSTANDARD_MAGIC_NUMBER):
-            decompressor = _get_zstandard_decompressor()
-            decompressor.copy_stream(io.BytesIO(self.compressed_value), file)
-            return
-
-        if self.compressed_value.startswith(GZIP_HEADER_START):
-            with gzip.GzipFile(fileobj=io.BytesIO(self.compressed_value)) as gz:
-                while True:
-                    block = gz.read(CHUNK_SIZE)
-                    if not block:
-                        break
-                    file.write(block)
-                return
-
-        # legacy zlib format
-        file.write(zlib.decompress(self.compressed_value))
+        file.writelines(_decode_compressed_stream(self.iter_compressed()))
 
     def iter_compressed(self, chunk_size: int = CHUNK_SIZE) -> Iterator[bytes]:
         """Iterate over the compressed content in chunks."""

--- a/tests/integration/test_report.py
+++ b/tests/integration/test_report.py
@@ -796,8 +796,7 @@ int main() { return f(42); }
         self.assertNotIn("StacktraceTop", pr)
         self.assertTrue(pr["UnreportableReason"].startswith("Invalid core dump"))
 
-    @unittest.mock.patch("gzip.GzipFile.read")
-    def test_add_gdb_info_damaged_gz_core(self, mock_gzread: MagicMock) -> None:
+    def test_add_gdb_info_damaged_gz_core(self) -> None:
         """add_gdb_info() with damaged gzip file of core dump"""
         pr = self._generate_sigsegv_report()
         del pr["Stacktrace"]
@@ -807,12 +806,13 @@ int main() { return f(42); }
 
         core = pr["CoreDump"][0]
         with open(core, "rb") as f:
-            pr["CoreDump"] = problem_report.CompressedValue(f.read())
-        mock_gzread.side_effect = EOFError(
-            "Compressed file ended before the end-of-stream marker was reached"
-        )
+            # Reading just the first kilobyte is enough for this test case.
+            core_dump = problem_report.CompressedValue(f.read(1024))
+        # Truncate just the tail to corrupt the end-of-stream marker
+        assert core_dump.compressed_value is not None
+        core_dump.compressed_value = core_dump.compressed_value[:-10]
+        pr["CoreDump"] = core_dump
         self.assertRaises(EOFError, pr.add_gdb_info)
-        self.assertTrue(mock_gzread.called)
 
         self.assertNotIn("Stacktrace", pr)
         self.assertNotIn("StacktraceTop", pr)


### PR DESCRIPTION
Use the iterator version `decode_compressed_stream` in `CompressedValue.write` to avoid code duplication.

This is in preparation for https://github.com/canonical/apport/pull/639 which is not ready yet.