### PR TITLE
problem_report: validate key names in ProblemReport.load

### DIFF
--- a/bin/apport-unpack
+++ b/bin/apport-unpack
@@ -91,14 +91,14 @@ def main() -> None:
             # the report needs to be loaded in one go.
             # The current implementation loads the whole report into memory.
             bin_keys = report.load(report_file, binary=args.report == "-")
-    except (OSError, problem_report.MalformedProblemReport) as error:
+    except (OSError, ValueError) as error:
         fatal("%s", str(error))
     unpack_report_to_directory(report, args.target_directory)
     if bin_keys:
         try:
             with open_report(args.report) as report_file:
                 report.extract_keys(report_file, bin_keys, args.target_directory)
-        except (OSError, problem_report.MalformedProblemReport) as error:
+        except (OSError, ValueError) as error:
             fatal("%s", str(error))
 
 

--- a/data/whoopsie-upload-all
+++ b/data/whoopsie-upload-all
@@ -29,7 +29,6 @@ import zlib
 
 import apport.fileutils
 import apport.report
-from problem_report import MalformedProblemReport
 
 
 def process_report(report):
@@ -82,7 +81,7 @@ def process_report(report):
                 return None
             r.load(f, binary="compressed")
             report_stat = os.stat(report)
-    except (MalformedProblemReport, OSError, zlib.error) as error:
+    except (OSError, ValueError, zlib.error) as error:
         sys.stderr.write(f"ERROR: cannot load {report}: {error!s}\n")
         return None
     if r.get("ProblemType", "") != "Crash" and "ExecutablePath" not in r:

--- a/problem_report.py
+++ b/problem_report.py
@@ -36,6 +36,10 @@ GZIP_HEADER_START = b"\037\213\010"
 ZSTANDARD_MAGIC_NUMBER = b"\x28\xb5\x2f\xfd"
 
 
+class InvalidProblemReportKeyError(ValueError):
+    """Raised when a problem report key contains invalid characters."""
+
+
 class MalformedProblemReport(ValueError):
     """Raised when a problem report violates the crash report format.
 
@@ -492,15 +496,15 @@ class ProblemReport(collections.UserDict):
                 if binary is False:
                     skipped_keys.append(key)
                 elif binary == "compressed":
-                    self.data[key] = CompressedValue(
+                    self[key] = CompressedValue(
                         name=key, compressed_value=b"".join(iterator)
                     )
                 else:
                     value = b"".join(CompressedValue.decode_compressed_stream(iterator))
-                    self.data[key] = self._try_unicode(key, value)
+                    self[key] = self._try_unicode(key, value)
 
             else:
-                self.data[key] = self._try_unicode(key, b"".join(iterator))
+                self[key] = self._try_unicode(key, b"".join(iterator))
 
             if remaining_keys is not None:
                 remaining_keys.remove(key)
@@ -993,7 +997,7 @@ class ProblemReport(collections.UserDict):
     def __setitem__(self, k: str, v: ProblemReportValue) -> None:
         assert hasattr(k, "isalnum")
         if not k.replace(".", "").replace("-", "").replace("_", "").isalnum():
-            raise ValueError(
+            raise InvalidProblemReportKeyError(
                 f"key '{k}' contains invalid characters"
                 f" (only numbers, letters, '.', '_', and '-' are allowed)"
             )

--- a/tests/unit/test_problem_report.py
+++ b/tests/unit/test_problem_report.py
@@ -116,7 +116,9 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
     def test_consistency_checks(self) -> None:
         """Various error conditions."""
         pr = problem_report.ProblemReport()
-        self.assertRaises(ValueError, pr.__setitem__, "a b", "1")
+        self.assertRaises(
+            problem_report.InvalidProblemReportKeyError, pr.__setitem__, "a b", "1"
+        )
         self.assertRaises(TypeError, pr.__setitem__, "a", 1)
         self.assertRaises(TypeError, pr.__setitem__, "a", (1,))
         self.assertRaises(TypeError, pr.__setitem__, "a", ("/tmp/nonexistent", ""))
@@ -266,6 +268,17 @@ class T(unittest.TestCase):  # pylint: disable=too-many-public-methods
             self.assertRaisesRegex(
                 problem_report.MalformedProblemReport,
                 r"Line '\\n' does not contain a colon",
+            ),
+        ):
+            report.load(report_file)
+
+    def test_load_invalid_key(self) -> None:
+        """Throw exception when the problem report key uses invalid characters."""
+        report = problem_report.ProblemReport()
+        with (
+            io.BytesIO(b"Invalid/key: value") as report_file,
+            self.assertRaisesRegex(
+                problem_report.InvalidProblemReportKeyError, "key 'Invalid/key'"
             ),
         ):
             report.load(report_file)


### PR DESCRIPTION
Apport report files consist of key/value pairs based on the standard RFC822 format, except that Apport uses case sensitive keys. Key names must only contain numbers, letters, '.', '_', and '-'. This is validated in `ProblemReport.__setitem__`, but not when loading a report in `ProblemReport.load`.

So use `ProblemReport.__setitem__` in `ProblemReport.load` as well.

This PR depends on https://github.com/canonical/apport/pull/580 landing first.

Bug: https://launchpad.net/bugs/2161697