### PR TITLE
Use compression.zstd from Python >= 3.14

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,7 +66,6 @@ jobs:
       fail-fast: false
       matrix:
         container:
-          - debian:stable-slim
           - debian:testing-slim
           - ubuntu:resolute
           - ubuntu:stonking

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
     container:
-      image: ubuntu:resolute
+      image: ubuntu:stonking
     steps:
       - uses: actions/checkout@v6
       - name: Install dependencies
@@ -69,6 +69,7 @@ jobs:
           - debian:stable-slim
           - debian:testing-slim
           - ubuntu:resolute
+          - ubuntu:stonking
         architecture:
           - ubuntu-latest
           - ubuntu-26.04-arm
@@ -150,6 +151,7 @@ jobs:
       matrix:
         container:
           - ubuntu:resolute
+          - ubuntu:stonking
     container:
       image: ${{ matrix.container }}
     steps:
@@ -180,6 +182,7 @@ jobs:
       matrix:
         container:
           - ubuntu:resolute
+          - ubuntu:stonking
         architecture:
           - ubuntu-latest
           - ubuntu-26.04-arm
@@ -264,6 +267,7 @@ jobs:
       matrix:
         container:
           - ubuntu:resolute
+          - ubuntu:stonking
         architecture:
           - ubuntu-latest
           - ubuntu-26.04-arm

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ env:
   common_deps: python3-distro-info python3-launchpadlib
   gtk_deps: gir1.2-gtk-3.0 gir1.2-wnck-3.0 gnome-icon-theme procps python3-gi
   kde_deps: procps pyqt6-dev-tools python3-pyqt6
-  unit_deps: locales python3-systemd python3-zstandard
+  unit_deps: locales python3-systemd
   integration_deps: >
     bash binutils gcc gdb kmod libc6-dev libglib2.0-dev libxml2-utils
     polkitd python3-systemd valgrind xterm
@@ -49,7 +49,7 @@ jobs:
           && apt-get install --no-install-recommends --yes
           black isort mypy pycodestyle pydocstyle pylint python3-typeshed
           python3-dbus python3-distutils-extra python3-rpm python3-yaml
-          python3-systemd python3-zstandard
+          python3-systemd
           $base_deps $common_deps $gtk_deps $kde_deps
       - name: Run linter tests
         run: tests/run-linters

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,7 +72,7 @@ jobs:
           - ubuntu:resolute
         architecture:
           - ubuntu-latest
-          - ubuntu-24.04-arm
+          - ubuntu-26.04-arm
     container:
       image: ${{ matrix.container }}
       options: --cap-add=SYS_PTRACE --security-opt seccomp=unconfined
@@ -106,7 +106,7 @@ jobs:
           path: ./coverage*.xml
 
   unit-and-integration-installed:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     strategy:
       fail-fast: false
     steps:
@@ -185,7 +185,7 @@ jobs:
           - ubuntu:resolute
         architecture:
           - ubuntu-latest
-          - ubuntu-24.04-arm
+          - ubuntu-26.04-arm
     container:
       image: ${{ matrix.container }}
     steps:
@@ -218,7 +218,7 @@ jobs:
           path: ./coverage.xml
 
   system-installed:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     strategy:
       fail-fast: false
     steps:
@@ -270,7 +270,7 @@ jobs:
           - ubuntu:resolute
         architecture:
           - ubuntu-latest
-          - ubuntu-24.04-arm
+          - ubuntu-26.04-arm
     container:
       image: ${{ matrix.container }}
     steps:
@@ -323,7 +323,7 @@ jobs:
           path: ./coverage.xml
 
   system-internet-installed:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     strategy:
       fail-fast: false
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,7 +68,6 @@ jobs:
         container:
           - debian:stable-slim
           - debian:testing-slim
-          - ubuntu:noble
           - ubuntu:resolute
         architecture:
           - ubuntu-latest
@@ -150,7 +149,6 @@ jobs:
       fail-fast: false
       matrix:
         container:
-          - ubuntu:noble
           - ubuntu:resolute
     container:
       image: ${{ matrix.container }}
@@ -181,7 +179,6 @@ jobs:
       fail-fast: false
       matrix:
         container:
-          - ubuntu:noble
           - ubuntu:resolute
         architecture:
           - ubuntu-latest
@@ -266,7 +263,6 @@ jobs:
       fail-fast: false
       matrix:
         container:
-          - ubuntu:noble
           - ubuntu:resolute
         architecture:
           - ubuntu-latest

--- a/apport/crashdb.py
+++ b/apport/crashdb.py
@@ -182,7 +182,7 @@ class CrashDatabase:
 
         try:
             report_package_version = report["Package"].split()[1]
-        except (KeyError, IndexError):
+        except KeyError, IndexError:
             report_package_version = None
 
         # check the existing IDs whether there is one that is unfixed or not

--- a/apport/crashdb_impl/debian.py
+++ b/apport/crashdb_impl/debian.py
@@ -71,7 +71,7 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
         # Frame the report in the format the BTS understands
         try:
             buggy_package, buggy_version = report["Package"].split(" ")
-        except (KeyError, ValueError):
+        except KeyError, ValueError:
             return False
 
         with tempfile.NamedTemporaryFile() as temp:

--- a/apport/crashdb_impl/launchpad.py
+++ b/apport/crashdb_impl/launchpad.py
@@ -52,7 +52,7 @@ def filter_filename(attachments):
     for attachment in attachments:
         try:
             f = attachment.data.open()
-        except (HTTPError, FailedToDecompressContent):
+        except HTTPError, FailedToDecompressContent:
             apport.logging.error("Broken attachment on bug, ignoring")
             continue
         name = f.filename
@@ -356,7 +356,7 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
             # ignore attachments with invalid keys
             try:
                 report[key] = ""
-            except (AssertionError, TypeError, ValueError):
+            except AssertionError, TypeError, ValueError:
                 continue
             if ext == ".txt":
                 report[key] = attachment.read()

--- a/apport/fileutils.py
+++ b/apport/fileutils.py
@@ -190,7 +190,7 @@ def find_snap(snap):
             response = c.getresponse()
             if response.status == 200:
                 return json.loads(response.read())["result"]
-    except (http.client.HTTPException, json.JSONDecodeError, OSError):
+    except http.client.HTTPException, json.JSONDecodeError, OSError:
         return None
     return None
 
@@ -285,7 +285,7 @@ def get_sys_gid_max() -> int:
     """Return maximum system group ID (SYS_GID_MAX from /etc/login.defs)."""
     try:
         return int(get_login_defs()["SYS_GID_MAX"])
-    except (KeyError, ValueError):
+    except KeyError, ValueError:
         return 999
 
 
@@ -293,7 +293,7 @@ def get_sys_uid_max() -> int:
     """Return maximum system user ID (SYS_UID_MAX from /etc/login.defs)."""
     try:
         return int(get_login_defs()["SYS_UID_MAX"])
-    except (KeyError, ValueError):
+    except KeyError, ValueError:
         return 999
 
 
@@ -400,7 +400,7 @@ def get_recent_crashes(report: IO[bytes]) -> int:
         if cur_time - report_time > 24 * 3600:
             return 0
         return count
-    except (ValueError, KeyError):
+    except ValueError, KeyError:
         return 0
 
 
@@ -515,7 +515,7 @@ def get_config(section, setting, default=None, path=None, boolean=False):
         if boolean:
             return config.getboolean(section, setting)
         return config.get(section, setting)
-    except (configparser.NoOptionError, configparser.NoSectionError):
+    except configparser.NoOptionError, configparser.NoSectionError:
         return default
 
 
@@ -653,7 +653,7 @@ def find_core_files_by_uid(uid: int) -> list[tuple[str, float]]:
             if f.split(".")[2] == str(uid):
                 core_file_time = os.path.getmtime(os.path.join(core_dir, f))
                 uid_files.append((f, core_file_time))
-        except (IndexError, FileNotFoundError):
+        except IndexError, FileNotFoundError:
             continue
     return uid_files
 
@@ -717,7 +717,7 @@ def should_skip_crash(report: ProblemReport, filename: str) -> str | None:
     """
     try:
         crash_counter = int(report["CrashCounter"])
-    except (KeyError, ValueError):
+    except KeyError, ValueError:
         crash_counter = 0
     if crash_counter > 1:
         return f"this executable already crashed {crash_counter} times, ignoring"

--- a/apport/hookutils.py
+++ b/apport/hookutils.py
@@ -960,7 +960,7 @@ def attach_mac_events(
                 profile = match[1:-1]
             else:
                 profile = bytes.fromhex(match).decode("UTF-8", errors="replace")
-        except (IndexError, ValueError):
+        except IndexError, ValueError:
             continue
 
         for search_profile in profiles:

--- a/apport/packaging_impl/apt_dpkg.py
+++ b/apport/packaging_impl/apt_dpkg.py
@@ -346,7 +346,7 @@ class _AptDpkgPackageInfo(PackageInfo):
             with open(mapping_file, "rb") as fp:
                 self._virtual_mapping_obj = pickle.load(fp)
             assert isinstance(self._virtual_mapping_obj, dict)
-        except (AssertionError, FileNotFoundError):
+        except AssertionError, FileNotFoundError:
             self._virtual_mapping_obj = {}
 
         return self._virtual_mapping_obj
@@ -378,7 +378,7 @@ class _AptDpkgPackageInfo(PackageInfo):
             assert isinstance(self._contents_mapping_obj, dict)
             # Discard files from Apport < 2.35.0
             assert isinstance(next(iter(self._contents_mapping_obj)), str)
-        except (AssertionError, FileNotFoundError):
+        except AssertionError, FileNotFoundError:
             self._contents_mapping_obj = {"release": release, "arch": arch}
 
         return self._contents_mapping_obj
@@ -1992,7 +1992,7 @@ class _AptDpkgPackageInfo(PackageInfo):
             try:
                 info = platform.freedesktop_os_release()
                 self._distro_codename = info["VERSION_CODENAME"]
-            except (KeyError, OSError):
+            except KeyError, OSError:
                 # Fall back to query lsb_release
                 lsb_release = subprocess.run(
                     ["lsb_release", "-sc"],

--- a/apport/report.py
+++ b/apport/report.py
@@ -285,7 +285,7 @@ def _check_bug_pattern(report, pattern):
                     regexp = regexp.encode("UTF-8")
                 try:
                     re_c = re.compile(regexp)
-                except (re.error, TypeError, ValueError):
+                except re.error, TypeError, ValueError:
                     continue
                 if not re_c.search(v):
                     return None
@@ -296,7 +296,7 @@ def _check_bug_pattern(report, pattern):
 def _check_bug_patterns(report, patterns):
     try:
         dom = xml.dom.minidom.parseString(patterns)
-    except (xml.parsers.expat.ExpatError, UnicodeEncodeError):
+    except xml.parsers.expat.ExpatError, UnicodeEncodeError:
         return None
 
     for pattern in dom.getElementsByTagName("pattern"):
@@ -1411,7 +1411,7 @@ class Report(problem_report.ProblemReport):
 
         try:
             dom = self._get_ignore_dom()
-        except (ValueError, KeyError):
+        except ValueError, KeyError:
             apport.logging.error("Could not get ignore file:")
             traceback.print_exc()
             return False
@@ -1428,7 +1428,7 @@ class Report(problem_report.ProblemReport):
                 if ignore.getAttribute("program") == self["ExecutablePath"]:
                     if float(ignore.getAttribute("mtime")) >= cur_mtime:
                         return True
-        except (ValueError, KeyError):
+        except ValueError, KeyError:
             pass
 
         return False
@@ -1960,7 +1960,7 @@ class Report(problem_report.ProblemReport):
         """Get ExecutableTimestamp if present and valid."""
         try:
             return int(self["ExecutableTimestamp"])
-        except (KeyError, ValueError):
+        except KeyError, ValueError:
             return None
 
     def gdb_command(

--- a/apport/ui.py
+++ b/apport/ui.py
@@ -64,7 +64,7 @@ def get_pid(report):
     try:
         pid = re.search("Pid:\t(.*)\n", report.get("ProcStatus", "")).group(1)
         return int(pid)
-    except (IndexError, AttributeError):
+    except IndexError, AttributeError:
         return None
 
 
@@ -76,7 +76,7 @@ def _get_env_int(key: str, default: int | None = None) -> int | None:
     """
     try:
         return int(os.environ[key])
-    except (KeyError, ValueError):
+    except KeyError, ValueError:
         return default
 
 
@@ -1372,7 +1372,7 @@ class UserInterface:
                 return False
             try:
                 self.crashdb = apport.crashdb.load_crashdb(None, spec)
-            except (ImportError, KeyError):
+            except ImportError, KeyError:
                 self.report["UnreportableReason"] = (
                     f"A package hook wants to send this report to the crash"
                     f' database "{self.report["CrashDB"]}"'
@@ -1383,7 +1383,7 @@ class UserInterface:
             # DB name
             try:
                 self.crashdb = apport.crashdb.get_crashdb(None, self.report["CrashDB"])
-            except (ImportError, KeyError):
+            except ImportError, KeyError:
                 self.report["UnreportableReason"] = (
                     f"A package hook wants to send this report to the crash"
                     f' database "{self.report["CrashDB"]}"'

--- a/apport_python_hook.py
+++ b/apport_python_hook.py
@@ -75,7 +75,7 @@ def apport_excepthook(
                 likely_packaged,
                 should_skip_crash,
             )
-        except (ImportError, OSError):
+        except ImportError, OSError:
             return
 
         # for interactive Python sessions, sys.argv[0] == ""
@@ -189,7 +189,7 @@ def dbus_service_unknown_analysis(
     try:
         assert exc_tb is not None
         dbus_name = extract_bus_name_from_traceback(exc_tb)
-    except (AssertionError, ValueError):
+    except AssertionError, ValueError:
         if sys.stderr:
             sys.stderr.write(
                 "Error: cannot parse D-BUS name from exception: "
@@ -209,7 +209,7 @@ def dbus_service_unknown_analysis(
                     subprocess.call(["pidof", "-sx", exe], stdout=subprocess.PIPE) == 0
                 )
                 services.append((service_file, exe, running))
-        except (NoSectionError, NoOptionError):
+        except NoSectionError, NoOptionError:
             if sys.stderr:
                 sys.stderr.write(
                     f"Invalid D-BUS .service file {service_file}:"

--- a/bin/apport-retrace
+++ b/bin/apport-retrace
@@ -286,7 +286,7 @@ def gen_source_stacktrace(report, sandbox):
     try:
         try:
             version = report["Package"].split()[1]
-        except (IndexError, KeyError):
+        except IndexError, KeyError:
             version = None
         srcdir = packaging.get_source_tree(
             report["SourcePackage"], workdir, version, sandbox=sandbox

--- a/bin/apport-valgrind
+++ b/bin/apport-valgrind
@@ -130,7 +130,7 @@ try:
         sys.stderr.write(_("Error: %s is not an executable. Stopping.") % options.exe)
         sys.stderr.write("\n")
         sys.exit(1)
-except (KeyboardInterrupt, SystemExit):
+except KeyboardInterrupt, SystemExit:
     sys.stderr.write("\nInterrupted during initialization\n")
     _exit_on_interrupt()
 
@@ -144,7 +144,7 @@ try:
         report.add_package_info()
 
         apport.logging.memdbg("\nCreated report")
-except (KeyboardInterrupt, SystemExit):
+except KeyboardInterrupt, SystemExit:
     sys.stderr.write("\nInterrupted during report creation\n")
     _exit_on_interrupt()
 
@@ -165,7 +165,7 @@ try:
             options.verbose,
         )
 
-except (KeyboardInterrupt, SystemExit):
+except KeyboardInterrupt, SystemExit:
     sys.stderr.write("\nInterrupted while creating sandbox\n")
     _exit_on_interrupt()
 
@@ -199,7 +199,7 @@ try:
     argv += [exepath]
 
     apport.logging.memdbg("before calling valgrind")
-except (KeyboardInterrupt, SystemExit):
+except KeyboardInterrupt, SystemExit:
     sys.stderr.write("\nInterrupted while preparing to create sandbox\n")
     _exit_on_interrupt()
 
@@ -207,7 +207,7 @@ valgrind_env = {k: v for k, v in os.environ.items() if k != "DEBUGINFOD_URLS"}
 
 try:
     subprocess.call(argv, env=valgrind_env)
-except (KeyboardInterrupt, SystemExit):
+except KeyboardInterrupt, SystemExit:
     sys.stderr.write("\nInterrupted while running valgrind\n")
     _exit_on_interrupt()
 

--- a/data/apport
+++ b/data/apport
@@ -83,7 +83,7 @@ class ProcPid(contextlib.ContextDecorator):
         Returns False for broken symbolic links."""
         try:
             self.stat(path)
-        except (OSError, ValueError):
+        except OSError, ValueError:
             return False
         return True
 
@@ -579,7 +579,7 @@ def forward_crash_to_container(
             "root/run/apport.socket", os.O_RDONLY | os.O_PATH, dir_fd=proc_pid.fd
         )
         socket_uid = os.fstat(sock_fd).st_uid
-    except (FileNotFoundError, ProcessLookupError):
+    except FileNotFoundError, ProcessLookupError:
         logger.error(
             "host pid %s crashed in a container without apport support",
             options.global_pid,
@@ -821,7 +821,7 @@ def main(args: list[str]) -> int:
 
     try:
         return process_crash_from_kernel(options)
-    except (SystemExit, KeyboardInterrupt):
+    except SystemExit, KeyboardInterrupt:
         pass
     except Exception:  # ruff: ignore[BLE001], pylint: disable=broad-except
         logger = logging.getLogger()
@@ -1191,7 +1191,7 @@ def process_crash(
         try:
             gid = pwd.getpwnam("whoopsie").pw_gid
             os.fchown(fd, report_owner.uid, gid)
-        except (OSError, KeyError):
+        except OSError, KeyError:
             os.fchown(fd, report_owner.uid, -1)
     except OSError as error:
         logger.error("Could not create report file: %s", str(error))

--- a/data/unkillable_shutdown
+++ b/data/unkillable_shutdown
@@ -88,7 +88,7 @@ def do_report(pid: int, omit_pids: Iterable[str]) -> None:
     report = apport.report.Report("Bug")
     try:
         report.add_proc_info(pid)
-    except (ValueError, AssertionError):
+    except ValueError, AssertionError:
         # happens if ExecutablePath doesn't exist (any more?), ignore
         return
 

--- a/problem_report.py
+++ b/problem_report.py
@@ -9,11 +9,10 @@
 # option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
 # the full text of the license.
 
-# pylint: disable=too-many-lines
-
 import base64
 import binascii
 import collections
+import compression.zstd
 import dataclasses
 import email.encoders
 import email.mime.base
@@ -134,9 +133,11 @@ def _decode_compressed_stream(entry: Iterator[bytes]) -> Iterator[bytes]:
     if block is None:
         return
     if block.startswith(ZSTANDARD_MAGIC_NUMBER):
-        yield from _zstandard_decoder(entry, block)
-        return
-    if block.startswith(GZIP_HEADER_START):
+        decompressor: compression.zstd.ZstdDecompressor | zlib._Decompress = (
+            compression.zstd.ZstdDecompressor()
+        )
+    # skip gzip header, if present
+    elif block.startswith(GZIP_HEADER_START):
         # Enable native gzip header & trailer processing
         decompressor = zlib.decompressobj(16 + zlib.MAX_WBITS)
     else:
@@ -146,7 +147,8 @@ def _decode_compressed_stream(entry: Iterator[bytes]) -> Iterator[bytes]:
     yield decompressor.decompress(block)
     for block in entry:
         yield decompressor.decompress(block)
-    yield decompressor.flush()
+    if not isinstance(decompressor, compression.zstd.ZstdDecompressor):
+        yield decompressor.flush()
 
     if not decompressor.eof:
         raise EOFError(
@@ -175,25 +177,6 @@ def _text_decoder(entry: Iterator[bytes], first_line: bytes) -> Iterator[bytes]:
         else:
             yield line[1:]
             length += len(line) - 1
-
-
-def _get_zstandard_decompressor():
-    try:
-        # pylint: disable-next=import-outside-toplevel
-        import zstandard
-    except ImportError as error:
-        raise RuntimeError(
-            f"Failed to import zstandard library: {error}."
-            f" Please install python3-zstandard."
-        ) from None
-    return zstandard.ZstdDecompressor()
-
-
-def _zstandard_decoder(entry: Iterator[bytes], first_block: bytes) -> Iterator[bytes]:
-    decompressor = _get_zstandard_decompressor().decompressobj()
-    yield decompressor.decompress(first_block)
-    for block in entry:
-        yield decompressor.decompress(block)
 
 
 def _parse_entry(entry: Iterator[bytes]) -> tuple[str, Iterator[bytes], bool]:
@@ -302,7 +285,7 @@ class CompressedValue:
         assert self.compressed_value is not None
 
         if self.compressed_value.startswith(ZSTANDARD_MAGIC_NUMBER):
-            return _get_zstandard_decompressor().decompress(self.compressed_value)
+            return compression.zstd.decompress(self.compressed_value)
         if self.compressed_value.startswith(GZIP_HEADER_START):
             return gzip.decompress(self.compressed_value)
         # legacy zlib format

--- a/problem_report.py
+++ b/problem_report.py
@@ -28,7 +28,6 @@ import time
 import typing
 import zlib
 from collections.abc import Generator, Iterable, Iterator
-from typing import TypeAlias
 
 CHUNK_SIZE = 131_072  # 128 kB chunks
 # magic number (0x1F 0x8B) and compression method (0x08 for DEFLATE)
@@ -337,7 +336,7 @@ class CompressedValue:
         return self.get_value().splitlines()
 
 
-ProblemReportValue: TypeAlias = bytes | CompressedFile | CompressedValue | str | tuple
+type ProblemReportValue = bytes | CompressedFile | CompressedValue | str | tuple
 _STRING_KEYS = {
     "Annotation",
     "Architecture",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ description = "intercept, process, and report crashes and bug reports"
 dynamic = ["version"]
 license = {text = "GPLv2+"}
 name = "apport"
-requires-python = ">=3.11"
+requires-python = ">=3.14"
 
 [tool.black]
 line-length = 88

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ try:
     SYSTEMD_TMPFILES_DIR = subprocess.check_output(
         ["pkg-config", "--variable=tmpfilesdir", "systemd"], universal_newlines=True
     ).strip()
-except (FileNotFoundError, subprocess.CalledProcessError):
+except FileNotFoundError, subprocess.CalledProcessError:
     # hardcoded fallback path
     SYSTEMD_UNIT_DIR = "/lib/systemd/system"
     SYSTEMD_TMPFILES_DIR = "/usr/lib/tmpfiles.d"
@@ -94,7 +94,7 @@ try:
     UDEV_DIR = subprocess.check_output(
         ["pkg-config", "--variable=udevdir", "udev"], text=True
     ).strip()
-except (FileNotFoundError, subprocess.CalledProcessError):
+except FileNotFoundError, subprocess.CalledProcessError:
     UDEV_DIR = "/lib/udev"
 
 cmdclass = register_java_sub_commands(build_extra, install_fix_completion_symlinks)

--- a/setuptools_apport/java.py
+++ b/setuptools_apport/java.py
@@ -85,7 +85,7 @@ def has_java(unused_command: Command) -> bool:
     """Check if the Java compiler is available."""
     try:
         subprocess.run(["javac", "-version"], capture_output=True, check=True)
-    except (OSError, subprocess.CalledProcessError):
+    except OSError, subprocess.CalledProcessError:
         logging.getLogger(__name__).warning(
             "Java support: Java not available, not building Java crash handler"
         )

--- a/tests/integration/test_crashdb_launchpad.py
+++ b/tests/integration/test_crashdb_launchpad.py
@@ -722,7 +722,7 @@ and more
         )
 
     @staticmethod
-    def _get_bug_target(db: CrashDatabase, report: Report) -> "Entry | None":
+    def _get_bug_target(db: CrashDatabase, report: Report) -> Entry | None:
         """Return the bug_target for this report."""
         project = db.options.get("project")
         if "SourcePackage" in report:

--- a/tests/system/test_packaging_apt_dpkg.py
+++ b/tests/system/test_packaging_apt_dpkg.py
@@ -24,7 +24,7 @@ from tests.paths import get_test_data_directory
 if shutil.which("dpkg") is None:
     pytest.skip("dpkg not installed", allow_module_level=True)
 
-AptStyle: typing.TypeAlias = typing.Literal["deb822", "one-line"]
+type AptStyle = typing.Literal["deb822", "one-line"]
 
 pytestmark = pytest.mark.parametrize("apt_style", ["one-line", "deb822"])
 

--- a/tests/system/test_ui_gtk.py
+++ b/tests/system/test_ui_gtk.py
@@ -1191,7 +1191,7 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
         self.app.ui_update_view()
 
     @staticmethod
-    def has_click_event_connected(widget: "Gtk.Widget") -> None:
+    def has_click_event_connected(widget: Gtk.Widget) -> None:
         signal_id = GObject.signal_lookup("clicked", widget)
         signal_handler_id = GObject.signal_handler_find(
             widget,

--- a/tests/unit/test_problem_report.py
+++ b/tests/unit/test_problem_report.py
@@ -3,23 +3,15 @@
 # pylint: disable=too-many-lines
 
 import base64
-import contextlib
 import datetime
 import email
 import io
 import json
 import locale
-import sys
 import textwrap
 import time
 import unittest
-import unittest.mock
-from unittest.mock import MagicMock, patch
-
-try:
-    import zstandard
-except ImportError:
-    zstandard = None  # type: ignore
+from unittest.mock import patch
 
 import problem_report
 
@@ -313,7 +305,6 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
         ):
             report.load(report_file)
 
-    @unittest.skipUnless(zstandard, "zstandard Python module not available")
     def test_load_zstd_compressed_data(self) -> None:
         """Test reading zstd-compressed data."""
         report = problem_report.ProblemReport()
@@ -330,7 +321,6 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
             " and is long enough for zstd to work.\n",
         )
 
-    @unittest.skipUnless(zstandard, "zstandard Python module not available")
     def test_reading_zstd_compressed_value(self) -> None:
         """Test reading zstd-compressed CompressedValue."""
         report = problem_report.ProblemReport()
@@ -347,7 +337,6 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
             b" which is long enough to be compressed\n",
         )
 
-    @unittest.skipUnless(zstandard, "zstandard Python module not available")
     def test_writing_zstd_compressed_value(self) -> None:
         """Test writing zstd-compressed CompressedValue."""
         compressed_value = problem_report.CompressedValue(
@@ -363,7 +352,6 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
             b"Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam\n",
         )
 
-    @unittest.skipUnless(zstandard, "zstandard Python module not available")
     def test_zstd_compressed_value_length(self) -> None:
         """Test getting length of zstd-compressed CompressedValue."""
         compressed_value = problem_report.CompressedValue(
@@ -374,36 +362,12 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
         )
         self.assertEqual(len(compressed_value), 65)
 
-    @unittest.skipUnless(zstandard, "zstandard Python module not available")
     def test_len_zstd_compressed_value_nosize(self) -> None:
         """Test len() on zstd-compressed CompressedValue without a size header."""
         compressed_value = problem_report.CompressedValue(
             compressed_value=base64.b64decode(b"KLUv/QBYEQAAe30=")
         )
         self.assertEqual(len(compressed_value), 2)
-
-    @unittest.mock.patch("builtins.__import__")
-    def test_zstandard_missing(self, import_mock: MagicMock) -> None:
-        """Test reading zstd-compressed data when zstandard is missing."""
-        with contextlib.suppress(KeyError):
-            sys.modules.pop("zstandard")
-        import_mock.side_effect = ImportError("mocked import error")
-
-        report = problem_report.ProblemReport()
-        content = (
-            b"CoreDump: base64\n"
-            b" KLUv/SROHQIAgoQOEqC7ASCSGCybZRrN7//Hsn7dVyActu7bbMcLaav0RC06\n"
-            b" m6fCZ/N7aeOeyqxspRVn88bSx8a8opWQAwEA/8OEAhOOwLA=\n"
-        )
-        expected_message = (
-            "Failed to import zstandard library: mocked import error."
-            " Please install python3-zstandard."
-        )
-        with (
-            self.assertRaisesRegex(RuntimeError, expected_message),
-            io.BytesIO(content) as report_file,
-        ):
-            report.load(report_file)
 
     def test_write_fileobj(self) -> None:
         """Write a report with a pointer to a file-like object."""
@@ -621,7 +585,6 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
             ],
         )
 
-    @unittest.skipUnless(zstandard, "zstandard Python module not available")
     def test_write_mime_binary_values(self) -> None:
         """write_mine() for binary values (gzip and zstd compressed)."""
         report = problem_report.ProblemReport(date="now!")


### PR DESCRIPTION
Use `compression.zstd` from Python >= 3.14 to avoid relying on the third-party library `zstandard`.

Bug: https://launchpad.net/bugs/2161787