### PR TITLE
fix(cli): gracefully handle non-TTY stdin in raw_input_char

### DIFF
--- a/bin/apport-cli
+++ b/bin/apport-cli
@@ -57,6 +57,15 @@ class CLIDialog:
         sys.stdout.flush()
 
         file = sys.stdin.fileno()
+        import os
+        if not os.isatty(file):
+            if multi_char:
+                response = str(sys.stdin.readline()).strip()
+            else:
+                response = str(sys.stdin.read(1))
+            sys.stdout.write("\n")
+            return response
+
         saved_attributes = termios.tcgetattr(file)
         attributes = termios.tcgetattr(file)
         attributes[3] = attributes[3] & ~(termios.ICANON)

--- a/bin/apport-cli
+++ b/bin/apport-cli
@@ -57,7 +57,6 @@ class CLIDialog:
         sys.stdout.flush()
 
         file = sys.stdin.fileno()
-        import os
 
         if not os.isatty(file):
             if multi_char:

--- a/bin/apport-cli
+++ b/bin/apport-cli
@@ -58,6 +58,7 @@ class CLIDialog:
 
         file = sys.stdin.fileno()
         import os
+
         if not os.isatty(file):
             if multi_char:
                 response = str(sys.stdin.readline()).strip()

--- a/tests/integration/test_ui_cli.py
+++ b/tests/integration/test_ui_cli.py
@@ -98,3 +98,29 @@ class TestApportCli(unittest.TestCase):
             run_mock.return_value = 4
             self.app.ui_present_report_details()
         self.assertIn(_("Problem report file:"), stdout_mock.getvalue())
+
+    @unittest.mock.patch("os.isatty")
+    @unittest.mock.patch("sys.stdout", new_callable=io.StringIO)
+    def test_raw_input_char_non_tty(self, mock_stdout, mock_isatty):
+        mock_isatty.return_value = False
+        mock_stdin = unittest.mock.MagicMock()
+        mock_stdin.fileno.return_value = 0
+        mock_stdin.read.return_value = "y"
+        with unittest.mock.patch("sys.stdin", mock_stdin):
+            response = apport_cli.CLIDialog.raw_input_char("Prompt?")
+            self.assertEqual(response, "y")
+            self.assertEqual(mock_stdout.getvalue(), "Prompt? \n")
+            mock_stdin.read.assert_called_with(1)
+
+    @unittest.mock.patch("os.isatty")
+    @unittest.mock.patch("sys.stdout", new_callable=io.StringIO)
+    def test_raw_input_char_non_tty_multi(self, mock_stdout, mock_isatty):
+        mock_isatty.return_value = False
+        mock_stdin = unittest.mock.MagicMock()
+        mock_stdin.fileno.return_value = 0
+        mock_stdin.readline.return_value = "yes\n"
+        with unittest.mock.patch("sys.stdin", mock_stdin):
+            response = apport_cli.CLIDialog.raw_input_char("Prompt?", multi_char=True)
+            self.assertEqual(response, "yes")
+            self.assertEqual(mock_stdout.getvalue(), "Prompt? \n")
+            mock_stdin.readline.assert_called_with()


### PR DESCRIPTION
When apport-cli is run in an environment where stdin is not a terminal (e.g., redirected input or background jobs), it crashed with an unhandled termios.error when trying to pause for input. This patch checks os.isatty() and reads normally if not a TTY.