### PR TITLE
Fix partial writes for coredumps larger than 2 GiB

### DIFF
--- a/apport/report.py
+++ b/apport/report.py
@@ -1943,8 +1943,8 @@ class Report(problem_report.ProblemReport):
         if isinstance(coredump, bytes):
             fd, core = tempfile.mkstemp(prefix="apport_core_")
             atexit.register(os.unlink, core)
-            os.write(fd, coredump)
-            os.close(fd)
+            with os.fdopen(fd, "wb") as f:
+                f.write(coredump)
         elif isinstance(coredump, problem_report.CompressedValue):
             fd, core = tempfile.mkstemp(prefix="apport_core_")
             atexit.register(os.unlink, core)

--- a/data/apport
+++ b/data/apport
@@ -263,6 +263,18 @@ def setup_signals():
     signal.signal(signal.SIGBUS, _log_signal_handler)
 
 
+def write_all(fd: int, data: bytes) -> None:
+    """Write all bytes to a file descriptor, handling potential partial writes."""
+    view = memoryview(data)
+    while view:
+        written = os.write(fd, view)
+        if written == 0:
+            raise OSError(f"os.write({fd}) returned 0 bytes written")
+        view = view[written:]
+
+
+# TODO: Split into smaller functions
+# pylint: disable-next=too-complex,too-many-locals
 def write_user_coredump(
     core_path: str,
     limit: int,
@@ -311,7 +323,13 @@ def write_user_coredump(
             os.unlink(core_path, dir_fd=cwd)
             return
         logger.info("writing core dump %s of size %i", core_path, core_size)
-        os.write(core_file, coredump)
+        try:
+            write_all(core_file, coredump)
+        except OSError as error:
+            logger.error("aborting core dump writing, could not write (%s)", error)
+            os.close(core_file)
+            os.unlink(core_path, dir_fd=cwd)
+            return
     else:
         assert coredump_fd is not None
         block = os.read(coredump_fd, 1048576)
@@ -328,8 +346,10 @@ def write_user_coredump(
                 os.close(core_file)
                 os.unlink(core_path, dir_fd=cwd)
                 return
-            if os.write(core_file, block) != size:
-                logger.error("aborting core dump writing, could not write")
+            try:
+                write_all(core_file, block)
+            except OSError as error:
+                logger.error("aborting core dump writing, could not write (%s)", error)
                 os.close(core_file)
                 os.unlink(core_path, dir_fd=cwd)
                 return


### PR DESCRIPTION
Python's `os.write()` is a low-level POSIX call that directly maps to the `write(2)` system call. The `write(2)` man page says:

> On Linux, write() (and similar system calls) will transfer at most 0x7ffff000 (2,147,479,552) bytes, returning the number of bytes actually transferred.

Because `os.write()` does not handle looping, writing raw `bytes` coredumps larger than 2 GiB results in truncated files of exactly 0x7ffff000 bytes, which are then reported as corrupted by gdb.

In `data/apport` loop over `os.write` until the whole coredump is written since that scripts operate on low level. In `apport.report` use `os.fdopen` to operate on a high-level file object to safely write all bytes.

Bug: https://launchpad.net/bugs/2109979