### PR TITLE
test: wait for child processes to complete execve()

### DIFF
--- a/tests/helper.py
+++ b/tests/helper.py
@@ -170,6 +170,22 @@ def wait_for_sleeping_state(pid: int, timeout: float = WAITING_TIMEOUT) -> None:
     )
 
 
+def wait_for_proc_exec(pid: int, timeout_sec: float = WAITING_TIMEOUT) -> None:
+    """Wait for a spawned child process to populate /proc/<pid>/cmdline."""
+    elapsed_time = 0.0
+    while elapsed_time < timeout_sec:
+        with open(f"/proc/{pid}/cmdline", encoding="utf-8") as fd:
+            if fd.read():
+                return
+
+        time.sleep(0.1)
+        elapsed_time += 0.1
+
+    raise TimeoutError(
+        f"/proc/{pid}/cmdline not readable within {int(elapsed_time)} seconds."
+    )
+
+
 def wait_for_process_to_appear(
     process: str, already_running: Set[int], timeout: float = WAITING_TIMEOUT
 ) -> int:

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -101,6 +101,7 @@ def run_test_executable(
     if args is None:
         args = (get_gnu_coreutils_cmd("sleep"), "86400")
     with subprocess.Popen(args, env=env) as test_process:
+        wait_for_proc_exec(test_process.pid)
         try:
             yield test_process.pid
         finally:
@@ -171,18 +172,27 @@ def wait_for_sleeping_state(pid: int, timeout: float = WAITING_TIMEOUT) -> None:
 
 
 def wait_for_proc_exec(pid: int, timeout_sec: float = WAITING_TIMEOUT) -> None:
-    """Wait for a spawned child process to populate /proc/<pid>/cmdline."""
+    """Wait for a spawned child process to complete execve().
+
+    Immediately after fork(), /proc/{pid}/cmdline temporarily inherits the
+    parent test runner's command line. This method blocks until execve() has
+    replaced the process image and updated /proc/{pid}/cmdline to match the
+    child process's own command line.
+    """
+    parent_cmdline = pathlib.Path("/proc/self/cmdline").read_text(encoding="utf-8")
     elapsed_time = 0.0
     while elapsed_time < timeout_sec:
         with open(f"/proc/{pid}/cmdline", encoding="utf-8") as fd:
-            if fd.read():
+            content = fd.read()
+            if content and content != parent_cmdline:
                 return
 
         time.sleep(0.1)
         elapsed_time += 0.1
 
     raise TimeoutError(
-        f"/proc/{pid}/cmdline not readable within {int(elapsed_time)} seconds."
+        f"/proc/{pid}/cmdline was not updated from parent cmdline"
+        f" within at least {int(elapsed_time)} seconds."
     )
 
 

--- a/tests/integration/test_report.py
+++ b/tests/integration/test_report.py
@@ -23,9 +23,9 @@ import apport.packaging
 import apport.report
 import problem_report
 from tests.helper import (
-    WAITING_TIMEOUT,
     get_gnu_coreutils_cmd,
     skip_if_command_is_missing,
+    wait_for_proc_exec,
 )
 from tests.paths import patch_data_dir, restore_data_dir
 
@@ -45,23 +45,6 @@ class T(unittest.TestCase):
     def tearDownClass(cls) -> None:
         restore_data_dir(apport.report, cls.orig_data_dir)
 
-    def wait_for_proc_cmdline(
-        self, pid: int, timeout_sec: float = WAITING_TIMEOUT
-    ) -> None:
-        assert pid
-        elapsed_time = 0.0
-        while elapsed_time < timeout_sec:
-            with open(f"/proc/{pid}/cmdline", encoding="utf-8") as fd:
-                if fd.read():
-                    return
-
-            time.sleep(0.1)
-            elapsed_time += 0.1
-
-        self.fail(
-            f"/proc/{pid}/cmdline not readable within {int(elapsed_time)} seconds."
-        )
-
     def _assert_open_fds_valid(self, open_fds: str) -> None:
         """Assert that OpenFds contains well-formed FD entries."""
         entries = open_fds.split("\n\n")
@@ -77,19 +60,6 @@ class T(unittest.TestCase):
                 fdinfo_keys.add(fdinfo_line.split(":\t", 1)[0])
             self.assertIn("pos", fdinfo_keys)
             self.assertIn("flags", fdinfo_keys)
-
-    @unittest.mock.patch("time.sleep")
-    def test_wait_for_proc_cmdline_failure(self, sleep_mock: MagicMock) -> None:
-        """Test wait_for_proc_cmdline() helper runs into timeout."""
-        open_mock = unittest.mock.mock_open(read_data="")
-        with (
-            unittest.mock.patch("builtins.open", open_mock),
-            self.assertRaises(AssertionError),
-        ):
-            self.wait_for_proc_cmdline(12345, 0.3)
-        open_mock.assert_called_with("/proc/12345/cmdline", encoding="utf-8")
-        sleep_mock.assert_called_with(0.1)
-        self.assertEqual(sleep_mock.call_count, 3)
 
     def test_add_package_info(self) -> None:
         """add_package_info()."""
@@ -217,7 +187,7 @@ class T(unittest.TestCase):
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         ) as cat:
-            self.wait_for_proc_cmdline(cat.pid)
+            wait_for_proc_exec(cat.pid)
             pr = apport.report.Report()
             pr.add_proc_info(pid=cat.pid)
             self.assertEqual(pr.pid, cat.pid)
@@ -231,7 +201,7 @@ class T(unittest.TestCase):
         # check correct handling of executable symlinks
         assert os.path.islink("/bin/sh"), "/bin/sh needs to be a symlink for this test"
         with subprocess.Popen(["sh"], stdin=subprocess.PIPE) as shell:
-            self.wait_for_proc_cmdline(shell.pid)
+            wait_for_proc_exec(shell.pid)
             pr = apport.report.Report()
             pr.pid = shell.pid
             pr.add_proc_info()
@@ -245,7 +215,7 @@ class T(unittest.TestCase):
 
         # check correct handling of interpreted executables: shell
         with subprocess.Popen(["zgrep", "foo"], stdin=subprocess.PIPE) as zgrep:
-            self.wait_for_proc_cmdline(zgrep.pid)
+            wait_for_proc_exec(zgrep.pid)
             pr = apport.report.Report()
             pr.add_proc_info(pid=zgrep.pid)
             zgrep.communicate(b"\n")
@@ -274,7 +244,7 @@ class T(unittest.TestCase):
             with subprocess.Popen(
                 [str(testscript)], stdin=subprocess.PIPE, stderr=subprocess.PIPE
             ) as process:
-                self.wait_for_proc_cmdline(process.pid)
+                wait_for_proc_exec(process.pid)
                 pr = apport.report.Report()
                 pr.add_proc_info(pid=process.pid)
                 process.communicate(b"\n")

--- a/tests/unit/test_helper.py
+++ b/tests/unit/test_helper.py
@@ -9,6 +9,7 @@ import psutil
 
 from tests.helper import (
     get_init_system,
+    wait_for_proc_exec,
     wait_for_process_to_appear,
     wait_for_sleeping_state,
     wrap_object,
@@ -37,6 +38,16 @@ class TestTestHelper(unittest.TestCase):
             multiply = Multiply(7)
             self.assertEqual(multiply.multiply(6), 42)
         mock.assert_called_once_with(7)
+
+    @patch("time.sleep")
+    def test_wait_for_proc_exec_failure(self, sleep_mock: MagicMock) -> None:
+        """Test wait_for_proc_exec() helper runs into timeout."""
+        open_mock = mock_open(read_data="")
+        with patch("builtins.open", open_mock), self.assertRaises(TimeoutError):
+            wait_for_proc_exec(12345, 0.3)
+        open_mock.assert_called_with("/proc/12345/cmdline", encoding="utf-8")
+        sleep_mock.assert_called_with(0.1)
+        self.assertEqual(sleep_mock.call_count, 3)
 
     @patch("time.sleep")
     @patch("psutil.Process", spec=psutil.Process)


### PR DESCRIPTION
`test_add_proc_info` fails with the parent cmdline content:

```
>       self.assertEqual(pr["ProcCmdline"], f"{catcmd} /foo\\ bar \\\\h \\\\\\ \\\\ -")
E       AssertionError: 'python3 -m pytest -ra -v -m not\\ require[37 chars]ion/' != '/usr/bin/gnucat /foo\\ bar \\\\h \\\\\\ \\\\ -'
E       - python3 -m pytest -ra -v -m not\ requires_internet tests/unit/ tests/integration/
E       + /usr/bin/gnucat /foo\ bar \\h \\\ \\ -
```

1. When `subprocess.Popen` spawns a process, it first calls `fork()` before calling `execve()`.
2. Immediately after `fork()`, the child process shares the parent's memory image.
3. During this brief window (before `execve()` completes), `/proc/{pid}/cmdline` contains the parent's command line.
4. The `wait_for_proc_exec` method checks if `/proc/{pid}/cmdline` has content. Because the parent's cmdline is non-empty, it return prematurely before `execve()` finishes replacing the process.
5. Apport then reads `/proc/{pid}/cmdline` while it still holds pytest's command line.

The same thing can happen in tests that use `run_test_executable`:

```
________________________ T.test_run_report_bug_pid_tags ________________________

self = <tests.integration.test_ui.T testMethod=test_run_report_bug_pid_tags>

    def test_run_report_bug_pid_tags(self) -> None:
        """run_report_bug() for a pid with extra tags"""
        with run_test_executable() as pid:
            # report a bug on text executable process
            argv = ["ui-test", "-f", "--tag", "foo", "-P", str(pid)]
            ui = UserInterfaceMock(argv)
            ui.present_details_response = apport.ui.Action(report=True)
            self.assertEqual(ui.run_argv(), True)

        assert ui.report
        self.assertIn("SourcePackage", ui.report)
        self.assertIn("Dependencies", ui.report)
        self.assertIn("ProcMaps", ui.report)
>       self.assertEqual(ui.report["ExecutablePath"], self.TEST_EXECUTABLE)
E       AssertionError: '/usr/lib/python3/dist-packages/pytest/__init__.py' != '/usr/bin/gnusleep'
E       - /usr/lib/python3/dist-packages/pytest/__init__.py
E       + /usr/bin/gnusleep

tests/integration/test_ui.py:795: AssertionError
```

Wait until the forked process changed the content of `cmdline`.

Bug: https://launchpad.net/bugs/2161888