### PR TITLE
apport_python_hook: support dbus-broker

### DIFF
--- a/apport_python_hook.py
+++ b/apport_python_hook.py
@@ -99,7 +99,7 @@ def apport_excepthook(
                 # (LP #914220)
                 return
             if name == "org.freedesktop.DBus.Error.ServiceUnknown":
-                dbus_service_unknown_analysis(exc_obj, report)
+                report.update(dbus_service_unknown_analysis(exc_obj))
             else:
                 report["_PythonExceptionQualifier"] = name
 
@@ -160,7 +160,7 @@ def apport_excepthook(
             sys.__excepthook__(exc_type, exc_obj, exc_tb)
 
 
-def dbus_service_unknown_analysis(exc_obj, report):
+def dbus_service_unknown_analysis(exc_obj: BaseException) -> dict[str, str]:
     """Analyze D-Bus service error and add analysis to report."""
     # pylint: disable=import-outside-toplevel; for Python startup time
     import re
@@ -168,6 +168,7 @@ def dbus_service_unknown_analysis(exc_obj, report):
     from configparser import ConfigParser, NoOptionError, NoSectionError
     from glob import glob
 
+    assert hasattr(exc_obj, "get_dbus_message")
     # determine D-BUS name
     match = re.search(
         r"name\s+(\S+)\s+was not provided by any .service", exc_obj.get_dbus_message()
@@ -178,7 +179,7 @@ def dbus_service_unknown_analysis(exc_obj, report):
                 "Error: cannot parse D-BUS name from exception: "
                 + exc_obj.get_dbus_message()
             )
-        return
+        return {}
 
     dbus_name = match.group(1)
 
@@ -203,13 +204,12 @@ def dbus_service_unknown_analysis(exc_obj, report):
             continue
 
     if not services:
-        report["DbusErrorAnalysis"] = f"no service file providing {dbus_name}"
+        analysis = f"no service file providing {dbus_name}"
     else:
-        report["DbusErrorAnalysis"] = "provided by"
+        analysis = "provided by"
         for service_file, exe, running in services:
-            report[
-                "DbusErrorAnalysis"
-            ] += f" {service_file} ({exe} is {'' if running else 'not '}running)"
+            analysis += f" {service_file} ({exe} is {'' if running else 'not '}running)"
+    return {"DbusErrorAnalysis": analysis}
 
 
 def install():

--- a/apport_python_hook.py
+++ b/apport_python_hook.py
@@ -206,10 +206,10 @@ def dbus_service_unknown_analysis(exc_obj, report):
         report["DbusErrorAnalysis"] = f"no service file providing {dbus_name}"
     else:
         report["DbusErrorAnalysis"] = "provided by"
-        for service, exe, running in services:
+        for service_file, exe, running in services:
             report[
                 "DbusErrorAnalysis"
-            ] += f" {service} ({exe} is {'' if running else 'not '}running)"
+            ] += f" {service_file} ({exe} is {'' if running else 'not '}running)"
 
 
 def install():

--- a/apport_python_hook.py
+++ b/apport_python_hook.py
@@ -99,7 +99,7 @@ def apport_excepthook(
                 # (LP #914220)
                 return
             if name == "org.freedesktop.DBus.Error.ServiceUnknown":
-                report.update(dbus_service_unknown_analysis(exc_obj))
+                report.update(dbus_service_unknown_analysis(exc_obj, exc_tb))
             else:
                 report["_PythonExceptionQualifier"] = name
 
@@ -160,28 +160,42 @@ def apport_excepthook(
             sys.__excepthook__(exc_type, exc_obj, exc_tb)
 
 
-def dbus_service_unknown_analysis(exc_obj: BaseException) -> dict[str, str]:
+def extract_bus_name_from_traceback(exc_tb: types.TracebackType) -> str:
+    """Extract the requested bus name from the frame locals within dbus-python."""
+    # pylint: disable=import-outside-toplevel; for Python startup time
+    import traceback
+
+    for frame, _ in traceback.walk_tb(exc_tb):
+        module_name = frame.f_globals.get("__name__", "")
+        if module_name.startswith("dbus.") or module_name == "dbus":
+            bus_name = frame.f_locals.get("bus_name")
+            if isinstance(bus_name, str):
+                return bus_name
+
+    raise ValueError("Could not extract D-Bus service name from traceback")
+
+
+def dbus_service_unknown_analysis(
+    exc_obj: BaseException, exc_tb: types.TracebackType | None
+) -> dict[str, str]:
     """Analyze D-Bus service error and add analysis to report."""
     # pylint: disable=import-outside-toplevel; for Python startup time
-    import re
     import subprocess
     from configparser import ConfigParser, NoOptionError, NoSectionError
     from glob import glob
 
     assert hasattr(exc_obj, "get_dbus_message")
     # determine D-BUS name
-    match = re.search(
-        r"name\s+(\S+)\s+was not provided by any .service", exc_obj.get_dbus_message()
-    )
-    if not match:
+    try:
+        assert exc_tb is not None
+        dbus_name = extract_bus_name_from_traceback(exc_tb)
+    except (AssertionError, ValueError):
         if sys.stderr:
             sys.stderr.write(
                 "Error: cannot parse D-BUS name from exception: "
                 + exc_obj.get_dbus_message()
             )
         return {}
-
-    dbus_name = match.group(1)
 
     # determine .service file and Exec name for the D-BUS name
     services = []  # tuples of (service file, exe name, running)

--- a/apport_python_hook.py
+++ b/apport_python_hook.py
@@ -178,7 +178,7 @@ def dbus_service_unknown_analysis(exc_obj, report):
                 "Error: cannot parse D-BUS name from exception: "
                 + exc_obj.get_dbus_message()
             )
-            return
+        return
 
     dbus_name = match.group(1)
 


### PR DESCRIPTION
The tests `test_dbus_service_unknown_wrongbus_notrunning` and `test_dbus_service_unknown_wrongbus_running` started to fail once Ubuntu switched to dbus-broker (see https://launchpad.net/bugs/2015538).

These tests create Python code similar to:

```python
#!/usr/bin/python3
import dbus

obj = dbus.SessionBus().get_object("org.gtk.vfs.Metadata", "/org/gtk/vfs/metadata")
assert obj
obj = dbus.SystemBus().get_object("org.gtk.vfs.Metadata", "/org/gtk/vfs/metadata")
```

On Ubuntu 26.04 this code fails with:

```
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/dbus/bus.py", line 173, in activate_name_owner
    return self.get_name_owner(bus_name)
           ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/dbus/bus.py", line 348, in get_name_owner
    return self.call_blocking(BUS_DAEMON_NAME, BUS_DAEMON_PATH,
           ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                              BUS_DAEMON_IFACE, 'GetNameOwner',
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                              's', (bus_name,))
                              ^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/dbus/connection.py", line 696, in call_blocking
    reply_message = self.send_message_with_reply_and_block(
        message, timeout)
dbus.exceptions.DBusException: org.freedesktop.DBus.Error.NameHasNoOwner: Could not get owner of name 'org.gtk.vfs.Metadata': no such name

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/bin/test.py", line 4, in <module>
    obj = dbus.SessionBus().get_object("org.gtk.vfs.Metadata", "/org/gtk/vfs/metadata")
  File "/usr/lib/python3/dist-packages/dbus/bus.py", line 237, in get_object
    return self.ProxyObjectClass(self, bus_name, object_path,
           ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                                 introspect=introspect,
                                 ^^^^^^^^^^^^^^^^^^^^^^
                                 follow_name_owner_changes=follow_name_owner_changes)
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/dbus/proxies.py", line 250, in __init__
    self._named_service = conn.activate_name_owner(bus_name)
                          ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/dbus/bus.py", line 178, in activate_name_owner
    self.start_service_by_name(bus_name)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/dbus/bus.py", line 273, in start_service_by_name
    return (True, self.call_blocking(BUS_DAEMON_NAME, BUS_DAEMON_PATH,
                  ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                                     BUS_DAEMON_IFACE,
                                     ^^^^^^^^^^^^^^^^^
                                     'StartServiceByName',
                                     ^^^^^^^^^^^^^^^^^^^^^
                                     'su', (bus_name, flags)))
                                     ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/dbus/connection.py", line 696, in call_blocking
    reply_message = self.send_message_with_reply_and_block(
        message, timeout)
dbus.exceptions.DBusException: org.freedesktop.DBus.Error.ServiceUnknown: The name org.gtk.vfs.Metadata was not provided by any .service files
```

On Ubuntu 26.10 with dbus-broker it fails with less information in the exception:

```
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/dbus/bus.py", line 173, in activate_name_owner
    return self.get_name_owner(bus_name)
           ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/dbus/bus.py", line 348, in get_name_owner
    return self.call_blocking(BUS_DAEMON_NAME, BUS_DAEMON_PATH,
           ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                              BUS_DAEMON_IFACE, 'GetNameOwner',
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                              's', (bus_name,))
                              ^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/dbus/connection.py", line 696, in call_blocking
    reply_message = self.send_message_with_reply_and_block(
        message, timeout)
dbus.exceptions.DBusException: org.freedesktop.DBus.Error.NameHasNoOwner: The name does not have an owner

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/bin/test.py", line 6, in <module>
    obj = dbus.SystemBus().get_object("org.gtk.vfs.Metadata", "/org/gtk/vfs/metadata")
  File "/usr/lib/python3/dist-packages/dbus/bus.py", line 237, in get_object
    return self.ProxyObjectClass(self, bus_name, object_path,
           ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                                 introspect=introspect,
                                 ^^^^^^^^^^^^^^^^^^^^^^
                                 follow_name_owner_changes=follow_name_owner_changes)
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/dbus/proxies.py", line 250, in __init__
    self._named_service = conn.activate_name_owner(bus_name)
                          ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/dbus/bus.py", line 178, in activate_name_owner
    self.start_service_by_name(bus_name)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/dbus/bus.py", line 273, in start_service_by_name
    return (True, self.call_blocking(BUS_DAEMON_NAME, BUS_DAEMON_PATH,
                  ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                                     BUS_DAEMON_IFACE,
                                     ^^^^^^^^^^^^^^^^^
                                     'StartServiceByName',
                                     ^^^^^^^^^^^^^^^^^^^^^
                                     'su', (bus_name, flags)))
                                     ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/dbus/connection.py", line 696, in call_blocking
    reply_message = self.send_message_with_reply_and_block(
        message, timeout)
dbus.exceptions.DBusException: org.freedesktop.DBus.Error.ServiceUnknown: The name is not activatable
```

The dbus-python code uses `bus_name` as variable before calling D-Bus in most cases. So walk down the traceback to extract the bus name from there.

Bug: https://launchpad.net/bugs/2163744